### PR TITLE
Re-enable Tab in tournaments

### DIFF
--- a/source/E2E.Tests/Services/Missions/Tournaments/TournamentMissionRulesTests.cs
+++ b/source/E2E.Tests/Services/Missions/Tournaments/TournamentMissionRulesTests.cs
@@ -396,4 +396,33 @@ public class TournamentMissionRulesTests
             collisionData.CollisionResult,
             recordedCollision);
     }
+
+    [Fact]
+    public void OnEndMissionRequest_BlocksVanillaProgressionWhileActive()
+    {
+        var controller =
+            ObjectHelper.SkipConstructor<
+                CoopTournamentFightMissionController>();
+
+        Assert.Null(controller.OnEndMissionRequest(out var defaultCanLeave));
+        Assert.False(defaultCanLeave);
+
+        controller.SetLeaveAllowedProvider(() => false);
+        Assert.Null(controller.OnEndMissionRequest(out var activeCanLeave));
+        Assert.False(activeCanLeave);
+    }
+
+    [Fact]
+    public void OnEndMissionRequest_AllowsLeaveOnceCompleted()
+    {
+        var controller =
+            ObjectHelper.SkipConstructor<
+                CoopTournamentFightMissionController>();
+        controller.SetLeaveAllowedProvider(() => true);
+
+        InquiryData inquiry = controller.OnEndMissionRequest(out var canLeave);
+
+        Assert.Null(inquiry);
+        Assert.True(canLeave);
+    }
 }

--- a/source/E2E.Tests/Services/Tournaments/TournamentTabFlowTests.cs
+++ b/source/E2E.Tests/Services/Tournaments/TournamentTabFlowTests.cs
@@ -1,0 +1,269 @@
+﻿using Common.Network;
+using E2E.Tests.Environment.Instance;
+using E2E.Tests.Util;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Tournaments;
+using GameInterface.Services.Tournaments.Data;
+using GameInterface.Services.Tournaments.Messages;
+using GameInterface.Services.Tournaments.UI;
+using System;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Tournaments;
+
+public class TournamentTabFlowTests : SyncTestBase
+{
+    private const string SessionId = "session-a";
+    private const string TownId = "town-a";
+
+    public TournamentTabFlowTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void AdvanceChoice_ContestantInMatch_Joins_OthersWatch()
+    {
+        EnvironmentInstance[] clients = Clients.ToArray();
+        SetControllerId(clients[0], "player-a");
+        SetControllerId(clients[1], "spectator-b");
+        TournamentSessionSnapshot snapshot = CreateSnapshot(
+            TournamentSessionPhase.AwaitingChoices,
+            1,
+            humanInCurrentMatch: true,
+            skipAllowed: false);
+
+        Broadcast(new NetworkTournamentSessionSnapshot(snapshot));
+
+        AssertAdvanceChoice(clients[0], "player-a", TournamentPlayerChoice.Join);
+        AssertAdvanceChoice(clients[1], "spectator-b", TournamentPlayerChoice.Watch);
+    }
+
+    [Fact]
+    public void AdvanceChoice_NoHumanInMatch_Skips()
+    {
+        EnvironmentInstance[] clients = Clients.ToArray();
+        SetControllerId(clients[0], "player-a");
+        SetControllerId(clients[1], "spectator-b");
+        TournamentSessionSnapshot snapshot = CreateSnapshot(
+            TournamentSessionPhase.AwaitingChoices,
+            1,
+            humanInCurrentMatch: false,
+            skipAllowed: true);
+
+        Broadcast(new NetworkTournamentSessionSnapshot(snapshot));
+
+        AssertAdvanceChoice(clients[0], "player-a", TournamentPlayerChoice.Skip);
+        AssertAdvanceChoice(clients[1], "spectator-b", TournamentPlayerChoice.Skip);
+    }
+
+    [Fact]
+    public void LeaveMenuPredicate_LiveMatchSpectatorOnly()
+    {
+        EnvironmentInstance[] clients = Clients.ToArray();
+        SetControllerId(clients[0], "player-a");
+        SetControllerId(clients[1], "spectator-b");
+        TournamentSessionSnapshot snapshot = CreateSnapshot(
+            TournamentSessionPhase.LiveMatch,
+            1,
+            humanInCurrentMatch: true,
+            skipAllowed: false);
+
+        Broadcast(new NetworkTournamentSessionSnapshot(snapshot));
+
+        AssertLeaveMenu(clients[0], "player-a", expectedOpen: false);
+        AssertLeaveMenu(clients[1], "spectator-b", expectedOpen: true);
+    }
+
+    [Fact]
+    public void TryLeaveActive_SpectatorDuringLiveMatch_DropsFromSession()
+    {
+        Server.Call(() =>
+        {
+            var registry = Server.Resolve<ITournamentSessionRegistry>();
+            TournamentSessionSnapshot snapshot = CreateStartedLiveSession(registry);
+
+            Assert.Contains("spectator-b", snapshot.SpectatorControllerIds);
+
+            TournamentMutationStatus status = registry.TryLeaveActive(
+                snapshot.SessionId,
+                snapshot.Revision,
+                "spectator-b",
+                900,
+                "Tournament Recruit",
+                out snapshot,
+                out var outcome,
+                out var noViewers);
+
+            Assert.Equal(TournamentMutationStatus.Applied, status);
+            Assert.Equal(TournamentBallotOutcome.Open, outcome);
+            Assert.DoesNotContain("spectator-b", snapshot.SpectatorControllerIds);
+            Assert.Equal(TournamentSessionPhase.LiveMatch, snapshot.Phase);
+            Assert.False(noViewers);
+            Assert.Equal(2, snapshot.Contestants.Count(contestant => contestant.IsHuman));
+            Assert.DoesNotContain(snapshot.Contestants, contestant => contestant.IsReplaced);
+        });
+    }
+
+    private static void AssertAdvanceChoice(
+        EnvironmentInstance client,
+        string controllerId,
+        TournamentPlayerChoice expected)
+    {
+        client.Call(() =>
+        {
+            Assert.True(client.Resolve<ITournamentSessionRegistry>().TryGet(SessionId, out var snapshot));
+            CoopTournamentVM.UIState state = CoopTournamentVM.CalculateUIState(snapshot, controllerId, false);
+            Assert.Equal(expected, CoopTournamentVM.GetAdvanceChoice(state));
+            Assert.False(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+        });
+    }
+
+    private static void AssertLeaveMenu(
+        EnvironmentInstance client,
+        string controllerId,
+        bool expectedOpen)
+    {
+        client.Call(() =>
+        {
+            Assert.True(client.Resolve<ITournamentSessionRegistry>().TryGet(SessionId, out var snapshot));
+            CoopTournamentVM.UIState state = CoopTournamentVM.CalculateUIState(snapshot, controllerId, false);
+            Assert.Null(CoopTournamentVM.GetAdvanceChoice(state));
+            Assert.Equal(expectedOpen, CoopTournamentVM.ShouldOpenLeaveMenu(state));
+        });
+    }
+
+    private void Broadcast<T>(T message) where T : Common.Messaging.IMessage
+        => Server.Call(() => Server.Resolve<INetwork>().SendAll(message));
+
+    private static void SetControllerId(EnvironmentInstance client, string controllerId)
+        => client.Call(() => client.Resolve<IControllerIdProvider>().SetControllerId(controllerId));
+
+    private static TournamentSessionSnapshot CreateSnapshot(
+        TournamentSessionPhase phase,
+        long revision,
+        bool humanInCurrentMatch,
+        bool skipAllowed)
+    {
+        var contestant = new TournamentContestantData(
+            "slot-a",
+            "character-a",
+            17,
+            "player-a",
+            "Player A",
+            true,
+            false,
+            true,
+            "npc-a");
+        string currentMatchSlot = humanInCurrentMatch ? contestant.SlotId : "npc-slot";
+        var match = new TournamentMatchData(
+            "match-a",
+            "round-a",
+            0,
+            1,
+            1,
+            new[]
+            {
+                new TournamentTeamData(
+                    "team-a",
+                    new[] { currentMatchSlot },
+                    0,
+                    false,
+                    0,
+                    null)
+            },
+            Array.Empty<string>());
+
+        return new TournamentSessionSnapshot(
+            SessionId,
+            "mission-a",
+            TownId,
+            "arena-a",
+            "prize-a",
+            phase,
+            revision,
+            1,
+            match.MatchId,
+            "player-a",
+            Array.Empty<string>(),
+            new[] { contestant },
+            new[] { "spectator-b" },
+            Array.Empty<TournamentPlayerChoiceData>(),
+            new[] { new TournamentRoundData("round-a", 0, 0, new[] { match }) },
+            0,
+            0,
+            2,
+            skipAllowed,
+            false,
+            null);
+    }
+
+    private static TournamentSessionSnapshot CreateStartedLiveSession(ITournamentSessionRegistry registry)
+    {
+        TournamentContestantData[] contestants = Enumerable.Range(0, 16)
+            .Select(index => new TournamentContestantData(
+                $"tab-session:slot:{index}",
+                $"npc-{index}",
+                index + 1,
+                null,
+                $"NPC {index}",
+                false,
+                false,
+                index == 15,
+                null,
+                0))
+            .ToArray();
+        var seed = new TournamentSessionSeed(
+            "tab-session",
+            "tab-session",
+            TownId,
+            "arena-scene",
+            "prize-item",
+            "basic-troop",
+            contestants);
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryCreate(seed, out var snapshot));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryJoin(
+            snapshot.SessionId, snapshot.Revision, "player-1", "player-character-1", "Player One", 500, false, out snapshot));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryJoin(
+            snapshot.SessionId, snapshot.Revision, "player-2", "player-character-2", "Player Two", 501, false, out snapshot));
+
+        string firstSlot = snapshot.Contestants.Single(contestant => contestant.ControllerId == "player-1").SlotId;
+        var teams = new[]
+        {
+            new TournamentTeamData("team-1", new[] { firstSlot }, 0, false, 1, null),
+            new TournamentTeamData("team-2", new[] { "tab-session:slot:0" }, 0, false, 2, null)
+        };
+        var match = new TournamentMatchData(
+            "match-1",
+            "round-1",
+            0,
+            1,
+            1,
+            teams,
+            Array.Empty<string>(),
+            1);
+        var rounds = new[] { new TournamentRoundData("round-1", 0, 0, new[] { match }) };
+
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryStart(
+            snapshot.SessionId, snapshot.Revision, "player-1", rounds, match.MatchId, out snapshot));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryRequestSpectate(
+            snapshot.SessionId, snapshot.Revision, "spectator-b", out snapshot));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryEnterMission(
+            snapshot.SessionId, snapshot.Revision, "player-1", out snapshot));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryEnterMission(
+            snapshot.SessionId, snapshot.Revision, "player-2", out snapshot));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryChoose(
+            snapshot.SessionId, snapshot.Revision, snapshot.CurrentMatchId, "player-1",
+            TournamentPlayerChoice.Join, out snapshot, out _));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryChoose(
+            snapshot.SessionId, snapshot.Revision, snapshot.CurrentMatchId, "player-2",
+            TournamentPlayerChoice.Watch, out snapshot, out _));
+        Assert.Equal(TournamentMutationStatus.Applied, registry.TryChoose(
+            snapshot.SessionId, snapshot.Revision, snapshot.CurrentMatchId, "spectator-b",
+            TournamentPlayerChoice.Watch, out snapshot, out _));
+
+        Assert.Equal(TournamentSessionPhase.LiveMatch, snapshot.Phase);
+        return snapshot;
+    }
+}

--- a/source/GameInterface.Tests/Services/Tournaments/TournamentTabInputPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Tournaments/TournamentTabInputPatchesTests.cs
@@ -6,20 +6,6 @@ namespace GameInterface.Tests.Services.Tournaments;
 public class TournamentTabInputPatchesTests
 {
     [Theory]
-    [InlineData(true, true, true)]
-    [InlineData(true, false, false)]
-    [InlineData(false, true, false)]
-    public void ShouldSuppress_OnlyBlocksTabDuringCoopTournamentMission(
-        bool isTab,
-        bool isCoopTournamentMissionActive,
-        bool expected)
-    {
-        Assert.Equal(
-            expected,
-            TournamentTabInputPatches.ShouldSuppress(isTab, isCoopTournamentMissionActive));
-    }
-
-    [Theory]
     [InlineData(true, false)]
     [InlineData(false, true)]
     public void ShouldRunScoreboardTick_BlocksEntireScoreboardDuringCoopTournament(

--- a/source/GameInterface.Tests/Services/Tournaments/UI/CoopTournamentVMStateTests.cs
+++ b/source/GameInterface.Tests/Services/Tournaments/UI/CoopTournamentVMStateTests.cs
@@ -294,6 +294,42 @@ public class CoopTournamentVMStateTests
     }
 
     [Fact]
+    public void ShouldOpenLeaveMenu_LiveMatchRestingContestant_ReturnsFalse()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateRestingContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.False(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+    }
+
+    [Fact]
+    public void ShouldOpenLeaveMenu_LiveMatchEliminatedContestant_ReturnsTrue()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateEliminatedContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.True(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+    }
+
+    [Fact]
     public void ShouldOpenLeaveMenu_AwaitingChoices_ReturnsFalse()
     {
         var snapshot = CreateSnapshot(
@@ -319,7 +355,7 @@ public class CoopTournamentVMStateTests
     }
 
     [Fact]
-    public void IsLocalInCurrentMatch_ContestantInCurrentMatch_IsTrue()
+    public void LocalRole_ContestantInCurrentMatch_IsFighter()
     {
         var snapshot = CreateSnapshot(
             new[] { CreateHumanContestant() },
@@ -333,11 +369,11 @@ public class CoopTournamentVMStateTests
 
         var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
 
-        Assert.True(state.IsInCurrentMatch);
+        Assert.Equal(CoopTournamentVM.UIState.PlayerRole.Fighter, state.Role);
     }
 
     [Fact]
-    public void IsLocalInCurrentMatch_RestingContestant_IsFalse()
+    public void LocalRole_RestingContestant_IsResting()
     {
         var snapshot = CreateSnapshot(
             new[] { CreateRestingContestant() },
@@ -351,11 +387,29 @@ public class CoopTournamentVMStateTests
 
         var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
 
-        Assert.False(state.IsInCurrentMatch);
+        Assert.Equal(CoopTournamentVM.UIState.PlayerRole.Resting, state.Role);
     }
 
     [Fact]
-    public void IsLocalInCurrentMatch_PureSpectator_IsFalse()
+    public void LocalRole_EliminatedContestant_IsEliminated()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateEliminatedContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.Equal(CoopTournamentVM.UIState.PlayerRole.Eliminated, state.Role);
+    }
+
+    [Fact]
+    public void LocalRole_PureSpectator_IsSpectator()
     {
         var snapshot = CreateSnapshot(
             Array.Empty<TournamentContestantData>(),
@@ -369,11 +423,11 @@ public class CoopTournamentVMStateTests
 
         var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
 
-        Assert.False(state.IsInCurrentMatch);
+        Assert.Equal(CoopTournamentVM.UIState.PlayerRole.Spectator, state.Role);
     }
 
     [Fact]
-    public void IsLocalInCurrentMatch_NoLocalPlayer_IsFalse()
+    public void LocalRole_NoLocalPlayer_IsNone()
     {
         var snapshot = CreateSnapshot(
             new[] { CreateContestant("slot-a", "player-b") },
@@ -387,7 +441,7 @@ public class CoopTournamentVMStateTests
 
         var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
 
-        Assert.False(state.IsInCurrentMatch);
+        Assert.Equal(CoopTournamentVM.UIState.PlayerRole.None, state.Role);
     }
 
     private static NetworkTournamentBetResult CreateBetResult(
@@ -423,6 +477,9 @@ public class CoopTournamentVMStateTests
     private static TournamentContestantData CreateRestingContestant()
         => CreateContestant("slot-b", "player-a");
 
+    private static TournamentContestantData CreateEliminatedContestant()
+        => CreateContestant("slot-c", "player-a");
+
     private static TournamentContestantData CreateContestant(string slotId, string controllerId)
         => new(
             slotId,
@@ -446,7 +503,7 @@ public class CoopTournamentVMStateTests
         long revision = 1,
         TournamentSessionPhase phase = TournamentSessionPhase.AwaitingChoices)
     {
-        var match = new TournamentMatchData(
+        var currentMatch = new TournamentMatchData(
             "match-a",
             "round-a",
             0,
@@ -463,6 +520,23 @@ public class CoopTournamentVMStateTests
                     null)
             },
             Array.Empty<string>());
+        var pendingMatch = new TournamentMatchData(
+            "match-b",
+            "round-a",
+            0,
+            1,
+            1,
+            new[]
+            {
+                new TournamentTeamData(
+                    "team-b",
+                    new[] { "slot-b" },
+                    0,
+                    false,
+                    0,
+                    null)
+            },
+            Array.Empty<string>());
 
         return new TournamentSessionSnapshot(
             "session-a",
@@ -473,13 +547,13 @@ public class CoopTournamentVMStateTests
             phase,
             revision,
             1,
-            match.MatchId,
+            currentMatch.MatchId,
             "host-a",
             Array.Empty<string>(),
             contestants,
             spectators,
             choices,
-            new[] { new TournamentRoundData("round-a", 0, 0, new[] { match }) },
+            new[] { new TournamentRoundData("round-a", 0, 0, new[] { currentMatch, pendingMatch }) },
             readyCount,
             skipCount,
             voterCount,

--- a/source/GameInterface.Tests/Services/Tournaments/UI/CoopTournamentVMStateTests.cs
+++ b/source/GameInterface.Tests/Services/Tournaments/UI/CoopTournamentVMStateTests.cs
@@ -312,7 +312,7 @@ public class CoopTournamentVMStateTests
     }
 
     [Fact]
-    public void ShouldOpenLeaveMenu_LiveMatchEliminatedContestant_ReturnsTrue()
+    public void ShouldOpenLeaveMenu_LiveMatchEliminatedContestant_ReturnsFalse()
     {
         var snapshot = CreateSnapshot(
             new[] { CreateEliminatedContestant() },
@@ -326,7 +326,7 @@ public class CoopTournamentVMStateTests
 
         var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
 
-        Assert.True(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+        Assert.False(CoopTournamentVM.ShouldOpenLeaveMenu(state));
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/Tournaments/UI/CoopTournamentVMStateTests.cs
+++ b/source/GameInterface.Tests/Services/Tournaments/UI/CoopTournamentVMStateTests.cs
@@ -188,6 +188,208 @@ public class CoopTournamentVMStateTests
         Assert.Equal(0, summary.ExpectedPayout);
     }
 
+    [Fact]
+    public void GetAdvanceChoice_ContestantInNextMatch_ReturnsJoin()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateHumanContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            true,
+            0,
+            0,
+            1);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.Equal(TournamentPlayerChoice.Join, CoopTournamentVM.GetAdvanceChoice(state));
+    }
+
+    [Fact]
+    public void GetAdvanceChoice_SpectatorWithSkipAllowed_ReturnsSkip()
+    {
+        var snapshot = CreateSnapshot(
+            Array.Empty<TournamentContestantData>(),
+            new[] { "player-a" },
+            Array.Empty<TournamentPlayerChoiceData>(),
+            true,
+            0,
+            0,
+            1);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.Equal(TournamentPlayerChoice.Skip, CoopTournamentVM.GetAdvanceChoice(state));
+    }
+
+    [Fact]
+    public void GetAdvanceChoice_SpectatorWithoutSkipAllowed_ReturnsWatch()
+    {
+        var snapshot = CreateSnapshot(
+            Array.Empty<TournamentContestantData>(),
+            new[] { "player-a" },
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.Equal(TournamentPlayerChoice.Watch, CoopTournamentVM.GetAdvanceChoice(state));
+    }
+
+    [Fact]
+    public void GetAdvanceChoice_NoEligibleChoice_ReturnsNull()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateHumanContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            true,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.Preparation);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.Null(CoopTournamentVM.GetAdvanceChoice(state));
+    }
+
+    [Fact]
+    public void ShouldOpenLeaveMenu_LiveMatchSpectator_ReturnsTrue()
+    {
+        var snapshot = CreateSnapshot(
+            Array.Empty<TournamentContestantData>(),
+            new[] { "player-a" },
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.True(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+    }
+
+    [Fact]
+    public void ShouldOpenLeaveMenu_LiveMatchContestantFighting_ReturnsFalse()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateHumanContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.False(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+    }
+
+    [Fact]
+    public void ShouldOpenLeaveMenu_AwaitingChoices_ReturnsFalse()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateHumanContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            true,
+            0,
+            0,
+            1);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.False(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+    }
+
+    [Fact]
+    public void ShouldOpenLeaveMenu_NoSnapshot_ReturnsFalse()
+    {
+        var state = CoopTournamentVM.CalculateUIState(null, "player-a", true);
+
+        Assert.False(CoopTournamentVM.ShouldOpenLeaveMenu(state));
+    }
+
+    [Fact]
+    public void IsLocalInCurrentMatch_ContestantInCurrentMatch_IsTrue()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateHumanContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.True(state.IsInCurrentMatch);
+    }
+
+    [Fact]
+    public void IsLocalInCurrentMatch_RestingContestant_IsFalse()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateRestingContestant() },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.False(state.IsInCurrentMatch);
+    }
+
+    [Fact]
+    public void IsLocalInCurrentMatch_PureSpectator_IsFalse()
+    {
+        var snapshot = CreateSnapshot(
+            Array.Empty<TournamentContestantData>(),
+            new[] { "player-a" },
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.False(state.IsInCurrentMatch);
+    }
+
+    [Fact]
+    public void IsLocalInCurrentMatch_NoLocalPlayer_IsFalse()
+    {
+        var snapshot = CreateSnapshot(
+            new[] { CreateContestant("slot-a", "player-b") },
+            Array.Empty<string>(),
+            Array.Empty<TournamentPlayerChoiceData>(),
+            false,
+            0,
+            0,
+            1,
+            phase: TournamentSessionPhase.LiveMatch);
+
+        var state = CoopTournamentVM.CalculateUIState(snapshot, "player-a", true);
+
+        Assert.False(state.IsInCurrentMatch);
+    }
+
     private static NetworkTournamentBetResult CreateBetResult(
         TournamentSessionSnapshot snapshot,
         long revision,
@@ -217,6 +419,21 @@ public class CoopTournamentVMStateTests
             false,
             true,
             "npc-a");
+
+    private static TournamentContestantData CreateRestingContestant()
+        => CreateContestant("slot-b", "player-a");
+
+    private static TournamentContestantData CreateContestant(string slotId, string controllerId)
+        => new(
+            slotId,
+            "character-b",
+            1,
+            controllerId,
+            "Player B",
+            true,
+            false,
+            true,
+            "npc-b");
 
     private static TournamentSessionSnapshot CreateSnapshot(
         TournamentContestantData[] contestants,

--- a/source/GameInterface/Services/Tournaments/Patches/TournamentTabInputPatches.cs
+++ b/source/GameInterface/Services/Tournaments/Patches/TournamentTabInputPatches.cs
@@ -1,35 +1,12 @@
 using GameInterface.Services.Tournaments.UI;
 using HarmonyLib;
-using System.Collections.Generic;
-using System.Reflection;
-using TaleWorlds.InputSystem;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.GauntletUI.Mission.Singleplayer;
 
 namespace GameInterface.Services.Tournaments.Patches;
 
-[HarmonyPatch]
 internal static class TournamentTabInputPatches
 {
-    [HarmonyTargetMethods]
-    private static IEnumerable<MethodBase> TargetMethods() => new MethodBase[]
-    {
-        AccessTools.Method(typeof(Input), nameof(Input.IsKeyPressed)),
-        AccessTools.Method(typeof(Input), nameof(Input.IsKeyDown)),
-        AccessTools.Method(typeof(Input), nameof(Input.IsKeyDownImmediate)),
-        AccessTools.Method(typeof(Input), nameof(Input.IsKeyReleased))
-    };
-
-    [HarmonyPostfix]
-    private static void SuppressTab(InputKey __0, ref bool __result)
-    {
-        if (ShouldSuppress(__0 == InputKey.Tab, IsCoopTournamentMissionActive()))
-            __result = false;
-    }
-
-    internal static bool ShouldSuppress(bool isTab, bool isCoopTournamentMissionActive)
-        => isTab && isCoopTournamentMissionActive;
-
     internal static bool IsCoopTournamentMissionActive()
     {
         return Mission.Current != null &&

--- a/source/GameInterface/Services/Tournaments/UI/CoopTournamentMissionView.cs
+++ b/source/GameInterface/Services/Tournaments/UI/CoopTournamentMissionView.cs
@@ -137,12 +137,23 @@ public sealed class CoopTournamentMissionView : MissionGauntletTournamentView
 
         dataSource.RefreshPendingBracket();
         UpdateBetInput();
+        UpdateTabInput();
+        UpdateUiVisibility();
+        UpdateCombatUi();
+    }
+
+    private void UpdateTabInput()
+    {
+        if (isPhotoMode || dataSource.IsBetWindowEnabled) return;
 
         bool advancePressed = Mission.InputManager?.IsGameKeyPressed((int)GameKeyDefinition.Leave) == true ||
             gauntletLayer.Input.IsGameKeyPressed((int)GameKeyDefinition.Leave);
-        if (advancePressed && !isPhotoMode && !dataSource.IsBetWindowEnabled)
+        if (advancePressed)
             HandleTabPressed();
+    }
 
+    private void UpdateUiVisibility()
+    {
         bool uiShouldShow = dataSource.ShouldShowUI || forceShowUi;
         if (uiShouldShow && !viewEnabled)
         {
@@ -158,7 +169,6 @@ public sealed class CoopTournamentMissionView : MissionGauntletTournamentView
             forceShowUi = false;
             dataSource.IsLeaveMenuOpen = false;
         }
-        UpdateCombatUi();
     }
 
     public override bool IsOpeningEscapeMenuOnFocusChangeAllowed()

--- a/source/GameInterface/Services/Tournaments/UI/CoopTournamentMissionView.cs
+++ b/source/GameInterface/Services/Tournaments/UI/CoopTournamentMissionView.cs
@@ -27,6 +27,8 @@ public sealed class CoopTournamentMissionView : MissionGauntletTournamentView
     private CoopTournamentVM dataSource;
     private bool viewModeResolved;
     private bool isCoopView;
+    private bool forceShowUi;
+    private bool isPhotoMode;
 
     public CoopTournamentMissionView()
     {
@@ -71,6 +73,8 @@ public sealed class CoopTournamentMissionView : MissionGauntletTournamentView
         dataSource = new CoopTournamentVM(DisableUi, behavior, initialSnapshot, controller);
         gauntletLayer = new GauntletLayer("MissionCoopTournament", ViewOrderPriority);
         gauntletLayer.Input.RegisterHotKeyCategory(HotKeyManager.GetCategory("GenericPanelGameKeyCategory"));
+        // Focused layers exclusively receive game keys; register Leave so Tab works while this layer holds focus
+        gauntletLayer.Input.RegisterHotKeyCategory(HotKeyManager.GetCategory("Generic"));
         gauntletLayer.InputRestrictions.SetInputRestrictions();
         gauntletLayer.IsFocusLayer = true;
         ScreenManager.TrySetFocus(gauntletLayer);
@@ -134,14 +138,25 @@ public sealed class CoopTournamentMissionView : MissionGauntletTournamentView
         dataSource.RefreshPendingBracket();
         UpdateBetInput();
 
-        if (dataSource.ShouldShowUI && !viewEnabled)
+        bool advancePressed = Mission.InputManager?.IsGameKeyPressed((int)GameKeyDefinition.Leave) == true ||
+            gauntletLayer.Input.IsGameKeyPressed((int)GameKeyDefinition.Leave);
+        if (advancePressed && !isPhotoMode && !dataSource.IsBetWindowEnabled)
+            HandleTabPressed();
+
+        bool uiShouldShow = dataSource.ShouldShowUI || forceShowUi;
+        if (uiShouldShow && !viewEnabled)
         {
             dataSource.Refresh();
             ShowUi();
         }
-        else if (!dataSource.ShouldShowUI && viewEnabled)
+        else if (!uiShouldShow && viewEnabled)
         {
             DisableUi();
+        }
+        if (dataSource.ShouldShowUI)
+        {
+            forceShowUi = false;
+            dataSource.IsLeaveMenuOpen = false;
         }
         UpdateCombatUi();
     }
@@ -172,6 +187,7 @@ public sealed class CoopTournamentMissionView : MissionGauntletTournamentView
             return;
         }
 
+        isPhotoMode = true;
         if (gauntletLayer != null) gauntletLayer.UIContext.ContextAlpha = 0f;
     }
 
@@ -183,8 +199,34 @@ public sealed class CoopTournamentMissionView : MissionGauntletTournamentView
             return;
         }
 
+        isPhotoMode = false;
         if (gauntletLayer != null) gauntletLayer.UIContext.ContextAlpha = viewEnabled ? 1f : 0f;
         UpdateCombatUi();
+    }
+
+    private void HandleTabPressed()
+    {
+        if (dataSource.ShouldShowUI)
+        {
+            TournamentPlayerChoice? advanceChoice = dataSource.GetAdvanceChoice();
+            if (advanceChoice == TournamentPlayerChoice.Join)
+                dataSource.ExecuteJoin();
+            else if (advanceChoice == TournamentPlayerChoice.Skip)
+                dataSource.ExecuteSkip();
+            else if (advanceChoice == TournamentPlayerChoice.Watch)
+                dataSource.ExecuteWatch();
+            return;
+        }
+
+        if (forceShowUi || dataSource.ShouldOpenLeaveMenu())
+        {
+            forceShowUi = !forceShowUi;
+            dataSource.IsLeaveMenuOpen = forceShowUi;
+            if (forceShowUi)
+                ShowUi();
+            else
+                DisableUi();
+        }
     }
 
     private void UpdateBetInput()

--- a/source/GameInterface/Services/Tournaments/UI/CoopTournamentVM.cs
+++ b/source/GameInterface/Services/Tournaments/UI/CoopTournamentVM.cs
@@ -27,6 +27,7 @@ internal sealed class CoopTournamentVM : TournamentVM
         public readonly bool CanLeave;
         public readonly bool CanBet;
         public readonly bool IsMatchActive;
+        public readonly bool IsInCurrentMatch;
         public readonly int ReadyCount;
         public readonly int SkipCount;
         public readonly int VoterCount;
@@ -39,6 +40,7 @@ internal sealed class CoopTournamentVM : TournamentVM
             bool canLeave,
             bool canBet,
             bool isMatchActive,
+            bool isInCurrentMatch,
             int readyCount,
             int skipCount,
             int voterCount,
@@ -50,6 +52,7 @@ internal sealed class CoopTournamentVM : TournamentVM
             CanLeave = canLeave;
             CanBet = canBet;
             IsMatchActive = isMatchActive;
+            IsInCurrentMatch = isInCurrentMatch;
             ReadyCount = readyCount;
             SkipCount = skipCount;
             VoterCount = voterCount;
@@ -89,6 +92,7 @@ internal sealed class CoopTournamentVM : TournamentVM
     private bool canBet;
     private bool isJoinVisible;
     private bool isCoopMatchActive;
+    private bool leaveMenuOpen;
     private string readyCountText;
     private string skipCountText;
     private string selectedChoiceText;
@@ -96,6 +100,7 @@ internal sealed class CoopTournamentVM : TournamentVM
     private bool hasAcceptedBetResult;
     private long acceptedBetSequence;
     private BetSummary acceptedBetSummary;
+    private UIState lastUIState;
 
     public CoopTournamentVM(
         Action disableUI,
@@ -184,11 +189,24 @@ internal sealed class CoopTournamentVM : TournamentVM
         {
             if (isCoopMatchActive == value) return;
             isCoopMatchActive = value;
-            base.IsCurrentMatchActive = value;
+            base.IsCurrentMatchActive = value && !leaveMenuOpen;
             OnPropertyChangedWithValue(value, nameof(IsCoopMatchActive));
             OnPropertyChanged(nameof(ShouldShowUI));
         }
     }
+
+    internal bool IsLeaveMenuOpen
+    {
+        get => leaveMenuOpen;
+        set
+        {
+            if (leaveMenuOpen == value) return;
+            leaveMenuOpen = value;
+            base.IsCurrentMatchActive = isCoopMatchActive && !leaveMenuOpen;
+        }
+    }
+
+    public bool IsInCurrentMatch => lastUIState.IsInCurrentMatch;
 
     [DataSourceProperty]
     public bool ShouldShowUI => TournamentMissionPresentationState
@@ -622,11 +640,27 @@ internal sealed class CoopTournamentVM : TournamentVM
             currentSnapshot != null && (localIsVoter || currentSnapshot.IsCompleted),
             awaitingChoice && localIsInCurrentMatch && hasRemainingBet,
             currentSnapshot?.Phase == TournamentSessionPhase.LiveMatch,
+            localIsInCurrentMatch,
             currentSnapshot?.ReadyCount ?? 0,
             currentSnapshot?.SkipCount ?? 0,
             currentSnapshot?.VoterCount ?? 0,
             selectedChoice);
     }
+
+    internal static TournamentPlayerChoice? GetAdvanceChoice(UIState state)
+    {
+        if (state.CanJoin) return TournamentPlayerChoice.Join;
+        if (state.CanSkip) return TournamentPlayerChoice.Skip;
+        if (state.CanWatch) return TournamentPlayerChoice.Watch;
+        return null;
+    }
+
+    internal static bool ShouldOpenLeaveMenu(UIState state)
+        => state.IsMatchActive && !state.IsInCurrentMatch && state.CanLeave;
+
+    internal TournamentPlayerChoice? GetAdvanceChoice() => GetAdvanceChoice(lastUIState);
+
+    internal bool ShouldOpenLeaveMenu() => ShouldOpenLeaveMenu(lastUIState);
 
     private static TournamentContestantData GetLocalContestant(
         TournamentSessionSnapshot currentSnapshot,
@@ -654,6 +688,7 @@ internal sealed class CoopTournamentVM : TournamentVM
         bool hasRemainingBet = snapshot != null && MaximumBetValue > 0;
         UIState state = CalculateUIState(snapshot, controller.LocalControllerId, hasRemainingBet);
 
+        lastUIState = state;
         CanJoin = state.CanJoin;
         IsJoinVisible = state.CanJoin;
         CanWatch = state.CanWatch;

--- a/source/GameInterface/Services/Tournaments/UI/CoopTournamentVM.cs
+++ b/source/GameInterface/Services/Tournaments/UI/CoopTournamentVM.cs
@@ -670,8 +670,7 @@ internal sealed class CoopTournamentVM : TournamentVM
     }
 
     internal static bool ShouldOpenLeaveMenu(UIState state)
-        => state.IsMatchActive && state.CanLeave &&
-            (state.Role == UIState.PlayerRole.Spectator || state.Role == UIState.PlayerRole.Eliminated);
+        => state.IsMatchActive && state.CanLeave && state.Role == UIState.PlayerRole.Spectator;
 
     internal TournamentPlayerChoice? GetAdvanceChoice() => GetAdvanceChoice(lastUIState);
 

--- a/source/GameInterface/Services/Tournaments/UI/CoopTournamentVM.cs
+++ b/source/GameInterface/Services/Tournaments/UI/CoopTournamentVM.cs
@@ -21,13 +21,22 @@ internal sealed class CoopTournamentVM : TournamentVM
 
     internal readonly struct UIState
     {
+        internal enum PlayerRole
+        {
+            None,
+            Fighter,
+            Resting,
+            Eliminated,
+            Spectator
+        }
+
         public readonly bool CanJoin;
         public readonly bool CanWatch;
         public readonly bool CanSkip;
         public readonly bool CanLeave;
         public readonly bool CanBet;
         public readonly bool IsMatchActive;
-        public readonly bool IsInCurrentMatch;
+        public readonly PlayerRole Role;
         public readonly int ReadyCount;
         public readonly int SkipCount;
         public readonly int VoterCount;
@@ -40,7 +49,7 @@ internal sealed class CoopTournamentVM : TournamentVM
             bool canLeave,
             bool canBet,
             bool isMatchActive,
-            bool isInCurrentMatch,
+            PlayerRole role,
             int readyCount,
             int skipCount,
             int voterCount,
@@ -52,7 +61,7 @@ internal sealed class CoopTournamentVM : TournamentVM
             CanLeave = canLeave;
             CanBet = canBet;
             IsMatchActive = isMatchActive;
-            IsInCurrentMatch = isInCurrentMatch;
+            Role = role;
             ReadyCount = readyCount;
             SkipCount = skipCount;
             VoterCount = voterCount;
@@ -205,8 +214,6 @@ internal sealed class CoopTournamentVM : TournamentVM
             base.IsCurrentMatchActive = isCoopMatchActive && !leaveMenuOpen;
         }
     }
-
-    public bool IsInCurrentMatch => lastUIState.IsInCurrentMatch;
 
     [DataSourceProperty]
     public bool ShouldShowUI => TournamentMissionPresentationState
@@ -628,7 +635,14 @@ internal sealed class CoopTournamentVM : TournamentVM
         bool localIsInCurrentMatch = localContestant != null && currentMatch?.Teams.Any(team =>
             team.ParticipantSlotIds.Contains(localContestant.SlotId)) == true;
         bool localIsSpectator = currentSnapshot?.SpectatorControllerIds.Contains(localControllerId) == true;
-        bool localIsVoter = localContestant != null || localIsSpectator;
+        UIState.PlayerRole role = localContestant == null
+            ? localIsSpectator ? UIState.PlayerRole.Spectator : UIState.PlayerRole.None
+            : localIsInCurrentMatch
+                ? UIState.PlayerRole.Fighter
+                : IsInRemainingBracket(currentSnapshot, localContestant.SlotId)
+                    ? UIState.PlayerRole.Resting
+                    : UIState.PlayerRole.Eliminated;
+        bool localIsVoter = role != UIState.PlayerRole.None;
         TournamentPlayerChoice selectedChoice = currentSnapshot?.Choices
             .FirstOrDefault(item => item.ControllerId == localControllerId)?.Choice ??
             TournamentPlayerChoice.None;
@@ -640,7 +654,7 @@ internal sealed class CoopTournamentVM : TournamentVM
             currentSnapshot != null && (localIsVoter || currentSnapshot.IsCompleted),
             awaitingChoice && localIsInCurrentMatch && hasRemainingBet,
             currentSnapshot?.Phase == TournamentSessionPhase.LiveMatch,
-            localIsInCurrentMatch,
+            role,
             currentSnapshot?.ReadyCount ?? 0,
             currentSnapshot?.SkipCount ?? 0,
             currentSnapshot?.VoterCount ?? 0,
@@ -656,7 +670,8 @@ internal sealed class CoopTournamentVM : TournamentVM
     }
 
     internal static bool ShouldOpenLeaveMenu(UIState state)
-        => state.IsMatchActive && !state.IsInCurrentMatch && state.CanLeave;
+        => state.IsMatchActive && state.CanLeave &&
+            (state.Role == UIState.PlayerRole.Spectator || state.Role == UIState.PlayerRole.Eliminated);
 
     internal TournamentPlayerChoice? GetAdvanceChoice() => GetAdvanceChoice(lastUIState);
 
@@ -677,6 +692,15 @@ internal sealed class CoopTournamentVM : TournamentVM
         return currentSnapshot?.Rounds
             .SelectMany(round => round.Matches)
             .FirstOrDefault(match => match.MatchId == currentSnapshot.CurrentMatchId);
+    }
+    private static bool IsInRemainingBracket(TournamentSessionSnapshot currentSnapshot, string slotId)
+    {
+        if (currentSnapshot?.Rounds == null) return false;
+        return currentSnapshot.Rounds
+            .SelectMany(round => round.Matches ?? Array.Empty<TournamentMatchData>())
+            .Where(match => match != null && match.State != (int)TournamentMatch.MatchState.Finished)
+            .SelectMany(match => match.Teams ?? Array.Empty<TournamentTeamData>())
+            .Any(team => team != null && team.ParticipantSlotIds.Contains(slotId));
     }
     private void RefreshCoopState()
     {

--- a/source/Missions/Tournaments/CoopTournamentController.cs
+++ b/source/Missions/Tournaments/CoopTournamentController.cs
@@ -167,6 +167,7 @@ public class CoopTournamentController : CoopMissionController
         tournamentBehavior = behavior ?? throw new ArgumentNullException(nameof(behavior));
         fightController = nativeFightController ?? throw new ArgumentNullException(nameof(nativeFightController));
         fightController.SetAgentRemovalProvider(() => !matchLifecycle.IsClearing);
+        fightController.SetLeaveAllowedProvider(() => tournamentBehavior.Snapshot.IsCompleted);
         fightController.SetHitProgressionRecorder(CaptureHitProgression);
         fightController.SetGuardReactionRecorder(
             coopMissionComponent.AgentActionHandler.ObserveBlockedHit);

--- a/source/Missions/Tournaments/CoopTournamentFightMissionController.cs
+++ b/source/Missions/Tournaments/CoopTournamentFightMissionController.cs
@@ -2,6 +2,7 @@
 using SandBox.Tournaments.MissionLogics;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 
 namespace Missions.Tournaments;
@@ -25,6 +26,7 @@ public delegate void TournamentGuardReactionRecorder(
 public class CoopTournamentFightMissionController : TournamentFightMissionController
 {
     private Func<bool> shouldProcessAgentRemoval = () => true;
+    private Func<bool> leaveAllowedProvider = () => false;
     private TournamentHitProgressionRecorder hitProgressionRecorder;
     private TournamentGuardReactionRecorder guardReactionRecorder;
 
@@ -36,6 +38,11 @@ public class CoopTournamentFightMissionController : TournamentFightMissionContro
     public void SetAgentRemovalProvider(Func<bool> provider)
     {
         shouldProcessAgentRemoval = provider ?? (() => true);
+    }
+
+    public void SetLeaveAllowedProvider(Func<bool> provider)
+    {
+        leaveAllowedProvider = provider ?? (() => false);
     }
 
     public void SetHitProgressionRecorder(TournamentHitProgressionRecorder recorder)
@@ -86,5 +93,11 @@ public class CoopTournamentFightMissionController : TournamentFightMissionContro
             in blow,
             in collisionData,
             shotDifficulty);
+    }
+
+    public override InquiryData OnEndMissionRequest(out bool canPlayerLeave)
+    {
+        canPlayerLeave = leaveAllowedProvider?.Invoke() ?? false;
+        return null;
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->
- [x] New feature (non-breaking change that adds functionality)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Tab button that brings up tournament overview is disabled, preventing spectators from leaving until the match is over.

## What is the new behavior?

Tab now casts the advance vote on a finished round (after the initial post-win delay) and toggles the spectator leave menu during the live match. Spectator can leave at any time while participant is only able to do so upon the match completion.
<!-- Insert issue id after hashtag. -->
Resolves #2058 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->

- Re-enable Tab button in tournaments

## Other information
