### PR TITLE
Prevent army encounter lock after battle

### DIFF
--- a/source/GameInterface.Tests/Services/MapEvents/BattleModeEncounterOptionsPatchTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/BattleModeEncounterOptionsPatchTests.cs
@@ -1,0 +1,78 @@
+﻿using Common.Util;
+using GameInterface.Services.MapEvents.Patches;
+using HarmonyLib;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.Core;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MapEvents;
+
+/// <summary>Verifies destroyed battle cleanup cannot be blocked by the abandon-army menu condition.</summary>
+public class BattleModeEncounterOptionsPatchTests
+{
+    [Fact]
+    public void HarmonyPatch_IncludesAbandonArmyCondition()
+    {
+        var harmony = new Harmony(nameof(HarmonyPatch_IncludesAbandonArmyCondition));
+        try
+        {
+            var patched = harmony.CreateClassProcessor(typeof(BattleModeEncounterOptionsPatch)).Patch();
+
+            Assert.Contains(
+                patched,
+                method => method.Name.Contains("game_menu_encounter_abandon_army_on_condition"));
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmony.Id);
+        }
+    }
+
+    [Fact]
+    public void ShouldSkipAbandonArmyCondition_ArmyFollowerWithoutMapEvent_ReturnsTrue()
+    {
+        var follower = CreateParty();
+        var leader = CreateParty();
+        var army = ObjectHelper.SkipConstructor<Army>();
+        army.LeaderParty = leader;
+        follower._army = army;
+
+        Assert.True(BattleModeEncounterOptionsPatch.ShouldSkipAbandonArmyCondition(follower));
+    }
+
+    [Fact]
+    public void ShouldSkipAbandonArmyCondition_ArmyFollowerWithMapEvent_ReturnsFalse()
+    {
+        var follower = CreateParty();
+        var leader = CreateParty();
+        var army = ObjectHelper.SkipConstructor<Army>();
+        army.LeaderParty = leader;
+        follower._army = army;
+        follower.Party._mapEventSide = new MapEventSide(
+            ObjectHelper.SkipConstructor<MapEvent>(),
+            BattleSideEnum.Attacker,
+            follower.Party);
+
+        Assert.False(BattleModeEncounterOptionsPatch.ShouldSkipAbandonArmyCondition(follower));
+    }
+
+    [Fact]
+    public void ShouldSkipAbandonArmyCondition_ArmyLeaderWithoutMapEvent_ReturnsFalse()
+    {
+        var leader = CreateParty();
+        var army = ObjectHelper.SkipConstructor<Army>();
+        army.LeaderParty = leader;
+        leader._army = army;
+
+        Assert.False(BattleModeEncounterOptionsPatch.ShouldSkipAbandonArmyCondition(leader));
+    }
+
+    private static MobileParty CreateParty()
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        party.Party = ObjectHelper.SkipConstructor<PartyBase>();
+        return party;
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Patches/BattleModeEncounterOptionsPatch.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/BattleModeEncounterOptionsPatch.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using GameInterface.Services.ObjectManager;
 using HarmonyLib;
@@ -23,7 +23,8 @@ namespace GameInterface.Services.MapEvents.Patches;
 /// auto-resolve (<see cref="BattleModeRegistry.IsSimulation"/>) the mission-start options grey out. The mode comes
 /// from the server's <see cref="Messages.Start.NetworkBattleModeSet"/>. The surrender option gets the inverse
 /// treatment: forced available for a defender that cannot fight (see <see cref="PostfixSurrenderCondition"/>) and
-/// refused while either mode owns the event. Other options (join, leave, talk) are untouched.
+/// refused while either mode owns the event. Abandon army is hidden while a destroyed battle waits for deferred
+/// encounter cleanup; other options (join, regular leave, talk) are untouched.
 /// </summary>
 /// <remarks>
 /// One shared postfix per option-condition in <see cref="MissionStartConditions"/> / <see cref="SimulationStartConditions"/> /
@@ -59,6 +60,7 @@ internal class BattleModeEncounterOptionsPatch
 
     // Handled inversely to the start buckets: forced available / refused rather than only greyed.
     private const string SurrenderCondition = "game_menu_encounter_surrender_on_condition"; // Surrender.
+    private const string AbandonArmyCondition = "game_menu_encounter_abandon_army_on_condition"; // Abandon army.
 
     static IEnumerable<MethodBase> TargetMethods()
     {
@@ -79,6 +81,26 @@ internal class BattleModeEncounterOptionsPatch
         var surrender = AccessTools.Method(typeof(EncounterGameMenuBehavior), SurrenderCondition);
         if (surrender != null)
             yield return surrender;
+
+        var abandonArmy = AccessTools.Method(typeof(EncounterGameMenuBehavior), AbandonArmyCondition);
+        if (abandonArmy != null)
+            yield return abandonArmy;
+    }
+
+    [HarmonyPrefix]
+    static bool Prefix(MethodBase __originalMethod, ref bool __result)
+    {
+        if (ModInformation.IsServer || __originalMethod.Name != AbandonArmyCondition) return true;
+        if (!ShouldSkipAbandonArmyCondition(MobileParty.MainParty)) return true;
+
+        __result = false;
+        return false;
+    }
+
+    internal static bool ShouldSkipAbandonArmyCondition(MobileParty mainParty)
+    {
+        var army = mainParty?.Army;
+        return army != null && army.LeaderParty != mainParty && mainParty.MapEvent == null;
     }
 
     [HarmonyPostfix]


### PR DESCRIPTION
## PR Checklist
- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
Army followers can return from a completed battle after their `MapEvent` has already been destroyed. The encounter menu's abandon-army condition dereferences that missing event and stops the deferred encounter cleanup, leaving the client stuck in the battle menu.

## What is the new behavior?
Resolves #3258

Hide the abandon-army option during that destroyed-event transition so map activation completes and the existing deferred cleanup can close the encounter. Followers with a valid battle, army leaders, and the server still use vanilla behavior.

## Bot Changelog Entry
- Fixed army members getting stuck in the encounter menu after winning a battle.

## How to test
`dotnet test source\GameInterface.Tests\GameInterface.Tests.csproj -c Release`
