### PR TITLE
[3254] Suppress equipment type errors during client battle spawns

### DIFF
--- a/source/E2E.Tests/Services/Equipments/EquipmentSyncTests.cs
+++ b/source/E2E.Tests/Services/Equipments/EquipmentSyncTests.cs
@@ -1,6 +1,11 @@
-﻿using E2E.Tests.Environment;
+﻿using Common.Logging;
+using E2E.Tests.Environment;
+using GameInterface.Surrogates;
 using HarmonyLib;
+using Missions.Battles;
+using Missions.Messages;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using Xunit.Abstractions;
 using static TaleWorlds.Core.Equipment;
 
@@ -11,6 +16,8 @@ namespace E2E.Tests.Services.Equipments;
 
 public class EquipmentSyncTests : IDisposable
 {
+    private const string EquipmentTypeDiagnostic = "Client updated managed \"_equipmentType\"";
+
     E2ETestEnvironment TestEnvironment { get; }
     public EquipmentSyncTests(ITestOutputHelper output)
     {
@@ -179,6 +186,125 @@ public class EquipmentSyncTests : IDisposable
             Assert.Equal(equipment._equipmentType, equipmentType);
         }
 
+    }
+
+    [Theory]
+    [InlineData(SpawnBatchPurpose.Initial)]
+    [InlineData(SpawnBatchPurpose.Deployment)]
+    [InlineData(SpawnBatchPurpose.CatchUp)]
+    public void ClientTransientSpawnEquipment_DoesNotReportManagedMutation(SpawnBatchPurpose purpose)
+    {
+        _ = new SurrogateCollection();
+        var server = TestEnvironment.Server;
+        var client = TestEnvironment.Clients.First();
+        NetworkSpawnBattleAgents? wireMessage = null;
+
+        server.Call(() =>
+        {
+            var codec = new BattleAgentSpawnBatchCodec();
+            var record = new BattleAgentSpawnData(
+                Guid.NewGuid(),
+                "imperial_infantry",
+                new Vec3(1f, 2f, 0f),
+                BattleSideEnum.Attacker,
+                100f,
+                "owner",
+                "map_event_party",
+                1,
+                new Equipment(EquipmentType.Civilian),
+                default,
+                missionEquipmentData: null);
+            NetworkSpawnBattleAgents encoded = codec.Encode(
+                new[] { record },
+                purpose).Single();
+
+            wireMessage = CreateWireMessage(encoded);
+        });
+
+        var diagnostics = new List<string>();
+        void CaptureEquipmentTypeDiagnostic(string message)
+        {
+            if (message == EquipmentTypeDiagnostic)
+                diagnostics.Add(message);
+        }
+
+        OutputSinkManager.AddLogCallback(CaptureEquipmentTypeDiagnostic);
+        try
+        {
+            client.Call(() =>
+            {
+                var codec = new BattleAgentSpawnBatchCodec();
+                Assert.True(codec.TryDecode(wireMessage!, out BattleAgentSpawnData[] decoded));
+
+                Equipment equipment = Assert.Single(decoded).SpawnEquipment;
+                Assert.Equal(EquipmentType.Civilian, equipment._equipmentType);
+                Assert.False(client.ObjectManager.Contains(equipment));
+            });
+        }
+        finally
+        {
+            OutputSinkManager.RemoveLogCallback(CaptureEquipmentTypeDiagnostic);
+        }
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void ClientRegisteredEquipmentMutation_ReportsManagedMutation()
+    {
+        var server = TestEnvironment.Server;
+        var client = TestEnvironment.Clients.First();
+        var field = AccessTools.Field(typeof(Equipment), nameof(Equipment._equipmentType));
+        var intercept = TestEnvironment.GetIntercept(field);
+        string? equipmentId = null;
+
+        server.Call(() =>
+        {
+            var equipment = new Equipment();
+            Assert.True(server.ObjectManager.TryGetId(equipment, out equipmentId));
+        });
+
+        var diagnostics = new List<string>();
+        void CaptureEquipmentTypeDiagnostic(string message)
+        {
+            if (message == EquipmentTypeDiagnostic)
+                diagnostics.Add(message);
+        }
+
+        OutputSinkManager.AddLogCallback(CaptureEquipmentTypeDiagnostic);
+        try
+        {
+            client.Call(() =>
+            {
+                Assert.True(client.ObjectManager.TryGetObject(equipmentId, out Equipment equipment));
+                Assert.True(client.ObjectManager.Contains(equipment));
+
+                intercept.Invoke(null, new object[] { equipment, EquipmentType.Civilian });
+
+                Assert.Equal(EquipmentType.Civilian, equipment._equipmentType);
+            });
+        }
+        finally
+        {
+            OutputSinkManager.RemoveLogCallback(CaptureEquipmentTypeDiagnostic);
+        }
+
+        Assert.Single(diagnostics);
+    }
+
+    private static NetworkSpawnBattleAgents CreateWireMessage(NetworkSpawnBattleAgents encoded)
+    {
+        return new NetworkSpawnBattleAgents(
+            encoded.Payload,
+            encoded.UncompressedLength,
+            encoded.RecordCount,
+            encoded.IsCompressed,
+            encoded.TransferId,
+            encoded.BatchIndex,
+            encoded.BatchCount,
+            encoded.Purpose,
+            encoded.PayloadSha256,
+            agents: null!);
     }
 
 }

--- a/source/GameInterface/AutoSync/AutoSyncRegistry.cs
+++ b/source/GameInterface/AutoSync/AutoSyncRegistry.cs
@@ -19,11 +19,15 @@ public class AutoSyncRegistry
     
     public readonly List<Action<object, object>> ReadonlySetters = new List<Action<object, object>>();
 
-    public void AddField(FieldInfo field, bool debug = false, bool coalesce = false)
+    public void AddField(
+        FieldInfo field,
+        bool debug = false,
+        bool coalesce = false,
+        bool suppressClientDiagnosticWhenUnregistered = false)
     {
         if (field == null) throw new ArgumentNullException(nameof(field));
 
-        if (!AddMember(field.DeclaringType, field, debug, coalesce)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Field: {field.Name} has already been registered as a synced field");
+        if (!AddMember(field.DeclaringType, field, debug, coalesce, suppressClientDiagnosticWhenUnregistered)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Field: {field.Name} has already been registered as a synced field");
     }
 
     public void AddProperty(PropertyInfo property, bool debug = false, bool coalesce = false)
@@ -33,7 +37,7 @@ public class AutoSyncRegistry
         // only prevent properties from being added if they are no collection like type
         if (property.CanWrite == false) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Property: {property.Name} does not have a set method");
 
-        if (!AddMember(property.DeclaringType, property, debug, coalesce)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Property: {property.Name} has already been registered as a synced property");
+        if (!AddMember(property.DeclaringType, property, debug, coalesce, false)) throw new ArgumentException($"{nameof(AutoSyncBuilder)} Property: {property.Name} has already been registered as a synced property");
     }
 
     public bool AddTargetMethod(Type type, MethodInfo methodInfo, string patchCategory = null)
@@ -75,7 +79,12 @@ public class AutoSyncRegistry
         return ReadonlySetters.Count - 1;
     }
 
-    private bool AddMember(Type type, MemberInfo memberInfo, bool debug, bool coalesce)
+    private bool AddMember(
+        Type type,
+        MemberInfo memberInfo,
+        bool debug,
+        bool coalesce,
+        bool suppressClientDiagnosticWhenUnregistered)
     {
         if (memberInfo is not FieldInfo && memberInfo is not PropertyInfo)
             return false;
@@ -89,7 +98,7 @@ public class AutoSyncRegistry
             if (Registrations[type].Contains(fieldInfo))
                 return false;
 
-            Registrations[type].AddField(fieldInfo, debug, coalesce);
+            Registrations[type].AddField(fieldInfo, debug, coalesce, suppressClientDiagnosticWhenUnregistered);
         }
         else if (memberInfo is PropertyInfo propertyInfo)
         {

--- a/source/GameInterface/AutoSync/AutoSyncRegistryItem.cs
+++ b/source/GameInterface/AutoSync/AutoSyncRegistryItem.cs
@@ -24,9 +24,9 @@ public class AutoSyncRegistryItem
             || Properties.Contains(new Debuggable<PropertyInfo>(property, false));
     }
 
-    public void AddField(FieldInfo field, bool debug, bool coalesce)
+    public void AddField(FieldInfo field, bool debug, bool coalesce, bool suppressClientDiagnosticWhenUnregistered)
     {
-        Fields.Add(new Debuggable<FieldInfo>(field, debug, coalesce));
+        Fields.Add(new Debuggable<FieldInfo>(field, debug, coalesce, suppressClientDiagnosticWhenUnregistered));
     }
 
     public void AddProperty(PropertyInfo property, bool debug, bool coalesce)
@@ -64,11 +64,17 @@ public class Debuggable<T>
     public bool Debug;
     // Route this member's per-change sends through the per-tick coalescer instead of SendAll.
     public bool Coalesce;
+    public bool SuppressClientDiagnosticWhenUnregistered;
 
-    public Debuggable(T value, bool debug, bool coalesce = false)
+    public Debuggable(
+        T value,
+        bool debug,
+        bool coalesce = false,
+        bool suppressClientDiagnosticWhenUnregistered = false)
     {
         Value = value;
         Debug = debug;
         Coalesce = coalesce;
+        SuppressClientDiagnosticWhenUnregistered = suppressClientDiagnosticWhenUnregistered;
     }
 }

--- a/source/GameInterface/AutoSync/Builders/AutoSyncBuilderBase.cs
+++ b/source/GameInterface/AutoSync/Builders/AutoSyncBuilderBase.cs
@@ -50,7 +50,8 @@ namespace GameInterface.AutoSync.Builders
                 MemberType = AutoSyncUtils.GetMemberTypeName(fieldInfo.FieldType),
                 ReadOnly = fieldInfo.IsInitOnly,
                 ReadOnlySetterIndex = fieldInfo.IsInitOnly ? GetReadOnlyFieldSetter(fieldInfo) : (int?)null,
-                Debug = fieldItem.Debug
+                Debug = fieldItem.Debug,
+                SuppressClientDiagnosticWhenUnregistered = fieldItem.SuppressClientDiagnosticWhenUnregistered
             });
         }
 

--- a/source/GameInterface/AutoSync/Templates/Patches/FieldSetTranspilerTemplate.txt
+++ b/source/GameInterface/AutoSync/Templates/Patches/FieldSetTranspilerTemplate.txt
@@ -50,7 +50,15 @@ public static void {{MemberName}}_Intercept({{MemberDeclaringType}} instance, {{
 
     if (ModInformation.IsClient)
     {
+{{~ if SuppressClientDiagnosticWhenUnregistered ~}}
+        if (!ContainerProvider.TryResolve<GameInterface.Services.ObjectManager.IObjectManager>(out var objectManager) ||
+            objectManager.Contains(instance))
+        {
+            Logger.Error("Client updated managed {type}", "{{MemberName}}");
+        }
+{{~ else ~}}
         Logger.Error("Client updated managed {type}", "{{MemberName}}");
+{{~ end ~}}
 {{~ if ReadOnly ~}}
 	    {{MemberName}}FieldInfo.SetValue(instance, newValue);
 {{~ else ~}}

--- a/source/GameInterface/Services/Equipments/EquipmentTypeSync.cs
+++ b/source/GameInterface/Services/Equipments/EquipmentTypeSync.cs
@@ -8,6 +8,8 @@ class EquipmentSync : IAutoSync
 {
     public EquipmentSync(AutoSyncRegistry autoSyncBuilder)
     {
-        autoSyncBuilder.AddField(AccessTools.Field(typeof(Equipment), nameof(Equipment._equipmentType)));
+        autoSyncBuilder.AddField(
+            AccessTools.Field(typeof(Equipment), nameof(Equipment._equipmentType)),
+            suppressClientDiagnosticWhenUnregistered: true);
     }
 }

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -154,8 +154,6 @@ internal static class BattleDebugCommands
             mission?.GetMissionBehavior<DefaultBattleMissionAgentSpawnLogic>();
         if (mission == null || controller == null || spawnLogic == null)
             return "COLUMN_REINFORCEMENT_FIXTURE no active coop battle";
-        if (!controller.Session.IsLocalHost)
-            return "COLUMN_REINFORCEMENT_FIXTURE run this on the battle-authority client";
         if (!controller.Deployment.IsActivated)
             return "COLUMN_REINFORCEMENT_FIXTURE finish deployment first";
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
@@ -207,8 +205,7 @@ internal static class BattleDebugCommands
 
         if (candidate == null)
         {
-            return "COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to a non-player formation " +
-                   "whose active human agents are all locally controlled";
+            return "COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to an eligible locally controlled formation";
         }
 
         columnReinforcementFixtureMission = mission;
@@ -246,13 +243,13 @@ internal static class BattleDebugCommands
 
             Agent[] agents = mission.Agents
                 .Where(agent => agent != null
+                    && agent != Agent.Main
                     && agent.IsActive()
                     && agent.IsHuman
-                    && agent.Formation == formation)
+                    && agent.Formation == formation
+                    && registry.IsLocallyControlled(agent))
                 .ToArray();
-            if (agents.Length == 0 || agents.Contains(Agent.Main))
-                continue;
-            if (agents.Any(agent => !registry.IsLocallyControlled(agent)))
+            if (agents.Length == 0)
                 continue;
 
             return new ColumnReinforcementCandidate
@@ -272,6 +269,8 @@ internal static class BattleDebugCommands
     {
         if (columnReinforcementFixtureMission == null)
             return "COLUMN_REINFORCEMENT_FIXTURE inactive";
+        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+            return "COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable";
         if (Mission.Current != columnReinforcementFixtureMission ||
             columnReinforcementFixtureFormation == null ||
             columnReinforcementFixtureSpawnContext == null)
@@ -283,7 +282,9 @@ internal static class BattleDebugCommands
         int active = Mission.Current.Agents.Count(agent => agent != null
             && agent.IsActive()
             && agent.IsHuman
-            && agent.Formation == columnReinforcementFixtureFormation);
+            && agent != Agent.Main
+            && agent.Formation == columnReinforcementFixtureFormation
+            && registry.IsLocallyControlled(agent));
         int vanguardPositions = columnReinforcementFixtureFormation.Arrangement is ColumnFormation column
             ? column.GetUnitPositionsOnVanguardFileIndex().Count
             : -1;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Entering a large battle or receiving deployment, catch-up, and reinforcement spawns can flood the client log with false equipment-type errors while remote agents are equipped, contributing to battle-entry and reinforcement hitches.

## What is the new behavior?

Resolves #3254

Initial, deployment, catch-up, and reinforcement spawns now keep their authoritative equipment types without reporting false client equipment mutations. Unsupported local changes to registered equipment still report an error.

## Bot Changelog Entry

- Fixed unimportant equipment errors when loading into battle.
