### PR TITLE
[3268] Prevent kingdom alliance decision screen freezes

### DIFF
--- a/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
+++ b/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
@@ -457,8 +457,8 @@ public class ClientKingdomHandler : IHandler
         var obj = payload.What;
         GameThread.RunSafe(() =>
         {
-            if (!objectManager.TryGetObjectWithLogging<Kingdom>(obj.RequestingKingdomId, out var requestingKingdom)) return;
-            if (!objectManager.TryGetObjectWithLogging<Kingdom>(obj.TargetKingdomId, out var targetKingdom)) return;
+            if (!StartAllianceDecisionData.TryGetKingdomReference(objectManager, obj.RequestingKingdomId, out var requestingKingdom)) return;
+            if (!StartAllianceDecisionData.TryGetKingdomReference(objectManager, obj.TargetKingdomId, out var targetKingdom)) return;
             AllianceOfferPendingRegistry.Set(requestingKingdom.StringId, targetKingdom.StringId, obj.IsPending);
         });
     }

--- a/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
+++ b/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
@@ -416,10 +416,9 @@ public class ClientKingdomHandler : IHandler
 
     private bool TryGetDecisionKingdom(NetworkAddDecision payload, out Kingdom kingdom)
     {
-        if (payload.Data is StartAllianceDecisionData startAllianceDecisionData &&
-            startAllianceDecisionData.TryGetProposerClanAndDecisionKingdom(objectManager, out _, out kingdom))
+        if (payload.Data is StartAllianceDecisionData startAllianceDecisionData)
         {
-            return true;
+            return startAllianceDecisionData.TryGetProposerClanAndDecisionKingdom(objectManager, out _, out kingdom);
         }
 
         return objectManager.TryGetObject(payload.KingdomId, out kingdom);

--- a/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
+++ b/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
@@ -5,6 +5,7 @@ using Common.Util;
 using Coop.Core.Server.Services.Kingdoms.Messages;
 using GameInterface.Services.Entity;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.Kingdoms.Patches;
 using GameInterface.Services.MobileParties.Messages.Behavior;
@@ -388,21 +389,40 @@ public class ClientKingdomHandler : IHandler
     private void HandleNetworkAddDecision(MessagePayload<NetworkAddDecision> obj)
     {
         var payload = obj.What;
-        if (!ShouldApplyNetworkDecision(payload.KingdomId)) return;
+        GameThread.RunSafe(() =>
+        {
+            if (!ShouldApplyNetworkDecision(payload, out string kingdomId)) return;
 
-        var message = new AddDecision(payload.KingdomId, payload.Data, payload.IgnoreInfluenceCost, payload.RandomNumber);
-        messageBroker.Publish(this, message);
+            var message = new AddDecision(kingdomId, payload.Data, payload.IgnoreInfluenceCost, payload.RandomNumber);
+            messageBroker.Publish(this, message);
+        }, context: nameof(ClientKingdomHandler));
     }
 
-    private bool ShouldApplyNetworkDecision(string kingdomId)
+    private bool ShouldApplyNetworkDecision(NetworkAddDecision payload, out string kingdomId)
     {
+        kingdomId = payload.KingdomId;
         if (string.IsNullOrWhiteSpace(kingdomId)) return false;
-        if (!objectManager.TryGetObject(kingdomId, out Kingdom kingdom)) return true;
+        if (!TryGetDecisionKingdom(payload, out Kingdom kingdom)) return true;
+        if (objectManager.TryGetId(kingdom, out string resolvedKingdomId))
+        {
+            kingdomId = resolvedKingdomId;
+        }
         if (!playerManager.TryGetPlayer(controllerIdProvider.ControllerId, out var player)) return true;
         if (string.IsNullOrWhiteSpace(player.ClanId)) return false;
         if (!objectManager.TryGetObject(player.ClanId, out Clan clan)) return false;
 
         return clan.Kingdom == kingdom;
+    }
+
+    private bool TryGetDecisionKingdom(NetworkAddDecision payload, out Kingdom kingdom)
+    {
+        if (payload.Data is StartAllianceDecisionData startAllianceDecisionData &&
+            startAllianceDecisionData.TryGetProposerClanAndDecisionKingdom(objectManager, out _, out kingdom))
+        {
+            return true;
+        }
+
+        return objectManager.TryGetObject(payload.KingdomId, out kingdom);
     }
 
     private void HandleDestroyKingdom(MessagePayload<DestroyKingdom> obj)

--- a/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
+++ b/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
@@ -457,8 +457,16 @@ public class ClientKingdomHandler : IHandler
         var obj = payload.What;
         GameThread.RunSafe(() =>
         {
-            if (!StartAllianceDecisionData.TryGetKingdomReference(objectManager, obj.RequestingKingdomId, out var requestingKingdom)) return;
-            if (!StartAllianceDecisionData.TryGetKingdomReference(objectManager, obj.TargetKingdomId, out var targetKingdom)) return;
+            if (!StartAllianceDecisionData.TryGetKingdomReference(
+                    objectManager,
+                    obj.RequestingKingdomId,
+                    obj.RequestingKingdomStringId,
+                    out var requestingKingdom)) return;
+            if (!StartAllianceDecisionData.TryGetKingdomReference(
+                    objectManager,
+                    obj.TargetKingdomId,
+                    obj.TargetKingdomStringId,
+                    out var targetKingdom)) return;
             AllianceOfferPendingRegistry.Set(requestingKingdom.StringId, targetKingdom.StringId, obj.IsPending);
         });
     }

--- a/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
+++ b/source/Coop.Core/Server/Connections/States/TransferSaveState.cs
@@ -70,7 +70,7 @@ public class TransferSaveState : ConnectionStateBase
                 var saveResults = saveInterface.SaveCurrentGame();
 
                 // Disconnect peer on failure — before touching Data, which a failed snapshot may leave null.
-                if (!saveResults.Success)
+                if (!saveResults.Success || saveResults.Data == null || saveResults.Data.Length == 0)
                 {
                     Logger.Error("Join save snapshot failed for peer {PeerId}; disconnecting", connectionLogic.Peer.Id);
                     connectionLogic.Peer.Disconnect();

--- a/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
+++ b/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
@@ -326,7 +326,12 @@ public class ServerKingdomHandler : IHandler
         if (!objectManager.TryGetIdWithLogging(obj.RequestingKingdom, out var requestingKingdomId)) return;
         if (!objectManager.TryGetIdWithLogging(obj.TargetKingdom, out var targetKingdomId)) return;
         AllianceOfferPendingRegistry.Set(obj.RequestingKingdom.StringId, obj.TargetKingdom.StringId, obj.IsPending);
-        network.SendAll(new NetworkAllianceOfferPendingStatusChanged(requestingKingdomId, targetKingdomId, obj.IsPending));
+        network.SendAll(new NetworkAllianceOfferPendingStatusChanged(
+            requestingKingdomId,
+            targetKingdomId,
+            obj.IsPending,
+            obj.RequestingKingdom.StringId,
+            obj.TargetKingdom.StringId));
     }
     public void Dispose()
     {

--- a/source/Coop.Core/Server/Services/Kingdoms/Messages/NetworkAllianceOfferPendingStatusChanged.cs
+++ b/source/Coop.Core/Server/Services/Kingdoms/Messages/NetworkAllianceOfferPendingStatusChanged.cs
@@ -12,11 +12,22 @@ public readonly struct NetworkAllianceOfferPendingStatusChanged : ICommand
     public readonly string TargetKingdomId;
     [ProtoMember(3)]
     public readonly bool IsPending;
+    [ProtoMember(4)]
+    public readonly string RequestingKingdomStringId;
+    [ProtoMember(5)]
+    public readonly string TargetKingdomStringId;
 
-    public NetworkAllianceOfferPendingStatusChanged(string requestingKingdomId, string targetKingdomId, bool isPending)
+    public NetworkAllianceOfferPendingStatusChanged(
+        string requestingKingdomId,
+        string targetKingdomId,
+        bool isPending,
+        string requestingKingdomStringId = null,
+        string targetKingdomStringId = null)
     {
         RequestingKingdomId = requestingKingdomId;
         TargetKingdomId = targetKingdomId;
         IsPending = isPending;
+        RequestingKingdomStringId = requestingKingdomStringId;
+        TargetKingdomStringId = targetKingdomStringId;
     }
 }

--- a/source/Coop.IntegrationTests/Kingdoms/KingdomAddDecisionTest.cs
+++ b/source/Coop.IntegrationTests/Kingdoms/KingdomAddDecisionTest.cs
@@ -31,7 +31,7 @@ namespace Coop.IntegrationTests.Kingdoms
             var triggerMessage = new DecisionAdded(kingdom, decision, false, 0.5f);
             var server = TestEnvironment.Server;
             // Act
-            server.SimulateMessage(this, triggerMessage);
+            GameThreadTestRunner.Run(() => server.SimulateMessage(this, triggerMessage));
             // Assert
             // Verify the server sends a single message to it's game interface
             Assert.Equal(1, server.NetworkSentMessages.GetMessageCount<NetworkAddDecision>());
@@ -52,7 +52,7 @@ namespace Coop.IntegrationTests.Kingdoms
             var decision = CreateDecision(client1);
             var triggerMessage = new DecisionAdded(kingdom, decision, false, 0f);
             // Act
-            client1.SimulateMessage(this, triggerMessage);
+            GameThreadTestRunner.Run(() => client1.SimulateMessage(this, triggerMessage));
             // Assert
             Assert.Equal(1, client1.NetworkSentMessages.GetMessageCount<NetworkAddDecision>());
             Assert.Equal(1, server.InternalMessages.GetMessageCount<NetworkAddDecision>());

--- a/source/Coop.Tests/Server/Connections/States/TransferCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/TransferCharacterStateTests.cs
@@ -144,10 +144,28 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
+        public void EnteringState_SuccessWithoutSaveData_DisconnectsJoiningPeer()
+        {
+            var saveMock = serverComponent.Container.Resolve<Mock<ISaveInterface>>();
+            saveMock.Setup(m => m.SaveCurrentGame()).Returns(new SaveResults(true, null, "12345"));
+
+            connectionLogic.SetState<TransferSaveState>();
+
+            Assert.Equal(ConnectionState.ShutdownRequested, playerPeer.ConnectionState);
+            var peerGotSave =
+                serverComponent.TestNetwork.SentPackets.TryGetValue(playerPeer.Id, out var packets) &&
+                packets.OfType<GameSaveDataChunkPacket>().Any();
+            Assert.False(peerGotSave);
+        }
+
+        [Fact]
         public void EnteringState_FlushFailureStillClearsSavingState()
         {
             serverComponent.TestNetwork.FlushPendingMessagesException =
                 new InvalidOperationException("Flush failed.");
+            serverComponent.Container.Resolve<Mock<ISaveInterface>>()
+                .Setup(m => m.SaveCurrentGame())
+                .Returns(new SaveResults(true, new byte[] { 1, 2, 3 }, "12345"));
 
             connectionLogic.SetState<TransferSaveState>();
 

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1607,7 +1607,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
-    public void NpcAllianceOffer_LegacyReloadWithoutProvenance_StillDeclines()
+    public void AllianceDecisions_LegacyReloadWithoutProvenance_LeavesAmbiguousDirectionsUntracked()
     {
         var player = CreateSyncedPlayerContext(ControllerId, Clients.First());
         var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
@@ -1624,6 +1624,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(proposingKingdomId, out var proposingKingdom));
             Assert.True(Server.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
 
             var npcDecision = new StartAllianceDecision(proposingClan, playerKingdom);
@@ -1632,33 +1633,26 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                 .Single(outcome => outcome.ShouldAllianceBeStarted);
             Assert.True(CoopKingdomElection.TryRedirectPlayerAllianceOffer(npcDecision, allianceOutcome));
 
-            var playerDecision = Assert.IsType<StartAllianceDecision>(
+            var inboundDecision = Assert.IsType<StartAllianceDecision>(
                 Assert.Single(playerKingdom.UnresolvedDecisions));
-            playerDecision.TriggerTime = CampaignTime.Zero;
-
-            var playerManager = Server.Resolve<IPlayerManager>();
-            Assert.True(playerManager.TryGetPlayer(ControllerId, out var registeredPlayer));
-            Assert.True(playerManager.RemovePlayer(registeredPlayer));
+            inboundDecision.TriggerTime = CampaignTime.Zero;
+            var outgoingDecision = new StartAllianceDecision(playerKingdom.RulingClan, proposingKingdom);
+            playerKingdom._unresolvedDecisions.Add(outgoingDecision);
 
             CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
                 new TestDataStore(isSaving: false, new Dictionary<string, object>()));
 
-            Assert.DoesNotContain(playerDecision, CoopKingdomElection._opponentProposedAllianceDecisions);
-            Assert.False(CoopKingdomElection.IsPendingPlayerAllianceOffer(playerDecision));
+            Assert.DoesNotContain(inboundDecision, CoopKingdomElection._opponentProposedAllianceDecisions);
+            Assert.False(CoopKingdomElection.IsPendingPlayerAllianceOffer(inboundDecision));
+            Assert.False(CoopKingdomElection.IsPendingPlayerAllianceOffer(outgoingDecision));
+            Assert.Contains(inboundDecision, playerKingdom.UnresolvedDecisions);
+            Assert.Contains(outgoingDecision, playerKingdom.UnresolvedDecisions);
+
             var resavedRecords = new Dictionary<string, object>();
             CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
                 new TestDataStore(isSaving: true, resavedRecords));
-            Assert.Empty(resavedRecords);
-            CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
-                new TestDataStore(isSaving: false, resavedRecords));
-            Assert.True(playerManager.AddPlayer(registeredPlayer));
-            Assert.True(CoopKingdomElection.IsPendingPlayerAllianceOffer(playerDecision));
-            Assert.True(playerDecision.OnShowDecision());
-            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
-            GetConcreteVoteManager(Server).ProcessVotingRounds(
-                DateTime.UtcNow + KingdomDecisionVoteManager.VotingRoundDuration + TimeSpan.FromSeconds(1));
-
-            Assert.Empty(playerKingdom.UnresolvedDecisions);
+            Assert.True(resavedRecords.TryGetValue("_coop_pending_player_alliance_offers", out object savedOffers));
+            Assert.Empty(Assert.IsType<List<StartAllianceDecision>>(savedOffers));
         });
 
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1864,6 +1864,69 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
+    public void StartAllianceDecision_ClanTypedTargetKingdomId_UsesReferencedClanKingdom()
+    {
+        const string compactTargetClanId = "target-alliance-collision";
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposerClanId = CreateSyncedNpcClan();
+        var targetRulerClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+        ConfigureClanInKingdom(proposerClanId, proposingKingdomId);
+        ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(proposingKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        ConfigureAllianceModelEverywhere();
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            var targetClanReference = ObjectHelper.SkipConstructor<Clan>();
+            targetClanReference._kingdom = targetKingdom;
+            Assert.True(client.ObjectManager.AddExisting($"Clan_{compactTargetClanId}", targetClanReference));
+            Assert.True(client.ObjectManager.AddExisting(
+                $"Kingdom_{compactTargetClanId}",
+                ObjectHelper.SkipConstructor<Kingdom>()));
+        });
+
+        var decisionData = new StartAllianceDecisionData(
+            proposerClanId,
+            recipientKingdomId,
+            triggerTime: 0,
+            isEnforced: false,
+            notifyPlayer: false,
+            playerExamined: false,
+            kingdomToStartAllianceWithId: compactTargetClanId,
+            isProposedByOpponent: true);
+
+        client.Call(() => client.SimulateMessage(
+            this,
+            new NetworkAddDecision(
+                recipientKingdomId,
+                decisionData,
+                ignoreInfluenceCost: true,
+                randomNumber: 0.5f)));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(compactTargetClanId, out var conflictingKingdom));
+
+            var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+            Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
+            Assert.NotSame(conflictingKingdom, decision.KingdomToStartAllianceWith);
+            Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
+        });
+    }
+
+    [Fact]
     public void AllianceTimeoutFixture_NormalizesEveryReversibleEligibilityInputAndRestoresThemAfterExplicitAndFailedStagePaths()
     {
         const string fixtureControllerId = "testclient";

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -35,6 +35,7 @@ using TaleWorlds.CampaignSystem.Encyclopedia;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.CampaignSystem.ComponentInterfaces;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
@@ -1758,19 +1759,24 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
-    public void AllianceTimeoutFixture_NormalizesLeaderRelationAndRestoresItAfterExplicitAndFailedStagePaths()
+    public void AllianceTimeoutFixture_NormalizesEveryReversibleEligibilityInputAndRestoresThemAfterExplicitAndFailedStagePaths()
     {
         const string fixtureControllerId = "testclient";
         const int initialRelation = -40;
+        const int initialSupporterRelation = 35;
+        const int initialRecipientHonor = -1;
+        const int initialSturgiaHonor = 0;
         var client = Clients.First();
         client.Resolve<IControllerIdProvider>().SetControllerId(fixtureControllerId);
         var player = CreateSyncedPlayerContext(fixtureControllerId, client);
         var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var sturgiaKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var recipientRulerClanId = CreateSyncedNpcClan();
+        var recipientSupporterClanId = CreateSyncedNpcClan();
         var sturgiaRulerClanId = CreateSyncedNpcClan();
 
         ConfigureClanInKingdom(recipientRulerClanId, recipientKingdomId);
+        ConfigureClanInKingdom(recipientSupporterClanId, recipientKingdomId);
         ConfigureClanInKingdom(sturgiaRulerClanId, sturgiaKingdomId);
         EnsureKingdomRegisteredEverywhere(recipientKingdomId);
         EnsureKingdomRegisteredEverywhere(sturgiaKingdomId);
@@ -1784,17 +1790,44 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.Contains(sturgia, Kingdom.All);
         });
 
-        bool allowAlliance = true;
+        bool rejectNpcElectionSupporterGate = false;
         int gateCallCount = 0;
-        int relationChangeEventCount = 0;
+        int playerSupportGateCallCount = 0;
+        int npcElectionSupporterGateCallCount = 0;
+        int unrelatedDueDecisionGateCallCount = 0;
+        bool unrelatedDueDecisionObservedNpcElectionSupporter = false;
+        int fixtureRelationChangeEventCount = 0;
         var relationChangeListenerOwner = new object();
+        Clan testclientClan = null;
+        Hero leaderRelationFirst = null;
+        Hero leaderRelationSecond = null;
+        Hero supporterRelationFirst = null;
+        Hero supporterRelationSecond = null;
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
             Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(player.ClanId, out testclientClan));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
+            Assert.False(recipientRulerClan.IsUnderMercenaryService);
+            Assert.False(recipientSupporterClan.IsUnderMercenaryService);
             recipientKingdom.Name = new TextObject("Recipient");
             sturgia.Name = new TextObject("Sturgia");
+            Campaign.Current.Models.DiplomacyModel.GetHeroesForEffectiveRelation(
+                recipientKingdom.Leader,
+                sturgia.Leader,
+                out leaderRelationFirst,
+                out leaderRelationSecond);
+            Campaign.Current.Models.DiplomacyModel.GetHeroesForEffectiveRelation(
+                recipientSupporterClan.Leader,
+                sturgia.Leader,
+                out supporterRelationFirst,
+                out supporterRelationSecond);
             SetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader, initialRelation);
+            SetEffectiveRelation(recipientSupporterClan.Leader, sturgia.Leader, initialSupporterRelation);
+            recipientKingdom.Leader.SetTraitLevel(DefaultTraits.Honor, initialRecipientHonor);
+            sturgia.Leader.SetTraitLevel(DefaultTraits.Honor, initialSturgiaHonor);
 
             var allianceModel = new Mock<AllianceModel>();
             allianceModel
@@ -1808,15 +1841,57 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                 {
                     gateCallCount++;
                     reason = null;
-                    return allowAlliance && kingdom == recipientKingdom && targetKingdom == sturgia &&
-                        GetEffectiveRelation(kingdom.Leader, targetKingdom.Leader) ==
+                    if (kingdom == sturgia && targetKingdom == recipientKingdom)
+                    {
+                        unrelatedDueDecisionGateCallCount++;
+                        unrelatedDueDecisionObservedNpcElectionSupporter =
+                            recipientKingdom.RulingClan.IsUnderMercenaryService ||
+                            recipientSupporterClan.IsUnderMercenaryService;
+                        return false;
+                    }
+                    if (kingdom != recipientKingdom || targetKingdom != sturgia ||
+                        sturgia.Leader.GetTraitLevel(DefaultTraits.Honor) != 1) return false;
+
+                    if (recipientKingdom.RulingClan.IsUnderMercenaryService)
+                    {
+                        npcElectionSupporterGateCallCount++;
+                        if (rejectNpcElectionSupporterGate) return false;
+                    }
+
+                    if (testclientClan.Kingdom != recipientKingdom)
+                    {
+                        return GetEffectiveRelation(kingdom.Leader, targetKingdom.Leader) ==
+                            Campaign.Current.Models.DiplomacyModel.MaxRelationLimit &&
+                            recipientKingdom.Leader.GetTraitLevel(DefaultTraits.Honor) == 1;
+                    }
+
+                    playerSupportGateCallCount++;
+                    return GetEffectiveRelation(kingdom.Leader, targetKingdom.Leader) ==
+                        Campaign.Current.Models.DiplomacyModel.MaxRelationLimit &&
+                        recipientKingdom.Leader.GetTraitLevel(DefaultTraits.Honor) == 1 &&
+                        GetEffectiveRelation(recipientSupporterClan.Leader, sturgia.Leader) ==
                         Campaign.Current.Models.DiplomacyModel.MaxRelationLimit;
                 }));
             allianceModel
                 .Setup(model => model.GetInfluenceCostOfProposingStartingAlliance(It.IsAny<Clan>()))
                 .Returns(0);
+            allianceModel
+                .Setup(model => model.GetSupportScoreOfStartingAllianceForClan(
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<Clan>(),
+                    out It.Ref<TextObject>.IsAny,
+                    It.IsAny<bool>()))
+                .Returns(200f);
+            allianceModel
+                .SetupGet(model => model.MaxNumberOfAlliances)
+                .Returns(3);
             Campaign.Current.Models.AllianceModel = allianceModel.Object;
         });
+        foreach (var environment in Clients)
+        {
+            ConfigureAllianceModel(environment);
+        }
 
         Server.Call(() =>
         {
@@ -1825,43 +1900,93 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                 (Hero effectiveHero, Hero effectiveTargetHero, int relationChange, bool showQuickNotification,
                     ChangeRelationAction.ChangeRelationDetail detail, Hero originalHero, Hero originalTargetHero) =>
                 {
-                    relationChangeEventCount++;
+                    if ((effectiveHero == leaderRelationFirst && effectiveTargetHero == leaderRelationSecond) ||
+                        (effectiveHero == leaderRelationSecond && effectiveTargetHero == leaderRelationFirst) ||
+                        (effectiveHero == supporterRelationFirst && effectiveTargetHero == supporterRelationSecond) ||
+                        (effectiveHero == supporterRelationSecond && effectiveTargetHero == supporterRelationFirst))
+                    {
+                        fixtureRelationChangeEventCount++;
+                    }
                 });
         });
 
         try
         {
+            Server.Call(() => Assert.NotSame(testclientClan, Clan.PlayerClan));
+
             string target = null;
             Server.Call(() => target = KingdomDebugCommand.GetAllianceTimeoutTarget(new List<string>()));
-            Assert.StartsWith("LIVE_TEST_JSON=", target);
+            Assert.True(target.StartsWith("LIVE_TEST_JSON="), target);
             Assert.Contains($"\"kingdomId\":\"{recipientKingdomId}\"", target);
             Server.Call(() =>
             {
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
                 Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Equal(initialSupporterRelation,
+                    GetEffectiveRelation(recipientSupporterClan.Leader, sturgia.Leader));
+                Assert.Equal(initialRecipientHonor, recipientKingdom.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.Equal(initialSturgiaHonor, sturgia.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.False(recipientRulerClan.IsUnderMercenaryService);
+                Assert.False(recipientSupporterClan.IsUnderMercenaryService);
             });
 
             ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
             string capture = null;
             Server.Call(() => capture = KingdomDebugCommand.CaptureAllianceTimeoutFixture(new List<string>()));
             Assert.StartsWith("LIVE_TEST_JSON=", capture);
+            Assert.Contains("\"eligibilityInputsChanged\":true", capture);
+            Assert.Contains("\"normalizedSupporterRelationCount\":1", capture);
             Server.Call(() =>
             {
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
                 Assert.Equal(Campaign.Current.Models.DiplomacyModel.MaxRelationLimit,
                     GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Equal(1,
+                    recipientKingdom.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.Equal(1, sturgia.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.Equal(Campaign.Current.Models.DiplomacyModel.MaxRelationLimit,
+                    GetEffectiveRelation(recipientSupporterClan.Leader, sturgia.Leader));
+                Assert.False(recipientRulerClan.IsUnderMercenaryService);
+                Assert.False(recipientSupporterClan.IsUnderMercenaryService);
             });
+            Assert.True(playerSupportGateCallCount > 0);
 
             string stage = null;
+            StartAllianceDecision unrelatedDueDecision = null;
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                unrelatedDueDecision = new StartAllianceDecision(sturgia.RulingClan, recipientKingdom)
+                {
+                    TriggerTime = CampaignTime.Zero
+                };
+                sturgia._unresolvedDecisions ??= new MBList<KingdomDecision>();
+                sturgia._unresolvedDecisions.Add(unrelatedDueDecision);
+            });
             Server.Call(() => stage = KingdomDebugCommand.StageAllianceTimeoutFixture(
                 new List<string> { recipientKingdomId, player.ClanId, sturgiaKingdomId }));
             Assert.StartsWith("LIVE_TEST_JSON=", stage);
+            Assert.Contains("\"normalizedNpcElectionSupporterCount\":2", stage);
+            Assert.Contains("\"npcElectionSupportersRestored\":true", stage);
+            Assert.True(unrelatedDueDecisionGateCallCount > 0);
+            Assert.False(unrelatedDueDecisionObservedNpcElectionSupporter);
 
             Server.Call(() =>
             {
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
+                Assert.False(recipientRulerClan.IsUnderMercenaryService);
+                Assert.False(recipientSupporterClan.IsUnderMercenaryService);
+                Assert.DoesNotContain(unrelatedDueDecision, sturgia.UnresolvedDecisions);
                 var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
                 var election = new CoopKingdomElection(decision);
                 int noOutcomeIndex = election._possibleOutcomes
@@ -1886,6 +2011,8 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.EndsWith("=False", finalNoResolution.OutcomeKey);
             Assert.Empty(Server.InternalMessages.GetMessages<AllianceStarted>());
             Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+            Assert.Empty(Server.InternalMessages.GetMessages<ClanMercenaryServiceChanged>());
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkClanMercenaryServiceChanged>());
 
             string serverState = null;
             Server.Call(() => serverState = KingdomDebugCommand.GetAllianceTimeoutServerState(
@@ -1900,7 +2027,15 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             {
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
                 Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Equal(initialSupporterRelation,
+                    GetEffectiveRelation(recipientSupporterClan.Leader, sturgia.Leader));
+                Assert.Equal(initialRecipientHonor, recipientKingdom.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.Equal(initialSturgiaHonor, sturgia.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.False(recipientRulerClan.IsUnderMercenaryService);
+                Assert.False(recipientSupporterClan.IsUnderMercenaryService);
                 Assert.Empty(recipientKingdom.UnresolvedDecisions);
             });
 
@@ -1910,6 +2045,8 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Server.Call(() => stage = KingdomDebugCommand.StageAllianceTimeoutFixture(
                 new List<string> { recipientKingdomId, player.ClanId, sturgiaKingdomId }));
             Assert.StartsWith("LIVE_TEST_JSON=", stage);
+            Assert.Contains("\"normalizedNpcElectionSupporterCount\":2", stage);
+            Assert.Contains("\"npcElectionSupportersRestored\":true", stage);
 
             int resolutionCountBeforeTimeout = Server.NetworkSentMessages
                 .GetMessages<NetworkKingdomDecisionResolved>()
@@ -1917,6 +2054,10 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Server.Call(() =>
             {
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
+                Assert.False(recipientRulerClan.IsUnderMercenaryService);
+                Assert.False(recipientSupporterClan.IsUnderMercenaryService);
                 var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
 
                 GetConcreteVoteManager(Server).ProcessVotingRounds(
@@ -1935,6 +2076,8 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.EndsWith("=False", timeoutResolution.OutcomeKey);
             Assert.Empty(Server.InternalMessages.GetMessages<AllianceStarted>());
             Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+            Assert.Empty(Server.InternalMessages.GetMessages<ClanMercenaryServiceChanged>());
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkClanMercenaryServiceChanged>());
 
             Server.Call(() => serverState = KingdomDebugCommand.GetAllianceTimeoutServerState(
                 new List<string> { recipientKingdomId, sturgiaKingdomId }));
@@ -1947,13 +2090,21 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             {
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
                 Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Equal(initialSupporterRelation,
+                    GetEffectiveRelation(recipientSupporterClan.Leader, sturgia.Leader));
+                Assert.Equal(initialRecipientHonor, recipientKingdom.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.Equal(initialSturgiaHonor, sturgia.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.False(recipientRulerClan.IsUnderMercenaryService);
+                Assert.False(recipientSupporterClan.IsUnderMercenaryService);
                 Assert.Empty(recipientKingdom.UnresolvedDecisions);
             });
 
             Server.Call(() => capture = KingdomDebugCommand.CaptureAllianceTimeoutFixture(new List<string>()));
             Assert.StartsWith("LIVE_TEST_JSON=", capture);
-            allowAlliance = false;
+            rejectNpcElectionSupporterGate = true;
 
             Server.Call(() => stage = KingdomDebugCommand.StageAllianceTimeoutFixture(
                 new List<string> { recipientKingdomId, player.ClanId, sturgiaKingdomId }));
@@ -1962,18 +2113,29 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             {
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
                 Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+                Assert.True(Server.ObjectManager.TryGetObject<Clan>(recipientSupporterClanId, out var recipientSupporterClan));
                 Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Equal(initialSupporterRelation,
+                    GetEffectiveRelation(recipientSupporterClan.Leader, sturgia.Leader));
+                Assert.Equal(initialRecipientHonor, recipientKingdom.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.Equal(initialSturgiaHonor, sturgia.Leader.GetTraitLevel(DefaultTraits.Honor));
+                Assert.False(recipientRulerClan.IsUnderMercenaryService);
+                Assert.False(recipientSupporterClan.IsUnderMercenaryService);
                 Assert.Empty(recipientKingdom.UnresolvedDecisions);
             });
             Assert.True(gateCallCount >= 6);
+            Assert.True(npcElectionSupporterGateCallCount >= 3);
             Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+            Assert.Empty(Server.InternalMessages.GetMessages<ClanMercenaryServiceChanged>());
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkClanMercenaryServiceChanged>());
         }
         finally
         {
             Server.Call(() => CampaignEvents.HeroRelationChanged.ClearListeners(relationChangeListenerOwner));
         }
 
-        Assert.Equal(0, relationChangeEventCount);
+        Assert.Equal(0, fixtureRelationChangeEventCount);
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -2149,6 +2149,74 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
+    public void StartAllianceDecision_UnhydratedClanReferences_UseCanonicalKingdomStringIds()
+    {
+        const string decisionKingdomStringId = "alliance_recipient";
+        const string targetKingdomStringId = "alliance_target";
+        const string decisionKingdomWireId = "unhydrated_recipient_clan";
+        const string targetKingdomWireId = "unhydrated_target_clan";
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposerClanId = CreateSyncedNpcClan();
+        var targetRulerClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+        ConfigureClanInKingdom(proposerClanId, recipientKingdomId);
+        ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        SetKingdomStringIdEverywhere(recipientKingdomId, decisionKingdomStringId);
+        SetKingdomStringIdEverywhere(targetKingdomId, targetKingdomStringId);
+        ConfigureAllianceModelEverywhere();
+
+        client.Call(() =>
+        {
+            var unhydratedRecipientClan = ObjectHelper.SkipConstructor<Clan>();
+            var unhydratedTargetClan = ObjectHelper.SkipConstructor<Clan>();
+            Assert.Null(unhydratedRecipientClan.Kingdom);
+            Assert.Null(unhydratedTargetClan.Kingdom);
+            Assert.True(client.ObjectManager.AddExisting($"Clan_{decisionKingdomWireId}", unhydratedRecipientClan));
+            Assert.True(client.ObjectManager.AddExisting($"Clan_{targetKingdomWireId}", unhydratedTargetClan));
+        });
+
+        var decisionData = new StartAllianceDecisionData(
+            proposerClanId,
+            decisionKingdomWireId,
+            triggerTime: 0,
+            isEnforced: false,
+            notifyPlayer: false,
+            playerExamined: false,
+            kingdomToStartAllianceWithId: targetKingdomWireId,
+            isProposedByOpponent: true,
+            decisionKingdomStringId: decisionKingdomStringId,
+            kingdomToStartAllianceWithStringId: targetKingdomStringId);
+
+        client.Call(() => client.SimulateMessage(
+            this,
+            new NetworkAddDecision(
+                decisionKingdomWireId,
+                decisionData,
+                ignoreInfluenceCost: true,
+                randomNumber: 0.5f)));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(proposerClanId, out var proposerClan));
+
+            var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+            Assert.Same(proposerClan, decision.ProposerClan);
+            Assert.Same(recipientKingdom, decision.Kingdom);
+            Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
+            Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
+        });
+    }
+
+    [Fact]
     public void AllianceOfferPendingStatusChanged_ClanReferences_UseOwningKingdoms()
     {
         var client = Clients.First();

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1820,7 +1820,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
 
             string compactIdOutcomes = KingdomDebugCommand.ListKingdomDecisionOutcomes(
                 new List<string> { compactRecipientClanId, "1" });
-            Assert.Equal("Decision index is out of bounds.", compactIdOutcomes);
+            Assert.StartsWith("Decision outcomes for StartAllianceDecision", compactIdOutcomes);
 
             var voteManager = GetVoteManager(client);
             voteManager.ApplyRoundStatus(new KingdomDecisionRoundStatusData(
@@ -1856,6 +1856,10 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             {
                 Clan.PlayerClan._kingdom = null;
             }
+
+            string kingdomlessCompactIdOutcomes = KingdomDebugCommand.ListKingdomDecisionOutcomes(
+                new List<string> { compactRecipientClanId, "1" });
+            Assert.StartsWith("Decision outcomes for StartAllianceDecision", kingdomlessCompactIdOutcomes);
 
             decisionsVm.OnFrameTick();
             Assert.Same(decision, decisionsVm.CurrentDecision.KingdomDecisionMaker._decision);

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -48,6 +48,7 @@ using TaleWorlds.Core;
 using TaleWorlds.Core.ViewModelCollection.Information;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
+using TaleWorlds.ObjectSystem;
 using Xunit.Abstractions;
 
 namespace E2E.Tests.Services.Kingdoms;
@@ -1994,6 +1995,72 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             string outcomes = KingdomDebugCommand.ListKingdomDecisionOutcomes(
                 new List<string> { proposerClanId, "1" });
             Assert.StartsWith("Decision outcomes for StartAllianceDecision", outcomes);
+        });
+    }
+
+    [Fact]
+    public void StartAllianceDecision_RulingClanReference_UsesRegisteredKingdomOutsideCampaignCollection()
+    {
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposerClanId = CreateSyncedNpcClan();
+        var targetRulerClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+        ConfigureClanInKingdom(proposerClanId, recipientKingdomId);
+        ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        ConfigureAllianceModelEverywhere();
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(proposerClanId, out var proposerClan));
+            using (new AllowedThread())
+            {
+                recipientKingdom._rulingClan = proposerClan;
+                KingdomCollectionSync.RemoveClan(recipientKingdom, proposerClan, publish: false);
+                Campaign.Current.CampaignObjectManager._kingdoms.Remove(recipientKingdom);
+            }
+            Assert.Null(proposerClan.Kingdom);
+            Assert.DoesNotContain(recipientKingdom, Kingdom.All);
+            Assert.Contains(recipientKingdom, MBObjectManager.Instance.GetObjectTypeList<Kingdom>());
+        });
+
+        var decisionData = new StartAllianceDecisionData(
+            proposerClanId,
+            proposerClanId,
+            triggerTime: 0,
+            isEnforced: false,
+            notifyPlayer: false,
+            playerExamined: false,
+            kingdomToStartAllianceWithId: targetKingdomId,
+            isProposedByOpponent: true);
+
+        client.Call(() => client.SimulateMessage(
+            this,
+            new NetworkAddDecision(
+                proposerClanId,
+                decisionData,
+                ignoreInfluenceCost: true,
+                randomNumber: 0.5f)));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(proposerClanId, out var proposerClan));
+
+            var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+            Assert.Same(proposerClan, decision.ProposerClan);
+            Assert.Same(recipientKingdom, decision.Kingdom);
+            Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
+            Assert.Same(recipientKingdom, proposerClan.Kingdom);
+            Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
         });
     }
 

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1824,9 +1824,14 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.StartsWith("Decision outcomes for StartAllianceDecision", compactIdOutcomes);
 
             var voteManager = GetVoteManager(client);
+            var earlierDecision = new DeclareWarDecision(recipientKingdom.RulingClan, targetKingdom);
+            using (new AllowedThread())
+            {
+                recipientKingdom._unresolvedDecisions.Insert(0, earlierDecision);
+            }
             voteManager.ApplyRoundStatus(new KingdomDecisionRoundStatusData(
                 compactRecipientClanId,
-                0,
+                1,
                 (DateTime.UtcNow + TimeSpan.FromSeconds(60)).Ticks,
                 new[]
                 {
@@ -1837,7 +1842,6 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                         hasFinalVote: false,
                         isConnected: true),
             }));
-
             Assert.False(voteManager.HasLocalPlayerSubmittedVote(decision));
             using (new AllowedThread())
             {
@@ -1859,7 +1863,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             }
 
             string kingdomlessCompactIdOutcomes = KingdomDebugCommand.ListKingdomDecisionOutcomes(
-                new List<string> { compactRecipientClanId, "1" });
+                new List<string> { compactRecipientClanId, "2" });
             Assert.StartsWith("Decision outcomes for StartAllianceDecision", kingdomlessCompactIdOutcomes);
 
             decisionsVm.OnFrameTick();
@@ -1871,6 +1875,23 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                 message => message.VoteData.IsFinal);
             Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkRequestStartAlliance>());
             Assert.True(voteManager.HasLocalPlayerSubmittedVote(decision));
+
+            CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(decision);
+            using (new AllowedThread())
+            {
+                recipientKingdom._unresolvedDecisions.Remove(earlierDecision);
+            }
+            var conflictingDecision = new StartAllianceDecision(proposingClan, conflictingKingdom);
+            using (new AllowedThread())
+            {
+                conflictingKingdom._unresolvedDecisions ??= new MBList<KingdomDecision>();
+                conflictingKingdom._unresolvedDecisions.Add(conflictingDecision);
+            }
+            voteManager.CloseDecision(compactRecipientClanId, 0);
+
+            Assert.Null(decisionsVm.CurrentDecision);
+            Assert.False(decisionItem.IsActive);
+            Assert.Same(conflictingDecision, Assert.Single(conflictingKingdom.UnresolvedDecisions));
 
             using (new AllowedThread())
             {

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -56,6 +56,12 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     private const string ControllerId = "Player";
     private const string SecondControllerId = "Player2";
     private const string KingdomName = "Real Kingdom";
+    private delegate bool AllianceGate(
+        Kingdom kingdom,
+        Kingdom targetKingdom,
+        IFaction evaluatingFaction,
+        out TextObject reason,
+        bool includeReason);
 
     private E2ETestEnvironment TestEnvironment { get; }
     private EnvironmentInstance Server => TestEnvironment.Server;
@@ -1749,6 +1755,225 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         Assert.EndsWith("=False", resolved.OutcomeKey);
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
         Assert.False(CoopKingdomElection.IsTrackedPlayerAllianceOffer(clientAllianceDecision));
+    }
+
+    [Fact]
+    public void AllianceTimeoutFixture_NormalizesLeaderRelationAndRestoresItAfterExplicitAndFailedStagePaths()
+    {
+        const string fixtureControllerId = "testclient";
+        const int initialRelation = -40;
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(fixtureControllerId);
+        var player = CreateSyncedPlayerContext(fixtureControllerId, client);
+        var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var sturgiaKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var recipientRulerClanId = CreateSyncedNpcClan();
+        var sturgiaRulerClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(recipientRulerClanId, recipientKingdomId);
+        ConfigureClanInKingdom(sturgiaRulerClanId, sturgiaKingdomId);
+        EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(sturgiaKingdomId);
+        SetKingdomStringId(Server, sturgiaKingdomId, "sturgia");
+        EnsureAllianceCampaignBehavior(Server);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+            Assert.Equal("sturgia", sturgia.StringId);
+            Assert.Contains(sturgia, Kingdom.All);
+        });
+
+        bool allowAlliance = true;
+        int gateCallCount = 0;
+        int relationChangeEventCount = 0;
+        var relationChangeListenerOwner = new object();
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+            recipientKingdom.Name = new TextObject("Recipient");
+            sturgia.Name = new TextObject("Sturgia");
+            SetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader, initialRelation);
+
+            var allianceModel = new Mock<AllianceModel>();
+            allianceModel
+                .Setup(model => model.CanMakeAlliance(
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<IFaction>(),
+                    out It.Ref<TextObject>.IsAny,
+                    It.IsAny<bool>()))
+                .Returns((AllianceGate)((Kingdom kingdom, Kingdom targetKingdom, IFaction evaluatingFaction, out TextObject reason, bool includeReason) =>
+                {
+                    gateCallCount++;
+                    reason = null;
+                    return allowAlliance && kingdom == recipientKingdom && targetKingdom == sturgia &&
+                        GetEffectiveRelation(kingdom.Leader, targetKingdom.Leader) ==
+                        Campaign.Current.Models.DiplomacyModel.MaxRelationLimit;
+                }));
+            allianceModel
+                .Setup(model => model.GetInfluenceCostOfProposingStartingAlliance(It.IsAny<Clan>()))
+                .Returns(0);
+            Campaign.Current.Models.AllianceModel = allianceModel.Object;
+        });
+
+        Server.Call(() =>
+        {
+            CampaignEvents.HeroRelationChanged.AddNonSerializedListener(
+                relationChangeListenerOwner,
+                (Hero effectiveHero, Hero effectiveTargetHero, int relationChange, bool showQuickNotification,
+                    ChangeRelationAction.ChangeRelationDetail detail, Hero originalHero, Hero originalTargetHero) =>
+                {
+                    relationChangeEventCount++;
+                });
+        });
+
+        try
+        {
+            string target = null;
+            Server.Call(() => target = KingdomDebugCommand.GetAllianceTimeoutTarget(new List<string>()));
+            Assert.StartsWith("LIVE_TEST_JSON=", target);
+            Assert.Contains($"\"kingdomId\":\"{recipientKingdomId}\"", target);
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+            });
+
+            ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+            string capture = null;
+            Server.Call(() => capture = KingdomDebugCommand.CaptureAllianceTimeoutFixture(new List<string>()));
+            Assert.StartsWith("LIVE_TEST_JSON=", capture);
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.Equal(Campaign.Current.Models.DiplomacyModel.MaxRelationLimit,
+                    GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+            });
+
+            string stage = null;
+            Server.Call(() => stage = KingdomDebugCommand.StageAllianceTimeoutFixture(
+                new List<string> { recipientKingdomId, player.ClanId, sturgiaKingdomId }));
+            Assert.StartsWith("LIVE_TEST_JSON=", stage);
+
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+                var election = new CoopKingdomElection(decision);
+                int noOutcomeIndex = election._possibleOutcomes
+                    .Select((outcome, index) => new { outcome, index })
+                    .Single(candidate => candidate.outcome is StartAllianceDecision.StartAllianceDecisionOutcome outcome &&
+                        !outcome.ShouldAllianceBeStarted)
+                    .index;
+                var finalNoVote = new KingdomDecisionVoteData(
+                    recipientKingdomId,
+                    decisionIndex: 0,
+                    outcomeIndex: noOutcomeIndex,
+                    supportWeight: (int)Supporter.SupportWeights.FullyPush,
+                    isAbstain: false,
+                    isFinal: true);
+
+                Assert.True(GetConcreteVoteManager(Server).HandleVoteRequest(fixtureControllerId, finalNoVote));
+                Assert.Empty(recipientKingdom.UnresolvedDecisions);
+            });
+            NetworkKingdomDecisionResolved finalNoResolution = Assert.Single(
+                Server.NetworkSentMessages.GetMessages<NetworkKingdomDecisionResolved>(),
+                message => message.KingdomId == recipientKingdomId && message.DecisionIndex == 0);
+            Assert.EndsWith("=False", finalNoResolution.OutcomeKey);
+            Assert.Empty(Server.InternalMessages.GetMessages<AllianceStarted>());
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+
+            string serverState = null;
+            Server.Call(() => serverState = KingdomDebugCommand.GetAllianceTimeoutServerState(
+                new List<string> { recipientKingdomId, sturgiaKingdomId }));
+            Assert.Contains("\"success\":true", serverState);
+
+            string restore = null;
+            Server.Call(() => restore = KingdomDebugCommand.RestoreAllianceTimeoutFixture(
+                new List<string> { recipientKingdomId, sturgiaKingdomId, bool.FalseString }));
+            Assert.StartsWith("LIVE_TEST_JSON=", restore);
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Empty(recipientKingdom.UnresolvedDecisions);
+            });
+
+            Server.Call(() => capture = KingdomDebugCommand.CaptureAllianceTimeoutFixture(new List<string>()));
+            Assert.StartsWith("LIVE_TEST_JSON=", capture);
+
+            Server.Call(() => stage = KingdomDebugCommand.StageAllianceTimeoutFixture(
+                new List<string> { recipientKingdomId, player.ClanId, sturgiaKingdomId }));
+            Assert.StartsWith("LIVE_TEST_JSON=", stage);
+
+            int resolutionCountBeforeTimeout = Server.NetworkSentMessages
+                .GetMessages<NetworkKingdomDecisionResolved>()
+                .Count(message => message.KingdomId == recipientKingdomId && message.DecisionIndex == 0);
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+
+                GetConcreteVoteManager(Server).ProcessVotingRounds(
+                    DateTime.UtcNow + KingdomDecisionVoteManager.VotingRoundDuration + TimeSpan.FromSeconds(1));
+
+                Assert.Empty(recipientKingdom.UnresolvedDecisions);
+            });
+            Assert.Equal(
+                resolutionCountBeforeTimeout + 1,
+                Server.NetworkSentMessages
+                    .GetMessages<NetworkKingdomDecisionResolved>()
+                    .Count(message => message.KingdomId == recipientKingdomId && message.DecisionIndex == 0));
+            NetworkKingdomDecisionResolved timeoutResolution = Server.NetworkSentMessages
+                .GetMessages<NetworkKingdomDecisionResolved>()
+                .Last(message => message.KingdomId == recipientKingdomId && message.DecisionIndex == 0);
+            Assert.EndsWith("=False", timeoutResolution.OutcomeKey);
+            Assert.Empty(Server.InternalMessages.GetMessages<AllianceStarted>());
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+
+            Server.Call(() => serverState = KingdomDebugCommand.GetAllianceTimeoutServerState(
+                new List<string> { recipientKingdomId, sturgiaKingdomId }));
+            Assert.Contains("\"success\":true", serverState);
+
+            Server.Call(() => restore = KingdomDebugCommand.RestoreAllianceTimeoutFixture(
+                new List<string> { recipientKingdomId, sturgiaKingdomId, bool.FalseString }));
+            Assert.StartsWith("LIVE_TEST_JSON=", restore);
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Empty(recipientKingdom.UnresolvedDecisions);
+            });
+
+            Server.Call(() => capture = KingdomDebugCommand.CaptureAllianceTimeoutFixture(new List<string>()));
+            Assert.StartsWith("LIVE_TEST_JSON=", capture);
+            allowAlliance = false;
+
+            Server.Call(() => stage = KingdomDebugCommand.StageAllianceTimeoutFixture(
+                new List<string> { recipientKingdomId, player.ClanId, sturgiaKingdomId }));
+            Assert.Contains("cannot currently receive a valid alliance offer", stage);
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+                Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(sturgiaKingdomId, out var sturgia));
+                Assert.Equal(initialRelation, GetEffectiveRelation(recipientKingdom.Leader, sturgia.Leader));
+                Assert.Empty(recipientKingdom.UnresolvedDecisions);
+            });
+            Assert.True(gateCallCount >= 6);
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+        }
+        finally
+        {
+            Server.Call(() => CampaignEvents.HeroRelationChanged.ClearListeners(relationChangeListenerOwner));
+        }
+
+        Assert.Equal(0, relationChangeEventCount);
     }
 
     [Fact]
@@ -3487,7 +3712,10 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         instance.Call(() =>
         {
             Assert.True(instance.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
-            kingdom.StringId = stringId;
+            using (new AllowedThread())
+            {
+                kingdom.StringId = stringId;
+            }
         });
     }
 
@@ -3769,6 +3997,43 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.True(instance.ObjectManager.TryGetObject<Kingdom>(faction2Id, out var faction2));
             VillageHostileFactionStanceHelper.ApplyWarStance(faction1, faction2);
             Assert.True(FactionManager.IsAtWarAgainstFaction(faction1, faction2));
+        });
+    }
+
+    private static int GetEffectiveRelation(Hero hero1, Hero hero2)
+    {
+        Campaign.Current.Models.DiplomacyModel.GetHeroesForEffectiveRelation(
+            hero1,
+            hero2,
+            out Hero effectiveHero1,
+            out Hero effectiveHero2);
+        Assert.NotNull(effectiveHero1);
+        Assert.NotNull(effectiveHero2);
+        Assert.NotSame(effectiveHero1, effectiveHero2);
+        return CharacterRelationManager.GetHeroRelation(effectiveHero1, effectiveHero2);
+    }
+
+    private static void SetEffectiveRelation(Hero hero1, Hero hero2, int value)
+    {
+        Campaign.Current.Models.DiplomacyModel.GetHeroesForEffectiveRelation(
+            hero1,
+            hero2,
+            out Hero effectiveHero1,
+            out Hero effectiveHero2);
+        Assert.NotNull(effectiveHero1);
+        Assert.NotNull(effectiveHero2);
+        Assert.NotSame(effectiveHero1, effectiveHero2);
+        CharacterRelationManager.SetHeroRelation(effectiveHero1, effectiveHero2, value);
+    }
+
+    private static void EnsureAllianceCampaignBehavior(EnvironmentInstance instance)
+    {
+        instance.Call(() =>
+        {
+            if (Campaign.Current.GetCampaignBehavior<AllianceCampaignBehavior>() != null) return;
+
+            ((CampaignBehaviorManager)Campaign.Current.CampaignBehaviorManager)
+                .AddBehavior(new AllianceCampaignBehavior());
         });
     }
 

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1818,6 +1818,10 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.Empty(conflictingKingdom.UnresolvedDecisions);
             Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
 
+            string compactIdOutcomes = KingdomDebugCommand.ListKingdomDecisionOutcomes(
+                new List<string> { compactRecipientClanId, "1" });
+            Assert.Equal("Decision index is out of bounds.", compactIdOutcomes);
+
             var voteManager = GetVoteManager(client);
             voteManager.ApplyRoundStatus(new KingdomDecisionRoundStatusData(
                 compactRecipientClanId,
@@ -1982,6 +1986,10 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.Same(recipientKingdom, proposerClan.Kingdom);
             Assert.Contains(proposerClan, recipientKingdom.Clans);
             Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
+
+            string outcomes = KingdomDebugCommand.ListKingdomDecisionOutcomes(
+                new List<string> { proposerClanId, "1" });
+            Assert.StartsWith("Decision outcomes for StartAllianceDecision", outcomes);
         });
     }
 

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1755,6 +1755,105 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
+    public void StartAllianceDecision_ClanTypedOuterKingdomId_UsesProposerCurrentKingdom()
+    {
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var recipientRulerClanId = CreateSyncedNpcClan();
+        var targetRulerClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(recipientRulerClanId, recipientKingdomId);
+        ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+        ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        ConfigureAllianceModelEverywhere();
+
+        var decisionData = new StartAllianceDecisionData(
+            recipientRulerClanId,
+            player.ClanId,
+            triggerTime: 0,
+            isEnforced: false,
+            notifyPlayer: false,
+            playerExamined: false,
+            kingdomToStartAllianceWithId: targetKingdomId,
+            isProposedByOpponent: true);
+
+        client.Call(() => client.SimulateMessage(
+            this,
+            new NetworkAddDecision(
+                player.ClanId,
+                decisionData,
+                ignoreInfluenceCost: true,
+                randomNumber: 0.5f)));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+
+            var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+            Assert.Same(recipientRulerClan, decision.ProposerClan);
+            Assert.Same(recipientKingdom, decision.Kingdom);
+            Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
+            Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
+        });
+    }
+
+    [Fact]
+    public void StartAllianceDecision_ValidSerializedKingdom_RemainsAuthoritativeAfterProposerMoves()
+    {
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposerCurrentKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposerClanId = CreateSyncedNpcClan();
+        var targetRulerClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+        ConfigureClanInKingdom(proposerClanId, proposerCurrentKingdomId);
+        ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(proposerCurrentKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        ConfigureAllianceModelEverywhere();
+
+        var decisionData = new StartAllianceDecisionData(
+            proposerClanId,
+            recipientKingdomId,
+            triggerTime: 0,
+            isEnforced: false,
+            notifyPlayer: false,
+            playerExamined: false,
+            kingdomToStartAllianceWithId: targetKingdomId,
+            isProposedByOpponent: true);
+
+        client.Call(() => client.SimulateMessage(
+            this,
+            new NetworkAddDecision(
+                player.ClanId,
+                decisionData,
+                ignoreInfluenceCost: true,
+                randomNumber: 0.5f)));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(proposerCurrentKingdomId, out var proposerCurrentKingdom));
+
+            var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+            Assert.Same(recipientKingdom, decision.Kingdom);
+            Assert.Empty(proposerCurrentKingdom.UnresolvedDecisions);
+        });
+    }
+
+    [Fact]
     public void AllianceTimeoutFixture_NormalizesEveryReversibleEligibilityInputAndRestoresThemAfterExplicitAndFailedStagePaths()
     {
         const string fixtureControllerId = "testclient";

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -8,6 +8,7 @@ using Coop.Core.Server.Services.Stances.Messages;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Util;
+using GameInterface.Services.Alliances.Messages;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Messages;
@@ -26,12 +27,15 @@ using GameInterface.Services.Stances.Messages;
 using GameInterface.Services.UI.Notifications.Messages;
 using GameInterface.Services.Villages.Interfaces;
 using HarmonyLib;
+using Moq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Encyclopedia;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.ComponentInterfaces;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
@@ -1046,6 +1050,38 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
+    public void KingdomDecisionUi_DecisionRemovedBeforeRegistration_ClosesLateModal()
+    {
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+
+        ConfigureClanInKingdom(player.ClanId, kingdomId);
+        EnsureKingdomRegisteredEverywhere(kingdomId);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(player.ClanId, out var proposerClan));
+            PolicyObject policy = PolicyObject.All.First(candidate => !kingdom.ActivePolicies.Contains(candidate));
+            var decision = new KingdomPolicyDecision(proposerClan, policy, false);
+
+            using (new AllowedThread())
+            {
+                kingdom._unresolvedDecisions.Add(decision);
+                kingdom._unresolvedDecisions.Remove(decision);
+            }
+
+            var decisionsVm = new KingdomDecisionsVM(() => { });
+            decisionsVm.RefreshWith(decision);
+
+            Assert.Null(decisionsVm.CurrentDecision);
+            Assert.Empty(GetVoteManager(client).GetDecisionDebugInfo(kingdom));
+        });
+    }
+
+    [Fact]
     public void KingdomDecisionResolution_DoesNotReopenBeforeRemovalApplies()
     {
         var client = Clients.First();
@@ -1419,7 +1455,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
-    public void NpcPeaceOffer_TargetingPlayerKingdom_ExpiresAsDeclined()
+    public void NpcPeaceOffer_TargetingPlayerKingdom_WaitsForVotingDeadlineThenDeclines()
     {
         var player = CreateSyncedPlayerContext(ControllerId, Clients.First());
         var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
@@ -1450,11 +1486,268 @@ public class PlayerKingdomCreationFlowTests : IDisposable
 
             CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
 
+            Assert.Same(playerDecision, Assert.Single(playerKingdom.UnresolvedDecisions));
+            Assert.True(FactionManager.IsAtWarAgainstFaction(playerKingdom, enemyKingdom));
+
+            GetConcreteVoteManager(Server).ProcessVotingRounds(
+                DateTime.UtcNow + KingdomDecisionVoteManager.VotingRoundDuration + TimeSpan.FromSeconds(1));
+
             Assert.Empty(playerKingdom.UnresolvedDecisions);
             Assert.True(FactionManager.IsAtWarAgainstFaction(playerKingdom, enemyKingdom));
         });
 
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkMakePeace>());
+    }
+
+    [Fact]
+    public void NpcAllianceOffer_TargetingPlayerKingdom_WaitsForVotingDeadlineThenDeclines()
+    {
+        var player = CreateSyncedPlayerContext(ControllerId, Clients.First());
+        var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, playerKingdomId);
+        ConfigureClanInKingdom(proposingClanId, proposingKingdomId);
+        EnsureKingdomRegisteredEverywhere(playerKingdomId);
+        EnsureKingdomRegisteredEverywhere(proposingKingdomId);
+        ConfigureKingdomCultureEverywhere(playerKingdomId, player.CultureId);
+        ConfigureAllianceModelEverywhere();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(proposingKingdomId, out var proposingKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
+
+            var npcDecision = new StartAllianceDecision(proposingClan, playerKingdom);
+            var allianceOutcome = npcDecision.DetermineInitialCandidates()
+                .OfType<StartAllianceDecision.StartAllianceDecisionOutcome>()
+                .Single(outcome => outcome.ShouldAllianceBeStarted);
+            Assert.True(CoopKingdomElection.TryRedirectPlayerAllianceOffer(npcDecision, allianceOutcome));
+
+            var playerDecision = Assert.IsType<StartAllianceDecision>(
+                Assert.Single(playerKingdom.UnresolvedDecisions));
+            playerDecision.TriggerTime = CampaignTime.Zero;
+
+            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+
+            Assert.Same(playerDecision, Assert.Single(playerKingdom.UnresolvedDecisions));
+            Assert.Contains(playerDecision, CoopKingdomElection._opponentProposedAllianceDecisions);
+
+            GetConcreteVoteManager(Server).ProcessVotingRounds(
+                DateTime.UtcNow + KingdomDecisionVoteManager.VotingRoundDuration + TimeSpan.FromSeconds(1));
+
+            Assert.Empty(playerKingdom.UnresolvedDecisions);
+            Assert.DoesNotContain(playerDecision, CoopKingdomElection._opponentProposedAllianceDecisions);
+        });
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+    }
+
+    [Fact]
+    public void NpcAllianceOffer_ReloadedBeforeVotingDeadline_StillDeclines()
+    {
+        var player = CreateSyncedPlayerContext(ControllerId, Clients.First());
+        var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, playerKingdomId);
+        ConfigureClanInKingdom(proposingClanId, proposingKingdomId);
+        EnsureKingdomRegisteredEverywhere(playerKingdomId);
+        EnsureKingdomRegisteredEverywhere(proposingKingdomId);
+        ConfigureKingdomCultureEverywhere(playerKingdomId, player.CultureId);
+        ConfigureAllianceModelEverywhere();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(proposingKingdomId, out var proposingKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
+
+            var outgoingDecision = new StartAllianceDecision(playerKingdom.RulingClan, proposingKingdom);
+            Assert.True(CoopKingdomElection.IsPlayerAllianceDecision(outgoingDecision));
+            Assert.False(CoopKingdomElection.IsPendingPlayerAllianceOffer(outgoingDecision));
+
+            var npcDecision = new StartAllianceDecision(proposingClan, playerKingdom);
+            var allianceOutcome = npcDecision.DetermineInitialCandidates()
+                .OfType<StartAllianceDecision.StartAllianceDecisionOutcome>()
+                .Single(outcome => outcome.ShouldAllianceBeStarted);
+            Assert.True(CoopKingdomElection.TryRedirectPlayerAllianceOffer(npcDecision, allianceOutcome));
+
+            var playerDecision = Assert.IsType<StartAllianceDecision>(
+                Assert.Single(playerKingdom.UnresolvedDecisions));
+            playerDecision.TriggerTime = CampaignTime.Zero;
+
+            var saveRecords = new Dictionary<string, object>();
+            CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
+                new TestDataStore(isSaving: true, saveRecords));
+            CoopKingdomElection._opponentProposedAllianceDecisions.Clear();
+            CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
+                new TestDataStore(isSaving: false, saveRecords));
+
+            Assert.Contains(playerDecision, CoopKingdomElection._opponentProposedAllianceDecisions);
+            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+            GetConcreteVoteManager(Server).ProcessVotingRounds(
+                DateTime.UtcNow + KingdomDecisionVoteManager.VotingRoundDuration + TimeSpan.FromSeconds(1));
+
+            Assert.Empty(playerKingdom.UnresolvedDecisions);
+            Assert.DoesNotContain(playerDecision, CoopKingdomElection._opponentProposedAllianceDecisions);
+        });
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+    }
+
+    [Fact]
+    public void NpcAllianceOffer_LegacyReloadWithoutProvenance_StillDeclines()
+    {
+        var player = CreateSyncedPlayerContext(ControllerId, Clients.First());
+        var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, playerKingdomId);
+        ConfigureClanInKingdom(proposingClanId, proposingKingdomId);
+        EnsureKingdomRegisteredEverywhere(playerKingdomId);
+        EnsureKingdomRegisteredEverywhere(proposingKingdomId);
+        ConfigureKingdomCultureEverywhere(playerKingdomId, player.CultureId);
+        ConfigureAllianceModelEverywhere();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
+
+            var npcDecision = new StartAllianceDecision(proposingClan, playerKingdom);
+            var allianceOutcome = npcDecision.DetermineInitialCandidates()
+                .OfType<StartAllianceDecision.StartAllianceDecisionOutcome>()
+                .Single(outcome => outcome.ShouldAllianceBeStarted);
+            Assert.True(CoopKingdomElection.TryRedirectPlayerAllianceOffer(npcDecision, allianceOutcome));
+
+            var playerDecision = Assert.IsType<StartAllianceDecision>(
+                Assert.Single(playerKingdom.UnresolvedDecisions));
+            playerDecision.TriggerTime = CampaignTime.Zero;
+
+            var playerManager = Server.Resolve<IPlayerManager>();
+            Assert.True(playerManager.TryGetPlayer(ControllerId, out var registeredPlayer));
+            Assert.True(playerManager.RemovePlayer(registeredPlayer));
+
+            CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
+                new TestDataStore(isSaving: false, new Dictionary<string, object>()));
+
+            Assert.DoesNotContain(playerDecision, CoopKingdomElection._opponentProposedAllianceDecisions);
+            Assert.False(CoopKingdomElection.IsPendingPlayerAllianceOffer(playerDecision));
+            var resavedRecords = new Dictionary<string, object>();
+            CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
+                new TestDataStore(isSaving: true, resavedRecords));
+            Assert.Empty(resavedRecords);
+            CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
+                new TestDataStore(isSaving: false, resavedRecords));
+            Assert.True(playerManager.AddPlayer(registeredPlayer));
+            Assert.True(CoopKingdomElection.IsPendingPlayerAllianceOffer(playerDecision));
+            Assert.True(playerDecision.OnShowDecision());
+            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+            GetConcreteVoteManager(Server).ProcessVotingRounds(
+                DateTime.UtcNow + KingdomDecisionVoteManager.VotingRoundDuration + TimeSpan.FromSeconds(1));
+
+            Assert.Empty(playerKingdom.UnresolvedDecisions);
+        });
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+    }
+
+    [Fact]
+    public void NpcAllianceOffer_TargetingPlayerKingdom_NoVoteClosesDecisionWithoutAlliance()
+    {
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var playerKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var playerKingdomNpcClanId = CreateSyncedNpcClan();
+        var proposingClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(playerKingdomNpcClanId, playerKingdomId);
+        ConfigureClanInKingdom(player.ClanId, playerKingdomId);
+        ConfigureClanInKingdom(proposingClanId, proposingKingdomId);
+        EnsureKingdomRegisteredEverywhere(playerKingdomId);
+        EnsureKingdomRegisteredEverywhere(proposingKingdomId);
+        ConfigureKingdomCultureEverywhere(playerKingdomId, player.CultureId);
+        ConfigureAllianceModelEverywhere();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
+
+            var npcDecision = new StartAllianceDecision(proposingClan, playerKingdom);
+            Assert.False(npcDecision.OnShowDecision());
+            var allianceOutcome = npcDecision.DetermineInitialCandidates()
+                .OfType<StartAllianceDecision.StartAllianceDecisionOutcome>()
+                .Single(outcome => outcome.ShouldAllianceBeStarted);
+            Assert.True(CoopKingdomElection.TryRedirectPlayerAllianceOffer(npcDecision, allianceOutcome));
+
+            var playerDecision = Assert.IsType<StartAllianceDecision>(
+                Assert.Single(playerKingdom.UnresolvedDecisions));
+            playerDecision.TriggerTime = CampaignTime.Zero;
+            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+
+            Assert.Same(playerDecision, Assert.Single(playerKingdom.UnresolvedDecisions));
+        });
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+
+        StartAllianceDecision clientAllianceDecision = null;
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(player.HeroId, out var playerHero));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(player.PartyId, out var playerParty));
+            using (new AllowedThread())
+            {
+                playerParty._partyComponent = new LordPartyComponent(playerHero, playerHero, null);
+            }
+            var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(playerKingdom.UnresolvedDecisions));
+            clientAllianceDecision = decision;
+            Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
+            Assert.NotSame(Clan.PlayerClan, decision.DetermineChooser());
+            Assert.True(new KingdomElection(decision).IsPlayerSupporter);
+            Assert.False(decision.IsSingleClanDecision());
+            Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkRequestStartAlliance>());
+            Campaign.Current.EncyclopediaManager ??= new EncyclopediaManager();
+            Campaign.Current.EncyclopediaManager.CreateEncyclopediaPages();
+            var decisionsVm = new KingdomDecisionsVM(() => { });
+            decisionsVm.RefreshWith(decision);
+
+            DecisionItemBaseVM decisionItem = decisionsVm.CurrentDecision;
+            DecisionOptionVM noOption = decisionItem.DecisionOptionsList.Single(candidate =>
+                candidate.Option is StartAllianceDecision.StartAllianceDecisionOutcome outcome &&
+                !outcome.ShouldAllianceBeStarted);
+            noOption.CurrentSupportWeight = Supporter.SupportWeights.FullyPush;
+            decisionItem._currentSelectedOption = noOption;
+            Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkRequestStartAlliance>());
+
+            decisionItem.ExecuteFinalSelection();
+
+            NetworkRequestKingdomDecisionVote finalVote = Assert.Single(
+                client.NetworkSentMessages.GetMessages<NetworkRequestKingdomDecisionVote>(),
+                message => message.VoteData.IsFinal);
+            Assert.EndsWith("=False", finalVote.VoteData.OutcomeKey);
+            Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkRequestStartAlliance>());
+            Assert.Null(decisionsVm.CurrentDecision);
+            Assert.False(decisionItem.IsActive);
+        });
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(playerKingdomId, out var playerKingdom));
+            Assert.Empty(playerKingdom.UnresolvedDecisions);
+        });
+        NetworkKingdomDecisionResolved resolved = Assert.Single(
+            Server.NetworkSentMessages.GetMessages<NetworkKingdomDecisionResolved>());
+        Assert.EndsWith("=False", resolved.OutcomeKey);
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());
+        Assert.False(CoopKingdomElection.IsTrackedPlayerAllianceOffer(clientAllianceDecision));
     }
 
     [Fact]
@@ -3478,6 +3771,63 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         });
     }
 
+    private void ConfigureAllianceModelEverywhere()
+    {
+        ConfigureAllianceModel(Server);
+        foreach (var client in Clients)
+        {
+            ConfigureAllianceModel(client);
+        }
+    }
+
+    private static void ConfigureAllianceModel(EnvironmentInstance instance)
+    {
+        instance.Call(() =>
+        {
+            var allianceModel = new Mock<AllianceModel>();
+            allianceModel
+                .Setup(model => model.GetSupportScoreOfStartingAllianceForClan(
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<Clan>(),
+                    out It.Ref<TextObject>.IsAny,
+                    It.IsAny<bool>()))
+                .Returns(0f);
+            allianceModel
+                .Setup(model => model.CanMakeAlliance(
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<Kingdom>(),
+                    It.IsAny<IFaction>(),
+                    out It.Ref<TextObject>.IsAny,
+                    It.IsAny<bool>()))
+                .Returns(true);
+            allianceModel
+                .Setup(model => model.GetInfluenceCostOfProposingStartingAlliance(It.IsAny<Clan>()))
+                .Returns(0);
+
+            Campaign.Current.Models.AllianceModel = allianceModel.Object;
+        });
+    }
+
+    private void ConfigureKingdomCultureEverywhere(string kingdomId, string cultureId)
+    {
+        ConfigureKingdomCulture(Server, kingdomId, cultureId);
+        foreach (var client in Clients)
+        {
+            ConfigureKingdomCulture(client, kingdomId, cultureId);
+        }
+    }
+
+    private static void ConfigureKingdomCulture(EnvironmentInstance instance, string kingdomId, string cultureId)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            Assert.True(instance.ObjectManager.TryGetObject<CultureObject>(cultureId, out var culture));
+            kingdom.Culture = culture;
+        });
+    }
+
     /// <summary>
     /// The debug create command inherits the new kingdom's culture from the ruling clan, which the shared
     /// player context leaves unset.
@@ -3582,6 +3932,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                 hero.Clan = clan;
                 clan.SetLeader(hero);
                 character.HeroObject = hero;
+                hero._characterObject = character;
                 if (setAsMainHero)
                 {
                     Game.Current.PlayerTroop = character;
@@ -3716,4 +4067,31 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         string PartyId,
         string CharacterId,
         string CultureId);
+
+    private sealed class TestDataStore : IDataStore
+    {
+        private readonly Dictionary<string, object> records;
+
+        public bool IsSaving { get; }
+        public bool IsLoading => !IsSaving;
+
+        public TestDataStore(bool isSaving, Dictionary<string, object> records)
+        {
+            IsSaving = isSaving;
+            this.records = records;
+        }
+
+        public bool SyncData<T>(string key, ref T data)
+        {
+            if (IsSaving)
+            {
+                records[key] = data;
+                return true;
+            }
+
+            if (!records.TryGetValue(key, out object value)) return false;
+            data = (T)value;
+            return true;
+        }
+    }
 }

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1690,6 +1690,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
 
             var playerDecision = Assert.IsType<StartAllianceDecision>(
                 Assert.Single(playerKingdom.UnresolvedDecisions));
+            Assert.Same(playerKingdom.RulingClan, playerDecision.ProposerClan);
             playerDecision.TriggerTime = CampaignTime.Zero;
             CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
 

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1811,6 +1811,23 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.Empty(proposingKingdom.UnresolvedDecisions);
             Assert.Empty(conflictingKingdom.UnresolvedDecisions);
             Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
+
+            var voteManager = GetVoteManager(client);
+            voteManager.ApplyRoundStatus(new KingdomDecisionRoundStatusData(
+                compactRecipientClanId,
+                0,
+                (DateTime.UtcNow + TimeSpan.FromSeconds(60)).Ticks,
+                new[]
+                {
+                    new KingdomDecisionRoundClanStatusData(
+                        player.ClanId,
+                        player.ClanId,
+                        ControllerId,
+                        hasFinalVote: true,
+                        isConnected: true),
+                }));
+
+            Assert.True(voteManager.HasLocalPlayerSubmittedVote(decision));
         });
     }
 

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1774,6 +1774,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         EnsureKingdomRegisteredEverywhere(recipientKingdomId);
         EnsureKingdomRegisteredEverywhere(proposingKingdomId);
         EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        ConfigureKingdomCultureEverywhere(recipientKingdomId, player.CultureId);
         ConfigureAllianceModelEverywhere();
         var compactRecipientClanId = ObjectManager.Compact(player.ClanId, typeof(Clan));
         Assert.Equal(ObjectManager.Compact(conflictingKingdomId, typeof(Kingdom)), compactRecipientClanId);
@@ -1787,6 +1788,9 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             playerExamined: false,
             kingdomToStartAllianceWithId: targetKingdomId,
             isProposedByOpponent: true);
+
+        KingdomDecisionsVM decisionsVm = null;
+        client.Call(() => decisionsVm = new KingdomDecisionsVM(() => { }));
 
         client.Call(() => client.SimulateMessage(
             this,
@@ -1803,6 +1807,8 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
             Assert.True(client.ObjectManager.TryGetObject<Kingdom>(conflictingKingdomId, out var conflictingKingdom));
             Assert.True(client.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(player.HeroId, out var playerHero));
+            Assert.True(client.ObjectManager.TryGetObject<MobileParty>(player.PartyId, out var playerParty));
 
             var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
             Assert.Same(proposingClan, decision.ProposerClan);
@@ -1823,11 +1829,44 @@ public class PlayerKingdomCreationFlowTests : IDisposable
                         player.ClanId,
                         player.ClanId,
                         ControllerId,
-                        hasFinalVote: true,
+                        hasFinalVote: false,
                         isConnected: true),
-                }));
+            }));
 
+            Assert.False(voteManager.HasLocalPlayerSubmittedVote(decision));
+            using (new AllowedThread())
+            {
+                playerParty._partyComponent = new LordPartyComponent(playerHero, playerHero, null);
+            }
+            Campaign.Current.EncyclopediaManager ??= new EncyclopediaManager();
+            Campaign.Current.EncyclopediaManager.CreateEncyclopediaPages();
+            decisionsVm.RefreshWith(decision);
+            DecisionItemBaseVM decisionItem = decisionsVm.CurrentDecision;
+            DecisionOptionVM noOption = decisionItem.DecisionOptionsList.Single(candidate =>
+                candidate.Option is StartAllianceDecision.StartAllianceDecisionOutcome outcome &&
+                !outcome.ShouldAllianceBeStarted);
+            noOption.CurrentSupportWeight = Supporter.SupportWeights.FullyPush;
+            decisionItem._currentSelectedOption = noOption;
+
+            using (new AllowedThread())
+            {
+                Clan.PlayerClan._kingdom = null;
+            }
+
+            decisionsVm.OnFrameTick();
+            Assert.Same(decision, decisionsVm.CurrentDecision.KingdomDecisionMaker._decision);
+            decisionItem.ExecuteFinalSelection();
+
+            Assert.Single(
+                client.NetworkSentMessages.GetMessages<NetworkRequestKingdomDecisionVote>(),
+                message => message.VoteData.IsFinal);
+            Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkRequestStartAlliance>());
             Assert.True(voteManager.HasLocalPlayerSubmittedVote(decision));
+
+            using (new AllowedThread())
+            {
+                Clan.PlayerClan._kingdom = recipientKingdom;
+            }
         });
     }
 

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1760,6 +1760,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         var client = Clients.First();
         client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
         var player = CreateSyncedPlayerContext(ControllerId, client);
+        var conflictingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var proposingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
@@ -1769,14 +1770,17 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
         ConfigureClanInKingdom(proposingClanId, proposingKingdomId);
         ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(conflictingKingdomId);
         EnsureKingdomRegisteredEverywhere(recipientKingdomId);
         EnsureKingdomRegisteredEverywhere(proposingKingdomId);
         EnsureKingdomRegisteredEverywhere(targetKingdomId);
         ConfigureAllianceModelEverywhere();
+        var compactRecipientClanId = ObjectManager.Compact(player.ClanId, typeof(Clan));
+        Assert.Equal(ObjectManager.Compact(conflictingKingdomId, typeof(Kingdom)), compactRecipientClanId);
 
         var decisionData = new StartAllianceDecisionData(
             proposingClanId,
-            player.ClanId,
+            compactRecipientClanId,
             triggerTime: 0,
             isEnforced: false,
             notifyPlayer: false,
@@ -1787,7 +1791,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         client.Call(() => client.SimulateMessage(
             this,
             new NetworkAddDecision(
-                player.ClanId,
+                compactRecipientClanId,
                 decisionData,
                 ignoreInfluenceCost: true,
                 randomNumber: 0.5f)));
@@ -1797,6 +1801,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
             Assert.True(client.ObjectManager.TryGetObject<Kingdom>(proposingKingdomId, out var proposingKingdom));
             Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(conflictingKingdomId, out var conflictingKingdom));
             Assert.True(client.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
 
             var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
@@ -1804,6 +1809,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.Same(recipientKingdom, decision.Kingdom);
             Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
             Assert.Empty(proposingKingdom.UnresolvedDecisions);
+            Assert.Empty(conflictingKingdom.UnresolvedDecisions);
             Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
         });
     }

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1590,6 +1590,8 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             var saveRecords = new Dictionary<string, object>();
             CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
                 new TestDataStore(isSaving: true, saveRecords));
+            Assert.True(saveRecords.TryGetValue("_coop_pending_player_alliance_offers", out object savedOffers));
+            Assert.Contains(playerDecision, Assert.IsType<List<KingdomDecision>>(savedOffers));
             CoopKingdomElection._opponentProposedAllianceDecisions.Clear();
             CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
                 new TestDataStore(isSaving: false, saveRecords));
@@ -1652,7 +1654,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             CoopKingdomDecisionProposalBehaviorPatch.SyncPendingPlayerAllianceOffers(
                 new TestDataStore(isSaving: true, resavedRecords));
             Assert.True(resavedRecords.TryGetValue("_coop_pending_player_alliance_offers", out object savedOffers));
-            Assert.Empty(Assert.IsType<List<StartAllianceDecision>>(savedOffers));
+            Assert.Empty(Assert.IsType<List<KingdomDecision>>(savedOffers));
         });
 
         Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkAllianceStarted>());

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1755,25 +1755,27 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
-    public void StartAllianceDecision_ClanTypedOuterKingdomId_UsesProposerCurrentKingdom()
+    public void StartAllianceDecision_ClanTypedDecisionKingdomId_UsesReferencedClanKingdom()
     {
         var client = Clients.First();
         client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
         var player = CreateSyncedPlayerContext(ControllerId, client);
         var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
-        var recipientRulerClanId = CreateSyncedNpcClan();
+        var proposingClanId = CreateSyncedNpcClan();
         var targetRulerClanId = CreateSyncedNpcClan();
 
-        ConfigureClanInKingdom(recipientRulerClanId, recipientKingdomId);
         ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+        ConfigureClanInKingdom(proposingClanId, proposingKingdomId);
         ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
         EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(proposingKingdomId);
         EnsureKingdomRegisteredEverywhere(targetKingdomId);
         ConfigureAllianceModelEverywhere();
 
         var decisionData = new StartAllianceDecisionData(
-            recipientRulerClanId,
+            proposingClanId,
             player.ClanId,
             triggerTime: 0,
             isEnforced: false,
@@ -1793,13 +1795,15 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         client.Call(() =>
         {
             Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(proposingKingdomId, out var proposingKingdom));
             Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
-            Assert.True(client.ObjectManager.TryGetObject<Clan>(recipientRulerClanId, out var recipientRulerClan));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(proposingClanId, out var proposingClan));
 
             var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
-            Assert.Same(recipientRulerClan, decision.ProposerClan);
+            Assert.Same(proposingClan, decision.ProposerClan);
             Assert.Same(recipientKingdom, decision.Kingdom);
             Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
+            Assert.Empty(proposingKingdom.UnresolvedDecisions);
             Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
         });
     }

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1864,6 +1864,64 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
+    public void StartAllianceDecision_DetachedClanDecisionKingdomReference_UsesProposerKingdom()
+    {
+        const string detachedClanReferenceId = "Clan_detached-alliance-kingdom";
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        var player = CreateSyncedPlayerContext(ControllerId, client);
+        var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var proposerClanId = CreateSyncedNpcClan();
+        var targetRulerClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
+        ConfigureClanInKingdom(proposerClanId, recipientKingdomId);
+        ConfigureClanInKingdom(targetRulerClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(recipientKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        ConfigureAllianceModelEverywhere();
+
+        client.Call(() =>
+        {
+            var detachedClanReference = ObjectHelper.SkipConstructor<Clan>();
+            Assert.Null(detachedClanReference.Kingdom);
+            Assert.True(client.ObjectManager.AddExisting(detachedClanReferenceId, detachedClanReference));
+        });
+
+        var decisionData = new StartAllianceDecisionData(
+            proposerClanId,
+            detachedClanReferenceId,
+            triggerTime: 0,
+            isEnforced: false,
+            notifyPlayer: false,
+            playerExamined: false,
+            kingdomToStartAllianceWithId: targetKingdomId,
+            isProposedByOpponent: true);
+
+        client.Call(() => client.SimulateMessage(
+            this,
+            new NetworkAddDecision(
+                detachedClanReferenceId,
+                decisionData,
+                ignoreInfluenceCost: true,
+                randomNumber: 0.5f)));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(proposerClanId, out var proposerClan));
+
+            var decision = Assert.IsType<StartAllianceDecision>(Assert.Single(recipientKingdom.UnresolvedDecisions));
+            Assert.Same(proposerClan, decision.ProposerClan);
+            Assert.Same(recipientKingdom, decision.Kingdom);
+            Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
+            Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
+        });
+    }
+
+    [Fact]
     public void StartAllianceDecision_ClanTypedTargetKingdomId_UsesReferencedClanKingdom()
     {
         const string compactTargetClanId = "target-alliance-collision";

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1993,6 +1993,34 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
+    public void AllianceOfferPendingStatusChanged_ClanReferences_UseOwningKingdoms()
+    {
+        var client = Clients.First();
+        var requestingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var requestingClanId = CreateSyncedNpcClan();
+        var targetClanId = CreateSyncedNpcClan();
+
+        ConfigureClanInKingdom(requestingClanId, requestingKingdomId);
+        ConfigureClanInKingdom(targetClanId, targetKingdomId);
+        EnsureKingdomRegisteredEverywhere(requestingKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(requestingKingdomId, out var requestingKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+
+            client.SimulateMessage(
+                this,
+                new NetworkAllianceOfferPendingStatusChanged(requestingClanId, targetClanId, isPending: true));
+
+            Assert.True(AllianceOfferPendingRegistry.IsPending(requestingKingdom.StringId, targetKingdom.StringId));
+            AllianceOfferPendingRegistry.Set(requestingKingdom.StringId, targetKingdom.StringId, isPending: false);
+        });
+    }
+
+    [Fact]
     public void AllianceTimeoutFixture_NormalizesEveryReversibleEligibilityInputAndRestoresThemAfterExplicitAndFailedStagePaths()
     {
         const string fixtureControllerId = "testclient";

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Messaging;
 using Common.Util;
 using Coop.Core.Client.Services.Kingdoms.Handlers;
 using Coop.Core.Client.Services.MobileParties.Messages;
@@ -2242,6 +2243,76 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.True(AllianceOfferPendingRegistry.IsPending(requestingKingdom.StringId, targetKingdom.StringId));
             AllianceOfferPendingRegistry.Set(requestingKingdom.StringId, targetKingdom.StringId, isPending: false);
         });
+    }
+
+    [Fact]
+    public void AllianceOfferPendingStatusChanged_UnhydratedClanReferences_UseCanonicalKingdomStringIds()
+    {
+        const string requestingKingdomStringId = "pending_alliance_requesting";
+        const string targetKingdomStringId = "pending_alliance_target";
+        const string requestingKingdomWireId = "pending_alliance_requesting_clan";
+        const string targetKingdomWireId = "pending_alliance_target_clan";
+        var client = Clients.First();
+        var requestingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+
+        EnsureKingdomRegisteredEverywhere(requestingKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        SetKingdomStringIdEverywhere(requestingKingdomId, requestingKingdomStringId);
+        SetKingdomStringIdEverywhere(targetKingdomId, targetKingdomStringId);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(requestingKingdomId, out var requestingKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+            var unhydratedRequestingClan = ObjectHelper.SkipConstructor<Clan>();
+            var unhydratedTargetClan = ObjectHelper.SkipConstructor<Clan>();
+            Assert.Null(unhydratedRequestingClan.Kingdom);
+            Assert.Null(unhydratedTargetClan.Kingdom);
+            Assert.True(client.ObjectManager.AddExisting($"Clan_{requestingKingdomWireId}", unhydratedRequestingClan));
+            Assert.True(client.ObjectManager.AddExisting($"Clan_{targetKingdomWireId}", unhydratedTargetClan));
+
+            client.SimulateMessage(
+                this,
+                new NetworkAllianceOfferPendingStatusChanged(
+                    requestingKingdomWireId,
+                    targetKingdomWireId,
+                    isPending: true,
+                    requestingKingdomStringId: requestingKingdomStringId,
+                    targetKingdomStringId: targetKingdomStringId));
+
+            Assert.True(AllianceOfferPendingRegistry.IsPending(requestingKingdom.StringId, targetKingdom.StringId));
+            AllianceOfferPendingRegistry.Set(requestingKingdom.StringId, targetKingdom.StringId, isPending: false);
+        });
+    }
+
+    [Fact]
+    public void AllianceOfferPendingStatusChanged_ServerIncludesCanonicalKingdomStringIds()
+    {
+        const string requestingKingdomStringId = "pending_alliance_requesting_server";
+        const string targetKingdomStringId = "pending_alliance_target_server";
+        var requestingKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+
+        EnsureKingdomRegisteredEverywhere(requestingKingdomId);
+        EnsureKingdomRegisteredEverywhere(targetKingdomId);
+        SetKingdomStringIdEverywhere(requestingKingdomId, requestingKingdomStringId);
+        SetKingdomStringIdEverywhere(targetKingdomId, targetKingdomStringId);
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(requestingKingdomId, out var requestingKingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(targetKingdomId, out var targetKingdom));
+
+            Server.Resolve<IMessageBroker>().Publish(
+                this,
+                new AllianceOfferPendingStatusChanged(requestingKingdom, targetKingdom, isPending: true));
+        });
+
+        var message = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkAllianceOfferPendingStatusChanged>());
+        Assert.Equal(requestingKingdomStringId, message.RequestingKingdomStringId);
+        Assert.Equal(targetKingdomStringId, message.TargetKingdomStringId);
+        AllianceOfferPendingRegistry.Set(requestingKingdomStringId, targetKingdomStringId, isPending: false);
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1864,15 +1864,15 @@ public class PlayerKingdomCreationFlowTests : IDisposable
     }
 
     [Fact]
-    public void StartAllianceDecision_DetachedClanDecisionKingdomReference_UsesProposerKingdom()
+    public void StartAllianceDecision_DetachedRulingClanReference_UsesOwningKingdomAndHydratesProposer()
     {
-        const string detachedClanReferenceId = "Clan_detached-alliance-kingdom";
         var client = Clients.First();
         client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
         var player = CreateSyncedPlayerContext(ControllerId, client);
         var recipientKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var targetKingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
         var proposerClanId = CreateSyncedNpcClan();
+        var compactProposerClanId = ObjectManager.Compact(proposerClanId, typeof(Clan));
         var targetRulerClanId = CreateSyncedNpcClan();
 
         ConfigureClanInKingdom(player.ClanId, recipientKingdomId);
@@ -1884,14 +1884,20 @@ public class PlayerKingdomCreationFlowTests : IDisposable
 
         client.Call(() =>
         {
-            var detachedClanReference = ObjectHelper.SkipConstructor<Clan>();
-            Assert.Null(detachedClanReference.Kingdom);
-            Assert.True(client.ObjectManager.AddExisting(detachedClanReferenceId, detachedClanReference));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(recipientKingdomId, out var recipientKingdom));
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(proposerClanId, out var proposerClan));
+            using (new AllowedThread())
+            {
+                recipientKingdom._rulingClan = proposerClan;
+                KingdomCollectionSync.RemoveClan(recipientKingdom, proposerClan, publish: false);
+            }
+            Assert.Null(proposerClan.Kingdom);
+            Assert.Same(proposerClan, recipientKingdom.RulingClan);
         });
 
         var decisionData = new StartAllianceDecisionData(
             proposerClanId,
-            detachedClanReferenceId,
+            compactProposerClanId,
             triggerTime: 0,
             isEnforced: false,
             notifyPlayer: false,
@@ -1902,7 +1908,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         client.Call(() => client.SimulateMessage(
             this,
             new NetworkAddDecision(
-                detachedClanReferenceId,
+                compactProposerClanId,
                 decisionData,
                 ignoreInfluenceCost: true,
                 randomNumber: 0.5f)));
@@ -1917,6 +1923,8 @@ public class PlayerKingdomCreationFlowTests : IDisposable
             Assert.Same(proposerClan, decision.ProposerClan);
             Assert.Same(recipientKingdom, decision.Kingdom);
             Assert.Same(targetKingdom, decision.KingdomToStartAllianceWith);
+            Assert.Same(recipientKingdom, proposerClan.Kingdom);
+            Assert.Contains(proposerClan, recipientKingdom.Clans);
             Assert.True(CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision));
         });
     }

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/StartAllianceDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/StartAllianceDecisionSerializationTest.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.Kingdoms.Commands;
+﻿using GameInterface.Services.Kingdoms.Commands;
 using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.ObjectManager;
 using Moq;
@@ -16,7 +16,9 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
         [Fact]
         public void SerializeStartAllianceDecision()
         {
-            StartAllianceDecisionData startAllianceDecisionData = new StartAllianceDecisionData("ProposerClan", "Kingdom", 10, true, true, true, "TargetKingdom", true);
+            StartAllianceDecisionData startAllianceDecisionData = new StartAllianceDecisionData(
+                "ProposerClan", "Kingdom", 10, true, true, true, "TargetKingdom", true,
+                "decision_kingdom", "target_kingdom");
             KingdomDecisionData kingdomDecisionDerivedData = startAllianceDecisionData;
             MemoryStream memoryStream = new MemoryStream();
             Serializer.Serialize(memoryStream, kingdomDecisionDerivedData);
@@ -31,6 +33,8 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.Equal(startAllianceDecisionData.NotifyPlayer, deserializedObj.NotifyPlayer);
             Assert.Equal(startAllianceDecisionData.IsEnforced, deserializedObj.IsEnforced);
             Assert.Equal(startAllianceDecisionData.KingdomToStartAllianceWithId, deserializedObj.KingdomToStartAllianceWithId);
+            Assert.Equal(startAllianceDecisionData.DecisionKingdomStringId, deserializedObj.DecisionKingdomStringId);
+            Assert.Equal(startAllianceDecisionData.KingdomToStartAllianceWithStringId, deserializedObj.KingdomToStartAllianceWithStringId);
             Assert.True(deserializedObj.IsProposedByOpponent);
         }
 

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/StartAllianceDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/StartAllianceDecisionSerializationTest.cs
@@ -11,7 +11,7 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
         [Fact]
         public void SerializeStartAllianceDecision()
         {
-            StartAllianceDecisionData startAllianceDecisionData = new StartAllianceDecisionData("ProposerClan", "Kingdom", 10, true, true, true, "TargetKingdom");
+            StartAllianceDecisionData startAllianceDecisionData = new StartAllianceDecisionData("ProposerClan", "Kingdom", 10, true, true, true, "TargetKingdom", true);
             KingdomDecisionData kingdomDecisionDerivedData = startAllianceDecisionData;
             MemoryStream memoryStream = new MemoryStream();
             Serializer.Serialize(memoryStream, kingdomDecisionDerivedData);
@@ -26,6 +26,7 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.Equal(startAllianceDecisionData.NotifyPlayer, deserializedObj.NotifyPlayer);
             Assert.Equal(startAllianceDecisionData.IsEnforced, deserializedObj.IsEnforced);
             Assert.Equal(startAllianceDecisionData.KingdomToStartAllianceWithId, deserializedObj.KingdomToStartAllianceWithId);
+            Assert.True(deserializedObj.IsProposedByOpponent);
         }
 
         [Fact]

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/StartAllianceDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/StartAllianceDecisionSerializationTest.cs
@@ -1,7 +1,12 @@
+using GameInterface.Services.Kingdoms.Commands;
 using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.ObjectManager;
+using Moq;
 using ProtoBuf;
+using Serilog;
 using System.IO;
 using System.Reflection;
+using TaleWorlds.CampaignSystem;
 using Xunit;
 
 namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
@@ -36,6 +41,31 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.NotNull(fieldInfo);
             object? obj = fieldInfo?.GetValue(null);
             Assert.NotNull(obj);
+        }
+
+        [Fact]
+        public void CompactClanReference_MatchesRegisteredPlayerClan()
+        {
+            var objectManager = new ObjectManager(Mock.Of<ILogger>());
+            var playerClan = new Clan();
+            const string registeredClanId = "Clan_Created_27";
+            Assert.True(objectManager.AddExisting(registeredClanId, playerClan));
+
+            Assert.True(KingdomDebugCommand.MatchesRegisteredReference(
+                objectManager,
+                "Created_27",
+                playerClan,
+                typeof(Clan)));
+            Assert.True(KingdomDebugCommand.MatchesRegisteredReference(
+                objectManager,
+                registeredClanId,
+                playerClan,
+                typeof(Clan)));
+            Assert.False(KingdomDebugCommand.MatchesRegisteredReference(
+                objectManager,
+                "Created_28",
+                playerClan,
+                typeof(Clan)));
         }
     }
 }

--- a/source/GameInterface.Tests/Services/Save/SaveManagerSaveDiagnosticsPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Save/SaveManagerSaveDiagnosticsPatchTests.cs
@@ -21,4 +21,16 @@ public class SaveManagerSaveDiagnosticsPatchTests
         Assert.Equal("<no details>", SaveManagerSaveDiagnosticsPatch.FormatErrorMessages(null));
         Assert.Equal("<no details>", SaveManagerSaveDiagnosticsPatch.FormatErrorMessages(Array.Empty<string>()));
     }
+
+    [Fact]
+    public void FormatFailure_PreservesResultAndOrderedErrorsForCommandDiagnostics()
+    {
+        string result = SaveManagerSaveDiagnosticsPatch.FormatFailure(
+            "GeneralFailure",
+            new[] { "definition failed", "serialization failed" });
+
+        Assert.Equal(
+            "saveResult=GeneralFailure|saveErrors=[0] definition failed | [1] serialization failed",
+            result);
+    }
 }

--- a/source/GameInterface.Tests/Services/Save/SaveManagerSaveDiagnosticsPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Save/SaveManagerSaveDiagnosticsPatchTests.cs
@@ -1,0 +1,24 @@
+﻿using GameInterface.Services.Save.Patches;
+using System;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Save;
+
+public class SaveManagerSaveDiagnosticsPatchTests
+{
+    [Fact]
+    public void FormatErrorMessages_PreservesEveryVanillaSaveError()
+    {
+        string result = SaveManagerSaveDiagnosticsPatch.FormatErrorMessages(
+            new[] { "definition failed", "serialization failed" });
+
+        Assert.Equal("[0] definition failed | [1] serialization failed", result);
+    }
+
+    [Fact]
+    public void FormatErrorMessages_ReportsMissingDetails()
+    {
+        Assert.Equal("<no details>", SaveManagerSaveDiagnosticsPatch.FormatErrorMessages(null));
+        Assert.Equal("<no details>", SaveManagerSaveDiagnosticsPatch.FormatErrorMessages(Array.Empty<string>()));
+    }
+}

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -6,9 +6,11 @@ using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Extentions;
 using GameInterface.Services.Kingdoms.Handlers;
 using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
+using GameInterface.Services.Kingdoms.Patches;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using Newtonsoft.Json;
@@ -21,6 +23,7 @@ using System.Reflection;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
@@ -41,6 +44,7 @@ public class KingdomDebugCommand
 {
     private static readonly ILogger Logger = LogManager.GetLogger<KingdomDebugCommand>();
     private static PolicyTimeoutFixture pendingPolicyTimeoutFixture;
+    private static AllianceTimeoutFixture pendingAllianceTimeoutFixture;
     private enum CollectionTarget
     {
         Armies,
@@ -394,6 +398,299 @@ public class KingdomDebugCommand
         });
     }
 
+    [CommandLineArgumentFunction("alliance_timeout_capture", "coop.debug.kingdom")]
+    public static string CaptureAllianceTimeoutFixture(List<string> args)
+    {
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 0) return "Usage: coop.debug.kingdom.alliance_timeout_capture";
+        if (pendingAllianceTimeoutFixture != null) return "An alliance-timeout fixture lifecycle is already active.";
+        if (!TryGetObjectManager(out var objectManager) || !TryGetPlayerManager(out var playerManager))
+            return "Unable to resolve alliance-timeout fixture services.";
+        if (!playerManager.TryGetPlayer("testclient", out var player))
+            return "No registered player has controller id 'testclient'.";
+        if (!objectManager.TryGetObject(player.ClanId, out Clan proposerClan) || proposerClan.Kingdom == null)
+            return "The testclient clan is not in a kingdom.";
+
+        Kingdom kingdom = proposerClan.Kingdom;
+        if (kingdom.RulingClan == null) return $"Kingdom {kingdom.StringId} has no ruling clan.";
+        if (kingdom.RulingClan == proposerClan)
+            return "The testclient clan must be a voting supporter under an NPC ruler.";
+        Kingdom targetKingdom = Kingdom.All.SingleOrDefault(candidate =>
+            string.Equals(candidate.StringId, "sturgia", StringComparison.Ordinal));
+        if (targetKingdom == null) return "The Sturgia kingdom is unavailable.";
+        if (targetKingdom == kingdom) return "The testclient clan is already in Sturgia.";
+        if (kingdom.UnresolvedDecisions.Count > 0)
+            return $"Kingdom {kingdom.StringId} already has an unresolved decision.";
+        if (FactionManager.IsAtWarAgainstFaction(kingdom, targetKingdom))
+            return $"Kingdom {kingdom.StringId} is at war with Sturgia.";
+
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
+        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
+        if (allianceBehavior.IsAllyWithKingdom(kingdom, targetKingdom))
+            return $"Kingdom {kingdom.StringId} is already allied with Sturgia.";
+        if (!objectManager.TryGetIdWithLogging(kingdom, out string kingdomId) ||
+            !objectManager.TryGetIdWithLogging(proposerClan, out string proposerClanId) ||
+            !objectManager.TryGetIdWithLogging(targetKingdom, out string targetKingdomId))
+            return "Unable to resolve alliance-timeout fixture ids.";
+
+        return LiveTestJsonResult(new
+        {
+            success = true,
+            controllerId = player.ControllerId,
+            kingdomId,
+            kingdomName = kingdom.Name.ToString(),
+            proposerClanId,
+            targetKingdomId,
+            targetKingdomName = targetKingdom.Name.ToString(),
+            allianceWasActive = false,
+            unresolvedDecisionCount = kingdom.UnresolvedDecisions.Count
+        });
+    }
+
+    [CommandLineArgumentFunction("alliance_timeout_stage", "coop.debug.kingdom")]
+    public static string StageAllianceTimeoutFixture(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.alliance_timeout_stage <kingdomId> <proposerClanId> <targetKingdomId>";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 3) return usage;
+        if (pendingAllianceTimeoutFixture != null) return "An alliance-timeout fixture lifecycle is already active.";
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager";
+        if (!objectManager.TryGetObject(args[0], out Kingdom kingdom)) return $"Kingdom with ID: '{args[0]}' not found";
+        if (!objectManager.TryGetObject(args[1], out Clan proposerClan)) return $"Clan with ID: '{args[1]}' not found";
+        if (!objectManager.TryGetObject(args[2], out Kingdom targetKingdom)) return $"Kingdom with ID: '{args[2]}' not found";
+        if (proposerClan.Kingdom != kingdom) return $"Clan {args[1]} is not in kingdom {args[0]}.";
+        if (kingdom.RulingClan == null || kingdom.RulingClan == proposerClan)
+            return "The testclient clan is no longer a voting supporter under an NPC ruler.";
+        if (kingdom.UnresolvedDecisions.Count > 0)
+            return $"Kingdom {args[0]} no longer has a clean decision fixture.";
+
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
+        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
+        if (allianceBehavior.IsAllyWithKingdom(kingdom, targetKingdom) ||
+            FactionManager.IsAtWarAgainstFaction(kingdom, targetKingdom))
+        {
+            return "The alliance-timeout fixture relationship changed after capture.";
+        }
+
+        var fixture = new AllianceTimeoutFixture(
+            kingdom,
+            proposerClan,
+            targetKingdom,
+            args[0],
+            args[2],
+            false);
+        pendingAllianceTimeoutFixture = fixture;
+
+        var decision = new StartAllianceDecision(fixture.ProposerClan, fixture.TargetKingdom);
+        CoopKingdomElection._opponentProposedAllianceDecisions.Add(decision);
+        fixture.Kingdom.AddDecision(decision, true);
+        decision.TriggerTime = CampaignTime.Zero;
+        CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+
+        int decisionIndex = fixture.Kingdom._unresolvedDecisions.IndexOf(decision) + 1;
+        if (decisionIndex <= 0) return "The alliance-timeout decision was not retained for co-op voting.";
+
+        return LiveTestJsonResult(new
+        {
+            success = true,
+            fixture.KingdomId,
+            fixture.TargetKingdomId,
+            decisionIndex,
+            triggerPast = decision.TriggerTime.IsPast,
+            votingDurationSeconds = (int)KingdomDecisionVoteManager.VotingRoundDuration.TotalSeconds
+        });
+    }
+
+    [CommandLineArgumentFunction("alliance_timeout_state", "coop.debug.kingdom")]
+    public static string GetAllianceTimeoutState(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.alliance_timeout_state <expectedActive>";
+        if (ModInformation.IsServer) return "Command can only be run on a client.";
+        if (args.Count != 1 || !bool.TryParse(args[0], out bool expectedActive)) return usage;
+
+        var kingdomScreen = ScreenManager.TopScreen as GauntletKingdomScreen;
+        DecisionItemBaseVM decisionItem = kingdomScreen?.DataSource?.Decision?.CurrentDecision;
+        var allianceItem = decisionItem as StartAllianceDecisionItemVM;
+        bool decisionActive = allianceItem?.IsActive ?? false;
+        var allianceDecision = allianceItem?.KingdomDecisionMaker?._decision as StartAllianceDecision;
+        string targetKingdomName = allianceDecision?.KingdomToStartAllianceWith?.Name?.ToString() ?? string.Empty;
+        string decisionTitle = allianceItem?.TitleText ?? string.Empty;
+        bool namesSturgia = string.Equals(targetKingdomName, "Sturgia", StringComparison.OrdinalIgnoreCase) ||
+            decisionTitle.IndexOf("Sturgia", StringComparison.OrdinalIgnoreCase) >= 0;
+        bool hasVotingCountdown = decisionTitle.IndexOf("Voting ends in", StringComparison.OrdinalIgnoreCase) >= 0;
+        bool observedExpectedState = expectedActive
+            ? decisionActive && namesSturgia && hasVotingCountdown
+            : decisionItem == null;
+        if (!observedExpectedState) return LiveTestJsonResult(null);
+
+        return LiveTestJsonResult(new
+        {
+            success = true,
+            expectedActive,
+            kingdomScreenActive = Game.Current?.GameStateManager?.ActiveState is KingdomState,
+            topScreenIsKingdom = kingdomScreen != null,
+            decisionPresent = decisionItem != null,
+            allianceDecisionActive = decisionActive,
+            decisionTitle,
+            targetKingdomName,
+            namesSturgia,
+            hasVotingCountdown,
+            inquiryActive = InformationManager.IsAnyInquiryActive()
+        });
+    }
+
+    [CommandLineArgumentFunction("alliance_timeout_submit_no", "coop.debug.kingdom")]
+    public static string SubmitAllianceTimeoutNoVote(List<string> args)
+    {
+        if (ModInformation.IsServer) return "Command can only be run on a client.";
+        if (args.Count != 0) return "Usage: coop.debug.kingdom.alliance_timeout_submit_no";
+
+        var kingdomScreen = ScreenManager.TopScreen as GauntletKingdomScreen;
+        var decisionItem = kingdomScreen?.DataSource?.Decision?.CurrentDecision as StartAllianceDecisionItemVM;
+        if (decisionItem == null || !decisionItem.IsActive) return "No active alliance decision is displayed.";
+
+        DecisionOptionVM noOption = decisionItem.DecisionOptionsList.SingleOrDefault(candidate =>
+            candidate.Option is StartAllianceDecision.StartAllianceDecisionOutcome outcome &&
+            !outcome.ShouldAllianceBeStarted);
+        if (noOption == null) return "The alliance decision has no No option.";
+
+        noOption.CurrentSupportWeight = Supporter.SupportWeights.FullyPush;
+        decisionItem._currentSelectedOption = noOption;
+        decisionItem.ExecuteFinalSelection();
+
+        return LiveTestJsonResult(new
+        {
+            success = true,
+            selectedOutcome = "No",
+            finalVoteSubmitted = true
+        });
+    }
+
+    [CommandLineArgumentFunction("alliance_timeout_server_state", "coop.debug.kingdom")]
+    public static string GetAllianceTimeoutServerState(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.alliance_timeout_server_state <kingdomId> <targetKingdomId>";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 2) return usage;
+        if (!TryMatchPendingAllianceTimeoutFixture(args[0], args[1], false, out var fixture, out string error))
+            return error;
+
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
+        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
+        bool decisionPresent = HasMatchingAllianceDecision(fixture);
+        bool allianceIsActive = allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom);
+        return LiveTestJsonResult(new
+        {
+            success = !decisionPresent && !allianceIsActive,
+            fixture.KingdomId,
+            fixture.TargetKingdomId,
+            decisionPresent,
+            allianceIsActive,
+            unresolvedDecisionCount = fixture.Kingdom.UnresolvedDecisions.Count
+        });
+    }
+
+    [CommandLineArgumentFunction("alliance_timeout_restore", "coop.debug.kingdom")]
+    public static string RestoreAllianceTimeoutFixture(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.alliance_timeout_restore <kingdomId> <targetKingdomId> <allianceWasActive>";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 3 || !bool.TryParse(args[2], out bool allianceWasActive)) return usage;
+        if (!TryMatchPendingAllianceTimeoutFixture(args[0], args[1], allianceWasActive, out var fixture, out string error))
+            return error;
+
+        foreach (StartAllianceDecision decision in fixture.Kingdom.UnresolvedDecisions
+            .OfType<StartAllianceDecision>()
+            .Where(candidate => candidate.KingdomToStartAllianceWith == fixture.TargetKingdom)
+            .ToList())
+        {
+            fixture.Kingdom.RemoveDecision(decision);
+            CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(decision);
+        }
+
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
+        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
+        bool allianceIsActive = allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom);
+        if (fixture.AllianceWasActive && !allianceIsActive)
+        {
+            allianceBehavior.StartAlliance(fixture.Kingdom, fixture.TargetKingdom);
+        }
+        else if (!fixture.AllianceWasActive && allianceIsActive)
+        {
+            allianceBehavior.EndAlliance(fixture.Kingdom, fixture.TargetKingdom);
+        }
+
+        pendingAllianceTimeoutFixture = null;
+        return LiveTestJsonResult(new
+        {
+            success = true,
+            fixture.KingdomId,
+            fixture.TargetKingdomId,
+            restoredAllianceActive = allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom),
+            unresolvedDecisionCount = fixture.Kingdom.UnresolvedDecisions.Count
+        });
+    }
+
+    [CommandLineArgumentFunction("alliance_timeout_verify", "coop.debug.kingdom")]
+    public static string VerifyAllianceTimeoutFixture(List<string> args)
+    {
+        const string usage = "Usage: coop.debug.kingdom.alliance_timeout_verify <kingdomId> <targetKingdomId> <allianceWasActive>";
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 3 || !bool.TryParse(args[2], out bool allianceWasActive)) return usage;
+        if (pendingAllianceTimeoutFixture != null) return "The alliance-timeout fixture lifecycle is still active.";
+        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager";
+        if (!objectManager.TryGetObject(args[0], out Kingdom kingdom)) return $"Kingdom with ID: '{args[0]}' not found";
+        if (!objectManager.TryGetObject(args[1], out Kingdom targetKingdom)) return $"Kingdom with ID: '{args[1]}' not found";
+
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
+        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
+        bool allianceIsActive = allianceBehavior.IsAllyWithKingdom(kingdom, targetKingdom);
+        bool decisionPresent = kingdom.UnresolvedDecisions
+            .OfType<StartAllianceDecision>()
+            .Any(decision => decision.KingdomToStartAllianceWith == targetKingdom);
+        bool success = allianceIsActive == allianceWasActive && !decisionPresent &&
+            kingdom.UnresolvedDecisions.Count == 0;
+        return LiveTestJsonResult(new
+        {
+            success,
+            kingdomId = args[0],
+            targetKingdomId = args[1],
+            expectedAllianceActive = allianceWasActive,
+            allianceIsActive,
+            decisionPresent,
+            unresolvedDecisionCount = kingdom.UnresolvedDecisions.Count
+        });
+    }
+
+    private static bool TryMatchPendingAllianceTimeoutFixture(
+        string kingdomId,
+        string targetKingdomId,
+        bool allianceWasActive,
+        out AllianceTimeoutFixture fixture,
+        out string error)
+    {
+        fixture = pendingAllianceTimeoutFixture;
+        error = string.Empty;
+        if (fixture == null)
+        {
+            error = "No alliance-timeout fixture has been captured.";
+            return false;
+        }
+        if (fixture.KingdomId != kingdomId || fixture.TargetKingdomId != targetKingdomId ||
+            fixture.AllianceWasActive != allianceWasActive)
+        {
+            error = "The alliance-timeout fixture arguments do not match the captured state.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasMatchingAllianceDecision(AllianceTimeoutFixture fixture) =>
+        fixture.Kingdom.UnresolvedDecisions
+            .OfType<StartAllianceDecision>()
+            .Any(decision => decision.KingdomToStartAllianceWith == fixture.TargetKingdom);
+
     private static bool TryMatchPendingPolicyTimeoutFixture(
         string kingdomId,
         string proposerClanId,
@@ -419,8 +716,36 @@ public class KingdomDebugCommand
         return true;
     }
 
-    private static string PolicyTimeoutJsonResult(object value) =>
+    private static string LiveTestJsonResult(object value) =>
         "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(value);
+
+    private static string PolicyTimeoutJsonResult(object value) => LiveTestJsonResult(value);
+
+    private sealed class AllianceTimeoutFixture
+    {
+        public Kingdom Kingdom { get; }
+        public Clan ProposerClan { get; }
+        public Kingdom TargetKingdom { get; }
+        public string KingdomId { get; }
+        public string TargetKingdomId { get; }
+        public bool AllianceWasActive { get; }
+
+        public AllianceTimeoutFixture(
+            Kingdom kingdom,
+            Clan proposerClan,
+            Kingdom targetKingdom,
+            string kingdomId,
+            string targetKingdomId,
+            bool allianceWasActive)
+        {
+            Kingdom = kingdom;
+            ProposerClan = proposerClan;
+            TargetKingdom = targetKingdom;
+            KingdomId = kingdomId;
+            TargetKingdomId = targetKingdomId;
+            AllianceWasActive = allianceWasActive;
+        }
+    }
 
     private sealed class PolicyTimeoutFixture
     {

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -32,6 +32,7 @@ using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.ItemTypes;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
+using TaleWorlds.Localization;
 using TaleWorlds.ScreenSystem;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
@@ -416,27 +417,33 @@ public class KingdomDebugCommand
         Kingdom sturgia = Kingdom.All.SingleOrDefault(candidate =>
             string.Equals(candidate.StringId, "sturgia", StringComparison.Ordinal));
         if (sturgia == null) return "The Sturgia kingdom is unavailable.";
+        if (sturgia.Leader == null) return "Sturgia has no ruling leader.";
 
         AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
         if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
 
-        Kingdom kingdom = Kingdom.All
+        Kingdom kingdom = null;
+        foreach (Kingdom candidate in Kingdom.All
             .Where(candidate =>
                 candidate != sturgia &&
                 candidate.RulingClan != null &&
+                candidate.Leader != null &&
                 candidate.UnresolvedDecisions.Count == 0 &&
                 !FactionManager.IsAtWarAgainstFaction(candidate, sturgia) &&
-                !allianceBehavior.IsAllyWithKingdom(candidate, sturgia) &&
-                Campaign.Current.Models.AllianceModel.CanMakeAlliance(
-                    candidate,
-                    sturgia,
-                    candidate.RulingClan,
-                    out _,
-                    includeReason: false))
-            .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal)
-            .FirstOrDefault();
+                !allianceBehavior.IsAllyWithKingdom(candidate, sturgia))
+            .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal))
+        {
+            if (!TryValidateAllianceTimeoutTarget(candidate, sturgia, out string error))
+            {
+                if (!string.IsNullOrEmpty(error)) return error;
+                continue;
+            }
+
+            kingdom = candidate;
+            break;
+        }
         if (kingdom == null)
-            return "No NPC-ruled kingdom can currently receive a valid alliance offer from Sturgia.";
+            return "No NPC-ruled kingdom can receive a valid alliance offer from Sturgia after reversible fixture normalization.";
         if (!objectManager.TryGetIdWithLogging(kingdom, out string kingdomId) ||
             !objectManager.TryGetIdWithLogging(sturgia, out string sturgiaId))
             return "Unable to resolve alliance-timeout target ids.";
@@ -467,11 +474,13 @@ public class KingdomDebugCommand
 
         Kingdom kingdom = proposerClan.Kingdom;
         if (kingdom.RulingClan == null) return $"Kingdom {kingdom.StringId} has no ruling clan.";
+        if (kingdom.Leader == null) return $"Kingdom {kingdom.StringId} has no ruling leader.";
         if (kingdom.RulingClan == proposerClan)
             return "The testclient clan must be a voting supporter under an NPC ruler.";
         Kingdom targetKingdom = Kingdom.All.SingleOrDefault(candidate =>
             string.Equals(candidate.StringId, "sturgia", StringComparison.Ordinal));
         if (targetKingdom == null) return "The Sturgia kingdom is unavailable.";
+        if (targetKingdom.Leader == null) return "Sturgia has no ruling leader.";
         if (targetKingdom == kingdom) return "The testclient clan is already in Sturgia.";
         if (kingdom.UnresolvedDecisions.Count > 0)
             return $"Kingdom {kingdom.StringId} already has an unresolved decision.";
@@ -482,19 +491,28 @@ public class KingdomDebugCommand
         if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
         if (allianceBehavior.IsAllyWithKingdom(kingdom, targetKingdom))
             return $"Kingdom {kingdom.StringId} is already allied with Sturgia.";
-        if (!Campaign.Current.Models.AllianceModel.CanMakeAlliance(
-                kingdom,
-                targetKingdom,
-                kingdom.RulingClan,
-                out var reason,
-                includeReason: true))
-        {
-            return $"Kingdom {kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}";
-        }
         if (!objectManager.TryGetIdWithLogging(kingdom, out string kingdomId) ||
             !objectManager.TryGetIdWithLogging(proposerClan, out string proposerClanId) ||
             !objectManager.TryGetIdWithLogging(targetKingdom, out string targetKingdomId))
             return "Unable to resolve alliance-timeout fixture ids.";
+
+        if (!TryCreateAllianceTimeoutFixture(
+                kingdom,
+                proposerClan,
+                targetKingdom,
+                kingdomId,
+                targetKingdomId,
+                out var fixture,
+                out string fixtureError))
+        {
+            return fixtureError;
+        }
+        pendingAllianceTimeoutFixture = fixture;
+        if (!TryPrepareAllianceTimeoutFixture(fixture, out string error))
+        {
+            if (fixture.LeaderRelationRestored) pendingAllianceTimeoutFixture = null;
+            return error;
+        }
 
         return LiveTestJsonResult(new
         {
@@ -506,6 +524,9 @@ public class KingdomDebugCommand
             targetKingdomId,
             targetKingdomName = targetKingdom.Name.ToString(),
             allianceWasActive = false,
+            leaderRelationBefore = fixture.LeaderRelationBefore,
+            leaderRelationAfter = fixture.CurrentLeaderRelation,
+            leaderRelationChanged = fixture.LeaderRelationChanged,
             unresolvedDecisionCount = kingdom.UnresolvedDecisions.Count
         });
     }
@@ -516,53 +537,79 @@ public class KingdomDebugCommand
         const string usage = "Usage: coop.debug.kingdom.alliance_timeout_stage <kingdomId> <proposerClanId> <targetKingdomId>";
         if (ModInformation.IsClient) return "Command can only be run on the server.";
         if (args.Count != 3) return usage;
-        if (pendingAllianceTimeoutFixture != null) return "An alliance-timeout fixture lifecycle is already active.";
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager";
-        if (!objectManager.TryGetObject(args[0], out Kingdom kingdom)) return $"Kingdom with ID: '{args[0]}' not found";
-        if (!objectManager.TryGetObject(args[1], out Clan proposerClan)) return $"Clan with ID: '{args[1]}' not found";
-        if (!objectManager.TryGetObject(args[2], out Kingdom targetKingdom)) return $"Kingdom with ID: '{args[2]}' not found";
-        if (proposerClan.Kingdom != kingdom) return $"Clan {args[1]} is not in kingdom {args[0]}.";
+        if (!TryMatchPendingAllianceTimeoutFixture(args[0], args[2], false, out var fixture, out string error))
+            return error;
+        if (!TryGetObjectManager(out var objectManager))
+            return FailAllianceTimeoutFixture(fixture, "Unable to resolve ObjectManager");
+        if (!objectManager.TryGetObject(args[0], out Kingdom kingdom))
+            return FailAllianceTimeoutFixture(fixture, $"Kingdom with ID: '{args[0]}' not found");
+        if (!objectManager.TryGetObject(args[1], out Clan proposerClan))
+            return FailAllianceTimeoutFixture(fixture, $"Clan with ID: '{args[1]}' not found");
+        if (!objectManager.TryGetObject(args[2], out Kingdom targetKingdom))
+            return FailAllianceTimeoutFixture(fixture, $"Kingdom with ID: '{args[2]}' not found");
+        if (proposerClan.Kingdom != kingdom)
+            return FailAllianceTimeoutFixture(fixture, $"Clan {args[1]} is not in kingdom {args[0]}.");
         if (kingdom.RulingClan == null || kingdom.RulingClan == proposerClan)
-            return "The testclient clan is no longer a voting supporter under an NPC ruler.";
+            return FailAllianceTimeoutFixture(fixture, "The testclient clan is no longer a voting supporter under an NPC ruler.");
         if (kingdom.UnresolvedDecisions.Count > 0)
-            return $"Kingdom {args[0]} no longer has a clean decision fixture.";
+            return FailAllianceTimeoutFixture(fixture, $"Kingdom {args[0]} no longer has a clean decision fixture.");
 
-        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
-        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
-        if (allianceBehavior.IsAllyWithKingdom(kingdom, targetKingdom) ||
-            FactionManager.IsAtWarAgainstFaction(kingdom, targetKingdom))
+        if (!TryVerifyUnchangedAllianceState(fixture, out string allianceStateError))
+            return FailAllianceTimeoutFixture(fixture, allianceStateError);
+        if (FactionManager.IsAtWarAgainstFaction(kingdom, targetKingdom))
         {
-            return "The alliance-timeout fixture relationship changed after capture.";
+            return FailAllianceTimeoutFixture(fixture, "The alliance-timeout fixture relationship changed after capture.");
+        }
+        if (!TryCanMakeAlliance(
+                kingdom,
+                targetKingdom,
+                kingdom.RulingClan,
+                includeReason: true,
+                out bool canMakeAlliance,
+                out TextObject reason,
+                out string gateError))
+        {
+            return FailAllianceTimeoutFixture(fixture, gateError);
+        }
+        if (!canMakeAlliance)
+        {
+            return FailAllianceTimeoutFixture(
+                fixture,
+                $"Kingdom {kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}");
         }
 
-        var fixture = new AllianceTimeoutFixture(
-            kingdom,
-            proposerClan,
-            targetKingdom,
-            args[0],
-            args[2],
-            false);
-        pendingAllianceTimeoutFixture = fixture;
-
-        // A redirected inbound offer is authored by the player kingdom's ruling clan.
-        var decision = new StartAllianceDecision(fixture.Kingdom.RulingClan, fixture.TargetKingdom);
-        CoopKingdomElection._opponentProposedAllianceDecisions.Add(decision);
-        fixture.Kingdom.AddDecision(decision, true);
-        decision.TriggerTime = CampaignTime.Zero;
-        CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
-
-        int decisionIndex = fixture.Kingdom._unresolvedDecisions.IndexOf(decision) + 1;
-        if (decisionIndex <= 0) return "The alliance-timeout decision was not retained for co-op voting.";
-
-        return LiveTestJsonResult(new
+        try
         {
-            success = true,
-            fixture.KingdomId,
-            fixture.TargetKingdomId,
-            decisionIndex,
-            triggerPast = decision.TriggerTime.IsPast,
-            votingDurationSeconds = (int)KingdomDecisionVoteManager.VotingRoundDuration.TotalSeconds
-        });
+            // A redirected inbound offer is authored by the player kingdom's ruling clan.
+            var decision = new StartAllianceDecision(fixture.Kingdom.RulingClan, fixture.TargetKingdom);
+            CoopKingdomElection._opponentProposedAllianceDecisions.Add(decision);
+            fixture.Kingdom.AddDecision(decision, true);
+            decision.TriggerTime = CampaignTime.Zero;
+            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+
+            if (!TryVerifyUnchangedAllianceState(fixture, out allianceStateError))
+                return FailAllianceTimeoutFixture(fixture, allianceStateError);
+
+            int decisionIndex = fixture.Kingdom._unresolvedDecisions.IndexOf(decision) + 1;
+            if (decisionIndex <= 0)
+                return FailAllianceTimeoutFixture(fixture, "The alliance-timeout decision was not retained for co-op voting.");
+
+            return LiveTestJsonResult(new
+            {
+                success = true,
+                fixture.KingdomId,
+                fixture.TargetKingdomId,
+                decisionIndex,
+                triggerPast = decision.TriggerTime.IsPast,
+                votingDurationSeconds = (int)KingdomDecisionVoteManager.VotingRoundDuration.TotalSeconds
+            });
+        }
+        catch (Exception exception)
+        {
+            return FailAllianceTimeoutFixture(
+                fixture,
+                $"The alliance-timeout decision could not be staged: {exception.Message}");
+        }
     }
 
     [CommandLineArgumentFunction("alliance_timeout_state", "coop.debug.kingdom")]
@@ -645,10 +692,11 @@ public class KingdomDebugCommand
         bool allianceIsActive = allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom);
         return LiveTestJsonResult(new
         {
-            success = !decisionPresent && !allianceIsActive,
+            success = !decisionPresent && allianceIsActive == fixture.AllianceWasActive,
             fixture.KingdomId,
             fixture.TargetKingdomId,
             decisionPresent,
+            expectedAllianceActive = fixture.AllianceWasActive,
             allianceIsActive,
             unresolvedDecisionCount = fixture.Kingdom.UnresolvedDecisions.Count
         });
@@ -663,34 +711,18 @@ public class KingdomDebugCommand
         if (!TryMatchPendingAllianceTimeoutFixture(args[0], args[1], allianceWasActive, out var fixture, out string error))
             return error;
 
-        foreach (StartAllianceDecision decision in fixture.Kingdom.UnresolvedDecisions
-            .OfType<StartAllianceDecision>()
-            .Where(candidate => candidate.KingdomToStartAllianceWith == fixture.TargetKingdom)
-            .ToList())
-        {
-            fixture.Kingdom.RemoveDecision(decision);
-            CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(decision);
-        }
-
-        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
-        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
-        bool allianceIsActive = allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom);
-        if (fixture.AllianceWasActive && !allianceIsActive)
-        {
-            allianceBehavior.StartAlliance(fixture.Kingdom, fixture.TargetKingdom);
-        }
-        else if (!fixture.AllianceWasActive && allianceIsActive)
-        {
-            allianceBehavior.EndAlliance(fixture.Kingdom, fixture.TargetKingdom);
-        }
+        if (!TryRestoreAllianceTimeoutFixture(fixture, out string restoreError)) return restoreError;
 
         pendingAllianceTimeoutFixture = null;
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current.GetCampaignBehavior<AllianceCampaignBehavior>();
         return LiveTestJsonResult(new
         {
             success = true,
             fixture.KingdomId,
             fixture.TargetKingdomId,
             restoredAllianceActive = allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom),
+            leaderRelationBefore = fixture.LeaderRelationBefore,
+            leaderRelationRestored = fixture.LeaderRelationRestored,
             unresolvedDecisionCount = fixture.Kingdom.UnresolvedDecisions.Count
         });
     }
@@ -755,6 +787,260 @@ public class KingdomDebugCommand
             .OfType<StartAllianceDecision>()
             .Any(decision => decision.KingdomToStartAllianceWith == fixture.TargetKingdom);
 
+    private static bool TryCreateAllianceTimeoutFixture(
+        Kingdom kingdom,
+        Clan proposerClan,
+        Kingdom targetKingdom,
+        string kingdomId,
+        string targetKingdomId,
+        out AllianceTimeoutFixture fixture,
+        out string error)
+    {
+        fixture = null;
+        error = string.Empty;
+        if (kingdom?.Leader == null || targetKingdom?.Leader == null)
+        {
+            error = "The alliance-timeout fixture requires both kingdom leaders.";
+            return false;
+        }
+
+        var campaign = Campaign.Current;
+        if (campaign?.Models?.DiplomacyModel == null)
+        {
+            error = "The campaign diplomacy model is unavailable.";
+            return false;
+        }
+
+        try
+        {
+            campaign.Models.DiplomacyModel.GetHeroesForEffectiveRelation(
+                kingdom.Leader,
+                targetKingdom.Leader,
+                out Hero effectiveLeader,
+                out Hero effectiveTargetLeader);
+            if (effectiveLeader == null || effectiveTargetLeader == null || effectiveLeader == effectiveTargetLeader)
+            {
+                error = "The alliance-timeout fixture could not resolve distinct effective relation heroes.";
+                return false;
+            }
+
+            fixture = new AllianceTimeoutFixture(
+                kingdom,
+                proposerClan,
+                targetKingdom,
+                kingdomId,
+                targetKingdomId,
+                false,
+                effectiveLeader,
+                effectiveTargetLeader,
+                CharacterRelationManager.GetHeroRelation(effectiveLeader, effectiveTargetLeader));
+            return true;
+        }
+        catch (Exception exception)
+        {
+            error = $"The alliance-timeout fixture could not resolve the effective relation: {exception.Message}";
+            return false;
+        }
+    }
+
+    private static bool TryValidateAllianceTimeoutTarget(Kingdom kingdom, Kingdom targetKingdom, out string error)
+    {
+        if (!TryCanMakeAlliance(
+                kingdom,
+                targetKingdom,
+                kingdom.RulingClan,
+                includeReason: false,
+                out bool canMakeAlliance,
+                out _,
+                out error)) return false;
+        if (canMakeAlliance) return true;
+
+        if (!TryCreateAllianceTimeoutFixture(
+                kingdom,
+                kingdom.RulingClan,
+                targetKingdom,
+                kingdom.StringId,
+                targetKingdom.StringId,
+                out var fixture,
+                out error))
+        {
+            return false;
+        }
+        if (!fixture.TryNormalizeLeaderRelation(out error)) return false;
+
+        bool targetIsEligible = false;
+        try
+        {
+            if (!TryCanMakeAlliance(
+                kingdom,
+                targetKingdom,
+                kingdom.RulingClan,
+                includeReason: false,
+                out canMakeAlliance,
+                out _,
+                out error)) return false;
+            targetIsEligible = canMakeAlliance;
+        }
+        finally
+        {
+            if (!fixture.TryRestoreLeaderRelation(out string restoreError))
+            {
+                error = $"Unable to restore alliance-timeout target normalization: {restoreError}";
+            }
+        }
+
+        return string.IsNullOrEmpty(error) && targetIsEligible;
+    }
+
+    private static bool TryPrepareAllianceTimeoutFixture(AllianceTimeoutFixture fixture, out string error)
+    {
+        if (!TryCanMakeAlliance(
+                fixture.Kingdom,
+                fixture.TargetKingdom,
+                fixture.Kingdom.RulingClan,
+                includeReason: false,
+                out bool canMakeAlliance,
+                out _,
+                out error)) return false;
+        if (!canMakeAlliance &&
+            !fixture.TryNormalizeLeaderRelation(out error))
+        {
+            return false;
+        }
+
+        if (!TryCanMakeAlliance(
+                fixture.Kingdom,
+                fixture.TargetKingdom,
+                fixture.Kingdom.RulingClan,
+                includeReason: true,
+                out canMakeAlliance,
+                out TextObject reason,
+                out string gateError))
+        {
+            if (!fixture.TryRestoreLeaderRelation(out string preparationRestoreError))
+            {
+                error = $"Unable to restore alliance-timeout fixture normalization: {preparationRestoreError}";
+                return false;
+            }
+
+            error = gateError;
+            return false;
+        }
+        if (canMakeAlliance) return true;
+
+        if (!fixture.TryRestoreLeaderRelation(out string failedGateRestoreError))
+        {
+            error = $"Unable to restore alliance-timeout fixture normalization: {failedGateRestoreError}";
+            return false;
+        }
+
+        error = $"Kingdom {fixture.Kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}";
+        return false;
+    }
+
+    private static bool TryCanMakeAlliance(
+        Kingdom kingdom,
+        Kingdom targetKingdom,
+        IFaction evaluatingFaction,
+        bool includeReason,
+        out bool canMakeAlliance,
+        out TextObject reason,
+        out string error)
+    {
+        canMakeAlliance = false;
+        reason = null;
+        error = string.Empty;
+        try
+        {
+            canMakeAlliance = Campaign.Current.Models.AllianceModel.CanMakeAlliance(
+                kingdom,
+                targetKingdom,
+                evaluatingFaction,
+                out reason,
+                includeReason);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            error = $"Alliance eligibility evaluation failed: {exception.Message}";
+            return false;
+        }
+    }
+
+    private static bool TryVerifyUnchangedAllianceState(AllianceTimeoutFixture fixture, out string error)
+    {
+        error = string.Empty;
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
+        if (allianceBehavior == null)
+        {
+            error = "The alliance campaign behavior is unavailable.";
+            return false;
+        }
+
+        try
+        {
+            if (allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom) == fixture.AllianceWasActive)
+                return true;
+
+            error = "The alliance state changed; the alliance-timeout fixture will not alter it.";
+            return false;
+        }
+        catch (Exception exception)
+        {
+            error = $"The alliance state could not be verified: {exception.Message}";
+            return false;
+        }
+    }
+
+    private static string FailAllianceTimeoutFixture(AllianceTimeoutFixture fixture, string failure)
+    {
+        if (TryRestoreAllianceTimeoutFixture(fixture, out string restoreError))
+        {
+            pendingAllianceTimeoutFixture = null;
+            return failure;
+        }
+
+        return $"{failure} Fixture restoration failed: {restoreError}";
+    }
+
+    private static bool TryRestoreAllianceTimeoutFixture(AllianceTimeoutFixture fixture, out string error)
+    {
+        var errors = new List<string>();
+        try
+        {
+            foreach (StartAllianceDecision decision in fixture.Kingdom.UnresolvedDecisions
+                .OfType<StartAllianceDecision>()
+                .Where(candidate => candidate.KingdomToStartAllianceWith == fixture.TargetKingdom)
+                .ToList())
+            {
+                fixture.Kingdom.RemoveDecision(decision);
+                CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(decision);
+            }
+        }
+        catch (Exception exception)
+        {
+            errors.Add($"The alliance decision could not be removed: {exception.Message}");
+        }
+
+        if (!TryVerifyUnchangedAllianceState(fixture, out string allianceStateError))
+        {
+            errors.Add(allianceStateError);
+        }
+
+        if (!fixture.TryRestoreLeaderRelation(out string relationError))
+        {
+            errors.Add($"The leader relation was not restored: {relationError}");
+        }
+        if (HasMatchingAllianceDecision(fixture) ||
+            fixture.Kingdom.UnresolvedDecisions.Count != fixture.UnresolvedDecisionCount)
+        {
+            errors.Add("The unresolved decision state was not restored.");
+        }
+
+        error = string.Join(" ", errors);
+        return errors.Count == 0;
+    }
+
     private static bool TryMatchPendingPolicyTimeoutFixture(
         string kingdomId,
         string proposerClanId,
@@ -793,6 +1079,13 @@ public class KingdomDebugCommand
         public string KingdomId { get; }
         public string TargetKingdomId { get; }
         public bool AllianceWasActive { get; }
+        public Hero EffectiveLeader { get; }
+        public Hero EffectiveTargetLeader { get; }
+        public int LeaderRelationBefore { get; }
+        public int UnresolvedDecisionCount { get; }
+        public bool LeaderRelationChanged { get; private set; }
+        public bool LeaderRelationRestored { get; private set; }
+        public int CurrentLeaderRelation => CharacterRelationManager.GetHeroRelation(EffectiveLeader, EffectiveTargetLeader);
 
         public AllianceTimeoutFixture(
             Kingdom kingdom,
@@ -800,7 +1093,10 @@ public class KingdomDebugCommand
             Kingdom targetKingdom,
             string kingdomId,
             string targetKingdomId,
-            bool allianceWasActive)
+            bool allianceWasActive,
+            Hero effectiveLeader,
+            Hero effectiveTargetLeader,
+            int leaderRelationBefore)
         {
             Kingdom = kingdom;
             ProposerClan = proposerClan;
@@ -808,6 +1104,88 @@ public class KingdomDebugCommand
             KingdomId = kingdomId;
             TargetKingdomId = targetKingdomId;
             AllianceWasActive = allianceWasActive;
+            EffectiveLeader = effectiveLeader;
+            EffectiveTargetLeader = effectiveTargetLeader;
+            LeaderRelationBefore = leaderRelationBefore;
+            UnresolvedDecisionCount = kingdom.UnresolvedDecisions.Count;
+            LeaderRelationRestored = true;
+        }
+
+        public bool TryNormalizeLeaderRelation(out string error)
+        {
+            error = string.Empty;
+            int maximumRelation = Campaign.Current.Models.DiplomacyModel.MaxRelationLimit;
+            int currentRelation = CurrentLeaderRelation;
+            if (currentRelation == maximumRelation) return true;
+
+            if (!TrySetLeaderRelation(maximumRelation, out string normalizationError))
+            {
+                if (!TryRestoreLeaderRelation(out string normalizationExceptionRestoreError))
+                {
+                    error = $"The normalized leader relation could not be restored: {normalizationExceptionRestoreError}";
+                    return false;
+                }
+
+                error = $"The alliance-timeout fixture could not normalize the leader relation: {normalizationError}";
+                return false;
+            }
+            if (CurrentLeaderRelation == maximumRelation)
+            {
+                LeaderRelationChanged = true;
+                LeaderRelationRestored = false;
+                return true;
+            }
+
+            if (!TryRestoreLeaderRelation(out string normalizationRestoreError))
+            {
+                error = $"The normalized leader relation could not be restored: {normalizationRestoreError}";
+                return false;
+            }
+
+            error = "The alliance-timeout fixture could not normalize the leader relation.";
+            return false;
+        }
+
+        public bool TryRestoreLeaderRelation(out string error)
+        {
+            error = string.Empty;
+            int currentRelation = CurrentLeaderRelation;
+            if (currentRelation != LeaderRelationBefore)
+            {
+                if (!TrySetLeaderRelation(LeaderRelationBefore, out string restoreError))
+                {
+                    error = restoreError;
+                }
+            }
+
+            LeaderRelationRestored = CurrentLeaderRelation == LeaderRelationBefore;
+            if (!LeaderRelationRestored)
+            {
+                error = string.IsNullOrEmpty(error)
+                    ? $"Expected {LeaderRelationBefore}, found {CurrentLeaderRelation}."
+                    : $"{error} Expected {LeaderRelationBefore}, found {CurrentLeaderRelation}.";
+            }
+
+            return LeaderRelationRestored;
+        }
+
+        private bool TrySetLeaderRelation(int relation, out string error)
+        {
+            error = string.Empty;
+            try
+            {
+                CharacterRelationManager.SetHeroRelation(EffectiveLeader, EffectiveTargetLeader, relation);
+            }
+            catch (Exception exception)
+            {
+                error = exception.Message;
+                return false;
+            }
+
+            if (CurrentLeaderRelation == relation) return true;
+
+            error = $"Expected {relation}, found {CurrentLeaderRelation}.";
+            return false;
         }
     }
 

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -1810,7 +1810,7 @@ public class KingdomDebugCommand
             }
 
             AllianceTimeoutNeighbor selectedThreat = GetVanillaThreateningNeighbor(querierKingdom, out float threatScore);
-            if (selectedThreat == threatNeighbor && threatScore > ThreatScoreThreshold) return true;
+            if (selectedThreat?.Kingdom == threatNeighbor.Kingdom && threatScore > ThreatScoreThreshold) return true;
 
             error = $"The alliance-timeout fixture could not select {threatNeighbor.Kingdom.StringId} " +
                 "as the vanilla threatening neighbor.";

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -161,10 +161,14 @@ public class KingdomDebugCommand
         if (args.Count < 2) return "Usage: <kingdomId> <decisionIndex>";
 
         KingdomDecision decision;
-        Kingdom playerKingdom = Clan.PlayerClan?.Kingdom;
+        Clan playerClan = Clan.PlayerClan;
+        Kingdom playerKingdom = playerClan?.Kingdom;
         bool isPlayerKingdom = playerKingdom != null &&
             (string.Equals(playerKingdom.StringId, args[0], StringComparison.Ordinal) ||
-             string.Equals($"{nameof(Kingdom)}_{playerKingdom.StringId}", args[0], StringComparison.Ordinal));
+             string.Equals($"{nameof(Kingdom)}_{playerKingdom.StringId}", args[0], StringComparison.Ordinal) ||
+             TryGetObjectManager(out var objectManager) &&
+             (MatchesRegisteredReference(objectManager, args[0], playerKingdom, typeof(Kingdom)) ||
+              MatchesRegisteredReference(objectManager, args[0], playerClan, typeof(Clan))));
         if (isPlayerKingdom)
         {
             if (!int.TryParse(args[1], out int index)) return $"Decision index is not a number: {args[1]}";
@@ -204,6 +208,23 @@ public class KingdomDebugCommand
         InformationManager.HideInquiry();
         inquiry.AffirmativeAction();
         return "KINGDOM_DECISION_SCREEN_OPENED";
+    }
+
+    internal static bool MatchesRegisteredReference(
+        IObjectManager objectManager,
+        string referenceId,
+        object instance,
+        Type referenceType)
+    {
+        if (objectManager == null || string.IsNullOrEmpty(referenceId) || instance == null || referenceType == null)
+            return false;
+        if (!objectManager.TryGetId(instance, out string registeredId)) return false;
+
+        return string.Equals(referenceId, registeredId, StringComparison.Ordinal) ||
+            string.Equals(
+                referenceId,
+                global::GameInterface.Services.ObjectManager.ObjectManager.Compact(registeredId, referenceType),
+                StringComparison.Ordinal);
     }
 
     [CommandLineArgumentFunction("close", "coop.debug.kingdom")]

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -24,8 +24,10 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.GameState;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
@@ -33,6 +35,7 @@ using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
+using TaleWorlds.ObjectSystem;
 using TaleWorlds.ScreenSystem;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
@@ -425,12 +428,7 @@ public class KingdomDebugCommand
         Kingdom kingdom = null;
         foreach (Kingdom candidate in Kingdom.All
             .Where(candidate =>
-                candidate != sturgia &&
-                candidate.RulingClan != null &&
-                candidate.Leader != null &&
-                candidate.UnresolvedDecisions.Count == 0 &&
-                !FactionManager.IsAtWarAgainstFaction(candidate, sturgia) &&
-                !allianceBehavior.IsAllyWithKingdom(candidate, sturgia))
+                IsEligibleAllianceTimeoutCandidate(candidate, sturgia, allianceBehavior))
             .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal))
         {
             if (!TryValidateAllianceTimeoutTarget(candidate, sturgia, out string error))
@@ -508,9 +506,9 @@ public class KingdomDebugCommand
             return fixtureError;
         }
         pendingAllianceTimeoutFixture = fixture;
-        if (!TryPrepareAllianceTimeoutFixture(fixture, out string error))
+        if (!TryPrepareAllianceTimeoutFixture(fixture, out _, out string error))
         {
-            if (fixture.LeaderRelationRestored) pendingAllianceTimeoutFixture = null;
+            if (fixture.EligibilityRestored) pendingAllianceTimeoutFixture = null;
             return error;
         }
 
@@ -527,6 +525,9 @@ public class KingdomDebugCommand
             leaderRelationBefore = fixture.LeaderRelationBefore,
             leaderRelationAfter = fixture.CurrentLeaderRelation,
             leaderRelationChanged = fixture.LeaderRelationChanged,
+            eligibilityInputsChanged = fixture.EligibilityInputsChanged,
+            normalizedThreatClanCount = fixture.NormalizedThreatClanCount,
+            normalizedSupporterRelationCount = fixture.NormalizedSupporterRelationCount,
             unresolvedDecisionCount = kingdom.UnresolvedDecisions.Count
         });
     }
@@ -578,38 +579,86 @@ public class KingdomDebugCommand
                 $"Kingdom {kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}");
         }
 
+        if (!fixture.TryNormalizeNpcElectionSupporters(out string electionSupporterError))
+            return FailAllianceTimeoutFixture(fixture, electionSupporterError);
+
+        string stageFailure = string.Empty;
+        int decisionIndex = 0;
+        StartAllianceDecision decision = null;
         try
         {
-            // A redirected inbound offer is authored by the player kingdom's ruling clan.
-            var decision = new StartAllianceDecision(fixture.Kingdom.RulingClan, fixture.TargetKingdom);
-            CoopKingdomElection._opponentProposedAllianceDecisions.Add(decision);
-            fixture.Kingdom.AddDecision(decision, true);
-            decision.TriggerTime = CampaignTime.Zero;
-            CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
-
-            if (!TryVerifyUnchangedAllianceState(fixture, out allianceStateError))
-                return FailAllianceTimeoutFixture(fixture, allianceStateError);
-
-            int decisionIndex = fixture.Kingdom._unresolvedDecisions.IndexOf(decision) + 1;
-            if (decisionIndex <= 0)
-                return FailAllianceTimeoutFixture(fixture, "The alliance-timeout decision was not retained for co-op voting.");
-
-            return LiveTestJsonResult(new
+            if (!TryCanMakeAlliance(
+                    kingdom,
+                    targetKingdom,
+                    kingdom.RulingClan,
+                    includeReason: true,
+                    out canMakeAlliance,
+                    out reason,
+                    out gateError))
             {
-                success = true,
-                fixture.KingdomId,
-                fixture.TargetKingdomId,
-                decisionIndex,
-                triggerPast = decision.TriggerTime.IsPast,
-                votingDurationSeconds = (int)KingdomDecisionVoteManager.VotingRoundDuration.TotalSeconds
-            });
+                stageFailure = gateError;
+            }
+            else if (!canMakeAlliance)
+            {
+                stageFailure = $"Kingdom {kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}";
+            }
+            else
+            {
+                // A redirected inbound offer is authored by the player kingdom's ruling clan.
+                decision = new StartAllianceDecision(fixture.Kingdom.RulingClan, fixture.TargetKingdom);
+                CoopKingdomElection._opponentProposedAllianceDecisions.Add(decision);
+                fixture.Kingdom.AddDecision(decision, true);
+                if (!fixture.TryRestoreNpcElectionSupporters(out string restoreError))
+                {
+                    stageFailure = $"The alliance-timeout election supporters could not be restored: {restoreError}";
+                }
+                else
+                {
+                    decision.TriggerTime = CampaignTime.Zero;
+                    CoopKingdomDecisionProposalBehaviorPatch.HourlyTickPrefix();
+
+                    if (!TryVerifyUnchangedAllianceState(fixture, out allianceStateError))
+                    {
+                        stageFailure = allianceStateError;
+                    }
+                    else
+                    {
+                        decisionIndex = fixture.Kingdom._unresolvedDecisions.IndexOf(decision) + 1;
+                        if (decisionIndex <= 0)
+                        {
+                            stageFailure = "The alliance-timeout decision was not retained for co-op voting.";
+                        }
+                    }
+                }
+            }
         }
         catch (Exception exception)
         {
-            return FailAllianceTimeoutFixture(
-                fixture,
-                $"The alliance-timeout decision could not be staged: {exception.Message}");
+            stageFailure = $"The alliance-timeout decision could not be staged: {exception.Message}";
         }
+        finally
+        {
+            if (!fixture.TryRestoreNpcElectionSupporters(out string restoreError))
+            {
+                stageFailure = string.IsNullOrEmpty(stageFailure)
+                    ? $"The alliance-timeout election supporters could not be restored: {restoreError}"
+                    : $"{stageFailure} Fixture election supporter restoration failed: {restoreError}";
+            }
+        }
+
+        if (!string.IsNullOrEmpty(stageFailure)) return FailAllianceTimeoutFixture(fixture, stageFailure);
+
+        return LiveTestJsonResult(new
+        {
+            success = true,
+            fixture.KingdomId,
+            fixture.TargetKingdomId,
+            decisionIndex,
+            normalizedNpcElectionSupporterCount = fixture.NormalizedNpcElectionSupporterCount,
+            npcElectionSupportersRestored = fixture.NpcElectionSupportersRestored,
+            triggerPast = decision.TriggerTime.IsPast,
+            votingDurationSeconds = (int)KingdomDecisionVoteManager.VotingRoundDuration.TotalSeconds
+        });
     }
 
     [CommandLineArgumentFunction("alliance_timeout_state", "coop.debug.kingdom")]
@@ -723,6 +772,7 @@ public class KingdomDebugCommand
             restoredAllianceActive = allianceBehavior.IsAllyWithKingdom(fixture.Kingdom, fixture.TargetKingdom),
             leaderRelationBefore = fixture.LeaderRelationBefore,
             leaderRelationRestored = fixture.LeaderRelationRestored,
+            eligibilityInputsRestored = fixture.EligibilityRestored,
             unresolvedDecisionCount = fixture.Kingdom.UnresolvedDecisions.Count
         });
     }
@@ -787,6 +837,59 @@ public class KingdomDebugCommand
             .OfType<StartAllianceDecision>()
             .Any(decision => decision.KingdomToStartAllianceWith == fixture.TargetKingdom);
 
+    private static bool IsEligibleAllianceTimeoutCandidate(
+        Kingdom kingdom,
+        Kingdom targetKingdom,
+        AllianceCampaignBehavior allianceBehavior)
+    {
+        if (kingdom == null || targetKingdom == null || kingdom == targetKingdom ||
+            kingdom.IsEliminated || targetKingdom.IsEliminated ||
+            kingdom.RulingClan == null || kingdom.Leader == null || targetKingdom.RulingClan == null ||
+            targetKingdom.Leader == null || kingdom.UnresolvedDecisions.Count != 0 ||
+            FactionManager.IsAtWarAgainstFaction(kingdom, targetKingdom) ||
+            allianceBehavior.IsAllyWithKingdom(kingdom, targetKingdom)) return false;
+
+        if (Campaign.Current?.Models?.AllianceModel == null) return false;
+
+        int maximumAlliances = Campaign.Current.Models.AllianceModel.MaxNumberOfAlliances;
+        if (kingdom.AlliedKingdoms.Count >= maximumAlliances ||
+            targetKingdom.AlliedKingdoms.Count >= maximumAlliances) return false;
+
+        // The vanilla gate owns the topology and directional score checks after preparation.
+        return true;
+    }
+
+    private static List<AllianceTimeoutNeighbor> GetAllianceTimeoutNeighbors(Kingdom kingdom)
+    {
+        var seenFortifications = new HashSet<Settlement>();
+        var neighborCounts = new Dictionary<Kingdom, float>();
+        float totalNeighborCount = 0f;
+        foreach (Town fief in kingdom.Fiefs)
+        {
+            foreach (Settlement fortification in fief.GetNeighborFortifications(MobileParty.NavigationType.All))
+            {
+                IFaction faction = fortification.MapFaction;
+                if (faction == kingdom || !faction.IsKingdomFaction || !seenFortifications.Add(fortification)) continue;
+
+                var neighboringKingdom = (Kingdom)faction;
+                if (neighborCounts.TryGetValue(neighboringKingdom, out float count))
+                {
+                    neighborCounts[neighboringKingdom] = count + 1f;
+                }
+                else
+                {
+                    neighborCounts.Add(neighboringKingdom, 1f);
+                }
+
+                totalNeighborCount++;
+            }
+        }
+
+        return neighborCounts
+            .Select(pair => new AllianceTimeoutNeighbor(pair.Key, pair.Value, totalNeighborCount))
+            .ToList();
+    }
+
     private static bool TryCreateAllianceTimeoutFixture(
         Kingdom kingdom,
         Clan proposerClan,
@@ -845,16 +948,6 @@ public class KingdomDebugCommand
 
     private static bool TryValidateAllianceTimeoutTarget(Kingdom kingdom, Kingdom targetKingdom, out string error)
     {
-        if (!TryCanMakeAlliance(
-                kingdom,
-                targetKingdom,
-                kingdom.RulingClan,
-                includeReason: false,
-                out bool canMakeAlliance,
-                out _,
-                out error)) return false;
-        if (canMakeAlliance) return true;
-
         if (!TryCreateAllianceTimeoutFixture(
                 kingdom,
                 kingdom.RulingClan,
@@ -866,34 +959,38 @@ public class KingdomDebugCommand
         {
             return false;
         }
-        if (!fixture.TryNormalizeLeaderRelation(out error)) return false;
 
-        bool targetIsEligible = false;
+        bool targetIsEligible;
+        bool gateRejected;
+        bool eligibilityRestored = false;
         try
         {
-            if (!TryCanMakeAlliance(
-                kingdom,
-                targetKingdom,
-                kingdom.RulingClan,
-                includeReason: false,
-                out canMakeAlliance,
-                out _,
-                out error)) return false;
-            targetIsEligible = canMakeAlliance;
+            targetIsEligible = TryPrepareAllianceTimeoutFixture(fixture, out gateRejected, out error);
         }
         finally
         {
-            if (!fixture.TryRestoreLeaderRelation(out string restoreError))
+            eligibilityRestored = fixture.TryRestoreEligibility(out string restoreError);
+            if (!eligibilityRestored)
             {
                 error = $"Unable to restore alliance-timeout target normalization: {restoreError}";
             }
         }
 
+        if (!targetIsEligible && gateRejected && eligibilityRestored)
+        {
+            error = string.Empty;
+            return false;
+        }
         return string.IsNullOrEmpty(error) && targetIsEligible;
     }
 
-    private static bool TryPrepareAllianceTimeoutFixture(AllianceTimeoutFixture fixture, out string error)
+    private static bool TryPrepareAllianceTimeoutFixture(
+        AllianceTimeoutFixture fixture,
+        out bool gateRejected,
+        out string error)
     {
+        gateRejected = false;
+        bool requiresPlayerSupportNormalization = fixture.RequiresPlayerSupportNormalization;
         if (!TryCanMakeAlliance(
                 fixture.Kingdom,
                 fixture.TargetKingdom,
@@ -902,12 +999,84 @@ public class KingdomDebugCommand
                 out bool canMakeAlliance,
                 out _,
                 out error)) return false;
-        if (!canMakeAlliance &&
-            !fixture.TryNormalizeLeaderRelation(out error))
+        if (canMakeAlliance && !requiresPlayerSupportNormalization) return true;
+
+        if (!fixture.TryNormalizeLeaderRelation(out string leaderRelationError))
         {
-            return false;
+            return TryFailAllianceTimeoutFixturePreparation(fixture, leaderRelationError, out error);
+        }
+        if (TryCanMakeAlliance(
+                fixture.Kingdom,
+                fixture.TargetKingdom,
+                fixture.Kingdom.RulingClan,
+                includeReason: false,
+                out canMakeAlliance,
+                out _,
+                out error) && canMakeAlliance && !requiresPlayerSupportNormalization) return true;
+        if (!string.IsNullOrEmpty(error))
+        {
+            string gateFailure = error;
+            return TryFailAllianceTimeoutFixturePreparation(fixture, gateFailure, out error);
         }
 
+        if (!fixture.TryNormalizeThreatStrengths(out string threatStrengthError))
+        {
+            return TryFailAllianceTimeoutFixturePreparation(fixture, threatStrengthError, out error);
+        }
+        if (TryCanMakeAlliance(
+                fixture.Kingdom,
+                fixture.TargetKingdom,
+                fixture.Kingdom.RulingClan,
+                includeReason: false,
+                out canMakeAlliance,
+                out _,
+                out error) && canMakeAlliance && !requiresPlayerSupportNormalization) return true;
+        if (!string.IsNullOrEmpty(error))
+        {
+            string gateFailure = error;
+            return TryFailAllianceTimeoutFixturePreparation(fixture, gateFailure, out error);
+        }
+
+        if (!fixture.TryNormalizeKingdomCultures(out string cultureError))
+        {
+            return TryFailAllianceTimeoutFixturePreparation(fixture, cultureError, out error);
+        }
+        if (TryCanMakeAlliance(
+                fixture.Kingdom,
+                fixture.TargetKingdom,
+                fixture.Kingdom.RulingClan,
+                includeReason: false,
+                out canMakeAlliance,
+                out _,
+                out error) && canMakeAlliance && !requiresPlayerSupportNormalization) return true;
+        if (!string.IsNullOrEmpty(error))
+        {
+            string gateFailure = error;
+            return TryFailAllianceTimeoutFixturePreparation(fixture, gateFailure, out error);
+        }
+
+        if (!fixture.TryNormalizeLeaderHonor(out string leaderHonorError))
+        {
+            return TryFailAllianceTimeoutFixturePreparation(fixture, leaderHonorError, out error);
+        }
+        if (TryCanMakeAlliance(
+                fixture.Kingdom,
+                fixture.TargetKingdom,
+                fixture.Kingdom.RulingClan,
+                includeReason: false,
+                out canMakeAlliance,
+                out _,
+                out error) && canMakeAlliance && !requiresPlayerSupportNormalization) return true;
+        if (!string.IsNullOrEmpty(error))
+        {
+            string gateFailure = error;
+            return TryFailAllianceTimeoutFixturePreparation(fixture, gateFailure, out error);
+        }
+
+        if (!fixture.TryNormalizePlayerSupport(out string playerSupportError))
+        {
+            return TryFailAllianceTimeoutFixturePreparation(fixture, playerSupportError, out error);
+        }
         if (!TryCanMakeAlliance(
                 fixture.Kingdom,
                 fixture.TargetKingdom,
@@ -917,24 +1086,29 @@ public class KingdomDebugCommand
                 out TextObject reason,
                 out string gateError))
         {
-            if (!fixture.TryRestoreLeaderRelation(out string preparationRestoreError))
-            {
-                error = $"Unable to restore alliance-timeout fixture normalization: {preparationRestoreError}";
-                return false;
-            }
-
-            error = gateError;
-            return false;
+            return TryFailAllianceTimeoutFixturePreparation(fixture, gateError, out error);
         }
         if (canMakeAlliance) return true;
 
-        if (!fixture.TryRestoreLeaderRelation(out string failedGateRestoreError))
+        gateRejected = true;
+        return TryFailAllianceTimeoutFixturePreparation(
+            fixture,
+            $"Kingdom {fixture.Kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}",
+            out error);
+    }
+
+    private static bool TryFailAllianceTimeoutFixturePreparation(
+        AllianceTimeoutFixture fixture,
+        string failure,
+        out string error)
+    {
+        if (!fixture.TryRestoreEligibility(out string restoreError))
         {
-            error = $"Unable to restore alliance-timeout fixture normalization: {failedGateRestoreError}";
+            error = $"{failure} Fixture restoration failed: {restoreError}";
             return false;
         }
 
-        error = $"Kingdom {fixture.Kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}";
+        error = failure;
         return false;
     }
 
@@ -1027,9 +1201,9 @@ public class KingdomDebugCommand
             errors.Add(allianceStateError);
         }
 
-        if (!fixture.TryRestoreLeaderRelation(out string relationError))
+        if (!fixture.TryRestoreEligibility(out string relationError))
         {
-            errors.Add($"The leader relation was not restored: {relationError}");
+            errors.Add($"The alliance eligibility inputs were not restored: {relationError}");
         }
         if (HasMatchingAllianceDecision(fixture) ||
             fixture.Kingdom.UnresolvedDecisions.Count != fixture.UnresolvedDecisionCount)
@@ -1073,6 +1247,17 @@ public class KingdomDebugCommand
 
     private sealed class AllianceTimeoutFixture
     {
+        private const float MinimumQuerierKingdomStrength = 1f;
+        private const float ThreatScoreThreshold = 430f;
+        private const float ThreatSelectionMargin = 1f;
+        private const float ThreatScoreCoefficient = 130f;
+        private const float ThreatScoreBaseline = 0.4f;
+        private const float MaximumThreatExposure = 1.7f;
+        private const float MaximumThreatPowerRatio = 3f;
+        private readonly List<AllianceTimeoutClanStrength> normalizedThreatClanStrengths = new List<AllianceTimeoutClanStrength>();
+        private readonly List<AllianceTimeoutRelation> normalizedSupporterRelations = new List<AllianceTimeoutRelation>();
+        private readonly List<AllianceTimeoutMercenaryStatus> normalizedNpcElectionSupporters = new List<AllianceTimeoutMercenaryStatus>();
+
         public Kingdom Kingdom { get; }
         public Clan ProposerClan { get; }
         public Kingdom TargetKingdom { get; }
@@ -1083,9 +1268,29 @@ public class KingdomDebugCommand
         public Hero EffectiveTargetLeader { get; }
         public int LeaderRelationBefore { get; }
         public int UnresolvedDecisionCount { get; }
+        public CultureObject KingdomCultureBefore { get; }
+        public CultureObject TargetKingdomCultureBefore { get; }
+        public int KingdomLeaderHonorBefore { get; }
+        public int TargetKingdomLeaderHonorBefore { get; }
         public bool LeaderRelationChanged { get; private set; }
         public bool LeaderRelationRestored { get; private set; }
+        public bool KingdomCultureChanged { get; private set; }
+        public bool TargetKingdomCultureChanged { get; private set; }
+        public bool KingdomLeaderHonorChanged { get; private set; }
+        public bool TargetKingdomLeaderHonorChanged { get; private set; }
+        public bool EligibilityRestored { get; private set; }
+        public bool NpcElectionSupportersRestored { get; private set; }
+        public bool EligibilityInputsChanged =>
+            LeaderRelationChanged || KingdomCultureChanged || TargetKingdomCultureChanged ||
+            KingdomLeaderHonorChanged || TargetKingdomLeaderHonorChanged ||
+            normalizedThreatClanStrengths.Count != 0 || normalizedSupporterRelations.Count != 0 ||
+            normalizedNpcElectionSupporters.Count != 0;
+        public int NormalizedThreatClanCount => normalizedThreatClanStrengths.Count;
+        public int NormalizedSupporterRelationCount => normalizedSupporterRelations.Count;
+        public int NormalizedNpcElectionSupporterCount => normalizedNpcElectionSupporters.Count;
         public int CurrentLeaderRelation => CharacterRelationManager.GetHeroRelation(EffectiveLeader, EffectiveTargetLeader);
+        public bool RequiresPlayerSupportNormalization =>
+            ProposerClan != null && ProposerClan.Kingdom == Kingdom && ProposerClan != Kingdom.RulingClan;
 
         public AllianceTimeoutFixture(
             Kingdom kingdom,
@@ -1108,7 +1313,13 @@ public class KingdomDebugCommand
             EffectiveTargetLeader = effectiveTargetLeader;
             LeaderRelationBefore = leaderRelationBefore;
             UnresolvedDecisionCount = kingdom.UnresolvedDecisions.Count;
+            KingdomCultureBefore = kingdom.Culture;
+            TargetKingdomCultureBefore = targetKingdom.Culture;
+            KingdomLeaderHonorBefore = kingdom.Leader.GetTraitLevel(DefaultTraits.Honor);
+            TargetKingdomLeaderHonorBefore = targetKingdom.Leader.GetTraitLevel(DefaultTraits.Honor);
             LeaderRelationRestored = true;
+            NpcElectionSupportersRestored = true;
+            EligibilityRestored = true;
         }
 
         public bool TryNormalizeLeaderRelation(out string error)
@@ -1133,6 +1344,7 @@ public class KingdomDebugCommand
             {
                 LeaderRelationChanged = true;
                 LeaderRelationRestored = false;
+                EligibilityRestored = false;
                 return true;
             }
 
@@ -1169,6 +1381,612 @@ public class KingdomDebugCommand
             return LeaderRelationRestored;
         }
 
+        public bool TryNormalizeThreatStrengths(out string error)
+        {
+            error = string.Empty;
+            if (!TryEnsureKingdomStrength(Kingdom, MinimumQuerierKingdomStrength, out error)) return false;
+            if (!TryEnsureKingdomStrength(TargetKingdom, MinimumQuerierKingdomStrength, out error)) return false;
+            if (!TryNormalizeThreateningNeighbor(Kingdom, TargetKingdom, out error)) return false;
+            if (!TryEnsureKingdomStrength(TargetKingdom, MinimumQuerierKingdomStrength, out error)) return false;
+            if (!TryNormalizeThreateningNeighbor(TargetKingdom, Kingdom, out error)) return false;
+            if (!TryEnsureKingdomStrength(Kingdom, MinimumQuerierKingdomStrength, out error)) return false;
+            return TryEnsureKingdomStrength(TargetKingdom, MinimumQuerierKingdomStrength, out error);
+        }
+
+        public bool TryNormalizeKingdomCultures(out string error)
+        {
+            if (!TryNormalizeKingdomCulture(Kingdom, TargetKingdom, true, out error)) return false;
+            return TryNormalizeKingdomCulture(TargetKingdom, Kingdom, false, out error);
+        }
+
+        public bool TryNormalizeLeaderHonor(out string error)
+        {
+            if (!TrySetKingdomLeaderHonor(1, out error)) return false;
+            return TrySetTargetKingdomLeaderHonor(1, out error);
+        }
+
+        public bool TryNormalizePlayerSupport(out string error)
+        {
+            error = string.Empty;
+            if (!RequiresPlayerSupportNormalization) return true;
+
+            int maximumRelation = Campaign.Current.Models.DiplomacyModel.MaxRelationLimit;
+            if (!TrySetLeaderRelation(maximumRelation, out error)) return false;
+            if (!TrySetKingdomLeaderHonor(1, out error)) return false;
+            if (!TrySetTargetKingdomLeaderHonor(1, out error)) return false;
+
+            foreach (Clan supporterClan in Kingdom.Clans
+                     .Where(candidate =>
+                         !candidate.IsUnderMercenaryService && candidate != ProposerClan &&
+                         candidate != Kingdom.RulingClan && candidate.Leader != null))
+            {
+                try
+                {
+                    Campaign.Current.Models.DiplomacyModel.GetHeroesForEffectiveRelation(
+                        supporterClan.Leader,
+                        TargetKingdom.Leader,
+                        out Hero effectiveSupporter,
+                        out Hero effectiveTarget);
+                    if (effectiveSupporter == null || effectiveTarget == null || effectiveSupporter == effectiveTarget)
+                    {
+                        error = "The alliance-timeout fixture could not resolve a supporter relation.";
+                        return false;
+                    }
+                    if (IsLeaderRelation(effectiveSupporter, effectiveTarget) ||
+                        normalizedSupporterRelations.Any(snapshot => snapshot.IsFor(effectiveSupporter, effectiveTarget)))
+                    {
+                        continue;
+                    }
+
+                    int currentRelation = CharacterRelationManager.GetHeroRelation(effectiveSupporter, effectiveTarget);
+                    if (currentRelation == maximumRelation) continue;
+
+                    var snapshot = new AllianceTimeoutRelation(
+                        effectiveSupporter,
+                        effectiveTarget,
+                        currentRelation);
+                    normalizedSupporterRelations.Add(snapshot);
+                    CharacterRelationManager.SetHeroRelation(effectiveSupporter, effectiveTarget, maximumRelation);
+                    if (CharacterRelationManager.GetHeroRelation(effectiveSupporter, effectiveTarget) != maximumRelation)
+                    {
+                        error = $"Expected supporter relation {maximumRelation}, found " +
+                            $"{CharacterRelationManager.GetHeroRelation(effectiveSupporter, effectiveTarget)}.";
+                        return false;
+                    }
+
+                    EligibilityRestored = false;
+                }
+                catch (Exception exception)
+                {
+                    error = $"The alliance-timeout fixture could not normalize supporter relation: {exception.Message}";
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public bool TryNormalizeNpcElectionSupporters(out string error)
+        {
+            error = string.Empty;
+            if (ProposerClan == null || ProposerClan.Kingdom != Kingdom)
+            {
+                error = "The alliance-timeout fixture no longer has a testclient voting clan.";
+                return false;
+            }
+            if (ProposerClan.IsUnderMercenaryService)
+            {
+                error = "The testclient voting clan cannot be under mercenary service.";
+                return false;
+            }
+            if (normalizedNpcElectionSupporters.Count != 0)
+            {
+                error = "The alliance-timeout fixture has already initialized its election supporters.";
+                return false;
+            }
+
+            foreach (Clan clan in Kingdom.Clans
+                     .Where(candidate => candidate != null && candidate != ProposerClan &&
+                         !candidate.IsUnderMercenaryService)
+                     .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal))
+            {
+                if (clan.Leader?.IsHumanPlayerCharacter == true)
+                {
+                    return TryFailNpcElectionSupporterNormalization(
+                        "The alliance-timeout fixture requires testclient to be the only non-mercenary human supporter.",
+                        out error);
+                }
+
+                var snapshot = new AllianceTimeoutMercenaryStatus(clan, clan.IsUnderMercenaryService);
+                normalizedNpcElectionSupporters.Add(snapshot);
+                try
+                {
+                    clan.IsUnderMercenaryService = true;
+                }
+                catch (Exception exception)
+                {
+                    return TryFailNpcElectionSupporterNormalization(
+                        $"The alliance-timeout fixture could not initialize election supporters: {exception.Message}",
+                        out error);
+                }
+                if (!clan.IsUnderMercenaryService)
+                {
+                    return TryFailNpcElectionSupporterNormalization(
+                        $"Expected {clan.StringId} to be under mercenary service during election setup.",
+                        out error);
+                }
+            }
+
+            if (normalizedNpcElectionSupporters.Count == 0)
+            {
+                error = "The alliance-timeout fixture could not find an NPC election supporter to initialize.";
+                return false;
+            }
+
+            NpcElectionSupportersRestored = false;
+            EligibilityRestored = false;
+            return true;
+        }
+
+        private bool TryFailNpcElectionSupporterNormalization(string failure, out string error)
+        {
+            if (TryRestoreNpcElectionSupporters(out string restoreError))
+            {
+                error = failure;
+                return false;
+            }
+
+            error = $"{failure} Fixture election supporter restoration failed: {restoreError}";
+            return false;
+        }
+
+        public bool TryRestoreNpcElectionSupporters(out string error)
+        {
+            var errors = new List<string>();
+            foreach (AllianceTimeoutMercenaryStatus snapshot in normalizedNpcElectionSupporters)
+            {
+                try
+                {
+                    if (snapshot.CurrentValue != snapshot.Value)
+                    {
+                        snapshot.Clan.IsUnderMercenaryService = snapshot.Value;
+                    }
+                    if (snapshot.CurrentValue != snapshot.Value)
+                    {
+                        errors.Add($"Expected {snapshot.Clan.StringId} mercenary status {snapshot.Value}, found {snapshot.CurrentValue}.");
+                    }
+                }
+                catch (Exception exception)
+                {
+                    errors.Add($"The election supporter {snapshot.Clan.StringId} could not be restored: {exception.Message}");
+                }
+            }
+
+            NpcElectionSupportersRestored = errors.Count == 0 &&
+                normalizedNpcElectionSupporters.All(snapshot => snapshot.CurrentValue == snapshot.Value);
+            if (!NpcElectionSupportersRestored && errors.Count == 0)
+            {
+                errors.Add("The alliance-timeout election supporters did not restore to their captured values.");
+            }
+
+            error = string.Join(" ", errors);
+            return NpcElectionSupportersRestored;
+        }
+
+        public bool TryRestoreEligibility(out string error)
+        {
+            var errors = new List<string>();
+            if (!TryRestoreNpcElectionSupporters(out string npcElectionSupporterError)) errors.Add(npcElectionSupporterError);
+            TryRestoreSupporterRelations(errors);
+            if (!TryRestoreLeaderRelation(out string leaderRelationError)) errors.Add(leaderRelationError);
+            TryRestoreKingdomLeaderHonor(errors);
+            TryRestoreTargetKingdomLeaderHonor(errors);
+            TryRestoreKingdomCultures(errors);
+            TryRestoreThreatStrengths(errors);
+
+            EligibilityRestored = errors.Count == 0 &&
+                LeaderRelationRestored &&
+                Kingdom.Culture == KingdomCultureBefore &&
+                TargetKingdom.Culture == TargetKingdomCultureBefore &&
+                Kingdom.Leader.GetTraitLevel(DefaultTraits.Honor) == KingdomLeaderHonorBefore &&
+                TargetKingdom.Leader.GetTraitLevel(DefaultTraits.Honor) == TargetKingdomLeaderHonorBefore &&
+                normalizedThreatClanStrengths.All(snapshot => snapshot.Clan.CurrentTotalStrength == snapshot.Value) &&
+                normalizedSupporterRelations.All(snapshot => snapshot.CurrentValue == snapshot.Value) &&
+                normalizedNpcElectionSupporters.All(snapshot => snapshot.CurrentValue == snapshot.Value) &&
+                NpcElectionSupportersRestored;
+            if (!EligibilityRestored && errors.Count == 0)
+            {
+                errors.Add("The alliance-timeout eligibility inputs did not restore to their captured values.");
+            }
+
+            error = string.Join(" ", errors);
+            return EligibilityRestored;
+        }
+
+        private bool TryNormalizeKingdomCulture(
+            Kingdom kingdom,
+            Kingdom otherKingdom,
+            bool isFixtureKingdom,
+            out string error)
+        {
+            error = string.Empty;
+            if (kingdom.Culture == null || !otherKingdom.Fiefs.Any(fief => fief.Culture == kingdom.Culture)) return true;
+
+            CultureObject culture = MBObjectManager.Instance.GetObjectTypeList<CultureObject>()
+                .Where(candidate => candidate != null && !otherKingdom.Fiefs.Any(fief => fief.Culture == candidate))
+                .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal)
+                .FirstOrDefault();
+            if (culture == null)
+            {
+                error = $"The alliance-timeout fixture could not find a reversible culture for {kingdom.StringId}.";
+                return false;
+            }
+
+            try
+            {
+                kingdom.Culture = culture;
+            }
+            catch (Exception exception)
+            {
+                error = $"The alliance-timeout fixture could not normalize kingdom culture: {exception.Message}";
+                return false;
+            }
+            if (kingdom.Culture != culture)
+            {
+                error = "The alliance-timeout fixture could not normalize kingdom culture.";
+                return false;
+            }
+
+            if (isFixtureKingdom) KingdomCultureChanged = true;
+            else TargetKingdomCultureChanged = true;
+            EligibilityRestored = false;
+            return true;
+        }
+
+        private bool TrySetKingdomLeaderHonor(int honor, out string error)
+        {
+            return TrySetLeaderHonor(Kingdom.Leader, honor, true, out error);
+        }
+
+        private bool TrySetTargetKingdomLeaderHonor(int honor, out string error)
+        {
+            return TrySetLeaderHonor(TargetKingdom.Leader, honor, false, out error);
+        }
+
+        private bool TrySetLeaderHonor(Hero leader, int honor, bool isFixtureKingdom, out string error)
+        {
+            error = string.Empty;
+            if (leader.GetTraitLevel(DefaultTraits.Honor) == honor) return true;
+
+            try
+            {
+                leader.SetTraitLevel(DefaultTraits.Honor, honor);
+            }
+            catch (Exception exception)
+            {
+                error = $"The alliance-timeout fixture could not normalize ruler honor: {exception.Message}";
+                return false;
+            }
+            if (leader.GetTraitLevel(DefaultTraits.Honor) != honor)
+            {
+                error = $"Expected ruler honor {honor}, found {leader.GetTraitLevel(DefaultTraits.Honor)}.";
+                return false;
+            }
+
+            if (isFixtureKingdom) KingdomLeaderHonorChanged = true;
+            else TargetKingdomLeaderHonorChanged = true;
+            EligibilityRestored = false;
+            return true;
+        }
+
+        private void TryRestoreSupporterRelations(List<string> errors)
+        {
+            foreach (AllianceTimeoutRelation snapshot in normalizedSupporterRelations)
+            {
+                try
+                {
+                    if (snapshot.CurrentValue != snapshot.Value)
+                    {
+                        CharacterRelationManager.SetHeroRelation(snapshot.First, snapshot.Second, snapshot.Value);
+                    }
+                    if (snapshot.CurrentValue != snapshot.Value)
+                    {
+                        errors.Add($"Expected supporter relation {snapshot.Value}, found {snapshot.CurrentValue}.");
+                    }
+                }
+                catch (Exception exception)
+                {
+                    errors.Add($"The supporter relation could not be restored: {exception.Message}");
+                }
+            }
+        }
+
+        private void TryRestoreKingdomLeaderHonor(List<string> errors)
+        {
+            TryRestoreLeaderHonor(Kingdom.Leader, KingdomLeaderHonorBefore, errors);
+        }
+
+        private void TryRestoreTargetKingdomLeaderHonor(List<string> errors)
+        {
+            TryRestoreLeaderHonor(TargetKingdom.Leader, TargetKingdomLeaderHonorBefore, errors);
+        }
+
+        private static void TryRestoreLeaderHonor(Hero leader, int honor, List<string> errors)
+        {
+            try
+            {
+                if (leader.GetTraitLevel(DefaultTraits.Honor) != honor)
+                {
+                    leader.SetTraitLevel(DefaultTraits.Honor, honor);
+                }
+                if (leader.GetTraitLevel(DefaultTraits.Honor) != honor)
+                {
+                    errors.Add($"Expected ruler honor {honor}, found {leader.GetTraitLevel(DefaultTraits.Honor)}.");
+                }
+            }
+            catch (Exception exception)
+            {
+                errors.Add($"The ruler honor could not be restored: {exception.Message}");
+            }
+        }
+
+        private void TryRestoreKingdomCultures(List<string> errors)
+        {
+            TryRestoreKingdomCulture(Kingdom, KingdomCultureBefore, errors);
+            TryRestoreKingdomCulture(TargetKingdom, TargetKingdomCultureBefore, errors);
+        }
+
+        private static void TryRestoreKingdomCulture(Kingdom kingdom, CultureObject culture, List<string> errors)
+        {
+            try
+            {
+                if (kingdom.Culture != culture) kingdom.Culture = culture;
+                if (kingdom.Culture != culture)
+                {
+                    errors.Add($"The culture for {kingdom.StringId} was not restored.");
+                }
+            }
+            catch (Exception exception)
+            {
+                errors.Add($"The culture for {kingdom.StringId} could not be restored: {exception.Message}");
+            }
+        }
+
+        private void TryRestoreThreatStrengths(List<string> errors)
+        {
+            foreach (AllianceTimeoutClanStrength snapshot in normalizedThreatClanStrengths)
+            {
+                try
+                {
+                    if (snapshot.Clan.CurrentTotalStrength != snapshot.Value)
+                    {
+                        snapshot.Clan.CurrentTotalStrength = snapshot.Value;
+                    }
+                    if (snapshot.Clan.CurrentTotalStrength != snapshot.Value)
+                    {
+                        errors.Add($"Expected threat strength {snapshot.Value}, found {snapshot.Clan.CurrentTotalStrength}.");
+                    }
+                }
+                catch (Exception exception)
+                {
+                    errors.Add($"Threat strength could not be restored: {exception.Message}");
+                }
+            }
+        }
+
+        private bool TryNormalizeThreateningNeighbor(
+            Kingdom querierKingdom,
+            Kingdom otherKingdom,
+            out string error)
+        {
+            error = string.Empty;
+            List<AllianceTimeoutNeighbor> neighbors = GetAllianceTimeoutNeighbors(querierKingdom);
+            float querierStrength = GetKingdomStrength(querierKingdom);
+            AllianceTimeoutNeighbor threatNeighbor = neighbors
+                .Where(candidate => candidate.Kingdom != otherKingdom && !candidate.Kingdom.IsEliminated)
+                .OrderByDescending(candidate => GetMaximumThreatScore(candidate, querierStrength))
+                .ThenBy(candidate => candidate.Kingdom.StringId, StringComparer.Ordinal)
+                .FirstOrDefault();
+            if (threatNeighbor == null ||
+                GetMaximumThreatScore(threatNeighbor, querierStrength) <= ThreatScoreThreshold) return true;
+
+            float requiredStrength = GetRequiredThreatStrength(
+                threatNeighbor,
+                querierStrength,
+                ThreatScoreThreshold + ThreatSelectionMargin);
+            if (!TryEnsureKingdomStrength(threatNeighbor.Kingdom, requiredStrength, out error)) return false;
+
+            float selectedThreatScore = GetThreatScore(threatNeighbor, querierStrength);
+            foreach (AllianceTimeoutNeighbor competingNeighbor in neighbors
+                     .Where(candidate => candidate.Kingdom != threatNeighbor.Kingdom))
+            {
+                if (GetThreatScore(competingNeighbor, querierStrength) < selectedThreatScore) continue;
+
+                float maximumStrength = GetMaximumThreatStrength(
+                    competingNeighbor,
+                    querierStrength,
+                    selectedThreatScore - ThreatSelectionMargin);
+                if (!TryLimitKingdomStrength(competingNeighbor.Kingdom, maximumStrength, out error)) return false;
+            }
+
+            AllianceTimeoutNeighbor selectedThreat = GetVanillaThreateningNeighbor(querierKingdom, out float threatScore);
+            if (selectedThreat == threatNeighbor && threatScore > ThreatScoreThreshold) return true;
+
+            error = $"The alliance-timeout fixture could not select {threatNeighbor.Kingdom.StringId} " +
+                "as the vanilla threatening neighbor.";
+            return false;
+        }
+
+        private bool TryEnsureKingdomStrength(Kingdom kingdom, float requiredStrength, out string error)
+        {
+            error = string.Empty;
+            float currentStrength = GetKingdomStrength(kingdom);
+            if (currentStrength >= requiredStrength) return true;
+
+            Clan clan = kingdom.Clans
+                .Where(candidate => !candidate.IsUnderMercenaryService)
+                .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal)
+                .FirstOrDefault();
+            if (clan == null)
+            {
+                error = $"The alliance-timeout fixture could not find a non-mercenary clan for {kingdom.StringId}.";
+                return false;
+            }
+
+            float normalizedStrength = clan.CurrentTotalStrength + requiredStrength - currentStrength;
+            if (!TrySetClanStrength(clan, normalizedStrength, out error)) return false;
+            if (GetKingdomStrength(kingdom) < requiredStrength)
+            {
+                error = $"Expected kingdom strength {requiredStrength}, found {GetKingdomStrength(kingdom)}.";
+                return false;
+            }
+
+            EligibilityRestored = false;
+            return true;
+        }
+
+        private bool TryLimitKingdomStrength(Kingdom kingdom, float maximumStrength, out string error)
+        {
+            error = string.Empty;
+            float currentStrength = GetKingdomStrength(kingdom);
+            if (currentStrength < maximumStrength) return true;
+
+            float remainingReduction = currentStrength - maximumStrength + ThreatSelectionMargin;
+            foreach (Clan clan in kingdom.Clans
+                     .Where(candidate => !candidate.IsUnderMercenaryService)
+                     .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal))
+            {
+                if (remainingReduction <= 0f) break;
+
+                float reduction = MathF.Min(clan.CurrentTotalStrength, remainingReduction);
+                if (reduction <= 0f) continue;
+                if (!TrySetClanStrength(clan, clan.CurrentTotalStrength - reduction, out error)) return false;
+                remainingReduction -= reduction;
+            }
+
+            if (GetKingdomStrength(kingdom) >= maximumStrength)
+            {
+                error = $"Expected kingdom strength below {maximumStrength}, found {GetKingdomStrength(kingdom)}.";
+                return false;
+            }
+
+            EligibilityRestored = false;
+            return true;
+        }
+
+        private bool TrySetClanStrength(Clan clan, float strength, out string error)
+        {
+            error = string.Empty;
+            if (!normalizedThreatClanStrengths.Any(snapshot => snapshot.Clan == clan))
+            {
+                normalizedThreatClanStrengths.Add(new AllianceTimeoutClanStrength(clan, clan.CurrentTotalStrength));
+            }
+
+            try
+            {
+                clan.CurrentTotalStrength = strength;
+            }
+            catch (Exception exception)
+            {
+                error = $"The alliance-timeout fixture could not normalize threat strength: {exception.Message}";
+                return false;
+            }
+
+            return true;
+        }
+
+        private AllianceTimeoutNeighbor GetVanillaThreateningNeighbor(
+            Kingdom querierKingdom,
+            out float threatScore)
+        {
+            AllianceTimeoutNeighbor selectedNeighbor = null;
+            threatScore = 0f;
+            float querierStrength = GetKingdomStrength(querierKingdom);
+            foreach (AllianceTimeoutNeighbor neighbor in GetAllianceTimeoutNeighbors(querierKingdom))
+            {
+                float candidateThreatScore = GetThreatScore(neighbor, querierStrength);
+                if (threatScore < candidateThreatScore)
+                {
+                    selectedNeighbor = neighbor;
+                    threatScore = candidateThreatScore;
+                }
+            }
+
+            return selectedNeighbor;
+        }
+
+        private static float GetMaximumThreatScore(AllianceTimeoutNeighbor neighbor, float querierStrength)
+        {
+            if (querierStrength <= 0f || neighbor.TotalNeighborScore <= 0f) return 0f;
+
+            float exposureScore = MBMath.Map(
+                neighbor.NeighborScore / neighbor.TotalNeighborScore,
+                0f,
+                1f,
+                1f,
+                2f);
+            return (MathF.Min(exposureScore, MaximumThreatExposure) + ThreatScoreBaseline +
+                MaximumThreatPowerRatio) * ThreatScoreCoefficient;
+        }
+
+        private float GetThreatScore(AllianceTimeoutNeighbor neighbor, float querierStrength)
+        {
+            if (querierStrength <= 0f || neighbor.TotalNeighborScore <= 0f) return 0f;
+
+            float exposureScore = MBMath.Map(
+                neighbor.NeighborScore / neighbor.TotalNeighborScore,
+                0f,
+                1f,
+                1f,
+                2f);
+            float powerRatio = MathF.Clamp(
+                GetKingdomStrength(neighbor.Kingdom) / querierStrength,
+                0f,
+                MaximumThreatPowerRatio);
+            return (MathF.Min(exposureScore, MaximumThreatExposure) + ThreatScoreBaseline +
+                powerRatio) * ThreatScoreCoefficient;
+        }
+
+        private static float GetRequiredThreatStrength(
+            AllianceTimeoutNeighbor neighbor,
+            float querierStrength,
+            float requiredThreatScore)
+        {
+            float exposureScore = MBMath.Map(
+                neighbor.NeighborScore / neighbor.TotalNeighborScore,
+                0f,
+                1f,
+                1f,
+                2f);
+            float requiredPowerRatio = (requiredThreatScore / ThreatScoreCoefficient) -
+                MathF.Min(exposureScore, MaximumThreatExposure) - ThreatScoreBaseline;
+            return querierStrength * MathF.Clamp(requiredPowerRatio, 0f, MaximumThreatPowerRatio);
+        }
+
+        private static float GetMaximumThreatStrength(
+            AllianceTimeoutNeighbor neighbor,
+            float querierStrength,
+            float maximumThreatScore)
+        {
+            float exposureScore = MBMath.Map(
+                neighbor.NeighborScore / neighbor.TotalNeighborScore,
+                0f,
+                1f,
+                1f,
+                2f);
+            float maximumPowerRatio = (maximumThreatScore / ThreatScoreCoefficient) -
+                MathF.Min(exposureScore, MaximumThreatExposure) - ThreatScoreBaseline;
+            return querierStrength * MathF.Clamp(maximumPowerRatio, 0f, MaximumThreatPowerRatio);
+        }
+
+        private bool IsLeaderRelation(Hero first, Hero second) =>
+            (first == EffectiveLeader && second == EffectiveTargetLeader) ||
+            (first == EffectiveTargetLeader && second == EffectiveLeader);
+
+        private static float GetKingdomStrength(Kingdom kingdom) => kingdom.Clans
+            .Where(clan => !clan.IsUnderMercenaryService)
+            .Sum(clan => clan.CurrentTotalStrength);
+
         private bool TrySetLeaderRelation(int relation, out string error)
         {
             error = string.Empty;
@@ -1186,6 +2004,63 @@ public class KingdomDebugCommand
 
             error = $"Expected {relation}, found {CurrentLeaderRelation}.";
             return false;
+        }
+    }
+
+    private sealed class AllianceTimeoutClanStrength
+    {
+        public Clan Clan { get; }
+        public float Value { get; }
+
+        public AllianceTimeoutClanStrength(Clan clan, float value)
+        {
+            Clan = clan;
+            Value = value;
+        }
+    }
+
+    private sealed class AllianceTimeoutRelation
+    {
+        public Hero First { get; }
+        public Hero Second { get; }
+        public int Value { get; }
+        public int CurrentValue => CharacterRelationManager.GetHeroRelation(First, Second);
+
+        public AllianceTimeoutRelation(Hero first, Hero second, int value)
+        {
+            First = first;
+            Second = second;
+            Value = value;
+        }
+
+        public bool IsFor(Hero first, Hero second) =>
+            (first == First && second == Second) || (first == Second && second == First);
+    }
+
+    private sealed class AllianceTimeoutMercenaryStatus
+    {
+        public Clan Clan { get; }
+        public bool Value { get; }
+        public bool CurrentValue => Clan.IsUnderMercenaryService;
+
+        public AllianceTimeoutMercenaryStatus(Clan clan, bool value)
+        {
+            Clan = clan;
+            Value = value;
+        }
+    }
+
+    private sealed class AllianceTimeoutNeighbor
+    {
+        public Kingdom Kingdom { get; }
+        public float NeighborScore { get; }
+        public float TotalNeighborScore { get; }
+
+        public AllianceTimeoutNeighbor(Kingdom kingdom, float neighborScore, float totalNeighborScore)
+        {
+            Kingdom = kingdom;
+            NeighborScore = neighborScore;
+            TotalNeighborScore = totalNeighborScore;
         }
     }
 

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -3179,16 +3179,6 @@ public class KingdomDebugCommand
             return false;
         }
 
-        bool isFullClanId = args[0].StartsWith("Clan_", StringComparison.Ordinal);
-        bool kingdomResolved = isFullClanId
-            ? StartAllianceDecisionData.TryGetKingdomReference(objectManager, args[0], out kingdom)
-            : objectManager.TryGetObject(args[0], out kingdom);
-        if (!kingdomResolved)
-        {
-            message = $"Kingdom with ID: '{args[0]}' not found";
-            return false;
-        }
-
         if (!int.TryParse(args[1], out int index))
         {
             message = $"Decision index is not a number: {args[1]}";
@@ -3196,6 +3186,26 @@ public class KingdomDebugCommand
         }
 
         zeroBasedIndex = index - 1;
+        if (StartAllianceDecisionData.TryGetKingdomReference(objectManager, args[0], out Kingdom allianceKingdom) &&
+            zeroBasedIndex >= 0 &&
+            zeroBasedIndex < allianceKingdom._unresolvedDecisions.Count)
+        {
+            KingdomDecision allianceDecision = allianceKingdom._unresolvedDecisions[zeroBasedIndex];
+            if (CoopKingdomElection.IsTrackedPlayerAllianceOffer(allianceDecision))
+            {
+                kingdom = allianceKingdom;
+                decision = allianceDecision;
+                message = string.Empty;
+                return true;
+            }
+        }
+
+        if (!objectManager.TryGetObject(args[0], out kingdom))
+        {
+            message = $"Kingdom with ID: '{args[0]}' not found";
+            return false;
+        }
+
         if (zeroBasedIndex < 0 || zeroBasedIndex >= kingdom._unresolvedDecisions.Count)
         {
             message = "Decision index is out of bounds.";

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -398,6 +398,60 @@ public class KingdomDebugCommand
         });
     }
 
+    [CommandLineArgumentFunction("alliance_timeout_target", "coop.debug.kingdom")]
+    public static string GetAllianceTimeoutTarget(List<string> args)
+    {
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        if (args.Count != 0) return "Usage: coop.debug.kingdom.alliance_timeout_target";
+        if (pendingAllianceTimeoutFixture != null) return "An alliance-timeout fixture lifecycle is already active.";
+        if (!TryGetObjectManager(out var objectManager) || !TryGetPlayerManager(out var playerManager))
+            return "Unable to resolve alliance-timeout fixture services.";
+        if (!playerManager.TryGetPlayer("testclient", out var player))
+            return "No registered player has controller id 'testclient'.";
+        if (!objectManager.TryGetObject(player.ClanId, out Clan playerClan))
+            return "Unable to resolve the testclient clan.";
+        if (playerClan.Kingdom != null)
+            return "The testclient clan must be kingdomless before selecting an alliance-timeout target.";
+
+        Kingdom sturgia = Kingdom.All.SingleOrDefault(candidate =>
+            string.Equals(candidate.StringId, "sturgia", StringComparison.Ordinal));
+        if (sturgia == null) return "The Sturgia kingdom is unavailable.";
+
+        AllianceCampaignBehavior allianceBehavior = Campaign.Current?.GetCampaignBehavior<AllianceCampaignBehavior>();
+        if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
+
+        Kingdom kingdom = Kingdom.All
+            .Where(candidate =>
+                candidate != sturgia &&
+                candidate.RulingClan != null &&
+                candidate.UnresolvedDecisions.Count == 0 &&
+                !FactionManager.IsAtWarAgainstFaction(candidate, sturgia) &&
+                !allianceBehavior.IsAllyWithKingdom(candidate, sturgia) &&
+                Campaign.Current.Models.AllianceModel.CanMakeAlliance(
+                    candidate,
+                    sturgia,
+                    candidate.RulingClan,
+                    out _,
+                    includeReason: false))
+            .OrderBy(candidate => candidate.StringId, StringComparer.Ordinal)
+            .FirstOrDefault();
+        if (kingdom == null)
+            return "No NPC-ruled kingdom can currently receive a valid alliance offer from Sturgia.";
+        if (!objectManager.TryGetIdWithLogging(kingdom, out string kingdomId) ||
+            !objectManager.TryGetIdWithLogging(sturgia, out string sturgiaId))
+            return "Unable to resolve alliance-timeout target ids.";
+
+        return LiveTestJsonResult(new
+        {
+            success = true,
+            kingdomId,
+            kingdomStringId = kingdom.StringId,
+            kingdomName = kingdom.Name.ToString(),
+            targetKingdomId = sturgiaId,
+            targetKingdomName = sturgia.Name.ToString()
+        });
+    }
+
     [CommandLineArgumentFunction("alliance_timeout_capture", "coop.debug.kingdom")]
     public static string CaptureAllianceTimeoutFixture(List<string> args)
     {
@@ -428,6 +482,15 @@ public class KingdomDebugCommand
         if (allianceBehavior == null) return "The alliance campaign behavior is unavailable.";
         if (allianceBehavior.IsAllyWithKingdom(kingdom, targetKingdom))
             return $"Kingdom {kingdom.StringId} is already allied with Sturgia.";
+        if (!Campaign.Current.Models.AllianceModel.CanMakeAlliance(
+                kingdom,
+                targetKingdom,
+                kingdom.RulingClan,
+                out var reason,
+                includeReason: true))
+        {
+            return $"Kingdom {kingdom.StringId} cannot currently receive a valid alliance offer from Sturgia: {reason}";
+        }
         if (!objectManager.TryGetIdWithLogging(kingdom, out string kingdomId) ||
             !objectManager.TryGetIdWithLogging(proposerClan, out string proposerClanId) ||
             !objectManager.TryGetIdWithLogging(targetKingdom, out string targetKingdomId))

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -481,7 +481,8 @@ public class KingdomDebugCommand
             false);
         pendingAllianceTimeoutFixture = fixture;
 
-        var decision = new StartAllianceDecision(fixture.ProposerClan, fixture.TargetKingdom);
+        // A redirected inbound offer is authored by the player kingdom's ruling clan.
+        var decision = new StartAllianceDecision(fixture.Kingdom.RulingClan, fixture.TargetKingdom);
         CoopKingdomElection._opponentProposedAllianceDecisions.Add(decision);
         fixture.Kingdom.AddDecision(decision, true);
         decision.TriggerTime = CampaignTime.Zero;

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -3158,7 +3158,11 @@ public class KingdomDebugCommand
             return false;
         }
 
-        if (objectManager.TryGetObject(args[0], out kingdom) == false)
+        bool isFullClanId = args[0].StartsWith("Clan_", StringComparison.Ordinal);
+        bool kingdomResolved = isFullClanId
+            ? StartAllianceDecisionData.TryGetKingdomReference(objectManager, args[0], out kingdom)
+            : objectManager.TryGetObject(args[0], out kingdom);
+        if (!kingdomResolved)
         {
             message = $"Kingdom with ID: '{args[0]}' not found";
             return false;

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -32,25 +32,24 @@ namespace GameInterface.Services.Kingdoms.Data
         {
             proposerClan = null;
             kingdom = null;
-            if (!objectManager.TryGetObject(ProposerClanId, out proposerClan))
+            if (!objectManager.TryGetObject(ProposerClanId, out proposerClan) ||
+                !objectManager.TryGetObject(KingdomId, out object kingdomReference))
             {
                 return false;
             }
 
-            if (objectManager.TryGetObject(KingdomId, out kingdom))
+            if (kingdomReference is Kingdom serializedKingdom)
             {
+                kingdom = serializedKingdom;
                 return true;
             }
 
-            if (!objectManager.TryGetObject(KingdomId, out Clan malformedKingdomIdClan) ||
-                proposerClan.Kingdom == null ||
-                malformedKingdomIdClan.Kingdom != proposerClan.Kingdom)
+            if (kingdomReference is not Clan serializedClan || serializedClan.Kingdom == null)
             {
-                kingdom = null;
                 return false;
             }
 
-            kingdom = proposerClan.Kingdom;
+            kingdom = serializedClan.Kingdom;
             return true;
         }
 

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Util;
 using GameInterface.Services.ObjectManager;
 using ProtoBuf;
+using System.Linq;
 using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
@@ -56,8 +57,7 @@ namespace GameInterface.Services.Kingdoms.Data
 
             if (objectManager.TryGetObject(KingdomId, out Clan compactClan))
             {
-                kingdom = compactClan.Kingdom;
-                return kingdom != null;
+                return TryGetKingdomFromReference(compactClan, out kingdom);
             }
 
             return objectManager.TryGetObject(KingdomId, out kingdom);
@@ -68,7 +68,14 @@ namespace GameInterface.Services.Kingdoms.Data
             kingdom = kingdomReference as Kingdom;
             if (kingdom != null) return true;
 
-            kingdom = (kingdomReference as Clan)?.Kingdom;
+            var clan = kingdomReference as Clan;
+            if (clan == null) return false;
+
+            kingdom = clan.Kingdom;
+            if (kingdom != null) return true;
+
+            kingdom = Kingdom.All.FirstOrDefault(candidate =>
+                candidate.RulingClan == clan || candidate.Clans.Contains(clan));
             return kingdom != null;
         }
 

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -58,12 +58,7 @@ namespace GameInterface.Services.Kingdoms.Data
 
         private bool TryGetDecisionKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
         {
-            if (TryGetKingdomByStringId(objectManager, DecisionKingdomStringId, out kingdom))
-            {
-                return true;
-            }
-
-            return TryGetKingdomReference(objectManager, KingdomId, out kingdom);
+            return TryGetKingdomReference(objectManager, KingdomId, DecisionKingdomStringId, out kingdom);
         }
 
         private static bool TryGetKingdomByStringId(IObjectManager objectManager, string kingdomStringId, out Kingdom kingdom)
@@ -72,6 +67,10 @@ namespace GameInterface.Services.Kingdoms.Data
             if (string.IsNullOrWhiteSpace(kingdomStringId)) return false;
 
             kingdom = Kingdom.All.FirstOrDefault(candidate => candidate.StringId == kingdomStringId);
+            if (kingdom != null) return true;
+
+            kingdom = Campaign.Current?.CampaignObjectManager?.Kingdoms
+                .FirstOrDefault(candidate => candidate.StringId == kingdomStringId);
             if (kingdom != null) return true;
 
             kingdom = MBObjectManager.Instance?.GetObjectTypeList<Kingdom>()
@@ -95,6 +94,16 @@ namespace GameInterface.Services.Kingdoms.Data
             }
 
             return objectManager.TryGetObject(kingdomId, out kingdom);
+        }
+
+        public static bool TryGetKingdomReference(IObjectManager objectManager, string kingdomId, string kingdomStringId, out Kingdom kingdom)
+        {
+            if (TryGetKingdomByStringId(objectManager, kingdomStringId, out kingdom))
+            {
+                return true;
+            }
+
+            return TryGetKingdomReference(objectManager, kingdomId, out kingdom);
         }
 
         private static bool TryGetKingdomFromReference(object kingdomReference, out Kingdom kingdom)
@@ -145,12 +154,11 @@ namespace GameInterface.Services.Kingdoms.Data
 
         private bool TryGetTargetKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
         {
-            if (TryGetKingdomByStringId(objectManager, KingdomToStartAllianceWithStringId, out kingdom))
-            {
-                return true;
-            }
-
-            return TryGetKingdomReference(objectManager, KingdomToStartAllianceWithId, out kingdom);
+            return TryGetKingdomReference(
+                objectManager,
+                KingdomToStartAllianceWithId,
+                KingdomToStartAllianceWithStringId,
+                out kingdom);
         }
     }
 }

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -32,47 +32,44 @@ namespace GameInterface.Services.Kingdoms.Data
         {
             proposerClan = null;
             kingdom = null;
-            if (!objectManager.TryGetObject(ProposerClanId, out proposerClan) ||
-                !TryGetDecisionKingdomReference(objectManager, out object kingdomReference))
+            if (!objectManager.TryGetObject(ProposerClanId, out proposerClan))
             {
                 return false;
             }
 
-            if (kingdomReference is Kingdom serializedKingdom)
+            if (TryGetDecisionKingdomReference(objectManager, out kingdom))
             {
-                kingdom = serializedKingdom;
                 return true;
             }
 
-            if (kingdomReference is not Clan serializedClan || serializedClan.Kingdom == null)
-            {
-                return false;
-            }
-
-            kingdom = serializedClan.Kingdom;
-            return true;
+            kingdom = proposerClan.Kingdom;
+            return kingdom != null;
         }
 
-        private bool TryGetDecisionKingdomReference(IObjectManager objectManager, out object kingdomReference)
+        private bool TryGetDecisionKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
         {
-            if (objectManager.TryGetObject(KingdomId, out kingdomReference))
+            kingdom = null;
+            if (objectManager.TryGetObject(KingdomId, out object kingdomReference))
             {
-                return true;
+                return TryGetKingdomFromReference(kingdomReference, out kingdom);
             }
 
-            if (objectManager.TryGetObject(KingdomId, out Clan serializedClan))
+            if (objectManager.TryGetObject(KingdomId, out Clan compactClan))
             {
-                kingdomReference = serializedClan;
-                return true;
+                kingdom = compactClan.Kingdom;
+                return kingdom != null;
             }
 
-            if (objectManager.TryGetObject(KingdomId, out Kingdom serializedKingdom))
-            {
-                kingdomReference = serializedKingdom;
-                return true;
-            }
+            return objectManager.TryGetObject(KingdomId, out kingdom);
+        }
 
-            return false;
+        private static bool TryGetKingdomFromReference(object kingdomReference, out Kingdom kingdom)
+        {
+            kingdom = kingdomReference as Kingdom;
+            if (kingdom != null) return true;
+
+            kingdom = (kingdomReference as Clan)?.Kingdom;
+            return kingdom != null;
         }
 
         /// <inheritdoc/>

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -19,9 +19,13 @@ namespace GameInterface.Services.Kingdoms.Data
         [ProtoMember(1)]
         public string KingdomToStartAllianceWithId { get; }
 
-        public StartAllianceDecisionData(string proposedClanId, string kingdomId, long triggerTime, bool isEnforced, bool notifyPlayer, bool playerExamined, string kingdomToStartAllianceWithId) : base(proposedClanId, kingdomId, triggerTime, isEnforced, notifyPlayer, playerExamined)
+        [ProtoMember(2)]
+        public bool IsProposedByOpponent { get; }
+
+        public StartAllianceDecisionData(string proposedClanId, string kingdomId, long triggerTime, bool isEnforced, bool notifyPlayer, bool playerExamined, string kingdomToStartAllianceWithId, bool isProposedByOpponent = false) : base(proposedClanId, kingdomId, triggerTime, isEnforced, notifyPlayer, playerExamined)
         {
             KingdomToStartAllianceWithId = kingdomToStartAllianceWithId;
+            IsProposedByOpponent = isProposedByOpponent;
         }
 
         /// <inheritdoc/>

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -33,7 +33,7 @@ namespace GameInterface.Services.Kingdoms.Data
             proposerClan = null;
             kingdom = null;
             if (!objectManager.TryGetObject(ProposerClanId, out proposerClan) ||
-                !objectManager.TryGetObject(KingdomId, out object kingdomReference))
+                !TryGetDecisionKingdomReference(objectManager, out object kingdomReference))
             {
                 return false;
             }
@@ -51,6 +51,28 @@ namespace GameInterface.Services.Kingdoms.Data
 
             kingdom = serializedClan.Kingdom;
             return true;
+        }
+
+        private bool TryGetDecisionKingdomReference(IObjectManager objectManager, out object kingdomReference)
+        {
+            if (objectManager.TryGetObject(KingdomId, out kingdomReference))
+            {
+                return true;
+            }
+
+            if (objectManager.TryGetObject(KingdomId, out Clan serializedClan))
+            {
+                kingdomReference = serializedClan;
+                return true;
+            }
+
+            if (objectManager.TryGetObject(KingdomId, out Kingdom serializedKingdom))
+            {
+                kingdomReference = serializedKingdom;
+                return true;
+            }
+
+            return false;
         }
 
         /// <inheritdoc/>

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.ObjectSystem;
 
 namespace GameInterface.Services.Kingdoms.Data
 {
@@ -81,6 +82,11 @@ namespace GameInterface.Services.Kingdoms.Data
 
             kingdom = Kingdom.All.FirstOrDefault(candidate =>
                 candidate.RulingClan == clan || candidate.Clans.Contains(clan));
+            if (kingdom != null) return true;
+
+            kingdom = MBObjectManager.Instance?.GetObjectTypeList<Kingdom>()
+                .FirstOrDefault(candidate =>
+                    candidate.RulingClan == clan || candidate.Clans.Contains(clan));
             return kingdom != null;
         }
 

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -28,10 +28,36 @@ namespace GameInterface.Services.Kingdoms.Data
             IsProposedByOpponent = isProposedByOpponent;
         }
 
+        public bool TryGetProposerClanAndDecisionKingdom(IObjectManager objectManager, out Clan proposerClan, out Kingdom kingdom)
+        {
+            proposerClan = null;
+            kingdom = null;
+            if (!objectManager.TryGetObject(ProposerClanId, out proposerClan))
+            {
+                return false;
+            }
+
+            if (objectManager.TryGetObject(KingdomId, out kingdom))
+            {
+                return true;
+            }
+
+            if (!objectManager.TryGetObject(KingdomId, out Clan malformedKingdomIdClan) ||
+                proposerClan.Kingdom == null ||
+                malformedKingdomIdClan.Kingdom != proposerClan.Kingdom)
+            {
+                kingdom = null;
+                return false;
+            }
+
+            kingdom = proposerClan.Kingdom;
+            return true;
+        }
+
         /// <inheritdoc/>
         public override bool TryGetKingdomDecision(IObjectManager objectManager, out KingdomDecision kingdomDecision)
         {
-            if (!TryGetProposerClanAndKingdom(objectManager, out Clan proposerClan, out Kingdom kingdom) ||
+            if (!TryGetProposerClanAndDecisionKingdom(objectManager, out Clan proposerClan, out Kingdom kingdom) ||
                 !objectManager.TryGetObject(KingdomToStartAllianceWithId, out Kingdom kingdomToStartAllianceWith))
             {
                 kingdomDecision = null;

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -49,18 +49,23 @@ namespace GameInterface.Services.Kingdoms.Data
 
         private bool TryGetDecisionKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
         {
+            return TryGetKingdomReference(objectManager, KingdomId, out kingdom);
+        }
+
+        public static bool TryGetKingdomReference(IObjectManager objectManager, string kingdomId, out Kingdom kingdom)
+        {
             kingdom = null;
-            if (objectManager.TryGetObject(KingdomId, out object kingdomReference))
+            if (objectManager.TryGetObject(kingdomId, out object kingdomReference))
             {
                 return TryGetKingdomFromReference(kingdomReference, out kingdom);
             }
 
-            if (objectManager.TryGetObject(KingdomId, out Clan compactClan))
+            if (objectManager.TryGetObject(kingdomId, out Clan compactClan))
             {
                 return TryGetKingdomFromReference(compactClan, out kingdom);
             }
 
-            return objectManager.TryGetObject(KingdomId, out kingdom);
+            return objectManager.TryGetObject(kingdomId, out kingdom);
         }
 
         private static bool TryGetKingdomFromReference(object kingdomReference, out Kingdom kingdom)
@@ -106,31 +111,7 @@ namespace GameInterface.Services.Kingdoms.Data
 
         private bool TryGetTargetKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
         {
-            kingdom = null;
-            if (objectManager.TryGetObject(KingdomToStartAllianceWithId, out object kingdomReference))
-            {
-                if (kingdomReference is Kingdom serializedKingdom)
-                {
-                    kingdom = serializedKingdom;
-                    return true;
-                }
-
-                if (kingdomReference is Clan serializedClan && serializedClan.Kingdom != null)
-                {
-                    kingdom = serializedClan.Kingdom;
-                    return true;
-                }
-
-                return false;
-            }
-
-            if (objectManager.TryGetObject(KingdomToStartAllianceWithId, out Clan compactClan) && compactClan.Kingdom != null)
-            {
-                kingdom = compactClan.Kingdom;
-                return true;
-            }
-
-            return objectManager.TryGetObject(KingdomToStartAllianceWithId, out kingdom);
+            return TryGetKingdomReference(objectManager, KingdomToStartAllianceWithId, out kingdom);
         }
     }
 }

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -24,10 +24,18 @@ namespace GameInterface.Services.Kingdoms.Data
         [ProtoMember(2)]
         public bool IsProposedByOpponent { get; }
 
-        public StartAllianceDecisionData(string proposedClanId, string kingdomId, long triggerTime, bool isEnforced, bool notifyPlayer, bool playerExamined, string kingdomToStartAllianceWithId, bool isProposedByOpponent = false) : base(proposedClanId, kingdomId, triggerTime, isEnforced, notifyPlayer, playerExamined)
+        [ProtoMember(3)]
+        public string DecisionKingdomStringId { get; }
+
+        [ProtoMember(4)]
+        public string KingdomToStartAllianceWithStringId { get; }
+
+        public StartAllianceDecisionData(string proposedClanId, string kingdomId, long triggerTime, bool isEnforced, bool notifyPlayer, bool playerExamined, string kingdomToStartAllianceWithId, bool isProposedByOpponent = false, string decisionKingdomStringId = null, string kingdomToStartAllianceWithStringId = null) : base(proposedClanId, kingdomId, triggerTime, isEnforced, notifyPlayer, playerExamined)
         {
             KingdomToStartAllianceWithId = kingdomToStartAllianceWithId;
             IsProposedByOpponent = isProposedByOpponent;
+            DecisionKingdomStringId = decisionKingdomStringId;
+            KingdomToStartAllianceWithStringId = kingdomToStartAllianceWithStringId;
         }
 
         public bool TryGetProposerClanAndDecisionKingdom(IObjectManager objectManager, out Clan proposerClan, out Kingdom kingdom)
@@ -50,7 +58,27 @@ namespace GameInterface.Services.Kingdoms.Data
 
         private bool TryGetDecisionKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
         {
+            if (TryGetKingdomByStringId(objectManager, DecisionKingdomStringId, out kingdom))
+            {
+                return true;
+            }
+
             return TryGetKingdomReference(objectManager, KingdomId, out kingdom);
+        }
+
+        private static bool TryGetKingdomByStringId(IObjectManager objectManager, string kingdomStringId, out Kingdom kingdom)
+        {
+            kingdom = null;
+            if (string.IsNullOrWhiteSpace(kingdomStringId)) return false;
+
+            kingdom = Kingdom.All.FirstOrDefault(candidate => candidate.StringId == kingdomStringId);
+            if (kingdom != null) return true;
+
+            kingdom = MBObjectManager.Instance?.GetObjectTypeList<Kingdom>()
+                .FirstOrDefault(candidate => candidate.StringId == kingdomStringId);
+            if (kingdom != null) return true;
+
+            return objectManager.TryGetObject(kingdomStringId, out kingdom);
         }
 
         public static bool TryGetKingdomReference(IObjectManager objectManager, string kingdomId, out Kingdom kingdom)
@@ -117,6 +145,11 @@ namespace GameInterface.Services.Kingdoms.Data
 
         private bool TryGetTargetKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
         {
+            if (TryGetKingdomByStringId(objectManager, KingdomToStartAllianceWithStringId, out kingdom))
+            {
+                return true;
+            }
+
             return TryGetKingdomReference(objectManager, KingdomToStartAllianceWithId, out kingdom);
         }
     }

--- a/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/StartAllianceDecisionData.cs
@@ -79,7 +79,7 @@ namespace GameInterface.Services.Kingdoms.Data
         public override bool TryGetKingdomDecision(IObjectManager objectManager, out KingdomDecision kingdomDecision)
         {
             if (!TryGetProposerClanAndDecisionKingdom(objectManager, out Clan proposerClan, out Kingdom kingdom) ||
-                !objectManager.TryGetObject(KingdomToStartAllianceWithId, out Kingdom kingdomToStartAllianceWith))
+                !TryGetTargetKingdomReference(objectManager, out Kingdom kingdomToStartAllianceWith))
             {
                 kingdomDecision = null;
                 return false;
@@ -98,6 +98,35 @@ namespace GameInterface.Services.Kingdoms.Data
             startAllianceDecision._allianceCampaignBehavior = allianceCampaignBehavior;
             kingdomDecision = startAllianceDecision;
             return true;
+        }
+
+        private bool TryGetTargetKingdomReference(IObjectManager objectManager, out Kingdom kingdom)
+        {
+            kingdom = null;
+            if (objectManager.TryGetObject(KingdomToStartAllianceWithId, out object kingdomReference))
+            {
+                if (kingdomReference is Kingdom serializedKingdom)
+                {
+                    kingdom = serializedKingdom;
+                    return true;
+                }
+
+                if (kingdomReference is Clan serializedClan && serializedClan.Kingdom != null)
+                {
+                    kingdom = serializedClan.Kingdom;
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (objectManager.TryGetObject(KingdomToStartAllianceWithId, out Clan compactClan) && compactClan.Kingdom != null)
+            {
+                kingdom = compactClan.Kingdom;
+                return true;
+            }
+
+            return objectManager.TryGetObject(KingdomToStartAllianceWithId, out kingdom);
         }
     }
 }

--- a/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
+++ b/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
@@ -2,6 +2,7 @@
 using GameInterface.Services.Clans.Extensions;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.Core;
@@ -13,6 +14,7 @@ namespace GameInterface.Services.Kingdoms.Extentions
     {
         private float? randomFloat;
         public static readonly HashSet<KingdomDecision> _opponentProposedAllianceDecisions = new();
+        private static readonly ConditionalWeakTable<KingdomDecision, HashSet<string>> DecisionReferences = new();
         public float RandomFloat
         {
             get
@@ -205,6 +207,29 @@ namespace GameInterface.Services.Kingdoms.Extentions
         internal static void RemoveTrackedPlayerAllianceOffer(KingdomDecision decision)
         {
             _opponentProposedAllianceDecisions.Remove(decision);
+        }
+
+        internal static void BindDecisionReference(KingdomDecision decision, string kingdomId)
+        {
+            if (decision == null || string.IsNullOrWhiteSpace(kingdomId)) return;
+
+            DecisionReferences.GetOrCreateValue(decision).Add(kingdomId);
+        }
+
+        internal static bool HasDecisionReference(KingdomDecision decision, string kingdomId)
+        {
+            return decision != null &&
+                   !string.IsNullOrWhiteSpace(kingdomId) &&
+                   DecisionReferences.TryGetValue(decision, out HashSet<string> references) &&
+                   references.Contains(kingdomId);
+        }
+
+        internal static void RemoveDecisionReferences(KingdomDecision decision)
+        {
+            if (decision != null)
+            {
+                DecisionReferences.Remove(decision);
+            }
         }
 
         internal static IEnumerable<StartAllianceDecision> GetTrackedPlayerAllianceOffers()

--- a/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
+++ b/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
@@ -13,6 +13,8 @@ namespace GameInterface.Services.Kingdoms.Extentions
     {
         private float? randomFloat;
         public static readonly HashSet<KingdomDecision> _opponentProposedAllianceDecisions = new();
+        private static readonly HashSet<KingdomDecision> LegacyPlayerAllianceDecisions = new();
+        private static bool restoreLegacyPlayerAllianceOffersPending;
         public float RandomFloat
         {
             get
@@ -112,10 +114,9 @@ namespace GameInterface.Services.Kingdoms.Extentions
 
         public void ApplyChosenOutcomeCoop()
         {
-            // The synchronized kingdom decision is the player-facing prompt. Native's peace
-            // notification checks process-local player singletons and must not run again when
-            // the explicit co-op vote is resolved on the authoritative server.
-            if (IsPendingPlayerPeaceOffer(this._decision) || this._decision.OnShowDecision() || IsPendingPlayerAllianceOffer(this._decision))
+            // The synchronized kingdom decision is the player-facing prompt. Native offer
+            // notifications check player singletons and must not run on the authoritative server.
+            if (IsPendingPlayerPeaceOffer(this._decision) || IsPendingPlayerAllianceOffer(this._decision) || this._decision.OnShowDecision())
             {
                 this.ApplyChosenOutcome();
             }
@@ -188,14 +189,87 @@ namespace GameInterface.Services.Kingdoms.Extentions
         internal static bool IsPendingPlayerAllianceOffer(KingdomDecision decision)
         {
             return decision is StartAllianceDecision 
-                    && _opponentProposedAllianceDecisions.Contains(decision) 
+                    && IsTrackedPlayerAllianceOffer(decision)
                     && decision.Kingdom?.Clans.Any(clan => clan.IsPlayerClan()) == true;
+        }
+
+        internal static bool IsPlayerAllianceDecision(KingdomDecision decision)
+        {
+            return decision is StartAllianceDecision
+                   && decision.Kingdom?.Clans.Any(clan => clan.IsPlayerClan()) == true;
+        }
+
+        internal static bool IsTrackedPlayerAllianceOffer(KingdomDecision decision)
+        {
+            TryRestoreLegacyPlayerAllianceOffers();
+            return _opponentProposedAllianceDecisions.Contains(decision)
+                   || LegacyPlayerAllianceDecisions.Contains(decision);
+        }
+
+        internal static void RemoveTrackedPlayerAllianceOffer(KingdomDecision decision)
+        {
+            _opponentProposedAllianceDecisions.Remove(decision);
+            LegacyPlayerAllianceDecisions.Remove(decision);
+        }
+
+        internal static IEnumerable<StartAllianceDecision> GetTrackedPlayerAllianceOffers()
+        {
+            TryRestoreLegacyPlayerAllianceOffers();
+            return _opponentProposedAllianceDecisions
+                .Concat(LegacyPlayerAllianceDecisions)
+                .OfType<StartAllianceDecision>()
+                .Distinct();
+        }
+
+        internal static bool IsLegacyPlayerAllianceOfferRestorePending => restoreLegacyPlayerAllianceOffersPending;
+
+        internal static void ScheduleLegacyPlayerAllianceOfferRestore()
+        {
+            RestoreTrackedPlayerAllianceOffers(Enumerable.Empty<StartAllianceDecision>(), isLegacyFallback: true);
+            restoreLegacyPlayerAllianceOffersPending = true;
+        }
+
+        private static void TryRestoreLegacyPlayerAllianceOffers()
+        {
+            if (!restoreLegacyPlayerAllianceOffersPending
+                || !Kingdom.All.Any(kingdom => kingdom?.Clans.Any(clan => clan.IsPlayerClan()) == true))
+            {
+                return;
+            }
+
+            LegacyPlayerAllianceDecisions.Clear();
+            foreach (StartAllianceDecision decision in Kingdom.All
+                         .Where(kingdom => kingdom?._unresolvedDecisions != null)
+                         .SelectMany(kingdom => kingdom.UnresolvedDecisions)
+                         .OfType<StartAllianceDecision>()
+                         .Where(IsPlayerAllianceDecision))
+            {
+                LegacyPlayerAllianceDecisions.Add(decision);
+            }
+
+            restoreLegacyPlayerAllianceOffersPending = false;
+        }
+
+        internal static void RestoreTrackedPlayerAllianceOffers(
+            IEnumerable<StartAllianceDecision> pendingOffers,
+            bool isLegacyFallback)
+        {
+            _opponentProposedAllianceDecisions.Clear();
+            LegacyPlayerAllianceDecisions.Clear();
+            restoreLegacyPlayerAllianceOffersPending = false;
+            HashSet<KingdomDecision> target = isLegacyFallback
+                ? LegacyPlayerAllianceDecisions
+                : _opponentProposedAllianceDecisions;
+            foreach (StartAllianceDecision decision in pendingOffers ?? Enumerable.Empty<StartAllianceDecision>())
+            {
+                target.Add(decision);
+            }
         }
 
         internal static bool TryRedirectPlayerAllianceOffer(KingdomDecision decision, DecisionOutcome chosenOutcome)
         {
             if (decision is not StartAllianceDecision allianceDecision
-                || _opponentProposedAllianceDecisions.Contains(allianceDecision)
+                || IsTrackedPlayerAllianceOffer(allianceDecision)
                 || allianceDecision.KingdomToStartAllianceWith is not Kingdom playerKingdom
                 || !playerKingdom.IsPlayerKingdom())
             {
@@ -212,7 +286,7 @@ namespace GameInterface.Services.Kingdoms.Extentions
             bool offerAlreadyPending = playerKingdom.UnresolvedDecisions
                 .OfType<StartAllianceDecision>()
                 .Any(existing => existing.KingdomToStartAllianceWith == proposingKingdom
-                && _opponentProposedAllianceDecisions.Contains(existing));
+                && IsTrackedPlayerAllianceOffer(existing));
 
             if (offerAlreadyPending || playerKingdom.RulingClan == null)
             {

--- a/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
+++ b/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
@@ -13,8 +13,6 @@ namespace GameInterface.Services.Kingdoms.Extentions
     {
         private float? randomFloat;
         public static readonly HashSet<KingdomDecision> _opponentProposedAllianceDecisions = new();
-        private static readonly HashSet<KingdomDecision> LegacyPlayerAllianceDecisions = new();
-        private static bool restoreLegacyPlayerAllianceOffersPending;
         public float RandomFloat
         {
             get
@@ -201,68 +199,27 @@ namespace GameInterface.Services.Kingdoms.Extentions
 
         internal static bool IsTrackedPlayerAllianceOffer(KingdomDecision decision)
         {
-            TryRestoreLegacyPlayerAllianceOffers();
-            return _opponentProposedAllianceDecisions.Contains(decision)
-                   || LegacyPlayerAllianceDecisions.Contains(decision);
+            return _opponentProposedAllianceDecisions.Contains(decision);
         }
 
         internal static void RemoveTrackedPlayerAllianceOffer(KingdomDecision decision)
         {
             _opponentProposedAllianceDecisions.Remove(decision);
-            LegacyPlayerAllianceDecisions.Remove(decision);
         }
 
         internal static IEnumerable<StartAllianceDecision> GetTrackedPlayerAllianceOffers()
         {
-            TryRestoreLegacyPlayerAllianceOffers();
             return _opponentProposedAllianceDecisions
-                .Concat(LegacyPlayerAllianceDecisions)
-                .OfType<StartAllianceDecision>()
-                .Distinct();
-        }
-
-        internal static bool IsLegacyPlayerAllianceOfferRestorePending => restoreLegacyPlayerAllianceOffersPending;
-
-        internal static void ScheduleLegacyPlayerAllianceOfferRestore()
-        {
-            RestoreTrackedPlayerAllianceOffers(Enumerable.Empty<StartAllianceDecision>(), isLegacyFallback: true);
-            restoreLegacyPlayerAllianceOffersPending = true;
-        }
-
-        private static void TryRestoreLegacyPlayerAllianceOffers()
-        {
-            if (!restoreLegacyPlayerAllianceOffersPending
-                || !Kingdom.All.Any(kingdom => kingdom?.Clans.Any(clan => clan.IsPlayerClan()) == true))
-            {
-                return;
-            }
-
-            LegacyPlayerAllianceDecisions.Clear();
-            foreach (StartAllianceDecision decision in Kingdom.All
-                         .Where(kingdom => kingdom?._unresolvedDecisions != null)
-                         .SelectMany(kingdom => kingdom.UnresolvedDecisions)
-                         .OfType<StartAllianceDecision>()
-                         .Where(IsPlayerAllianceDecision))
-            {
-                LegacyPlayerAllianceDecisions.Add(decision);
-            }
-
-            restoreLegacyPlayerAllianceOffersPending = false;
+                .OfType<StartAllianceDecision>();
         }
 
         internal static void RestoreTrackedPlayerAllianceOffers(
-            IEnumerable<StartAllianceDecision> pendingOffers,
-            bool isLegacyFallback)
+            IEnumerable<StartAllianceDecision> pendingOffers)
         {
             _opponentProposedAllianceDecisions.Clear();
-            LegacyPlayerAllianceDecisions.Clear();
-            restoreLegacyPlayerAllianceOffersPending = false;
-            HashSet<KingdomDecision> target = isLegacyFallback
-                ? LegacyPlayerAllianceDecisions
-                : _opponentProposedAllianceDecisions;
             foreach (StartAllianceDecision decision in pendingOffers ?? Enumerable.Empty<StartAllianceDecision>())
             {
-                target.Add(decision);
+                _opponentProposedAllianceDecisions.Add(decision);
             }
         }
 

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -525,10 +525,9 @@ public class KingdomHandler : IHandler
 
     private bool TryGetDecisionKingdom(AddDecision payload, out Kingdom kingdom)
     {
-        if (payload.Data is StartAllianceDecisionData startAllianceDecisionData &&
-            startAllianceDecisionData.TryGetProposerClanAndDecisionKingdom(objectManager, out _, out kingdom))
+        if (payload.Data is StartAllianceDecisionData startAllianceDecisionData)
         {
-            return true;
+            return startAllianceDecisionData.TryGetProposerClanAndDecisionKingdom(objectManager, out _, out kingdom);
         }
 
         return objectManager.TryGetObject(payload.KingdomId, out kingdom);

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -499,26 +499,39 @@ public class KingdomHandler : IHandler
     private void HandleAddDecision(MessagePayload<AddDecision> obj)
     {
         var payload = obj.What;
-
-        if (!objectManager.TryGetObject(payload.KingdomId, out Kingdom kingdom))
+        RunKingdomMutation(() =>
         {
-            Logger.Debug("Kingdom not found in KingdomDecisionHandler with KingdomId: {id}", payload.KingdomId);
-            return;
+            if (!TryGetDecisionKingdom(payload, out Kingdom kingdom))
+            {
+                Logger.Debug("Kingdom not found in KingdomDecisionHandler with KingdomId: {id}", payload.KingdomId);
+                return;
+            }
+
+            if (!payload.Data.TryGetKingdomDecision(objectManager, out KingdomDecision kingdomDecision))
+            {
+                Logger.Warning("KingdomDecision could not be deserialized in KingdomDecisionHandler.");
+                return;
+            }
+
+            bool isPendingPlayerAllianceOffer = payload.Data is StartAllianceDecisionData { IsProposedByOpponent: true };
+            kingdomInterface.RunAddDecision(
+                kingdom,
+                kingdomDecision,
+                payload.IgnoreInfluenceCost,
+                payload.RandomNumber,
+                isPendingPlayerAllianceOffer);
+        });
+    }
+
+    private bool TryGetDecisionKingdom(AddDecision payload, out Kingdom kingdom)
+    {
+        if (payload.Data is StartAllianceDecisionData startAllianceDecisionData &&
+            startAllianceDecisionData.TryGetProposerClanAndDecisionKingdom(objectManager, out _, out kingdom))
+        {
+            return true;
         }
 
-        if (!payload.Data.TryGetKingdomDecision(objectManager, out KingdomDecision kingdomDecision))
-        {
-            Logger.Warning("KingdomDecision could not be deserialized in KingdomDecisionHandler.");
-            return;
-        }
-
-        bool isPendingPlayerAllianceOffer = payload.Data is StartAllianceDecisionData { IsProposedByOpponent: true };
-        kingdomInterface.RunAddDecision(
-            kingdom,
-            kingdomDecision,
-            payload.IgnoreInfluenceCost,
-            payload.RandomNumber,
-            isPendingPlayerAllianceOffer);
+        return objectManager.TryGetObject(payload.KingdomId, out kingdom);
     }
 
     private static void RunKingdomMutation(Action action)

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -507,6 +507,8 @@ public class KingdomHandler : IHandler
                 return;
             }
 
+            HydrateInboundAllianceProposer(payload.Data, kingdom);
+
             if (!payload.Data.TryGetKingdomDecision(objectManager, out KingdomDecision kingdomDecision))
             {
                 Logger.Warning("KingdomDecision could not be deserialized in KingdomDecisionHandler.");
@@ -531,6 +533,19 @@ public class KingdomHandler : IHandler
         }
 
         return objectManager.TryGetObject(payload.KingdomId, out kingdom);
+    }
+
+    private void HydrateInboundAllianceProposer(KingdomDecisionData data, Kingdom kingdom)
+    {
+        if (!ModInformation.IsClient) return;
+        if (data is not StartAllianceDecisionData { IsProposedByOpponent: true } startAllianceDecisionData) return;
+        if (!objectManager.TryGetObject(startAllianceDecisionData.ProposerClanId, out Clan proposerClan)) return;
+        if (proposerClan.Kingdom != null) return;
+
+        using (new AllowedThread())
+        {
+            kingdomMembershipState.EnsureClanInKingdom(kingdom, proposerClan, publishCollectionChanges: false);
+        }
     }
 
     private static void RunKingdomMutation(Action action)

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -5,6 +5,7 @@ using Common.Messaging;
 using Common.Util;
 using GameInterface.Registry.Auto;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
@@ -511,7 +512,13 @@ public class KingdomHandler : IHandler
             return;
         }
 
-        kingdomInterface.RunAddDecision(kingdom, kingdomDecision, payload.IgnoreInfluenceCost, payload.RandomNumber);
+        bool isPendingPlayerAllianceOffer = payload.Data is StartAllianceDecisionData { IsProposedByOpponent: true };
+        kingdomInterface.RunAddDecision(
+            kingdom,
+            kingdomDecision,
+            payload.IgnoreInfluenceCost,
+            payload.RandomNumber,
+            isPendingPlayerAllianceOffer);
     }
 
     private static void RunKingdomMutation(Action action)

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionDataConverter.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionDataConverter.cs
@@ -1,4 +1,5 @@
 ﻿using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.Kingdoms.Extentions;
 using GameInterface.Services.ObjectManager;
 using System;
 using System.Collections.Generic;
@@ -163,7 +164,8 @@ namespace GameInterface.Services.Kingdoms
             if (startAllianceDecision != null)
             {
                 return new StartAllianceDecisionData(GetId(startAllianceDecision.ProposerClan), GetId(startAllianceDecision.Kingdom),
-                    startAllianceDecision.TriggerTime._numTicks, startAllianceDecision.IsEnforced, startAllianceDecision.NotifyPlayer, startAllianceDecision.PlayerExamined, GetId(startAllianceDecision.KingdomToStartAllianceWith));
+                    startAllianceDecision.TriggerTime._numTicks, startAllianceDecision.IsEnforced, startAllianceDecision.NotifyPlayer, startAllianceDecision.PlayerExamined,
+                    GetId(startAllianceDecision.KingdomToStartAllianceWith), CoopKingdomElection.IsTrackedPlayerAllianceOffer(startAllianceDecision));
             }
             else
             {

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionDataConverter.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionDataConverter.cs
@@ -165,7 +165,8 @@ namespace GameInterface.Services.Kingdoms
             {
                 return new StartAllianceDecisionData(GetId(startAllianceDecision.ProposerClan), GetId(startAllianceDecision.Kingdom),
                     startAllianceDecision.TriggerTime._numTicks, startAllianceDecision.IsEnforced, startAllianceDecision.NotifyPlayer, startAllianceDecision.PlayerExamined,
-                    GetId(startAllianceDecision.KingdomToStartAllianceWith), CoopKingdomElection.IsTrackedPlayerAllianceOffer(startAllianceDecision));
+                    GetId(startAllianceDecision.KingdomToStartAllianceWith), CoopKingdomElection.IsTrackedPlayerAllianceOffer(startAllianceDecision),
+                    startAllianceDecision.Kingdom.StringId, startAllianceDecision.KingdomToStartAllianceWith.StringId);
             }
             else
             {

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -1552,12 +1552,25 @@ namespace GameInterface.Services.Kingdoms
         {
             decision = null;
             if (objectManager == null) return false;
+            if (StartAllianceDecisionData.TryGetKingdomReference(objectManager, kingdomId, out Kingdom allianceKingdom) &&
+                TryGetDecision(allianceKingdom, decisionIndex, out KingdomDecision allianceDecision) &&
+                CoopKingdomElection.IsTrackedPlayerAllianceOffer(allianceDecision))
+            {
+                decision = allianceDecision;
+                return true;
+            }
             if (!objectManager.TryGetObject(kingdomId, out Kingdom kingdom)) return false;
-            if (kingdom._unresolvedDecisions == null) return false;
+            return TryGetDecision(kingdom, decisionIndex, out decision);
+        }
+
+        private static bool TryGetDecision(Kingdom kingdom, int decisionIndex, out KingdomDecision decision)
+        {
+            decision = null;
+            if (kingdom?._unresolvedDecisions == null) return false;
             if (decisionIndex < 0 || decisionIndex >= kingdom._unresolvedDecisions.Count) return false;
 
             decision = kingdom._unresolvedDecisions[decisionIndex];
-            return true;
+            return decision != null;
         }
 
         private static bool TryGetDecisionIndex(KingdomDecision decision, out int decisionIndex)

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -412,6 +412,12 @@ namespace GameInterface.Services.Kingdoms
             if (decisionItem == null || ActiveDecisionItems.Contains(decisionItem)) return;
 
             KingdomDecision decision = decisionItem.KingdomDecisionMaker?._decision;
+            if (decision != null && !IsDecisionUnresolved(decision))
+            {
+                CloseDecisionItem(decisionItem);
+                return;
+            }
+
             if (decision != null)
             {
                 KingdomDecisionVoteState state = GetOrCreateState(decision);
@@ -1042,10 +1048,7 @@ namespace GameInterface.Services.Kingdoms
             }
             if (state.Decision is StartAllianceDecision startAllianceDecision)
             {
-                if (CoopKingdomElection._opponentProposedAllianceDecisions.Contains(startAllianceDecision))
-                {
-                    CoopKingdomElection._opponentProposedAllianceDecisions.Remove(startAllianceDecision);
-                }
+                CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(startAllianceDecision);
                 if (startAllianceDecision.Kingdom is Kingdom playerKingdom && playerKingdom.IsPlayerKingdom()
                     && startAllianceDecision.KingdomToStartAllianceWith is Kingdom playerkingdom2 && playerkingdom2.IsPlayerKingdom())
                 {
@@ -1693,8 +1696,27 @@ namespace GameInterface.Services.Kingdoms
                 state.FinalVotes.Count,
                 state.EligibleClanIds.Count);
             ApplyMissingAbstentions(state);
+            SelectDeclinedOutcomeForUnansweredPlayerOffer(state);
             ResolveDecision(state);
             return true;
+        }
+
+        private static void SelectDeclinedOutcomeForUnansweredPlayerOffer(KingdomDecisionVoteState state)
+        {
+            if (state.FinalVotes.Count != 0) return;
+
+            if (CoopKingdomElection.IsPendingPlayerPeaceOffer(state.Decision))
+            {
+                state.Election._chosenOutcome = state.Election._possibleOutcomes
+                    .OfType<MakePeaceKingdomDecision.MakePeaceDecisionOutcome>()
+                    .FirstOrDefault(outcome => !outcome.ShouldPeaceBeDeclared);
+            }
+            else if (CoopKingdomElection.IsPendingPlayerAllianceOffer(state.Decision))
+            {
+                state.Election._chosenOutcome = state.Election._possibleOutcomes
+                    .OfType<StartAllianceDecision.StartAllianceDecisionOutcome>()
+                    .FirstOrDefault(outcome => !outcome.ShouldAllianceBeStarted);
+            }
         }
 
         private static bool IsDecisionUnresolved(KingdomDecision decision)

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Logging;
 using Common.Messaging;
+using GameInterface.Services.Clans.Extensions;
 using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Extentions;
@@ -366,7 +367,7 @@ namespace GameInterface.Services.Kingdoms
         public bool ShouldSuppressLocalDecision(KingdomDecision decision)
         {
             if (decision == null || Clan.PlayerClan == null) return false;
-            if (Clan.PlayerClan.Kingdom != decision.Kingdom) return false;
+            if (!IsLocalPlayerDecisionKingdomMember(decision)) return false;
             if (DecisionStates.TryGetValue(decision, out KingdomDecisionVoteState state) && state.IsResolved) return true;
             return !IsLocalPlayerEligible(decision);
         }
@@ -379,7 +380,7 @@ namespace GameInterface.Services.Kingdoms
         public bool HasLocalPlayerSubmittedVote(KingdomDecision decision)
         {
             if (decision == null || Clan.PlayerClan == null) return false;
-            if (Clan.PlayerClan.Kingdom != decision.Kingdom) return false;
+            if (!IsLocalPlayerDecisionKingdomMember(decision)) return false;
             if (LocalSubmittedDecisions.Contains(decision)) return true;
             if (!TryGetClanId(Clan.PlayerClan, out string canonicalClanId)) return false;
 
@@ -401,7 +402,7 @@ namespace GameInterface.Services.Kingdoms
 
             if (DecisionStates.TryGetValue(decision, out KingdomDecisionVoteState state) && state.HasRoundSnapshot)
             {
-                return Clan.PlayerClan.Kingdom == decision.Kingdom;
+                return IsLocalPlayerDecisionKingdomMember(decision);
             }
 
             return IsLocalPlayerEligible(decision);
@@ -1532,7 +1533,7 @@ namespace GameInterface.Services.Kingdoms
         private bool IsLocalPlayerEligible(KingdomDecision decision)
         {
             if (decision == null || Clan.PlayerClan == null) return false;
-            if (Clan.PlayerClan.Kingdom != decision.Kingdom) return false;
+            if (!IsLocalPlayerDecisionKingdomMember(decision)) return false;
 
             if (DecisionStates.TryGetValue(decision, out KingdomDecisionVoteState state) && state.HasRoundSnapshot)
             {
@@ -1540,6 +1541,14 @@ namespace GameInterface.Services.Kingdoms
             }
 
             return true;
+        }
+
+        private static bool IsLocalPlayerDecisionKingdomMember(KingdomDecision decision)
+        {
+            if (Clan.PlayerClan.Kingdom == decision.Kingdom) return true;
+
+            return CoopKingdomElection.IsTrackedPlayerAllianceOffer(decision) &&
+                   decision.Kingdom?.Clans.Any(clan => clan.IsPlayerClan()) == true;
         }
 
         private bool TryGetDecision(KingdomDecisionVoteData voteData, out KingdomDecision decision)

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -128,6 +128,11 @@ namespace GameInterface.Services.Kingdoms
             }
         }
 
+        private static void BindDecisionReference(KingdomDecision decision, string kingdomId)
+        {
+            CoopKingdomElection.BindDecisionReference(decision, kingdomId);
+        }
+
         public bool TryCreateVoteData(DecisionOptionVM decisionOption, out KingdomDecisionVoteData voteData, bool isFinal = false)
         {
             voteData = null;
@@ -240,6 +245,7 @@ namespace GameInterface.Services.Kingdoms
                 return;
             }
 
+            BindDecisionReference(decision, status.KingdomId);
             KingdomDecisionVoteState state = GetOrCreateState(decision);
             if (state.LastPublishedRoundStatus != null &&
                 state.LastPublishedRoundStatus.HasSameContent(status))
@@ -703,6 +709,7 @@ namespace GameInterface.Services.Kingdoms
             if (decision == null) return;
 
             DecisionStates.Remove(decision);
+            CoopKingdomElection.RemoveDecisionReferences(decision);
             LocalSubmittedDecisions.Remove(decision);
             foreach (KingdomDecision staleDecision in DecisionStates.Keys
                          .Where(key => key == null || key.Kingdom == null)
@@ -1561,6 +1568,22 @@ namespace GameInterface.Services.Kingdoms
         {
             decision = null;
             if (objectManager == null) return false;
+
+            List<KingdomDecision> boundDecisions = DecisionStates.Values
+                .Where(state =>
+                    CoopKingdomElection.HasDecisionReference(state.Decision, kingdomId) &&
+                    TryGetDecisionIndex(state.DecisionKingdom, state.Decision, out int currentIndex) &&
+                    currentIndex == decisionIndex)
+                .Select(state => state.Decision)
+                .ToList();
+            if (boundDecisions.Count > 0)
+            {
+                if (boundDecisions.Count != 1) return false;
+
+                decision = boundDecisions[0];
+                return true;
+            }
+
             if (StartAllianceDecisionData.TryGetKingdomReference(objectManager, kingdomId, out Kingdom allianceKingdom) &&
                 TryGetDecision(allianceKingdom, decisionIndex, out KingdomDecision allianceDecision) &&
                 CoopKingdomElection.IsTrackedPlayerAllianceOffer(allianceDecision))
@@ -1588,6 +1611,18 @@ namespace GameInterface.Services.Kingdoms
             if (decision?.Kingdom?._unresolvedDecisions == null) return false;
 
             decisionIndex = decision.Kingdom._unresolvedDecisions.IndexOf(decision);
+            return decisionIndex >= 0;
+        }
+
+        private static bool TryGetDecisionIndex(
+            Kingdom kingdom,
+            KingdomDecision decision,
+            out int decisionIndex)
+        {
+            decisionIndex = -1;
+            if (kingdom?._unresolvedDecisions == null || decision == null) return false;
+
+            decisionIndex = kingdom._unresolvedDecisions.IndexOf(decision);
             return decisionIndex >= 0;
         }
 
@@ -2060,6 +2095,7 @@ namespace GameInterface.Services.Kingdoms
         {
             public string KingdomId { get; private set; }
             public KingdomDecision Decision { get; }
+            public Kingdom DecisionKingdom { get; }
             public CoopKingdomElection Election { get; }
             public int DecisionIndex { get; private set; }
             public HashSet<string> EligibleClanIds { get; }
@@ -2084,6 +2120,7 @@ namespace GameInterface.Services.Kingdoms
             {
                 KingdomId = kingdomId;
                 Decision = decision;
+                DecisionKingdom = decision?.Kingdom;
                 DecisionIndex = decisionIndex;
                 Election = new CoopKingdomElection(decision);
                 Election.SetupPlayerVoteElection();

--- a/source/GameInterface/Services/Kingdoms/KingdomInterface.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomInterface.cs
@@ -16,7 +16,7 @@ public interface IKingdomInterface : IGameAbstraction
     bool AddPolicyPrefix(Kingdom kingdom, PolicyObject policy);
     bool RemovePolicyPrefix(Kingdom kingdom, PolicyObject policy);
     float AddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float? randomFloat = null, bool applyInfluenceCost = true);
-    void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat);
+    void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat, bool isPendingPlayerAllianceOffer = false);
     void RemoveDecision(Kingdom kingdom, KingdomDecision kingdomDecision);
     void ChangeKingdomPolicy(Kingdom kingdom, PolicyObject policy, bool isAdd);
 }
@@ -104,20 +104,51 @@ internal class KingdomInterface : IKingdomInterface
         decisionVoteManager.RegisterDecision(kingdomDecision);
         return default;
     }
-    public void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat)
+    public void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat, bool isPendingPlayerAllianceOffer = false)
     {
         RunKingdomMutation(() =>
         {
-            AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, randomFloat, ModInformation.IsServer);
+            if (isPendingPlayerAllianceOffer)
+            {
+                CoopKingdomElection._opponentProposedAllianceDecisions.Add(kingdomDecision);
+            }
+
+            try
+            {
+                AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, randomFloat, ModInformation.IsServer);
+            }
+            catch
+            {
+                if (kingdom._unresolvedDecisions?.Contains(kingdomDecision) != true)
+                {
+                    CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(kingdomDecision);
+                }
+                throw;
+            }
+
+            if (kingdom._unresolvedDecisions?.Contains(kingdomDecision) != true)
+            {
+                CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(kingdomDecision);
+            }
         });
     }
     public void RemoveDecision(Kingdom kingdom, KingdomDecision kingdomDecision)
     {
         RunKingdomMutation(() =>
         {
-            using (new AllowedThread())
+            try
             {
-                kingdom.RemoveDecision(kingdomDecision);
+                using (new AllowedThread())
+                {
+                    kingdom.RemoveDecision(kingdomDecision);
+                }
+            }
+            finally
+            {
+                if (kingdom._unresolvedDecisions?.Contains(kingdomDecision) != true)
+                {
+                    CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(kingdomDecision);
+                }
             }
         });
     }

--- a/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
@@ -57,11 +57,12 @@ namespace GameInterface.Services.Kingdoms.Patches
         internal static void SyncPendingPlayerAllianceOffers(IDataStore dataStore)
         {
             const string saveKey = "_coop_pending_player_alliance_offers";
-            List<StartAllianceDecision> pendingOffers = null;
+            List<KingdomDecision> pendingOffers = null;
             if (dataStore.IsSaving)
             {
                 pendingOffers = CoopKingdomElection.GetTrackedPlayerAllianceOffers()
                     .Where(decision => decision.Kingdom?._unresolvedDecisions?.Contains(decision) == true)
+                    .Cast<KingdomDecision>()
                     .ToList();
             }
 
@@ -78,7 +79,8 @@ namespace GameInterface.Services.Kingdoms.Patches
             }
 
             CoopKingdomElection.RestoreTrackedPlayerAllianceOffers(
-                (pendingOffers ?? new List<StartAllianceDecision>())
+                (pendingOffers ?? new List<KingdomDecision>())
+                    .OfType<StartAllianceDecision>()
                     .Where(decision => decision?.Kingdom?._unresolvedDecisions?.Contains(decision) == true));
         }
 

--- a/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
@@ -63,7 +63,6 @@ namespace GameInterface.Services.Kingdoms.Patches
                 pendingOffers = CoopKingdomElection.GetTrackedPlayerAllianceOffers()
                     .Where(decision => decision.Kingdom?._unresolvedDecisions?.Contains(decision) == true)
                     .ToList();
-                if (CoopKingdomElection.IsLegacyPlayerAllianceOfferRestorePending) return;
             }
 
             bool hasSavedProvenance = dataStore.SyncData(saveKey, ref pendingOffers);
@@ -71,14 +70,16 @@ namespace GameInterface.Services.Kingdoms.Patches
 
             if (!hasSavedProvenance)
             {
-                CoopKingdomElection.ScheduleLegacyPlayerAllianceOfferRestore();
+                // The mirrored inbound offer has the same saved shape as a player-originated
+                // ruling-clan proposal, so legacy decisions cannot be classified safely.
+                CoopKingdomElection.RestoreTrackedPlayerAllianceOffers(
+                    Enumerable.Empty<StartAllianceDecision>());
                 return;
             }
 
             CoopKingdomElection.RestoreTrackedPlayerAllianceOffers(
                 (pendingOffers ?? new List<StartAllianceDecision>())
-                    .Where(decision => decision?.Kingdom?._unresolvedDecisions?.Contains(decision) == true),
-                isLegacyFallback: false);
+                    .Where(decision => decision?.Kingdom?._unresolvedDecisions?.Contains(decision) == true));
         }
 
         /// <summary>

--- a/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
@@ -8,6 +8,7 @@ using GameInterface.Services.Kingdoms.Messages;
 using HarmonyLib;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
@@ -45,6 +46,40 @@ namespace GameInterface.Services.Kingdoms.Patches
         [HarmonyPatch(nameof(KingdomDecisionProposalBehavior.RegisterEvents))]
         [HarmonyPrefix]
         public static bool RegisterEventsPrefix() => ModInformation.IsServer;
+
+        [HarmonyPatch(nameof(KingdomDecisionProposalBehavior.SyncData))]
+        [HarmonyPostfix]
+        private static void SyncDataPostfix(IDataStore dataStore)
+        {
+            SyncPendingPlayerAllianceOffers(dataStore);
+        }
+
+        internal static void SyncPendingPlayerAllianceOffers(IDataStore dataStore)
+        {
+            const string saveKey = "_coop_pending_player_alliance_offers";
+            List<StartAllianceDecision> pendingOffers = null;
+            if (dataStore.IsSaving)
+            {
+                pendingOffers = CoopKingdomElection.GetTrackedPlayerAllianceOffers()
+                    .Where(decision => decision.Kingdom?._unresolvedDecisions?.Contains(decision) == true)
+                    .ToList();
+                if (CoopKingdomElection.IsLegacyPlayerAllianceOfferRestorePending) return;
+            }
+
+            bool hasSavedProvenance = dataStore.SyncData(saveKey, ref pendingOffers);
+            if (!dataStore.IsLoading) return;
+
+            if (!hasSavedProvenance)
+            {
+                CoopKingdomElection.ScheduleLegacyPlayerAllianceOfferRestore();
+                return;
+            }
+
+            CoopKingdomElection.RestoreTrackedPlayerAllianceOffers(
+                (pendingOffers ?? new List<StartAllianceDecision>())
+                    .Where(decision => decision?.Kingdom?._unresolvedDecisions?.Contains(decision) == true),
+                isLegacyFallback: false);
+        }
 
         /// <summary>
         /// Replacement for the per-clan daily proposer. Mirrors the vanilla logic but
@@ -175,16 +210,20 @@ namespace GameInterface.Services.Kingdoms.Patches
                                         (Kingdom)startalliancedecision.KingdomToStartAllianceWith,
                                         startalliancedecision.Kingdom,
                                         isPending: false));
-                                    if (CoopKingdomElection._opponentProposedAllianceDecisions.Contains(startalliancedecision))
-                                    {
-                                        CoopKingdomElection._opponentProposedAllianceDecisions.Remove(startalliancedecision);
-                                    }
+                                    CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(startalliancedecision);
                                 }
                             }
                             CampaignEventDispatcher.Instance.OnKingdomDecisionCancelled(decision, isPlayerInvolved);
                         }
                         else if (decision.TriggerTime.IsPast)
                         {
+                            if (ContainerProvider.TryResolve<IKingdomDecisionVoteManager>(out var voteManager) &&
+                                voteManager.HasEligiblePlayerClan(decision))
+                            {
+                                voteManager.TryResolveDecision(decision);
+                                continue;
+                            }
+
                             // An unanswered inbound player peace offer expires as a decline.
                             // It must never fall through to the forced AI resolution path.
                             if (CoopKingdomElection.IsPendingPlayerPeaceOffer(decision) || CoopKingdomElection.IsPendingPlayerAllianceOffer(decision))
@@ -203,19 +242,9 @@ namespace GameInterface.Services.Kingdoms.Patches
                                         (Kingdom)startalliancedecision.KingdomToStartAllianceWith,
                                         startalliancedecision.Kingdom,
                                         isPending: false));
-                                    if (CoopKingdomElection._opponentProposedAllianceDecisions.Contains(startalliancedecision))
-                                    {
-                                        CoopKingdomElection._opponentProposedAllianceDecisions.Remove(startalliancedecision);
-                                    }
+                                    CoopKingdomElection.RemoveTrackedPlayerAllianceOffer(startalliancedecision);
                                 }
                                 CampaignEventDispatcher.Instance.OnKingdomDecisionCancelled(decision, true);
-                                continue;
-                            }
-
-                            if (ContainerProvider.TryResolve<IKingdomDecisionVoteManager>(out var voteManager) &&
-                                voteManager.HasEligiblePlayerClan(decision))
-                            {
-                                voteManager.TryResolveDecision(decision);
                                 continue;
                             }
 

--- a/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
@@ -1,6 +1,7 @@
 ﻿using GameInterface.Services.Kingdoms.Extentions;
 using Common.Logging;
 using GameInterface.Services.Clans.Handlers;
+using GameInterface.Services.Clans.Extensions;
 using HarmonyLib;
 using Serilog;
 using System;
@@ -51,6 +52,30 @@ namespace GameInterface.Services.Kingdoms.Patches
 
             voteManager.RegisterDecisionItem(__instance.CurrentDecision);
             KingdomDecisionWaitingStatusWidgetPatch.EnsureAttached(__instance);
+        }
+
+        [HarmonyPatch(nameof(KingdomDecisionsVM.OnFrameTick))]
+        [HarmonyPrefix]
+        internal static bool OnFrameTickPrefix(KingdomDecisionsVM __instance)
+        {
+            if (Clan.PlayerClan?.Kingdom != null) return true;
+
+            StartAllianceDecision currentAllianceDecision =
+                __instance.CurrentDecision?.KingdomDecisionMaker?._decision as StartAllianceDecision;
+            if (CoopKingdomElection.IsTrackedPlayerAllianceOffer(currentAllianceDecision))
+            {
+                __instance.IsActive = __instance.IsCurrentDecisionActive;
+                return false;
+            }
+
+            bool hasPendingAllianceDecision = CoopKingdomElection.GetTrackedPlayerAllianceOffers()
+                .Any(decision =>
+                    decision?.Kingdom?._unresolvedDecisions?.Contains(decision) == true &&
+                    decision.Kingdom.Clans.Any(clan => clan.IsPlayerClan()));
+            if (!hasPendingAllianceDecision) return true;
+
+            __instance.IsActive = __instance.IsCurrentDecisionActive;
+            return false;
         }
 
         [HarmonyPatch(nameof(KingdomDecisionsVM.OnFrameTick))]

--- a/source/GameInterface/Services/Kingdoms/Patches/MakePeaceKingdomDecisionPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/MakePeaceKingdomDecisionPatches.cs
@@ -1,3 +1,4 @@
+﻿using Common;
 using GameInterface.Services.Kingdoms.Extentions;
 using HarmonyLib;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -39,6 +40,22 @@ internal static class PendingPlayerPeaceOfferCancellationPatch
                 || __instance.Kingdom.IsAtWarWith(allianceDecision.KingdomToStartAllianceWith);
             return false;
         }
+        return true;
+    }
+}
+
+[HarmonyPatch(typeof(StartAllianceDecision), nameof(StartAllianceDecision.OnShowDecision))]
+internal static class DedicatedServerStartAllianceDecisionShowPatch
+{
+    [HarmonyPrefix]
+    private static bool OnShowDecisionPrefix(StartAllianceDecision __instance, ref bool __result)
+    {
+        if (ModInformation.IsServer)
+        {
+            __result = __instance.KingdomToStartAllianceWith?.IsPlayerKingdom() != true;
+            return false;
+        }
+
         return true;
     }
 }

--- a/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
+++ b/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using GameInterface.Services.Save.Patches;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -13,6 +14,17 @@ namespace GameInterface.Services.Save.Commands
 
 #if DEBUG
         private static int evidenceHoldMilliseconds;
+
+        [CommandLineArgumentFunction("last_failure", "coop.debug.save")]
+        public static string LastFailure(List<string> args)
+        {
+            if (!ModInformation.IsServer)
+                return "Command can only be run on the server.";
+            if (args.Count != 0)
+                return "Usage: coop.debug.save.last_failure";
+
+            return SaveManagerSaveDiagnosticsPatch.LastFailure;
+        }
 #endif
 
         [CommandLineArgumentFunction("save_as", "coop.debug.save")]

--- a/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
+++ b/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
@@ -35,7 +35,20 @@ internal class SaveInterface : ISaveInterface
         CampaignEventDispatcher.Instance.OnBeforeSave();
 
         var saveDriver = new CoopInMemSaveDriver();
-        Game.Current.Save(metaData, "TransferSave", saveDriver, (SaveResult) => { });
+        SaveResult saveResult = SaveResult.GeneralFailure;
+        Game.Current.Save(metaData, "TransferSave", saveDriver, result => saveResult = result);
+
+        if (saveResult != SaveResult.Success)
+        {
+            Logger.Error("Failed to package game save. Save result was {SaveResult}.", saveResult);
+            return new SaveResults(false, Array.Empty<byte>(), null);
+        }
+
+        if (saveDriver.Data == null || saveDriver.Data.Length == 0)
+        {
+            Logger.Error("Failed to package game save. The completed save returned no data.");
+            return new SaveResults(false, Array.Empty<byte>(), null);
+        }
 
         return new SaveResults(true, saveDriver.Data, Campaign.Current?.UniqueGameId);
     }

--- a/source/GameInterface/Services/Save/Patches/SaveManagerSaveDiagnosticsPatch.cs
+++ b/source/GameInterface/Services/Save/Patches/SaveManagerSaveDiagnosticsPatch.cs
@@ -1,0 +1,42 @@
+﻿using Common.Logging;
+using HarmonyLib;
+using Serilog;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.SaveSystem;
+using TaleWorlds.SaveSystem.Save;
+
+namespace GameInterface.Services.Save.Patches;
+
+[HarmonyPatch(typeof(SaveManager), nameof(SaveManager.Save))]
+internal static class SaveManagerSaveDiagnosticsPatch
+{
+    private static readonly ILogger Logger = LogManager.GetLogger(typeof(SaveManagerSaveDiagnosticsPatch));
+
+    [HarmonyPostfix]
+    internal static void Postfix(SaveOutput __result)
+    {
+        if (__result == null)
+        {
+            Logger.Error("Game save failed without a save result.");
+            return;
+        }
+
+        if (__result.Successful) return;
+
+        Logger.Error(
+            "Game save failed with {SaveResult}: {SaveErrors}",
+            __result.Result,
+            FormatErrorMessages(__result.Errors?.Select(error => error?.Message)));
+    }
+
+    internal static string FormatErrorMessages(IEnumerable<string> errors)
+    {
+        if (errors == null) return "<no details>";
+
+        string[] messages = errors
+            .Select((message, index) => $"[{index}] {message ?? "<empty>"}")
+            .ToArray();
+        return messages.Length == 0 ? "<no details>" : string.Join(" | ", messages);
+    }
+}

--- a/source/GameInterface/Services/Save/Patches/SaveManagerSaveDiagnosticsPatch.cs
+++ b/source/GameInterface/Services/Save/Patches/SaveManagerSaveDiagnosticsPatch.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using Serilog;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using TaleWorlds.SaveSystem;
 using TaleWorlds.SaveSystem.Save;
 
@@ -12,23 +13,37 @@ namespace GameInterface.Services.Save.Patches;
 internal static class SaveManagerSaveDiagnosticsPatch
 {
     private static readonly ILogger Logger = LogManager.GetLogger(typeof(SaveManagerSaveDiagnosticsPatch));
+    private const string NoFailure = "saveResult=none|saveErrors=<no details>";
+    private static string lastFailure = NoFailure;
+
+    internal static string LastFailure => Volatile.Read(ref lastFailure);
 
     [HarmonyPostfix]
     internal static void Postfix(SaveOutput __result)
     {
         if (__result == null)
         {
+            Volatile.Write(ref lastFailure, FormatFailure("<null>", null));
             Logger.Error("Game save failed without a save result.");
             return;
         }
 
-        if (__result.Successful) return;
+        if (__result.Successful)
+        {
+            Volatile.Write(ref lastFailure, NoFailure);
+            return;
+        }
 
-        Logger.Error(
-            "Game save failed with {SaveResult}: {SaveErrors}",
-            __result.Result,
-            FormatErrorMessages(__result.Errors?.Select(error => error?.Message)));
+        string failure = FormatFailure(
+            __result.Result.ToString(),
+            __result.Errors?.Select(error => error?.Message));
+        Volatile.Write(ref lastFailure, failure);
+
+        Logger.Error("Game save failed: {SaveFailure}", failure);
     }
+
+    internal static string FormatFailure(string saveResult, IEnumerable<string> errors) =>
+        $"saveResult={saveResult}|saveErrors={FormatErrorMessages(errors)}";
 
     internal static string FormatErrorMessages(IEnumerable<string> errors)
     {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

An inbound kingdom alliance or peace offer can expire while a player is deciding, leaving the kingdom decision screen stuck. Restarting the session can present the same unresolved decision again.

## What is the new behavior?

Resolves #3268

Inbound alliance and peace offers now remain available until the co-op decision deadline. Submitted choices resolve normally, completely unanswered offers are declined, and the decision screen closes when the decision has already ended.

## Bot Changelog Entry

- Fixed kingdom alliance and peace decision screens becoming stuck when an offer expires.
