### PR TITLE
Save details of the last connection

### DIFF
--- a/UIMovies/CoopConnectionUIMovie.xml
+++ b/UIMovies/CoopConnectionUIMovie.xml
@@ -229,6 +229,7 @@
                       </Children>
                     </ListPanel>
                     <!-- End of Filter Buttons -->
+
                     <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="52"
                                 IsVisible="@IsSteamLobbyStatusVisible" Brush="Clan.TabControl.Text"
                                 Brush.FontSize="24" Brush.FontColor="#B8B8B8FF"
@@ -362,6 +363,50 @@
                                          IsDisabled="@IsNextSteamLobbyPageDisabled"
                                          Command.Click="ActionNextSteamLobbyPage"
                                          Parameter.Text="@NextPageButtonText"/>
+                      </Children>
+                    </ListPanel>
+                  </Children>
+                </ListPanel>
+
+                <!-- Last Connection Tab -->
+                <ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
+                           IsVisible="@IsLastConnectionTabVisible"
+                           StackLayout.LayoutMethod="VerticalTopToBottom">
+                  <Children>
+                    <!-- Empty state -->
+                    <TextWidget IsVisible="@HasNoLastConnection"
+                                WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="60"
+                                Brush="Clan.TabControl.Text" Brush.FontSize="22" Brush.FontColor="#B8B8B8FF"
+                                Brush.TextHorizontalAlignment="Left" Brush.TextVerticalAlignment="Center"
+                                Text="No previous connections saved. Join a server to save it here."/>
+
+                    <!-- Last direct connection row -->
+                    <ListPanel IsVisible="@HasLastDirectConnection"
+                               WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="58"
+                               MarginBottom="12" StackLayout.LayoutMethod="HorizontalLeftToRight">
+                      <Children>
+                        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
+                                    Brush="Clan.TabControl.Text" Brush.FontSize="22" Brush.FontColor="#B8B8B8FF"
+                                    Brush.TextHorizontalAlignment="Left" Brush.TextVerticalAlignment="Center"
+                                    Text="@LastDirectConnectionText"/>
+                        <Standard.Button WidthSizePolicy="Fixed" SuggestedWidth="160" HeightSizePolicy="Fixed" SuggestedHeight="58"
+                                         VerticalAlignment="Center"
+                                         Command.Click="ActionConnect" Parameter.Text="@ReconnectButtonText"/>
+                      </Children>
+                    </ListPanel>
+
+                    <!-- Last Steam lobby row -->
+                    <ListPanel IsVisible="@HasLastSteamLobby"
+                               WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="58"
+                               StackLayout.LayoutMethod="HorizontalLeftToRight">
+                      <Children>
+                        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
+                                    Brush="Clan.TabControl.Text" Brush.FontSize="22" Brush.FontColor="#B8B8B8FF"
+                                    Brush.TextHorizontalAlignment="Left" Brush.TextVerticalAlignment="Center"
+                                    Text="@LastSteamLobbyText"/>
+                        <Standard.Button WidthSizePolicy="Fixed" SuggestedWidth="160" HeightSizePolicy="Fixed" SuggestedHeight="58"
+                                         VerticalAlignment="Center"
+                                         Command.Click="ActionReconnectSteamLobby" Parameter.Text="@ReconnectButtonText"/>
                       </Children>
                     </ListPanel>
                   </Children>

--- a/UIMovies/CoopConnectionUIMovie.xml
+++ b/UIMovies/CoopConnectionUIMovie.xml
@@ -391,7 +391,7 @@
                                     Text="@LastDirectConnectionText"/>
                         <Standard.Button WidthSizePolicy="Fixed" SuggestedWidth="160" HeightSizePolicy="Fixed" SuggestedHeight="58"
                                          VerticalAlignment="Center"
-                                         Command.Click="ActionConnect" Parameter.Text="@ReconnectButtonText"/>
+                                         Command.Click="ActionReconnectDirect" Parameter.Text="@ReconnectButtonText"/>
                       </Children>
                     </ListPanel>
 

--- a/source/Common/Network/Session/Messages/JoinSteamLobby.cs
+++ b/source/Common/Network/Session/Messages/JoinSteamLobby.cs
@@ -1,4 +1,4 @@
-﻿using Common.Messaging;
+using Common.Messaging;
 
 namespace Common.Network.Session.Messages;
 
@@ -9,8 +9,15 @@ public record JoinSteamLobby : ICommand
 {
     public ulong LobbyId { get; }
 
-    public JoinSteamLobby(ulong lobbyId)
+    /// <summary>
+    /// Password to use if the lobby requires one.  When non-null, the join flow skips
+    /// the interactive password prompt and supplies this value directly.
+    /// </summary>
+    public string PreSuppliedPassword { get; }
+
+    public JoinSteamLobby(ulong lobbyId, string preSuppliedPassword = null)
     {
         LobbyId = lobbyId;
+        PreSuppliedPassword = preSuppliedPassword;
     }
 }

--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -48,7 +48,8 @@ public class ClientModule : CommonModule
         builder.RegisterType<ClientSyncPolicy>().As<ISyncPolicy>().InstancePerLifetimeScope();
 
         // Steam registrations only when the boot probe found Steam, so tests and non-Steam installs never load Steamworks types.
-        if (SessionDiscovery.SteamAvailable)
+        // JoinListener guard handles the edge case where SteamAvailable is stale but CreateServices never completed.
+        if (SessionDiscovery.SteamAvailable && SteamBoot.JoinListener != null)
         {
             RegisterSteamSessionServices(builder);
         }

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -46,6 +46,7 @@ namespace Coop.Core
         private volatile bool hostedSession;
         private volatile bool clientConnectedOnce;
         private bool passwordInquiryPending;
+        private string pendingPreSuppliedPassword;
         private int coopStartGeneration;
         // Bumped when a new host attempt starts, so a prior attempt's deferred exit handling drops out.
         private volatile int hostSessionGeneration;
@@ -72,6 +73,7 @@ namespace Coop.Core
             this.coopLogFilePath = coopLogFilePath;
 
             messageBroker.Subscribe<AttemptJoin>(Handle);
+            messageBroker.Subscribe<JoinSteamLobby>(Handle);
             messageBroker.Subscribe<AttemptHost>(Handle);
             messageBroker.Subscribe<HostSaveGame>(Handle);
             messageBroker.Subscribe<EndCoopMode>(Handle);
@@ -268,6 +270,12 @@ namespace Coop.Core
         {
             clientConnectedOnce = true;
             setCrashPhase("connected");
+            messageBroker.Publish(this, new ClientNetworkConnected());
+        }
+
+        private void Handle(MessagePayload<JoinSteamLobby> payload)
+        {
+            pendingPreSuppliedPassword = payload.What.PreSuppliedPassword;
         }
 
         private void Handle(MessagePayload<SessionJoinInfoResolved> obj)
@@ -277,7 +285,16 @@ namespace Coop.Core
 
             if (joinInfo.PasswordRequired)
             {
-                PromptForSessionPassword(joinInfo);
+                if (!string.IsNullOrEmpty(pendingPreSuppliedPassword))
+                {
+                    joinInfo.Password = pendingPreSuppliedPassword;
+                    pendingPreSuppliedPassword = null;
+                    StartResolvedJoin(joinInfo);
+                }
+                else
+                {
+                    PromptForSessionPassword(joinInfo);
+                }
                 return;
             }
 

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -241,6 +241,7 @@ namespace Coop.Core
             hostSessionGeneration++;
             hostedSession = false;
             clientConnectedOnce = false;
+            pendingPreSuppliedPassword = null;
         }
 
         private void Handle(MessagePayload<HostedServerExited> obj)

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -47,6 +47,7 @@ namespace Coop.Core
         private volatile bool clientConnectedOnce;
         private bool passwordInquiryPending;
         private string pendingPreSuppliedPassword;
+        private string acceptedSessionPassword;
         private int coopStartGeneration;
         // Bumped when a new host attempt starts, so a prior attempt's deferred exit handling drops out.
         private volatile int hostSessionGeneration;
@@ -242,6 +243,7 @@ namespace Coop.Core
             hostedSession = false;
             clientConnectedOnce = false;
             pendingPreSuppliedPassword = null;
+            acceptedSessionPassword = null;
         }
 
         private void Handle(MessagePayload<HostedServerExited> obj)
@@ -271,7 +273,11 @@ namespace Coop.Core
         {
             clientConnectedOnce = true;
             setCrashPhase("connected");
-            messageBroker.Publish(this, new ClientNetworkConnected());
+            var accepted = acceptedSessionPassword;
+            acceptedSessionPassword = null;
+            GameThread.RunSafe(
+                () => messageBroker.Publish(this, new ClientNetworkConnected { AcceptedPassword = accepted }),
+                context: nameof(NetworkConnected));
         }
 
         private void Handle(MessagePayload<JoinSteamLobby> payload)
@@ -284,12 +290,14 @@ namespace Coop.Core
             var joinInfo = obj.What.JoinInfo;
             if (!CanStartResolvedJoin()) return;
 
+            var preSuppliedPassword = pendingPreSuppliedPassword;
+            pendingPreSuppliedPassword = null;
+
             if (joinInfo.PasswordRequired)
             {
-                if (!string.IsNullOrEmpty(pendingPreSuppliedPassword))
+                if (!string.IsNullOrEmpty(preSuppliedPassword))
                 {
-                    joinInfo.Password = pendingPreSuppliedPassword;
-                    pendingPreSuppliedPassword = null;
+                    joinInfo.Password = preSuppliedPassword;
                     StartResolvedJoin(joinInfo);
                 }
                 else
@@ -318,6 +326,7 @@ namespace Coop.Core
                 {
                     passwordInquiryPending = false;
                     joinInfo.Password = password ?? string.Empty;
+                    acceptedSessionPassword = joinInfo.Password;
                     StartResolvedJoin(joinInfo);
                 },
                 () =>

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -435,6 +435,8 @@ namespace Coop.Core
         private void Handle(MessagePayload<EndCoopMode> payload)
         {
             setCrashPhase("ending-session");
+            pendingPreSuppliedPassword = null;
+            acceptedSessionPassword = null;
 
             // Network callbacks can publish this event from the poller. Teardown on the game thread
             // lets the poll callback return before the container waits for that poller to stop.
@@ -448,6 +450,7 @@ namespace Coop.Core
                 clientConnectedOnce = false;
 
                 messageBroker.Publish(this, new CoopModeEnded());
+                messageBroker.Publish(this, new ClientSessionEnded());
             }, context: nameof(EndCoopMode));
         }
 

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -80,6 +80,7 @@ namespace Coop.Core
             messageBroker.Subscribe<EndCoopMode>(Handle);
             messageBroker.Subscribe<SessionJoinInfoResolved>(Handle);
             messageBroker.Subscribe<SessionJoinFailed>(Handle);
+            messageBroker.Subscribe<SessionJoinAbandoned>(Handle);
             messageBroker.Subscribe<HostedServerExited>(Handle);
             messageBroker.Subscribe<NetworkConnected>(Handle);
         }
@@ -415,7 +416,15 @@ namespace Coop.Core
 
         private void Handle(MessagePayload<SessionJoinFailed> obj)
         {
+            pendingPreSuppliedPassword = null;
+            acceptedSessionPassword = null;
             InformationManager.DisplayMessage(new InformationMessage(obj.What.Reason));
+        }
+
+        private void Handle(MessagePayload<SessionJoinAbandoned> obj)
+        {
+            pendingPreSuppliedPassword = null;
+            acceptedSessionPassword = null;
         }
 
         private void Handle(MessagePayload<HostSaveGame> obj)

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -503,7 +503,6 @@ public class CoopConnectMenuVMTests
         using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
 
         SelectSteamLobbiesTab(viewModel);
-        viewModel.Password = "lobbypass";
         browser.Complete(CreateLobby(777, "Test Keep"));
         viewModel.SteamLobbies[0].ExecuteJoin();
         messageBroker.Publish(viewModel, new ClientNetworkConnected());
@@ -514,11 +513,11 @@ public class CoopConnectMenuVMTests
 
         Assert.NotNull(published);
         Assert.Equal(777UL, published.LobbyId);
-        Assert.Equal("lobbypass", published.PreSuppliedPassword);
+        Assert.Null(published.PreSuppliedPassword);
     }
 
     [Fact]
-    public void LastConnection_SteamLobby_PasswordRoundTrip()
+    public void LastConnection_SteamLobby_DirectPasswordNotSavedOnJoin()
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
@@ -527,7 +526,7 @@ public class CoopConnectMenuVMTests
         using (var viewModel = new CoopConnectMenuVM(browser, messageBroker, store))
         {
             SelectSteamLobbiesTab(viewModel);
-            viewModel.Password = "supersecret";
+            viewModel.Password = "directformpassword";
             browser.Complete(CreateLobby(42, "Fortress"));
             viewModel.SteamLobbies[0].ExecuteJoin();
             messageBroker.Publish(viewModel, new ClientNetworkConnected());
@@ -535,7 +534,7 @@ public class CoopConnectMenuVMTests
 
         var saved = store.Options.GetSectionOrDefault<LastConnectionData>(
             LastConnectionData.TabId, LastConnectionData.SectionId, null);
-        Assert.NotNull(saved.SteamLobbyPasswordProtected);
+        Assert.True(string.IsNullOrEmpty(saved.SteamLobbyPasswordProtected));
 
         using var viewModel2 = new CoopConnectMenuVM(browser, messageBroker, store);
         JoinSteamLobby published = null;
@@ -543,7 +542,7 @@ public class CoopConnectMenuVMTests
         viewModel2.ActionReconnectSteamLobby();
 
         Assert.NotNull(published);
-        Assert.Equal("supersecret", published.PreSuppliedPassword);
+        Assert.True(string.IsNullOrEmpty(published.PreSuppliedPassword));
     }
 
     [Fact]
@@ -616,6 +615,49 @@ public class CoopConnectMenuVMTests
 
         Assert.True(viewModel.HasNoLastConnection);
         Assert.False(viewModel.HasLastSteamLobby);
+    }
+
+    [Fact]
+    public void NormalSteamJoin_DoesNotPassDirectConnectPassword_AsPreSuppliedPassword()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+
+        viewModel.Password = "directpass";
+
+        JoinSteamLobby published = null;
+        messageBroker.Subscribe<JoinSteamLobby>(payload => published = payload.What);
+
+        SelectSteamLobbiesTab(viewModel);
+        browser.Complete(CreateLobby(42, "Test Keep"));
+        viewModel.SteamLobbies[0].ExecuteJoin();
+
+        Assert.NotNull(published);
+        Assert.Null(published.PreSuppliedPassword);
+    }
+
+    [Fact]
+    public void FailedDirect_ThenSteamSuccess_PersistsSteamNotDirect()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        // Direct attempt — connection never confirmed (no ClientNetworkConnected)
+        viewModel.Ip = "10.0.0.1";
+        viewModel.Port = "4200";
+        viewModel.ActionConnect();
+
+        // Steam join now succeeds
+        SelectSteamLobbiesTab(viewModel);
+        browser.Complete(CreateLobby(999, "Stronghold"));
+        viewModel.SteamLobbies[0].ExecuteJoin();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
+
+        Assert.False(viewModel.HasLastDirectConnection);
+        Assert.True(viewModel.HasLastSteamLobby);
     }
 
     private static void SelectLastConnectionTab(CoopConnectMenuVM viewModel)

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Messaging;
 using Common.Network.Session;
+using Common.Network.Session.Messages;
 using GameInterface.Services.UI;
 using GameInterface.Services.UI.CoopOptions;
 using GameInterface.Services.UI.Messages;
@@ -493,10 +494,145 @@ public class CoopConnectMenuVMTests
         Assert.Equal("10.0.0.1", published.Address.ToString());
     }
 
+    [Fact]
+    public void LastConnection_ActionReconnectSteamLobby_UsesSnapshot()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        SelectSteamLobbiesTab(viewModel);
+        viewModel.Password = "lobbypass";
+        browser.Complete(CreateLobby(777, "Test Keep"));
+        viewModel.SteamLobbies[0].ExecuteJoin();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
+
+        JoinSteamLobby published = null;
+        messageBroker.Subscribe<JoinSteamLobby>(payload => published = payload.What);
+        viewModel.ActionReconnectSteamLobby();
+
+        Assert.NotNull(published);
+        Assert.Equal(777UL, published.LobbyId);
+        Assert.Equal("lobbypass", published.PreSuppliedPassword);
+    }
+
+    [Fact]
+    public void LastConnection_SteamLobby_PasswordRoundTrip()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+
+        using (var viewModel = new CoopConnectMenuVM(browser, messageBroker, store))
+        {
+            SelectSteamLobbiesTab(viewModel);
+            viewModel.Password = "supersecret";
+            browser.Complete(CreateLobby(42, "Fortress"));
+            viewModel.SteamLobbies[0].ExecuteJoin();
+            messageBroker.Publish(viewModel, new ClientNetworkConnected());
+        }
+
+        var saved = store.Options.GetSectionOrDefault<LastConnectionData>(
+            LastConnectionData.TabId, LastConnectionData.SectionId, null);
+        Assert.NotNull(saved.SteamLobbyPasswordProtected);
+
+        using var viewModel2 = new CoopConnectMenuVM(browser, messageBroker, store);
+        JoinSteamLobby published = null;
+        messageBroker.Subscribe<JoinSteamLobby>(payload => published = payload.What);
+        viewModel2.ActionReconnectSteamLobby();
+
+        Assert.NotNull(published);
+        Assert.Equal("supersecret", published.PreSuppliedPassword);
+    }
+
+    [Fact]
+    public void LastConnection_NoSave_IfNetworkConnectedNeverFires()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        viewModel.Ip = "10.0.0.1";
+        viewModel.Port = "4200";
+        viewModel.ActionConnect();
+        // ClientNetworkConnected deliberately NOT published — connection failed
+
+        var saved = store.Options.GetSectionOrDefault<LastConnectionData>(
+            LastConnectionData.TabId, LastConnectionData.SectionId, null);
+        Assert.Null(saved);
+        Assert.True(viewModel.HasNoLastConnection);
+    }
+
+    [Fact]
+    public void LastConnection_HasNoLastConnection_RefreshesAfterSteamLobbyJoin()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        Assert.True(viewModel.HasNoLastConnection);
+
+        SelectSteamLobbiesTab(viewModel);
+        browser.Complete(CreateLobby(1, "Arena"));
+        viewModel.SteamLobbies[0].ExecuteJoin();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
+
+        Assert.False(viewModel.HasNoLastConnection);
+        Assert.True(viewModel.HasLastSteamLobby);
+    }
+
+    [Fact]
+    public void LastConnection_DirectConnection_NotPersistedInMemory_OnSaveFailure()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new FailingCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        viewModel.Ip = "10.0.0.1";
+        viewModel.Port = "4200";
+        viewModel.ActionConnect();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
+
+        Assert.True(viewModel.HasNoLastConnection);
+        Assert.False(viewModel.HasLastDirectConnection);
+    }
+
+    [Fact]
+    public void LastConnection_SteamLobby_NotPersistedInMemory_OnSaveFailure()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new FailingCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        SelectSteamLobbiesTab(viewModel);
+        browser.Complete(CreateLobby(42, "Test Keep"));
+        viewModel.SteamLobbies[0].ExecuteJoin();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
+
+        Assert.True(viewModel.HasNoLastConnection);
+        Assert.False(viewModel.HasLastSteamLobby);
+    }
+
     private static void SelectLastConnectionTab(CoopConnectMenuVM viewModel)
     {
         Assert.Equal(CoopConnectMenuVM.LastConnectionTabId, viewModel.Tabs[2].Id);
         viewModel.Tabs[2].ExecuteSelection();
+    }
+
+    private sealed class FailingCoopOptionsStore : ICoopOptionsStore
+    {
+        public string FilePath => null;
+
+        public bool TryLoad(out CoopOptionsData options) { options = new CoopOptionsData(); return true; }
+
+        public CoopOptionsData LoadOrDefault() => new CoopOptionsData();
+
+        public void Save(CoopOptionsData options) => throw new System.IO.IOException("disk full");
     }
 
     private sealed class TestCoopOptionsStore : ICoopOptionsStore

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Network.Session;
 using GameInterface.Services.UI;
 using GameInterface.Services.UI.CoopOptions;
+using GameInterface.Services.UI.Messages;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -368,17 +369,18 @@ public class CoopConnectMenuVMTests
         viewModel.Port = "4200";
         viewModel.Password = "secret";
         viewModel.ActionConnect();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
 
         Assert.True(viewModel.HasLastDirectConnection);
         Assert.False(viewModel.HasNoLastConnection);
-        Assert.Contains("127.0.0.1:4200", viewModel.LastDirectConnectionText);
+        Assert.DoesNotContain("127.0.0.1", viewModel.LastDirectConnectionText);
 
         var saved = store.Options.GetSectionOrDefault<LastConnectionData>(
             LastConnectionData.TabId, LastConnectionData.SectionId, null);
         Assert.NotNull(saved);
         Assert.Equal("127.0.0.1", saved.DirectIp);
         Assert.Equal("4200", saved.DirectPort);
-        Assert.Equal("secret", saved.DirectPassword);
+        Assert.NotNull(saved.DirectPasswordProtected);
     }
 
     [Fact]
@@ -394,13 +396,14 @@ public class CoopConnectMenuVMTests
             viewModel.Port = "5000";
             viewModel.Password = "";
             viewModel.ActionConnect();
+            messageBroker.Publish(viewModel, new ClientNetworkConnected());
         }
 
         using var viewModel2 = new CoopConnectMenuVM(browser, messageBroker, store);
         Assert.True(viewModel2.HasLastDirectConnection);
         Assert.Equal("10.0.0.1", viewModel2.Ip);
         Assert.Equal("5000", viewModel2.Port);
-        Assert.Contains("10.0.0.1:5000", viewModel2.LastDirectConnectionText);
+        Assert.DoesNotContain("10.0.0.1", viewModel2.LastDirectConnectionText);
     }
 
     [Fact]
@@ -414,10 +417,11 @@ public class CoopConnectMenuVMTests
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(CreateLobby(999, "Castle Keep"));
         viewModel.SteamLobbies[0].ExecuteJoin();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
 
         Assert.True(viewModel.HasLastSteamLobby);
         Assert.False(viewModel.HasNoLastConnection);
-        Assert.Contains("Castle Keep", viewModel.LastSteamLobbyText);
+        Assert.DoesNotContain("Castle Keep", viewModel.LastSteamLobbyText);
 
         var saved = store.Options.GetSectionOrDefault<LastConnectionData>(
             LastConnectionData.TabId, LastConnectionData.SectionId, null);
@@ -438,11 +442,55 @@ public class CoopConnectMenuVMTests
             SelectSteamLobbiesTab(viewModel);
             browser.Complete(CreateLobby(42, "Iron Citadel"));
             viewModel.SteamLobbies[0].ExecuteJoin();
+            messageBroker.Publish(viewModel, new ClientNetworkConnected());
         }
 
         using var viewModel2 = new CoopConnectMenuVM(browser, messageBroker, store);
         Assert.True(viewModel2.HasLastSteamLobby);
-        Assert.Contains("Iron Citadel", viewModel2.LastSteamLobbyText);
+        Assert.DoesNotContain("Iron Citadel", viewModel2.LastSteamLobbyText);
+    }
+
+    [Fact]
+    public void LastConnection_HasNoLastConnection_RefreshesAfterConnect()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        Assert.True(viewModel.HasNoLastConnection);
+
+        viewModel.Ip = "127.0.0.1";
+        viewModel.Port = "4200";
+        viewModel.ActionConnect();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
+
+        Assert.False(viewModel.HasNoLastConnection);
+        Assert.True(viewModel.HasLastDirectConnection);
+    }
+
+    [Fact]
+    public void LastConnection_ActionReconnectDirect_UsesSnapshot()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        viewModel.Ip = "10.0.0.1";
+        viewModel.Port = "4200";
+        viewModel.ActionConnect();
+        messageBroker.Publish(viewModel, new ClientNetworkConnected());
+
+        // Edit the live form to a different address — reconnect must ignore this
+        viewModel.Ip = "1.2.3.4";
+
+        AttemptJoin published = null;
+        messageBroker.Subscribe<AttemptJoin>(payload => published = payload.What);
+        viewModel.ActionReconnectDirect();
+
+        Assert.NotNull(published);
+        Assert.Equal("10.0.0.1", published.Address.ToString());
     }
 
     private static void SelectLastConnectionTab(CoopConnectMenuVM viewModel)

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -2,6 +2,7 @@
 using Common.Messaging;
 using Common.Network.Session;
 using GameInterface.Services.UI;
+using GameInterface.Services.UI.CoopOptions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -324,6 +325,147 @@ public class CoopConnectMenuVMTests
     private static string[] VisibleHosts(CoopConnectMenuVM viewModel)
     {
         return viewModel.SteamLobbies.Select(lobby => lobby.HostText).ToArray();
+    }
+
+    [Fact]
+    public void LastConnectionTab_IsVisible_WhenSelected()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+
+        Assert.False(viewModel.IsLastConnectionTabVisible);
+
+        SelectLastConnectionTab(viewModel);
+
+        Assert.True(viewModel.IsLastConnectionTabVisible);
+        Assert.False(viewModel.IsDirectTabVisible);
+        Assert.False(viewModel.IsSteamLobbiesTabVisible);
+    }
+
+    [Fact]
+    public void LastConnection_HasNoLastConnection_Initially()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        Assert.True(viewModel.HasNoLastConnection);
+        Assert.False(viewModel.HasLastDirectConnection);
+        Assert.False(viewModel.HasLastSteamLobby);
+    }
+
+    [Fact]
+    public void LastConnection_DirectConnection_SavedAfterConnect()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        viewModel.Ip = "127.0.0.1";
+        viewModel.Port = "4200";
+        viewModel.Password = "secret";
+        viewModel.ActionConnect();
+
+        Assert.True(viewModel.HasLastDirectConnection);
+        Assert.False(viewModel.HasNoLastConnection);
+        Assert.Contains("127.0.0.1:4200", viewModel.LastDirectConnectionText);
+
+        var saved = store.Options.GetSectionOrDefault<LastConnectionData>(
+            LastConnectionData.TabId, LastConnectionData.SectionId, null);
+        Assert.NotNull(saved);
+        Assert.Equal("127.0.0.1", saved.DirectIp);
+        Assert.Equal("4200", saved.DirectPort);
+        Assert.Equal("secret", saved.DirectPassword);
+    }
+
+    [Fact]
+    public void LastConnection_DirectConnection_LoadedByNewInstance()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+
+        using (var viewModel = new CoopConnectMenuVM(browser, messageBroker, store))
+        {
+            viewModel.Ip = "10.0.0.1";
+            viewModel.Port = "5000";
+            viewModel.Password = "";
+            viewModel.ActionConnect();
+        }
+
+        using var viewModel2 = new CoopConnectMenuVM(browser, messageBroker, store);
+        Assert.True(viewModel2.HasLastDirectConnection);
+        Assert.Equal("10.0.0.1", viewModel2.Ip);
+        Assert.Equal("5000", viewModel2.Port);
+        Assert.Contains("10.0.0.1:5000", viewModel2.LastDirectConnectionText);
+    }
+
+    [Fact]
+    public void LastConnection_SteamLobby_SavedAfterJoin()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, store);
+
+        SelectSteamLobbiesTab(viewModel);
+        browser.Complete(CreateLobby(999, "Castle Keep"));
+        viewModel.SteamLobbies[0].ExecuteJoin();
+
+        Assert.True(viewModel.HasLastSteamLobby);
+        Assert.False(viewModel.HasNoLastConnection);
+        Assert.Contains("Castle Keep", viewModel.LastSteamLobbyText);
+
+        var saved = store.Options.GetSectionOrDefault<LastConnectionData>(
+            LastConnectionData.TabId, LastConnectionData.SectionId, null);
+        Assert.NotNull(saved);
+        Assert.Equal(999UL, saved.SteamLobbyId);
+        Assert.Equal("Castle Keep", saved.SteamLobbyHostName);
+    }
+
+    [Fact]
+    public void LastConnection_SteamLobby_LoadedByNewInstance()
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        var store = new TestCoopOptionsStore();
+
+        using (var viewModel = new CoopConnectMenuVM(browser, messageBroker, store))
+        {
+            SelectSteamLobbiesTab(viewModel);
+            browser.Complete(CreateLobby(42, "Iron Citadel"));
+            viewModel.SteamLobbies[0].ExecuteJoin();
+        }
+
+        using var viewModel2 = new CoopConnectMenuVM(browser, messageBroker, store);
+        Assert.True(viewModel2.HasLastSteamLobby);
+        Assert.Contains("Iron Citadel", viewModel2.LastSteamLobbyText);
+    }
+
+    private static void SelectLastConnectionTab(CoopConnectMenuVM viewModel)
+    {
+        Assert.Equal(CoopConnectMenuVM.LastConnectionTabId, viewModel.Tabs[2].Id);
+        viewModel.Tabs[2].ExecuteSelection();
+    }
+
+    private sealed class TestCoopOptionsStore : ICoopOptionsStore
+    {
+        public CoopOptionsData Options { get; private set; } = new CoopOptionsData();
+
+        public string FilePath => null;
+
+        public bool TryLoad(out CoopOptionsData options)
+        {
+            options = Options;
+            return true;
+        }
+
+        public CoopOptionsData LoadOrDefault() => Options;
+
+        public void Save(CoopOptionsData options) => Options = options;
     }
 
     private sealed class TestSteamLobbyBrowser : ISteamLobbyBrowser

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -402,8 +402,8 @@ public class CoopConnectMenuVMTests
 
         using var viewModel2 = new CoopConnectMenuVM(browser, messageBroker, store);
         Assert.True(viewModel2.HasLastDirectConnection);
-        Assert.Equal("10.0.0.1", viewModel2.Ip);
-        Assert.Equal("5000", viewModel2.Port);
+        Assert.Equal("localhost", viewModel2.Ip);
+        Assert.Equal("4200", viewModel2.Port);
         Assert.DoesNotContain("10.0.0.1", viewModel2.LastDirectConnectionText);
     }
 

--- a/source/GameInterface/GameInterface.csproj
+++ b/source/GameInterface/GameInterface.csproj
@@ -217,6 +217,7 @@
     <PackageReference Include="protobuf-net" Version="3.2.56" />
     <PackageReference Include="Scriban" Version="7.2.0" />
     <PackageReference Include="Scrutor" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
   </ItemGroup>
     <ItemGroup>
 	    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -55,6 +55,16 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     private ulong lastSteamLobbyId;
     private string lastSteamLobbyHostName = string.Empty;
     private bool hasLastDirectConnection;
+    private string lastDirectIp;
+    private string lastDirectPort;
+    private string lastDirectPassword;
+    private string lastSteamLobbyPassword;
+    private string pendingDirectIp;
+    private string pendingDirectPort;
+    private string pendingDirectPassword;
+    private ulong pendingSteamLobbyId;
+    private string pendingSteamHostName;
+    private string pendingSteamPassword;
 
     public string JoinButtonText => "Join";
     public string RefreshButtonText => "Refresh";
@@ -131,6 +141,8 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             new CoopConnectionTabVM(LastConnectionTabId, "Last Connection", SelectTab),
         };
         SteamLobbies = new MBBindingList<SteamLobbyListItemVM>();
+
+        messageBroker.Subscribe<ClientNetworkConnected>(HandleNetworkConnected);
 
         LoadLastConnection();
         SelectTab(Tabs[0]);
@@ -326,6 +338,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             hasLastDirectConnection = value;
             OnPropertyChanged(nameof(HasLastDirectConnection));
             OnPropertyChanged(nameof(LastDirectConnectionText));
+            OnPropertyChanged(nameof(HasNoLastConnection));
         }
     }
 
@@ -443,7 +456,9 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             }
 
             messageBroker.Publish(this, new AttemptJoin(ip, port, connectPassword, steamInvites));
-            SaveDirectConnection();
+            pendingDirectIp = connectIP;
+            pendingDirectPort = connectPort;
+            pendingDirectPassword = connectPassword;
         }
         catch (Exception ex)
         {
@@ -452,11 +467,39 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         }
     }
 
+    public void ActionReconnectDirect()
+    {
+        if (disposed || string.IsNullOrEmpty(lastDirectIp)) return;
+
+        if (!int.TryParse(lastDirectPort, out var port) || port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
+            return;
+
+        try
+        {
+            bool steamInvites = SessionDiscovery.SteamAvailable && IsLoopbackAddress(lastDirectIp);
+
+            IPAddress ip;
+            if (IPAddress.TryParse(lastDirectIp, out var parsedIp))
+            {
+                ip = parsedIp;
+            }
+            else
+            {
+                var addresses = Dns.GetHostAddresses(lastDirectIp);
+                ip = addresses.FirstOrDefault(x => x.AddressFamily == AddressFamily.InterNetwork);
+                if (ip == null) return;
+            }
+
+            messageBroker.Publish(this, new AttemptJoin(ip, port, lastDirectPassword ?? string.Empty, steamInvites));
+        }
+        catch { }
+    }
+
     public void ActionReconnectSteamLobby()
     {
         if (disposed || lastSteamLobbyId == 0) return;
 
-        messageBroker.Publish(this, new JoinSteamLobby(lastSteamLobbyId));
+        messageBroker.Publish(this, new JoinSteamLobby(lastSteamLobbyId, lastSteamLobbyPassword));
     }
 
     public void ActionCancel()
@@ -479,6 +522,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         if (disposed) return;
 
         disposed = true;
+        messageBroker.Unsubscribe<ClientNetworkConnected>(HandleNetworkConnected);
         lobbyRequestGeneration++;
         IsRefreshingSteamLobbies = false;
         discoveredSteamLobbies.Clear();
@@ -620,8 +664,26 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     {
         if (disposed || lobbyId == 0) return;
 
-        SaveSteamLobby(lobbyId);
-        messageBroker.Publish(this, new JoinSteamLobby(lobbyId));
+        pendingSteamLobbyId = lobbyId;
+        pendingSteamHostName = discoveredSteamLobbies.FirstOrDefault(l => l.LobbyId == lobbyId)?.HostText
+            ?? string.Empty;
+        pendingSteamPassword = connectPassword;
+        messageBroker.Publish(this, new JoinSteamLobby(lobbyId, connectPassword));
+    }
+
+    private void HandleNetworkConnected(MessagePayload<ClientNetworkConnected> payload)
+    {
+        if (!string.IsNullOrEmpty(pendingDirectIp))
+        {
+            PersistDirectConnection(pendingDirectIp, pendingDirectPort, pendingDirectPassword);
+            pendingDirectIp = pendingDirectPort = pendingDirectPassword = null;
+        }
+        else if (pendingSteamLobbyId != 0)
+        {
+            PersistSteamLobby(pendingSteamLobbyId, pendingSteamHostName, pendingSteamPassword);
+            pendingSteamLobbyId = 0;
+            pendingSteamHostName = pendingSteamPassword = null;
+        }
     }
 
     private void LoadLastConnection()
@@ -637,9 +699,12 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
             if (!string.IsNullOrEmpty(data.DirectIp))
             {
-                connectIP = data.DirectIp;
-                connectPort = data.DirectPort ?? connectPort;
-                connectPassword = data.DirectPassword ?? string.Empty;
+                lastDirectIp = data.DirectIp;
+                lastDirectPort = data.DirectPort ?? connectPort;
+                lastDirectPassword = LastConnectionData.UnprotectPassword(data.DirectPasswordProtected);
+                connectIP = lastDirectIp;
+                connectPort = lastDirectPort;
+                connectPassword = lastDirectPassword;
                 hasLastDirectConnection = true;
             }
 
@@ -647,6 +712,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             {
                 lastSteamLobbyId = data.SteamLobbyId;
                 lastSteamLobbyHostName = data.SteamLobbyHostName ?? string.Empty;
+                lastSteamLobbyPassword = LastConnectionData.UnprotectPassword(data.SteamLobbyPasswordProtected);
             }
         }
         catch
@@ -655,7 +721,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         }
     }
 
-    private void SaveDirectConnection()
+    private void PersistDirectConnection(string ip, string port, string password)
     {
         try
         {
@@ -663,9 +729,9 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             if (options.TryGetSection<LastConnectionData>(
                 LastConnectionData.TabId, LastConnectionData.SectionId, out var existing))
             {
-                existing.DirectIp = connectIP;
-                existing.DirectPort = connectPort;
-                existing.DirectPassword = connectPassword;
+                existing.DirectIp = ip;
+                existing.DirectPort = port;
+                existing.DirectPasswordProtected = LastConnectionData.ProtectPassword(password);
                 options.SetSection(LastConnectionData.TabId, LastConnectionData.SectionId, existing);
             }
             else
@@ -673,12 +739,15 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                 options.SetSection(LastConnectionData.TabId, LastConnectionData.SectionId,
                     new LastConnectionData
                     {
-                        DirectIp = connectIP,
-                        DirectPort = connectPort,
-                        DirectPassword = connectPassword,
+                        DirectIp = ip,
+                        DirectPort = port,
+                        DirectPasswordProtected = LastConnectionData.ProtectPassword(password),
                     });
             }
             optionsStore.Save(options);
+            lastDirectIp = ip;
+            lastDirectPort = port;
+            lastDirectPassword = password;
             HasLastDirectConnection = true;
         }
         catch
@@ -687,11 +756,8 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         }
     }
 
-    private void SaveSteamLobby(ulong lobbyId)
+    private void PersistSteamLobby(ulong lobbyId, string hostName, string password)
     {
-        var hostName = discoveredSteamLobbies.FirstOrDefault(l => l.LobbyId == lobbyId)?.HostText
-            ?? string.Empty;
-
         try
         {
             var options = optionsStore.LoadOrDefault();
@@ -700,6 +766,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             {
                 existing.SteamLobbyId = lobbyId;
                 existing.SteamLobbyHostName = hostName;
+                existing.SteamLobbyPasswordProtected = LastConnectionData.ProtectPassword(password);
                 options.SetSection(LastConnectionData.TabId, LastConnectionData.SectionId, existing);
             }
             else
@@ -709,6 +776,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                     {
                         SteamLobbyId = lobbyId,
                         SteamLobbyHostName = hostName,
+                        SteamLobbyPasswordProtected = LastConnectionData.ProtectPassword(password),
                     });
             }
             optionsStore.Save(options);
@@ -720,8 +788,10 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
         lastSteamLobbyId = lobbyId;
         lastSteamLobbyHostName = hostName;
+        lastSteamLobbyPassword = password;
         OnPropertyChanged(nameof(HasLastSteamLobby));
         OnPropertyChanged(nameof(LastSteamLobbyText));
+        OnPropertyChanged(nameof(HasNoLastConnection));
     }
 
     private static bool IsLoopbackAddress(string address)

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -459,6 +459,9 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             pendingDirectIp = connectIP;
             pendingDirectPort = connectPort;
             pendingDirectPassword = connectPassword;
+            pendingSteamLobbyId = 0;
+            pendingSteamHostName = null;
+            pendingSteamPassword = null;
         }
         catch (Exception ex)
         {
@@ -499,6 +502,10 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     {
         if (disposed || lastSteamLobbyId == 0) return;
 
+        pendingSteamLobbyId = lastSteamLobbyId;
+        pendingSteamHostName = lastSteamLobbyHostName;
+        pendingSteamPassword = lastSteamLobbyPassword;
+        pendingDirectIp = pendingDirectPort = pendingDirectPassword = null;
         messageBroker.Publish(this, new JoinSteamLobby(lastSteamLobbyId, lastSteamLobbyPassword));
     }
 
@@ -667,8 +674,11 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         pendingSteamLobbyId = lobbyId;
         pendingSteamHostName = discoveredSteamLobbies.FirstOrDefault(l => l.LobbyId == lobbyId)?.HostText
             ?? string.Empty;
-        pendingSteamPassword = connectPassword;
-        messageBroker.Publish(this, new JoinSteamLobby(lobbyId, connectPassword));
+        pendingSteamPassword = null;
+        pendingDirectIp = null;
+        pendingDirectPort = null;
+        pendingDirectPassword = null;
+        messageBroker.Publish(this, new JoinSteamLobby(lobbyId, null));
     }
 
     private void HandleNetworkConnected(MessagePayload<ClientNetworkConnected> payload)
@@ -682,7 +692,8 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         }
         else if (pendingSteamLobbyId != 0)
         {
-            PersistSteamLobby(pendingSteamLobbyId, pendingSteamHostName, pendingSteamPassword);
+            var steamPassword = payload.What.AcceptedPassword ?? pendingSteamPassword;
+            PersistSteamLobby(pendingSteamLobbyId, pendingSteamHostName, steamPassword);
             pendingSteamLobbyId = 0;
             pendingSteamHostName = pendingSteamPassword = null;
         }

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -146,6 +146,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         messageBroker.Subscribe<ClientNetworkConnected>(HandleNetworkConnected);
         messageBroker.Subscribe<SessionJoinFailed>(HandleJoinFailed);
         messageBroker.Subscribe<SessionJoinAbandoned>(HandleJoinAbandoned);
+        messageBroker.Subscribe<ClientSessionEnded>(HandleSessionEnded);
 
         LoadLastConnection();
         SelectTab(Tabs[0]);
@@ -510,7 +511,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     public void ActionReconnectSteamLobby()
     {
-        if (disposed || lastSteamLobbyId == 0) return;
+        if (disposed || lastSteamLobbyId == 0 || steamJoinInFlight) return;
 
         steamJoinInFlight = true;
         pendingSteamLobbyId = lastSteamLobbyId;
@@ -543,6 +544,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         messageBroker.Unsubscribe<ClientNetworkConnected>(HandleNetworkConnected);
         messageBroker.Unsubscribe<SessionJoinFailed>(HandleJoinFailed);
         messageBroker.Unsubscribe<SessionJoinAbandoned>(HandleJoinAbandoned);
+        messageBroker.Unsubscribe<ClientSessionEnded>(HandleSessionEnded);
         lobbyRequestGeneration++;
         IsRefreshingSteamLobbies = false;
         discoveredSteamLobbies.Clear();
@@ -817,6 +819,14 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         {
             // IO failure — not critical
         }
+    }
+
+    private void HandleSessionEnded(MessagePayload<ClientSessionEnded> _)
+    {
+        steamJoinInFlight = false;
+        pendingDirectIp = pendingDirectPort = pendingDirectPassword = null;
+        pendingSteamLobbyId = 0;
+        pendingSteamHostName = pendingSteamPassword = null;
     }
 
     private void HandleJoinFailed(MessagePayload<SessionJoinFailed> _)

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -673,6 +673,8 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     private void HandleNetworkConnected(MessagePayload<ClientNetworkConnected> payload)
     {
+        if (disposed) return;
+
         if (!string.IsNullOrEmpty(pendingDirectIp))
         {
             PersistDirectConnection(pendingDirectIp, pendingDirectPort, pendingDirectPassword);
@@ -780,18 +782,17 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                     });
             }
             optionsStore.Save(options);
+            lastSteamLobbyId = lobbyId;
+            lastSteamLobbyHostName = hostName;
+            lastSteamLobbyPassword = password;
+            OnPropertyChanged(nameof(HasLastSteamLobby));
+            OnPropertyChanged(nameof(LastSteamLobbyText));
+            OnPropertyChanged(nameof(HasNoLastConnection));
         }
         catch
         {
             // IO failure — not critical
         }
-
-        lastSteamLobbyId = lobbyId;
-        lastSteamLobbyHostName = hostName;
-        lastSteamLobbyPassword = password;
-        OnPropertyChanged(nameof(HasLastSteamLobby));
-        OnPropertyChanged(nameof(LastSteamLobbyText));
-        OnPropertyChanged(nameof(HasNoLastConnection));
     }
 
     private static bool IsLoopbackAddress(string address)

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -65,6 +65,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     private ulong pendingSteamLobbyId;
     private string pendingSteamHostName;
     private string pendingSteamPassword;
+    private bool steamJoinInFlight;
 
     public string JoinButtonText => "Join";
     public string RefreshButtonText => "Refresh";
@@ -143,6 +144,8 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         SteamLobbies = new MBBindingList<SteamLobbyListItemVM>();
 
         messageBroker.Subscribe<ClientNetworkConnected>(HandleNetworkConnected);
+        messageBroker.Subscribe<SessionJoinFailed>(HandleJoinFailed);
+        messageBroker.Subscribe<SessionJoinAbandoned>(HandleJoinAbandoned);
 
         LoadLastConnection();
         SelectTab(Tabs[0]);
@@ -455,13 +458,14 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                 }
             }
 
-            messageBroker.Publish(this, new AttemptJoin(ip, port, connectPassword, steamInvites));
             pendingDirectIp = connectIP;
             pendingDirectPort = connectPort;
             pendingDirectPassword = connectPassword;
             pendingSteamLobbyId = 0;
             pendingSteamHostName = null;
             pendingSteamPassword = null;
+            steamJoinInFlight = false;
+            messageBroker.Publish(this, new AttemptJoin(ip, port, connectPassword, steamInvites));
         }
         catch (Exception ex)
         {
@@ -493,6 +497,12 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                 if (ip == null) return;
             }
 
+            pendingDirectIp = lastDirectIp;
+            pendingDirectPort = lastDirectPort;
+            pendingDirectPassword = lastDirectPassword ?? string.Empty;
+            pendingSteamLobbyId = 0;
+            pendingSteamHostName = pendingSteamPassword = null;
+            steamJoinInFlight = false;
             messageBroker.Publish(this, new AttemptJoin(ip, port, lastDirectPassword ?? string.Empty, steamInvites));
         }
         catch { }
@@ -502,6 +512,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     {
         if (disposed || lastSteamLobbyId == 0) return;
 
+        steamJoinInFlight = true;
         pendingSteamLobbyId = lastSteamLobbyId;
         pendingSteamHostName = lastSteamLobbyHostName;
         pendingSteamPassword = lastSteamLobbyPassword;
@@ -530,6 +541,8 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
         disposed = true;
         messageBroker.Unsubscribe<ClientNetworkConnected>(HandleNetworkConnected);
+        messageBroker.Unsubscribe<SessionJoinFailed>(HandleJoinFailed);
+        messageBroker.Unsubscribe<SessionJoinAbandoned>(HandleJoinAbandoned);
         lobbyRequestGeneration++;
         IsRefreshingSteamLobbies = false;
         discoveredSteamLobbies.Clear();
@@ -670,7 +683,9 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     private void RequestSteamLobbyJoin(ulong lobbyId)
     {
         if (disposed || lobbyId == 0) return;
+        if (steamJoinInFlight) return;
 
+        steamJoinInFlight = true;
         pendingSteamLobbyId = lobbyId;
         pendingSteamHostName = discoveredSteamLobbies.FirstOrDefault(l => l.LobbyId == lobbyId)?.HostText
             ?? string.Empty;
@@ -684,6 +699,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     private void HandleNetworkConnected(MessagePayload<ClientNetworkConnected> payload)
     {
         if (disposed) return;
+        steamJoinInFlight = false;
 
         if (!string.IsNullOrEmpty(pendingDirectIp))
         {
@@ -715,9 +731,6 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                 lastDirectIp = data.DirectIp;
                 lastDirectPort = data.DirectPort ?? connectPort;
                 lastDirectPassword = LastConnectionData.UnprotectPassword(data.DirectPasswordProtected);
-                connectIP = lastDirectIp;
-                connectPort = lastDirectPort;
-                connectPassword = lastDirectPassword;
                 hasLastDirectConnection = true;
             }
 
@@ -804,6 +817,22 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         {
             // IO failure — not critical
         }
+    }
+
+    private void HandleJoinFailed(MessagePayload<SessionJoinFailed> _)
+    {
+        steamJoinInFlight = false;
+        pendingDirectIp = pendingDirectPort = pendingDirectPassword = null;
+        pendingSteamLobbyId = 0;
+        pendingSteamHostName = pendingSteamPassword = null;
+    }
+
+    private void HandleJoinAbandoned(MessagePayload<SessionJoinAbandoned> _)
+    {
+        steamJoinInFlight = false;
+        pendingDirectIp = pendingDirectPort = pendingDirectPassword = null;
+        pendingSteamLobbyId = 0;
+        pendingSteamHostName = pendingSteamPassword = null;
     }
 
     private static bool IsLoopbackAddress(string address)

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -331,7 +331,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     [DataSourceProperty]
     public string LastDirectConnectionText => hasLastDirectConnection
-        ? $"Reconnect to {connectIP}:{connectPort}"
+        ? "Reconnect to last direct connection"
         : string.Empty;
 
     [DataSourceProperty]
@@ -339,7 +339,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     [DataSourceProperty]
     public string LastSteamLobbyText => lastSteamLobbyId != 0
-        ? $"Reconnect to {lastSteamLobbyHostName}"
+        ? "Reconnect to last Steam lobby"
         : string.Empty;
 
     public void ActionCycleSteamLobbyPasswordFilter()

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -2,6 +2,7 @@
 using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
+using GameInterface.Services.UI.CoopOptions;
 using GameInterface.Services.UI.Donate;
 using GameInterface.Services.UI.Messages;
 using System;
@@ -30,12 +31,14 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 {
     public const string DirectTabId = "direct";
     public const string SteamLobbiesTabId = "steam_lobbies";
+    public const string LastConnectionTabId = "last_connection";
     public const int SteamLobbyPageSize = 4;
 
     public event Action SteamLobbiesTabActivated;
 
     private readonly ISteamLobbyBrowser steamLobbyBrowser;
     private readonly IMessageBroker messageBroker;
+    private readonly ICoopOptionsStore optionsStore;
     private readonly List<SteamLobbyListItemVM> discoveredSteamLobbies = new();
 
     private CoopConnectionTabVM selectedTab;
@@ -49,6 +52,9 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     private int filteredSteamLobbyCount;
     private long filteredSteamLobbyPlayerCount;
     private int steamLobbyPageIndex;
+    private ulong lastSteamLobbyId;
+    private string lastSteamLobbyHostName = string.Empty;
+    private bool hasLastDirectConnection;
 
     public string JoinButtonText => "Join";
     public string RefreshButtonText => "Refresh";
@@ -61,6 +67,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string CreditsButtonText => "Credits";
     public string MovieTextHeader => "Join Co-op Sandbox";
     public string CommunityText => "Join the Community";
+    public string ReconnectButtonText => "Reconnect";
     public string SteamLobbiesHeaderText =>
         $"Hosted Steam Servers ({filteredSteamLobbyCount} servers; " +
         $"{filteredSteamLobbyPlayerCount} players)";
@@ -106,22 +113,26 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string connectPassword = "";
 
     public CoopConnectMenuVM()
-        : this(SessionDiscovery.SteamLobbyBrowser, MessageBroker.Instance)
+        : this(SessionDiscovery.SteamLobbyBrowser, MessageBroker.Instance, new CoopOptionsStore())
     {
     }
 
-    public CoopConnectMenuVM(ISteamLobbyBrowser steamLobbyBrowser, IMessageBroker messageBroker)
+    public CoopConnectMenuVM(ISteamLobbyBrowser steamLobbyBrowser, IMessageBroker messageBroker,
+        ICoopOptionsStore optionsStore = null)
     {
         this.steamLobbyBrowser = steamLobbyBrowser;
         this.messageBroker = messageBroker ?? throw new ArgumentNullException(nameof(messageBroker));
+        this.optionsStore = optionsStore ?? new CoopOptionsStore();
 
         Tabs = new MBBindingList<CoopConnectionTabVM>
         {
             new CoopConnectionTabVM(DirectTabId, "Direct", SelectTab),
             new CoopConnectionTabVM(SteamLobbiesTabId, "Steam Lobbies", SelectTab),
+            new CoopConnectionTabVM(LastConnectionTabId, "Last Connection", SelectTab),
         };
         SteamLobbies = new MBBindingList<SteamLobbyListItemVM>();
 
+        LoadLastConnection();
         SelectTab(Tabs[0]);
     }
 
@@ -197,6 +208,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             OnPropertyChanged(nameof(SelectedTab));
             OnPropertyChanged(nameof(IsDirectTabVisible));
             OnPropertyChanged(nameof(IsSteamLobbiesTabVisible));
+            OnPropertyChanged(nameof(IsLastConnectionTabVisible));
         }
     }
 
@@ -205,6 +217,12 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     [DataSourceProperty]
     public bool IsSteamLobbiesTabVisible => SelectedTab?.Id == SteamLobbiesTabId;
+
+    [DataSourceProperty]
+    public bool IsLastConnectionTabVisible => SelectedTab?.Id == LastConnectionTabId;
+
+    [DataSourceProperty]
+    public bool HasNoLastConnection => !HasLastDirectConnection && !HasLastSteamLobby;
 
     [DataSourceProperty]
     public bool IsRefreshingSteamLobbies
@@ -296,6 +314,33 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             OnPropertyChanged(nameof(Password));
         }
     }
+
+    [DataSourceProperty]
+    public bool HasLastDirectConnection
+    {
+        get => hasLastDirectConnection;
+        private set
+        {
+            if (hasLastDirectConnection == value) return;
+
+            hasLastDirectConnection = value;
+            OnPropertyChanged(nameof(HasLastDirectConnection));
+            OnPropertyChanged(nameof(LastDirectConnectionText));
+        }
+    }
+
+    [DataSourceProperty]
+    public string LastDirectConnectionText => hasLastDirectConnection
+        ? $"Reconnect to {connectIP}:{connectPort}"
+        : string.Empty;
+
+    [DataSourceProperty]
+    public bool HasLastSteamLobby => lastSteamLobbyId != 0;
+
+    [DataSourceProperty]
+    public string LastSteamLobbyText => lastSteamLobbyId != 0
+        ? $"Reconnect to {lastSteamLobbyHostName}"
+        : string.Empty;
 
     public void ActionCycleSteamLobbyPasswordFilter()
     {
@@ -398,12 +443,20 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             }
 
             messageBroker.Publish(this, new AttemptJoin(ip, port, connectPassword, steamInvites));
+            SaveDirectConnection();
         }
         catch (Exception ex)
         {
             InformationManager.DisplayMessage(new InformationMessage(
                 $"ERROR: The connection address could not be resolved: {ex.Message}"));
         }
+    }
+
+    public void ActionReconnectSteamLobby()
+    {
+        if (disposed || lastSteamLobbyId == 0) return;
+
+        messageBroker.Publish(this, new JoinSteamLobby(lastSteamLobbyId));
     }
 
     public void ActionCancel()
@@ -567,7 +620,108 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     {
         if (disposed || lobbyId == 0) return;
 
+        SaveSteamLobby(lobbyId);
         messageBroker.Publish(this, new JoinSteamLobby(lobbyId));
+    }
+
+    private void LoadLastConnection()
+    {
+        try
+        {
+            var options = optionsStore.LoadOrDefault();
+            if (!options.TryGetSection<LastConnectionData>(
+                LastConnectionData.TabId, LastConnectionData.SectionId, out var data))
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(data.DirectIp))
+            {
+                connectIP = data.DirectIp;
+                connectPort = data.DirectPort ?? connectPort;
+                connectPassword = data.DirectPassword ?? string.Empty;
+                hasLastDirectConnection = true;
+            }
+
+            if (data.SteamLobbyId != 0)
+            {
+                lastSteamLobbyId = data.SteamLobbyId;
+                lastSteamLobbyHostName = data.SteamLobbyHostName ?? string.Empty;
+            }
+        }
+        catch
+        {
+            // corrupt or missing file — start with defaults
+        }
+    }
+
+    private void SaveDirectConnection()
+    {
+        try
+        {
+            var options = optionsStore.LoadOrDefault();
+            if (options.TryGetSection<LastConnectionData>(
+                LastConnectionData.TabId, LastConnectionData.SectionId, out var existing))
+            {
+                existing.DirectIp = connectIP;
+                existing.DirectPort = connectPort;
+                existing.DirectPassword = connectPassword;
+                options.SetSection(LastConnectionData.TabId, LastConnectionData.SectionId, existing);
+            }
+            else
+            {
+                options.SetSection(LastConnectionData.TabId, LastConnectionData.SectionId,
+                    new LastConnectionData
+                    {
+                        DirectIp = connectIP,
+                        DirectPort = connectPort,
+                        DirectPassword = connectPassword,
+                    });
+            }
+            optionsStore.Save(options);
+            HasLastDirectConnection = true;
+        }
+        catch
+        {
+            // IO failure — not critical
+        }
+    }
+
+    private void SaveSteamLobby(ulong lobbyId)
+    {
+        var hostName = discoveredSteamLobbies.FirstOrDefault(l => l.LobbyId == lobbyId)?.HostText
+            ?? string.Empty;
+
+        try
+        {
+            var options = optionsStore.LoadOrDefault();
+            if (options.TryGetSection<LastConnectionData>(
+                LastConnectionData.TabId, LastConnectionData.SectionId, out var existing))
+            {
+                existing.SteamLobbyId = lobbyId;
+                existing.SteamLobbyHostName = hostName;
+                options.SetSection(LastConnectionData.TabId, LastConnectionData.SectionId, existing);
+            }
+            else
+            {
+                options.SetSection(LastConnectionData.TabId, LastConnectionData.SectionId,
+                    new LastConnectionData
+                    {
+                        SteamLobbyId = lobbyId,
+                        SteamLobbyHostName = hostName,
+                    });
+            }
+            optionsStore.Save(options);
+        }
+        catch
+        {
+            // IO failure — not critical
+        }
+
+        lastSteamLobbyId = lobbyId;
+        lastSteamLobbyHostName = hostName;
+        OnPropertyChanged(nameof(HasLastSteamLobby));
+        OnPropertyChanged(nameof(LastSteamLobbyText));
     }
 
     private static bool IsLoopbackAddress(string address)

--- a/source/GameInterface/Services/UI/LastConnectionData.cs
+++ b/source/GameInterface/Services/UI/LastConnectionData.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace GameInterface.Services.UI;
 
+/// <summary>Persisted data for the last direct-connection and Steam lobby the player joined.</summary>
 public class LastConnectionData
 {
     public const string TabId = "Connection";

--- a/source/GameInterface/Services/UI/LastConnectionData.cs
+++ b/source/GameInterface/Services/UI/LastConnectionData.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace GameInterface.Services.UI;
+
+public class LastConnectionData
+{
+    public const string TabId = "Connection";
+    public const string SectionId = "LastSession";
+
+    [JsonPropertyName("directIp")] public string DirectIp { get; set; }
+    [JsonPropertyName("directPort")] public string DirectPort { get; set; }
+    [JsonPropertyName("directPassword")] public string DirectPassword { get; set; }
+    [JsonPropertyName("steamLobbyId")] public ulong SteamLobbyId { get; set; }
+    [JsonPropertyName("steamLobbyHostName")] public string SteamLobbyHostName { get; set; }
+}

--- a/source/GameInterface/Services/UI/LastConnectionData.cs
+++ b/source/GameInterface/Services/UI/LastConnectionData.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json.Serialization;
 
 namespace GameInterface.Services.UI;
@@ -10,7 +13,28 @@ public class LastConnectionData
 
     [JsonPropertyName("directIp")] public string DirectIp { get; set; }
     [JsonPropertyName("directPort")] public string DirectPort { get; set; }
-    [JsonPropertyName("directPassword")] public string DirectPassword { get; set; }
+    [JsonPropertyName("directPasswordProtected")] public string DirectPasswordProtected { get; set; }
     [JsonPropertyName("steamLobbyId")] public ulong SteamLobbyId { get; set; }
     [JsonPropertyName("steamLobbyHostName")] public string SteamLobbyHostName { get; set; }
+    [JsonPropertyName("steamLobbyPasswordProtected")] public string SteamLobbyPasswordProtected { get; set; }
+
+    internal static string ProtectPassword(string password)
+    {
+        if (string.IsNullOrEmpty(password)) return null;
+        var encrypted = ProtectedData.Protect(
+            Encoding.UTF8.GetBytes(password), null, DataProtectionScope.CurrentUser);
+        return Convert.ToBase64String(encrypted);
+    }
+
+    internal static string UnprotectPassword(string blob)
+    {
+        if (string.IsNullOrEmpty(blob)) return string.Empty;
+        try
+        {
+            var decrypted = ProtectedData.Unprotect(
+                Convert.FromBase64String(blob), null, DataProtectionScope.CurrentUser);
+            return Encoding.UTF8.GetString(decrypted);
+        }
+        catch { return string.Empty; }
+    }
 }

--- a/source/GameInterface/Services/UI/Messages/ClientNetworkConnected.cs
+++ b/source/GameInterface/Services/UI/Messages/ClientNetworkConnected.cs
@@ -7,4 +7,11 @@ namespace GameInterface.Services.UI.Messages;
 /// established a network session — direct or Steam lobby.  Used by the connection
 /// UI to persist the last-session details only on confirmed success.
 /// </summary>
-public record ClientNetworkConnected : IEvent { }
+public record ClientNetworkConnected : IEvent
+{
+    /// <summary>
+    /// Password accepted by the server on this connection, if a native password
+    /// dialog was shown. Null when no prompt was needed (open server or pre-supplied password).
+    /// </summary>
+    public string AcceptedPassword { get; init; }
+}

--- a/source/GameInterface/Services/UI/Messages/ClientNetworkConnected.cs
+++ b/source/GameInterface/Services/UI/Messages/ClientNetworkConnected.cs
@@ -1,0 +1,10 @@
+using Common.Messaging;
+
+namespace GameInterface.Services.UI.Messages;
+
+/// <summary>
+/// Published (via a relay from NetworkConnected) when the client has successfully
+/// established a network session — direct or Steam lobby.  Used by the connection
+/// UI to persist the last-session details only on confirmed success.
+/// </summary>
+public record ClientNetworkConnected : IEvent { }

--- a/source/GameInterface/Services/UI/Messages/ClientSessionEnded.cs
+++ b/source/GameInterface/Services/UI/Messages/ClientSessionEnded.cs
@@ -1,0 +1,11 @@
+using Common.Messaging;
+
+namespace GameInterface.Services.UI.Messages;
+
+/// <summary>
+/// Published on the game thread when a client session ends (disconnect, kicked, or manual leave).
+/// Used by UI to reset in-flight state that is not cleared by join-failure or join-abandon paths.
+/// </summary>
+public record ClientSessionEnded : IEvent
+{
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?
The join screen has no memory of previous sessions. Every time a player wants to reconnect they must re-enter the server address, port, and password manually. The Steam Lobbies tab also triggers a full lobby search immediately on selection, even when the player only wants to reconnect.

## What is the new behavior?
Resolves #2402
After joining a direct-connection server or a Steam lobby, the details are saved to the player's local coop options file. A new "Last Connection" tab appears in the join screen showing the last direct server and last Steam lobby with a one-click Reconnect button for each. Reconnecting this way never triggers a lobby search.

## Bot Changelog Entry
- Added a "Last Connection" tab to the join screen that saves and displays the last direct connection and Steam lobby you joined, allowing one-click reconnect without re-entering details.

## Other information
Saved connection data is stored in Documents\Mount and Blade II Bannerlord\Configs\BannerlordCoop\coop_options.json under the Connection.LastSession key. If the file is absent or corrupt the tab starts empty with no error. This means passwords are stored in plain text but only locally to the Client. Also, I have been unable to test the Steam connection as I could see no way to do so without a second Steam account setup but I believe it's logically sound. Happy to do more testing if there is a preferred method to do so.