### PR TITLE
[3256] Stop HomeSettlement AutoSync errors during client save load

### DIFF
--- a/source/E2E.Tests/Services/Heroes/HeroSyncTests.cs
+++ b/source/E2E.Tests/Services/Heroes/HeroSyncTests.cs
@@ -1,4 +1,12 @@
-﻿using E2E.Tests.Util;
+﻿using Autofac;
+using Common.Logging;
+using E2E.Tests.Util;
+using GameInterface;
+using GameInterface.Policies;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
@@ -103,6 +111,135 @@ namespace E2E.Tests.Services.Heroes
             assertHelper.AssertPropertyOwnerField<Hero, CharacterAttribute>(nameof(Hero._characterAttributes));
 
             TestEnvironment.AssertField<Hero, int>(nameof(Hero.Level), 10, defaultValue: hero.Level);
+        }
+
+        [Fact]
+        public void Server_UpdateHomeSettlement_ReplicatesBackingCache()
+        {
+            string settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject(HeroId, out Hero hero));
+                Assert.True(Server.ObjectManager.TryGetObject(settlementId, out Settlement settlement));
+                hero._clan = null;
+                hero._companionOf = null;
+                hero._governorOf = null;
+                hero._stayingInSettlement = null;
+                hero._bornSettlement = settlement;
+                hero._homeSettlement = null;
+
+                hero.UpdateHomeSettlement();
+
+                Assert.Same(settlement, hero._homeSettlement);
+            });
+
+            foreach (var client in Clients)
+            {
+                client.Call(() =>
+                {
+                    Assert.True(client.ObjectManager.TryGetObject(HeroId, out Hero hero));
+                    Assert.True(client.ObjectManager.TryGetObject(settlementId, out Settlement settlement));
+                    Assert.Same(settlement, hero._homeSettlement);
+                });
+            }
+        }
+
+        [Fact]
+        public void Client_HomeSettlementGetter_RebuildsCacheWithoutMutationDiagnostic()
+        {
+            string settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+
+            int diagnosticCount = 0;
+            Action<string> captureDiagnostic = message =>
+            {
+                if (message.Contains("Client updated managed") && message.Contains("HomeSettlement"))
+                    Interlocked.Increment(ref diagnosticCount);
+            };
+            OutputSinkManager.AddLogCallback(captureDiagnostic);
+
+            try
+            {
+                foreach (var client in Clients)
+                {
+                    client.Call(() =>
+                    {
+                        Assert.True(client.ObjectManager.TryGetObject(HeroId, out Hero hero));
+                        Assert.True(client.ObjectManager.TryGetObject(settlementId, out Settlement settlement));
+                        hero._clan = null;
+                        hero._companionOf = null;
+                        hero._governorOf = null;
+                        hero._stayingInSettlement = null;
+                        hero._bornSettlement = settlement;
+                        hero._homeSettlement = null;
+
+                        Settlement resolved = Task.Run(() => hero.HomeSettlement).GetAwaiter().GetResult();
+
+                        Assert.Same(settlement, resolved);
+                        Assert.Same(settlement, hero._homeSettlement);
+                    });
+                }
+
+                Assert.Equal(0, Volatile.Read(ref diagnosticCount));
+            }
+            finally
+            {
+                OutputSinkManager.RemoveLogCallback(captureDiagnostic);
+            }
+        }
+
+        [Fact]
+        public void Client_UpdateHomeSettlementOutsideGetter_RetainsMutationDiagnostic()
+        {
+            string settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
+
+            int diagnosticCount = 0;
+            Action<string> captureDiagnostic = message =>
+            {
+                if (message.Contains("Client updated managed") && message.Contains("HomeSettlement"))
+                    Interlocked.Increment(ref diagnosticCount);
+            };
+            OutputSinkManager.AddLogCallback(captureDiagnostic);
+
+            try
+            {
+                foreach (var client in Clients)
+                {
+                    client.Call(() =>
+                    {
+                        Assert.True(client.ObjectManager.TryGetObject(HeroId, out Hero hero));
+                        Assert.True(client.ObjectManager.TryGetObject(settlementId, out Settlement settlement));
+                        hero._clan = null;
+                        hero._companionOf = null;
+                        hero._governorOf = null;
+                        hero._stayingInSettlement = null;
+                        hero._bornSettlement = settlement;
+                        hero._homeSettlement = null;
+
+                        var builder = new ContainerBuilder();
+                        builder.RegisterInstance(new DenyOriginalSyncPolicy()).As<ISyncPolicy>();
+                        using var container = builder.Build();
+                        using (ContainerProvider.UseContainerThreadSafe(container))
+                        {
+                            Assert.False(CallOriginalPolicy.IsOriginalAllowed());
+                            hero.UpdateHomeSettlement();
+                        }
+
+                        Assert.Same(settlement, hero._homeSettlement);
+                    });
+                }
+
+                Assert.Equal(Clients.Count(), Volatile.Read(ref diagnosticCount));
+            }
+            finally
+            {
+                OutputSinkManager.RemoveLogCallback(captureDiagnostic);
+            }
+        }
+
+        private sealed class DenyOriginalSyncPolicy : ISyncPolicy
+        {
+            public bool AllowOriginal() => false;
         }
 
         // Calls the REAL patched game method (not a reflection-invoked intercept), so this covers the

--- a/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
+++ b/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
@@ -52,7 +52,7 @@ public class CallOriginalPolicyTests
     }
 
     [Fact]
-    public async Task CurrentOperationScope_IsLimitedToInvokingThread()
+    public void CurrentOperationScope_IsLimitedToInvokingThread()
     {
         Assert.False(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
 
@@ -60,7 +60,8 @@ public class CallOriginalPolicyTests
         {
             Assert.True(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
             Assert.True(CallOriginalPolicy.IsOriginalAllowed());
-            Assert.False(await Task.Run(() => CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation));
+            Assert.False(Task.Run(() => CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation)
+                .GetAwaiter().GetResult());
         }
 
         Assert.False(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);

--- a/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
+++ b/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
@@ -1,4 +1,4 @@
-using GameInterface.Policies;
+﻿using GameInterface.Policies;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -49,5 +49,51 @@ public class CallOriginalPolicyTests
         }
 
         Assert.False(CallOriginalPolicy.AreOriginalsAllowedOnAllThreads);
+    }
+
+    [Fact]
+    public async Task CurrentOperationScope_IsLimitedToInvokingThread()
+    {
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+
+        using (CallOriginalPolicy.AllowOriginalsForCurrentOperation())
+        {
+            Assert.True(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+            Assert.True(CallOriginalPolicy.IsOriginalAllowed());
+            Assert.False(await Task.Run(() => CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation));
+        }
+
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+    }
+
+    [Fact]
+    public void NestedCurrentOperationScope_DoesNotRevokeOuterScope()
+    {
+        using (CallOriginalPolicy.AllowOriginalsForCurrentOperation())
+        {
+            using (CallOriginalPolicy.AllowOriginalsForCurrentOperation())
+            {
+                Assert.True(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+            }
+
+            Assert.True(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+        }
+
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+    }
+
+    [Fact]
+    public void CurrentOperationScope_DoubleDispose_DoesNotRevokeAnotherScope()
+    {
+        using (CallOriginalPolicy.AllowOriginalsForCurrentOperation())
+        {
+            var scope = CallOriginalPolicy.AllowOriginalsForCurrentOperation();
+            scope.Dispose();
+            scope.Dispose();
+
+            Assert.True(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+        }
+
+        Assert.False(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
     }
 }

--- a/source/GameInterface/Policies/CallOriginalPolicy.cs
+++ b/source/GameInterface/Policies/CallOriginalPolicy.cs
@@ -12,13 +12,21 @@ public class CallOriginalPolicy
 
     private static int _allThreadsAllowedCount;
 
+    [ThreadStatic]
+    private static int _currentOperationAllowedCount;
+
     internal static bool AreOriginalsAllowedOnAllThreads =>
         Volatile.Read(ref _allThreadsAllowedCount) > 0;
+
+    internal static bool AreOriginalsAllowedForCurrentOperation =>
+        _currentOperationAllowedCount > 0;
 
     public static bool IsOriginalAllowed()
     {
         // While using an allowed thread or operation, allow original call
-        if (AllowedThread.IsThisThreadAllowed() || AreOriginalsAllowedOnAllThreads) return true;
+        if (AllowedThread.IsThisThreadAllowed() ||
+            AreOriginalsAllowedOnAllThreads ||
+            AreOriginalsAllowedForCurrentOperation) return true;
 
         if (ContainerProvider.TryResolve<ISyncPolicy>(out var syncPolicy) == false)
         {
@@ -37,6 +45,29 @@ public class CallOriginalPolicy
     /// engine-owned threads and wait for all of it to finish before the scope is disposed.
     /// </summary>
     public static IDisposable AllowOriginalsOnAllThreads() => new AllThreadsScope();
+
+    /// <summary>
+    /// Allows original calls made synchronously by the current operation on this thread.
+    /// </summary>
+    internal static IDisposable AllowOriginalsForCurrentOperation() => new CurrentOperationScope();
+
+    private sealed class CurrentOperationScope : IDisposable
+    {
+        private int _disposed;
+
+        public CurrentOperationScope()
+        {
+            _currentOperationAllowedCount++;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                _currentOperationAllowedCount--;
+            }
+        }
+    }
 
     private sealed class AllThreadsScope : IDisposable
     {

--- a/source/GameInterface/Services/Heroes/Commands/HeroDebugCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/HeroDebugCommand.cs
@@ -4,6 +4,7 @@ using GameInterface.Services.Heroes.Audit;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.ObjectManager.Extensions;
 using GameInterface.Utils.Commands;
+using Newtonsoft.Json;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -63,6 +64,65 @@ public class HeroDebugCommand
     {
         return string.IsNullOrEmpty(prefix) ||
                heroName?.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    [CommandLineArgumentFunction("home_settlement_snapshot", "coop.debug.hero")]
+    public static string HomeSettlementSnapshot(List<string> args)
+    {
+        if (args.Count != 1 || !bool.TryParse(args[0], out bool resolveMissing))
+            return "Usage: coop.debug.hero.home_settlement_snapshot <true|false>";
+
+        if (Campaign.Current == null)
+            return "Campaign is not loaded.";
+
+        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            return $"Unable to get {nameof(IObjectManager)}";
+
+        var homeSettlements = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        int cacheMissesBeforeRead = 0;
+        int nullCount = 0;
+        int unregisteredSettlementCount = 0;
+
+        foreach (var hero in Campaign.Current.CampaignObjectManager.GetAllHeroes())
+        {
+            if (!objectManager.TryGetId(hero, out string heroId)) continue;
+
+            if (hero._homeSettlement == null) cacheMissesBeforeRead++;
+            var homeSettlement = resolveMissing ? hero.HomeSettlement : hero._homeSettlement;
+            if (homeSettlement == null)
+            {
+                homeSettlements.Add(heroId, null);
+                nullCount++;
+                continue;
+            }
+
+            if (objectManager.TryGetId(homeSettlement, out string settlementId))
+            {
+                homeSettlements.Add(heroId, settlementId);
+            }
+            else
+            {
+                homeSettlements.Add(heroId, $"unregistered:{homeSettlement.StringId}");
+                unregisteredSettlementCount++;
+            }
+        }
+
+        string role = ModInformation.IsServer ? "server" : "client";
+        string structuredState = JsonConvert.SerializeObject(new
+        {
+            role,
+            resolveMissing,
+            heroCount = homeSettlements.Count,
+            cacheMissesBeforeRead,
+            nullCount,
+            unregisteredSettlementCount,
+            homeSettlements,
+        });
+
+        return $"role={role} resolveMissing={resolveMissing} heroCount={homeSettlements.Count} " +
+               $"cacheMissesBeforeRead={cacheMissesBeforeRead} nullCount={nullCount} " +
+               $"unregisteredSettlementCount={unregisteredSettlementCount}" + Environment.NewLine +
+               $"LIVE_TEST_JSON={structuredState}";
     }
 
     [CommandLineArgumentFunction("id", "coop.debug.hero")]

--- a/source/GameInterface/Services/Heroes/Patches/HeroFieldPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/HeroFieldPatches.cs
@@ -5,6 +5,7 @@ using GameInterface.Policies;
 using GameInterface.Services.Heroes.Messages;
 using HarmonyLib;
 using Serilog;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -17,6 +18,25 @@ using TaleWorlds.Localization;
 
 namespace GameInterface.Services.Heroes.Patches
 {
+    [HarmonyPatch(typeof(Hero), nameof(Hero.HomeSettlement), MethodType.Getter)]
+    internal class HeroHomeSettlementGetterPatch
+    {
+        [HarmonyPrefix]
+        internal static void Prefix(Hero __instance, out IDisposable __state)
+        {
+            __state = ModInformation.IsClient && __instance._homeSettlement == null
+                ? CallOriginalPolicy.AllowOriginalsForCurrentOperation()
+                : null;
+        }
+
+        [HarmonyFinalizer]
+        internal static Exception Finalizer(IDisposable __state, Exception __exception)
+        {
+            __state?.Dispose();
+            return __exception;
+        }
+    }
+
     [HarmonyPatch]
     internal class HeroFieldPatches
     {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

After a client loads a co-op save or returns to the campaign map, the client log can be flooded with HomeSettlement managed-state errors.

## What is the new behavior?

Resolves #3256

Clients can rebuild missing hero home-settlement data when the campaign map is read without producing false mutation errors, while genuine client changes and server synchronization continue to be reported normally.

## Bot Changelog Entry

- Fixed unimportant HomeSettlement error bursts when loading into the map.
