### PR TITLE
Host-Coop button spawns the bundled dedicated server

### DIFF
--- a/source/Coop.Core/Common/Session/ServerLaunchArguments.cs
+++ b/source/Coop.Core/Common/Session/ServerLaunchArguments.cs
@@ -61,6 +61,38 @@ public static class ServerLaunchArguments
         return string.Join(" ", tokens.Select(QuoteArgument));
     }
 
+    /// <summary>
+    /// Builds the command line for the bundled dedicated-server launcher: only the coop
+    /// session tokens. The launcher owns its engine invocation — mode and module list
+    /// are pinned by the deployment — so the engine tokens the game-instance spawn
+    /// needs would be junk here.
+    /// </summary>
+    public static string BuildDedicatedServerArguments(string saveName, int ownerProcessId,
+        string password, ServerVisibility visibility)
+    {
+        if (saveName == null) throw new ArgumentNullException(nameof(saveName));
+        if (!Enum.IsDefined(typeof(ServerVisibility), visibility))
+            throw new ArgumentOutOfRangeException(nameof(visibility));
+
+        var tokens = new List<string>
+        {
+            SaveArgument,
+            saveName,
+            OwnerArgument,
+            ownerProcessId.ToString(CultureInfo.InvariantCulture),
+            VisibilityArgument,
+            FormatVisibility(visibility),
+        };
+
+        if (!string.IsNullOrEmpty(password))
+        {
+            tokens.Add(PasswordArgument);
+            tokens.Add(password);
+        }
+
+        return string.Join(" ", tokens.Select(QuoteArgument));
+    }
+
     /// <summary>Formats the module ids as the engine's <c>_MODULES_*A*B*_MODULES_</c> launch token.</summary>
     public static string BuildModuleList(IReadOnlyList<string> moduleIds)
     {

--- a/source/Coop.Core/Common/Session/ServerProcessManager.cs
+++ b/source/Coop.Core/Common/Session/ServerProcessManager.cs
@@ -54,12 +54,25 @@ public class ServerProcessManager : IDisposable
             CleanupLocked();
 
             var currentProcess = Process.GetCurrentProcess();
-            var exePath = ManagedServerLauncher.GetEngineExecutablePath();
-            var arguments = ServerLaunchArguments.BuildManagedServerArguments(
-                ManagedServerLauncher.GetActiveModuleIds(), saveName, currentProcess.Id, password, visibility);
 
             // The arguments may contain the hosted-server password, so never write them to a log.
-            Logger.Information("Spawning co-op server for save '{SaveName}': {Exe}", saveName, exePath);
+            string arguments;
+            var exePath = ResolveDedicatedServerExecutable();
+            if (exePath != null)
+            {
+                arguments = ServerLaunchArguments.BuildDedicatedServerArguments(
+                    saveName, currentProcess.Id, password, visibility);
+                Logger.Information("Spawning bundled dedicated co-op server for save '{SaveName}': {Exe}",
+                    saveName, exePath);
+            }
+            else
+            {
+                exePath = ManagedServerLauncher.GetEngineExecutablePath();
+                arguments = ServerLaunchArguments.BuildManagedServerArguments(
+                    ManagedServerLauncher.GetActiveModuleIds(), saveName, currentProcess.Id, password, visibility);
+                Logger.Information("Spawning co-op game-instance server for save '{SaveName}': {Exe}",
+                    saveName, exePath);
+            }
 
             var process = new Process
             {
@@ -97,6 +110,25 @@ public class ServerProcessManager : IDisposable
         {
             CleanupLocked();
         }
+    }
+
+    /// <summary>
+    /// The dedicated server bundled with the Coop module, when it is installed and can host
+    /// the active module set; null falls the spawn back to a game-instance server.
+    /// </summary>
+    private static string ResolveDedicatedServerExecutable()
+    {
+        var exePath = ManagedServerLauncher.GetDedicatedServerExecutablePath();
+        if (exePath == null) return null;
+
+        if (!ManagedServerLauncher.CanDedicatedServerHostActiveModules())
+        {
+            Logger.Information(
+                "Dedicated server skipped: the active community modules need a game-instance server");
+            return null;
+        }
+
+        return exePath;
     }
 
     private void OnServerExited(object sender, EventArgs e)

--- a/source/Coop.Tests/Session/ServerLaunchArgumentsTests.cs
+++ b/source/Coop.Tests/Session/ServerLaunchArgumentsTests.cs
@@ -234,4 +234,87 @@ public class ServerLaunchArgumentsTests
 
         Assert.DoesNotContain(ServerLaunchArguments.PasswordArgument, built);
     }
+
+    [Fact]
+    public void BuildDedicatedServerArguments_CarriesOnlyTheCoopSessionTokens()
+    {
+        var built = ServerLaunchArguments.BuildDedicatedServerArguments(
+            "My Save", 42, "Secret words", ServerVisibility.FriendsOnly);
+
+        Assert.Equal("/coopsave \"My Save\" /coopowner 42 /coopvisibility friends_only /cooppassword \"Secret words\"", built);
+    }
+
+    [Fact]
+    public void BuildDedicatedServerArguments_OmitsEngineTokens()
+    {
+        var built = ServerLaunchArguments.BuildDedicatedServerArguments(
+            "MP", 42, string.Empty, ServerVisibility.Public);
+
+        Assert.DoesNotContain("/server", built);
+        Assert.DoesNotContain("/singleplayer", built);
+        Assert.DoesNotContain("_MODULES_", built);
+    }
+
+    [Fact]
+    public void BuildDedicatedServerArguments_OmitsPasswordArgumentWhenUnprotected()
+    {
+        var built = ServerLaunchArguments.BuildDedicatedServerArguments(
+            "MP", 42, string.Empty, ServerVisibility.Public);
+
+        Assert.Equal("/coopsave MP /coopowner 42 /coopvisibility public", built);
+    }
+
+    [Fact]
+    public void BuildDedicatedServerArguments_RoundTripsThroughTryParse()
+    {
+        var built = ServerLaunchArguments.BuildDedicatedServerArguments(
+            "My Save", 1234, "Secret words", ServerVisibility.None);
+        var args = SplitLikeWindows(built);
+
+        Assert.True(ServerLaunchArguments.TryParse(
+            args, out var saveName, out var ownerProcessId, out var password, out var visibility));
+        Assert.Equal("My Save", saveName);
+        Assert.Equal(1234, ownerProcessId);
+        Assert.Equal("Secret words", password);
+        Assert.Equal(ServerVisibility.None, visibility);
+    }
+
+    [Fact]
+    public void BuildDedicatedServerArguments_RejectsMissingSaveAndUndefinedVisibility()
+    {
+        Assert.Throws<System.ArgumentNullException>(() =>
+            ServerLaunchArguments.BuildDedicatedServerArguments(null, 42, "", ServerVisibility.Public));
+        Assert.Throws<System.ArgumentOutOfRangeException>(() =>
+            ServerLaunchArguments.BuildDedicatedServerArguments("MP", 42, "", (ServerVisibility)99));
+    }
+
+    /// <summary>Minimal Windows-rule splitter for round-trip tests (quotes only; the
+    /// builder never emits embedded quotes for these inputs).</summary>
+    private static string[] SplitLikeWindows(string commandLine)
+    {
+        var tokens = new System.Collections.Generic.List<string>();
+        bool inQuotes = false;
+        var current = new System.Text.StringBuilder();
+        foreach (var c in commandLine)
+        {
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (c == ' ' && !inQuotes)
+            {
+                if (current.Length > 0)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                }
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+        if (current.Length > 0) tokens.Add(current.ToString());
+        return tokens.ToArray();
+    }
 }

--- a/source/GameInterface.Tests/Services/GameState/ManagedServerLauncherTests.cs
+++ b/source/GameInterface.Tests/Services/GameState/ManagedServerLauncherTests.cs
@@ -58,6 +58,14 @@ public class ManagedServerLauncherTests
     }
 
     [Fact]
+    public void ResolveCoopModuleId_ReturnsNightlyId_WhenNightlyIsActive()
+    {
+        var moduleIds = new[] { "Native", "CoopNightly" };
+
+        Assert.Equal("CoopNightly", ManagedServerLauncher.ResolveCoopModuleId(moduleIds));
+    }
+
+    [Fact]
     public void CanDedicatedServerHostModules_AcceptsTheStockModuleSet()
     {
         var modules = new List<ModuleInfo>
@@ -67,6 +75,18 @@ public class ManagedServerLauncherTests
             new ModuleInfo("Sandbox", isOfficial: true, isDlc: false, default),
             new ModuleInfo("StoryMode", isOfficial: true, isDlc: false, default),
             new ModuleInfo("Coop", isOfficial: false, isDlc: false, default),
+        };
+
+        Assert.True(ManagedServerLauncher.CanDedicatedServerHostModules(modules));
+    }
+
+    [Fact]
+    public void CanDedicatedServerHostModules_AcceptsTheNightlyModuleSet()
+    {
+        var modules = new List<ModuleInfo>
+        {
+            new ModuleInfo("Native", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("CoopNightly", isOfficial: false, isDlc: false, default),
         };
 
         Assert.True(ManagedServerLauncher.CanDedicatedServerHostModules(modules));

--- a/source/GameInterface.Tests/Services/GameState/ManagedServerLauncherTests.cs
+++ b/source/GameInterface.Tests/Services/GameState/ManagedServerLauncherTests.cs
@@ -99,6 +99,19 @@ public class ManagedServerLauncherTests
     }
 
     [Fact]
+    public void CanDedicatedServerHostModules_RejectsDlcModules()
+    {
+        var modules = new List<ModuleInfo>
+        {
+            new ModuleInfo("Native", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("Coop", isOfficial: false, isDlc: false, default),
+            new ModuleInfo("WarSails", isOfficial: true, isDlc: true, default),
+        };
+
+        Assert.False(ManagedServerLauncher.CanDedicatedServerHostModules(modules));
+    }
+
+    [Fact]
     public void CanDedicatedServerHostModules_RejectsNullCollection()
     {
         Assert.False(ManagedServerLauncher.CanDedicatedServerHostModules(null));

--- a/source/GameInterface.Tests/Services/GameState/ManagedServerLauncherTests.cs
+++ b/source/GameInterface.Tests/Services/GameState/ManagedServerLauncherTests.cs
@@ -1,0 +1,106 @@
+using GameInterface.Services.GameState;
+using GameInterface.Services.Modules;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace GameInterface.Tests.Services.GameState;
+
+public class ManagedServerLauncherTests
+{
+    [Fact]
+    public void ResolveDedicatedServerExecutable_ReturnsPath_WhenBundledServerExists()
+    {
+        var moduleRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var executablePath = Path.Combine(
+            moduleRoot,
+            ManagedServerLauncher.DedicatedServerFolderName,
+            ManagedServerLauncher.DedicatedServerExecutableName);
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(executablePath)!);
+            File.WriteAllText(executablePath, string.Empty);
+
+            Assert.Equal(executablePath,
+                ManagedServerLauncher.ResolveDedicatedServerExecutable(moduleRoot));
+        }
+        finally
+        {
+            Directory.Delete(moduleRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveDedicatedServerExecutable_ReturnsNull_WhenServerIsNotInstalled()
+    {
+        var moduleRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            // A module folder without a DedicatedServer deployment inside it.
+            Directory.CreateDirectory(moduleRoot);
+
+            Assert.Null(ManagedServerLauncher.ResolveDedicatedServerExecutable(moduleRoot));
+        }
+        finally
+        {
+            Directory.Delete(moduleRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveDedicatedServerExecutable_ReturnsNull_WithoutModuleRoot()
+    {
+        Assert.Null(ManagedServerLauncher.ResolveDedicatedServerExecutable(null));
+        Assert.Null(ManagedServerLauncher.ResolveDedicatedServerExecutable(string.Empty));
+    }
+
+    [Fact]
+    public void CanDedicatedServerHostModules_AcceptsTheStockModuleSet()
+    {
+        var modules = new List<ModuleInfo>
+        {
+            new ModuleInfo("Native", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("SandBoxCore", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("Sandbox", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("StoryMode", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("Coop", isOfficial: false, isDlc: false, default),
+        };
+
+        Assert.True(ManagedServerLauncher.CanDedicatedServerHostModules(modules));
+    }
+
+    [Fact]
+    public void CanDedicatedServerHostModules_AcceptsTheDedicatedServerHostModules()
+    {
+        var modules = new List<ModuleInfo>
+        {
+            new ModuleInfo("Native", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("coop", isOfficial: false, isDlc: false, default),
+            new ModuleInfo("DedicatedServer.Windows", isOfficial: false, isDlc: false, default),
+        };
+
+        Assert.True(ManagedServerLauncher.CanDedicatedServerHostModules(modules));
+    }
+
+    [Fact]
+    public void CanDedicatedServerHostModules_RejectsCommunityModules()
+    {
+        var modules = new List<ModuleInfo>
+        {
+            new ModuleInfo("Native", isOfficial: true, isDlc: false, default),
+            new ModuleInfo("Coop", isOfficial: false, isDlc: false, default),
+            new ModuleInfo("SomeCommunityMod", isOfficial: false, isDlc: false, default),
+        };
+
+        Assert.False(ManagedServerLauncher.CanDedicatedServerHostModules(modules));
+    }
+
+    [Fact]
+    public void CanDedicatedServerHostModules_RejectsNullCollection()
+    {
+        Assert.False(ManagedServerLauncher.CanDedicatedServerHostModules(null));
+    }
+}

--- a/source/GameInterface/Services/GameState/ManagedServerLauncher.cs
+++ b/source/GameInterface/Services/GameState/ManagedServerLauncher.cs
@@ -1,17 +1,31 @@
-﻿using System.Diagnostics;
+using GameInterface.Services.Modules;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using TaleWorlds.ModuleManager;
+using ModuleInfo = GameInterface.Services.Modules.ModuleInfo;
 
 namespace GameInterface.Services.GameState;
 
 /// <summary>
-/// Resolves how to spawn the managed dedicated-server process: the game engine executable
-/// and the active module list, both read from the running game so the spawned server loads
-/// the same engine and mods as the hosting client.
+/// Resolves how to spawn the server process a Host click creates: preferably the dedicated
+/// server shipped inside the Coop module's DedicatedServer folder, otherwise the game engine
+/// executable with the active module list, both read from the running game so the spawned
+/// server matches the hosting client.
 /// </summary>
 public static class ManagedServerLauncher
 {
+    /// <summary>The dedicated-server deployment folder nested inside the Coop module.</summary>
+    public const string DedicatedServerFolderName = "DedicatedServer";
+
+    /// <summary>The dedicated-server launcher executable at that deployment's root.</summary>
+    public const string DedicatedServerExecutableName = "BannerlordCoopServer.exe";
+
+    /// <summary>The id of this mod's module, whose folder carries the dedicated server.</summary>
+    public const string CoopModuleId = "Coop";
+
     /// <summary>
     /// The Bannerlord engine executable. Under Steam the current process is the launcher that
     /// hosts the engine, so this resolves Bannerlord.exe from the same bin directory rather than
@@ -21,6 +35,67 @@ public static class ManagedServerLauncher
     {
         var binDir = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
         return Path.Combine(binDir, "Bannerlord.exe");
+    }
+
+    /// <summary>
+    /// The dedicated server bundled with the installed Coop module, or null when the module
+    /// does not carry one (the Host flow then falls back to spawning the game engine).
+    /// </summary>
+    public static string GetDedicatedServerExecutablePath()
+    {
+        string coopModuleRoot;
+        try
+        {
+            coopModuleRoot = ModuleHelper.GetModuleFullPath(CoopModuleId);
+        }
+        catch (Exception)
+        {
+            // An unresolvable module path only ever means "no dedicated server here".
+            return null;
+        }
+
+        return ResolveDedicatedServerExecutable(coopModuleRoot);
+    }
+
+    /// <summary>
+    /// Resolves <see cref="DedicatedServerExecutableName"/> inside the module's
+    /// <see cref="DedicatedServerFolderName"/> folder; null when it is not installed there.
+    /// </summary>
+    public static string ResolveDedicatedServerExecutable(string coopModuleRoot)
+    {
+        if (string.IsNullOrEmpty(coopModuleRoot)) return null;
+
+        string executablePath = Path.Combine(
+            coopModuleRoot, DedicatedServerFolderName, DedicatedServerExecutableName);
+
+        return File.Exists(executablePath) ? executablePath : null;
+    }
+
+    /// <summary>
+    /// Whether the dedicated server can host the currently active module set. Its module list
+    /// is pinned, so a session with extra community modules must be hosted by the game engine
+    /// instead — the dedicated server could not load them and module validation would then
+    /// reject every joining client that has them enabled.
+    /// </summary>
+    public static bool CanDedicatedServerHostActiveModules()
+    {
+        return CanDedicatedServerHostModules(CompatibilityInfo.Get().Modules);
+    }
+
+    /// <summary>
+    /// True when every module is loadable by the dedicated server's pinned module list:
+    /// official game modules, this mod itself, and the DedicatedServer.* host modules
+    /// (the same set <see cref="Modules.Validators.ModuleValidator"/> exempts from matching).
+    /// </summary>
+    public static bool CanDedicatedServerHostModules(IEnumerable<ModuleInfo> modules)
+    {
+        if (modules == null) return false;
+
+        return modules.All(module =>
+            module.IsOfficial ||
+            string.Equals(module.Id, CoopModuleId, StringComparison.OrdinalIgnoreCase) ||
+            (module.Id != null &&
+                module.Id.StartsWith("DedicatedServer.", StringComparison.OrdinalIgnoreCase)));
     }
 
     /// <summary>The ids of every currently active module, in load (dependency) order.</summary>

--- a/source/GameInterface/Services/GameState/ManagedServerLauncher.cs
+++ b/source/GameInterface/Services/GameState/ManagedServerLauncher.cs
@@ -84,15 +84,16 @@ public static class ManagedServerLauncher
 
     /// <summary>
     /// True when every module is loadable by the dedicated server's pinned module list:
-    /// official game modules, this mod itself, and the DedicatedServer.* host modules
+    /// official non-DLC game modules, this mod itself, and the DedicatedServer.* host modules
     /// (the same set <see cref="Modules.Validators.ModuleValidator"/> exempts from matching).
+    /// DLC is official but not part of that pinned list, so it disqualifies the dedicated server.
     /// </summary>
     public static bool CanDedicatedServerHostModules(IEnumerable<ModuleInfo> modules)
     {
         if (modules == null) return false;
 
         return modules.All(module =>
-            module.IsOfficial ||
+            (module.IsOfficial && !module.IsDlc) ||
             string.Equals(module.Id, CoopModuleId, StringComparison.OrdinalIgnoreCase) ||
             (module.Id != null &&
                 module.Id.StartsWith("DedicatedServer.", StringComparison.OrdinalIgnoreCase)));

--- a/source/GameInterface/Services/GameState/ManagedServerLauncher.cs
+++ b/source/GameInterface/Services/GameState/ManagedServerLauncher.cs
@@ -23,8 +23,10 @@ public static class ManagedServerLauncher
     /// <summary>The dedicated-server launcher executable at that deployment's root.</summary>
     public const string DedicatedServerExecutableName = "BannerlordCoopServer.exe";
 
-    /// <summary>The id of this mod's module, whose folder carries the dedicated server.</summary>
+    /// <summary>The id of this mod's stable module, whose folder carries the dedicated server.</summary>
     public const string CoopModuleId = "Coop";
+
+    private const string CoopNightlyModuleId = "CoopNightly";
 
     /// <summary>
     /// The Bannerlord engine executable. Under Steam the current process is the launcher that
@@ -46,7 +48,10 @@ public static class ManagedServerLauncher
         string coopModuleRoot;
         try
         {
-            coopModuleRoot = ModuleHelper.GetModuleFullPath(CoopModuleId);
+            string coopModuleId = ResolveCoopModuleId(GetActiveModuleIds());
+            if (coopModuleId == null) return null;
+
+            coopModuleRoot = ModuleHelper.GetModuleFullPath(coopModuleId);
         }
         catch (Exception)
         {
@@ -94,9 +99,20 @@ public static class ManagedServerLauncher
 
         return modules.All(module =>
             (module.IsOfficial && !module.IsDlc) ||
-            string.Equals(module.Id, CoopModuleId, StringComparison.OrdinalIgnoreCase) ||
+            IsCoopModuleId(module.Id) ||
             (module.Id != null &&
                 module.Id.StartsWith("DedicatedServer.", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    internal static string ResolveCoopModuleId(IEnumerable<string> moduleIds)
+    {
+        return moduleIds?.FirstOrDefault(IsCoopModuleId);
+    }
+
+    private static bool IsCoopModuleId(string moduleId)
+    {
+        return string.Equals(moduleId, CoopModuleId, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(moduleId, CoopNightlyModuleId, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>The ids of every currently active module, in load (dependency) order.</summary>


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

The Host button always spawns a second Bannerlord.exe game instance as the co-op server.

## What is the new behavior?

Resolves #2517

The Host click first resolves `BannerlordCoopServer.exe` from the Coop module's `DedicatedServer` folder (where the Steam bundle nests it) and spawns it with the coop session tokens (`/coopsave`, `/coopowner`, `/coopvisibility`, `/cooppassword`). It falls back to the game-instance server when the dedicated server is not installed, or when extra community modules are active (the dedicated server's pinned module list could not host them).

The dedicated-server side (accepting the tokens, hosting the clicked save from the game's own save folder) lives in the DedicatedServer repo.

## Bot Changelog Entry

- Hosting a co-op game now starts the bundled dedicated server when it is installed, instead of a second game instance.

## Other information