### PR TITLE
Fix duplicate cutscenes for joining kingdoms

### DIFF
--- a/source/E2E.Tests/Services/DefaultCutscenesCampaignBehaviors/DefaultCutscenesCampaignBehaviorPatchesTests.cs
+++ b/source/E2E.Tests/Services/DefaultCutscenesCampaignBehaviors/DefaultCutscenesCampaignBehaviorPatchesTests.cs
@@ -1,0 +1,74 @@
+﻿using Autofac;
+using GameInterface;
+using GameInterface.Services.Clans.Patches;
+using Moq;
+using TaleWorlds.CampaignSystem.Actions;
+
+namespace E2E.Tests.Services.DefaultCutscenesCampaignBehaviors;
+
+public class DefaultCutscenesCampaignBehaviorPatchesTests : IDisposable
+{
+    public DefaultCutscenesCampaignBehaviorPatchesTests()
+    {
+        ContainerProvider.Clear();
+    }
+
+    public void Dispose()
+    {
+        ContainerProvider.Clear();
+    }
+
+    [Fact]
+    public void Prefix_ActiveCoopContainer_SuppressesVanillaJoinKingdomScene()
+    {
+        using var container = BuildContainerWithGameInterface();
+
+        using (ContainerProvider.UseContainerThreadSafe(container))
+        {
+            bool runOriginal = ClanKingdomPatches.Prefix(
+                clan: null,
+                oldKingdom: null,
+                newKingdom: null,
+                detail: ChangeKingdomAction.ChangeKingdomActionDetail.JoinKingdom,
+                showNotification: true);
+
+            Assert.False(runOriginal);
+        }
+    }
+
+    [Fact]
+    public void Prefix_NoActiveContainer_AllowsVanillaJoinKingdomScene()
+    {
+        bool runOriginal = ClanKingdomPatches.Prefix(
+            clan: null,
+            oldKingdom: null,
+            newKingdom: null,
+            detail: ChangeKingdomAction.ChangeKingdomActionDetail.JoinKingdom,
+            showNotification: true);
+
+        Assert.True(runOriginal);
+    }
+
+    [Fact]
+    public void Prefix_AfterContainerClearedLikeDestroyContainerCore_AllowsVanilla()
+    {
+        using var container = BuildContainerWithGameInterface();
+
+        using (ContainerProvider.UseContainerThreadSafe(container))
+        {
+            Assert.False(ClanKingdomPatches.Prefix(
+                null, null, null, ChangeKingdomAction.ChangeKingdomActionDetail.JoinKingdom, true));
+        }
+        ContainerProvider.Clear();
+
+        Assert.True(ClanKingdomPatches.Prefix(
+            null, null, null, ChangeKingdomAction.ChangeKingdomActionDetail.JoinKingdom, true));
+    }
+
+    private static IContainer BuildContainerWithGameInterface()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(new Mock<IGameInterface>().Object).As<IGameInterface>();
+        return builder.Build();
+    }
+}

--- a/source/GameInterface/Services/Clans/Patches/ClanKingdomPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanKingdomPatches.cs
@@ -22,6 +22,6 @@ internal class ClanKingdomPatches
     [HarmonyPrefix]
     private static bool Prefix(Clan clan, Kingdom oldKingdom, Kingdom newKingdom, ChangeKingdomAction.ChangeKingdomActionDetail detail, bool showNotification = true)
     {
-        return ModInformation.IsClient;
+        return false;
     }
 }

--- a/source/GameInterface/Services/Clans/Patches/ClanKingdomPatches.cs
+++ b/source/GameInterface/Services/Clans/Patches/ClanKingdomPatches.cs
@@ -20,8 +20,9 @@ internal class ClanKingdomPatches
     }
     [HarmonyPatch(typeof(DefaultCutscenesCampaignBehavior), nameof(DefaultCutscenesCampaignBehavior.OnClanChangedKingdom))]
     [HarmonyPrefix]
-    private static bool Prefix(Clan clan, Kingdom oldKingdom, Kingdom newKingdom, ChangeKingdomAction.ChangeKingdomActionDetail detail, bool showNotification = true)
+    public static bool Prefix(Clan clan, Kingdom oldKingdom, Kingdom newKingdom, ChangeKingdomAction.ChangeKingdomActionDetail detail, bool showNotification = true)
     {
+        if (!ContainerProvider.TryResolve<IGameInterface>(out _)) return true;
         return false;
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Clients would see two cutscenes playing when joining a kingdom.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3232 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Clients only see one cutscene playing when joining a kingdom.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information
`ShowSceneNotification` is called in the vanilla `OnClanChangedKingdom` but also in the modified `OnClanChangedFaction`. In vanilla bannerlord, `OnClanChangedFaction` does not do this. 
The fix: Disable `DefaultCutScenesCampaignBehavior.OnClanChangedKingdom`, because the modified `OnClanChangedFaction` already shows the scene notification and it has an added culture restore fix, making it better suited.