### PR TITLE
Prevent critical raid, kingdom, and companion softlocks

### DIFF
--- a/source/E2E.Tests/Services/Locations/LocationAuthorityMigratorTests.cs
+++ b/source/E2E.Tests/Services/Locations/LocationAuthorityMigratorTests.cs
@@ -1,0 +1,86 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.Locations.Conversations;
+using Missions;
+using Missions.Agents;
+using Missions.Agents.Handlers;
+using Missions.Locations;
+using Missions.Messages;
+using Missions.Services.Network;
+using Moq;
+using System;
+using System.Threading;
+
+namespace E2E.Tests.Services.Locations;
+
+public class LocationAuthorityMigratorTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void PeerDeparture_EndsConversationBeforePartyPuppetRemoval(bool disconnected)
+    {
+        const string instanceId = "location";
+        const string controllerId = "departed";
+        using var broker = new MessageBroker();
+        var session = new Mock<ILocationSession>();
+        session.SetupGet(value => value.InstanceId).Returns(instanceId);
+
+        var agentId = Guid.NewGuid();
+        var agentInfo = new CoopAgentInfo(controllerId, controllerId, controllerId, null, agentId, 0);
+        var registry = new Mock<INetworkAgentRegistry>();
+        registry.Setup(value => value.GetAgents(controllerId)).Returns(new[] { agentInfo });
+
+        int order = 0;
+        var conversationAgentGuard = new Mock<ILocationConversationAgentGuard>();
+        conversationAgentGuard
+            .Setup(value => value.EndConversationWithAgent(null))
+            .Callback(() => Assert.Equal(0, order++));
+        registry
+            .Setup(value => value.RemoveAgent(agentId))
+            .Callback(() => Assert.Equal(1, order++))
+            .Returns(true);
+
+        var movementHandler = new Mock<IAgentMovementHandler>();
+        movementHandler.SetupGet(value => value.Interpolator).Returns(Mock.Of<IAgentPositionInterpolator>());
+        var missionComponent = new Mock<ICoopMissionComponent>();
+        missionComponent.SetupGet(value => value.AgentRegistry).Returns(registry.Object);
+        missionComponent.SetupGet(value => value.AgentMovementHandler).Returns(movementHandler.Object);
+
+        using var migrator = new LocationAuthorityMigrator(
+            broker,
+            missionComponent.Object,
+            session.Object,
+            Mock.Of<ILocationAgentBindingMap>(),
+            Mock.Of<ILocationPartyAgentMap>(),
+            Mock.Of<IMissionContext>(),
+            Mock.Of<ILocationNpcHoldRegistry>(),
+            conversationAgentGuard.Object);
+
+        int previousGameThreadId = GameThread.Instance.GameThreadId;
+        GameThread.Instance.MarkGameThread();
+        try
+        {
+            var networkThread = new Thread(() =>
+            {
+                if (disconnected)
+                    broker.Publish(this, new MissionPeerDisconnected(controllerId, instanceId));
+                else
+                    broker.Publish(this, new MissionPeerLeft(controllerId, instanceId));
+            });
+            networkThread.Start();
+            networkThread.Join();
+
+            GameThread.Instance.Update(TimeSpan.Zero);
+
+            Assert.Equal(2, order);
+            conversationAgentGuard.Verify(value => value.EndConversationWithAgent(null), Times.Once);
+            registry.Verify(value => value.RemoveAgent(agentId), Times.Once);
+        }
+        finally
+        {
+            GameThread.Instance.DiscardQueuedActions();
+            GameThread.Instance.RestoreGameThread(previousGameThreadId);
+        }
+    }
+}

--- a/source/E2E.Tests/Services/Locations/LocationControllerWithdrawalStateTests.cs
+++ b/source/E2E.Tests/Services/Locations/LocationControllerWithdrawalStateTests.cs
@@ -1,6 +1,7 @@
 ﻿using Common;
 using Common.Messaging;
 using GameInterface.Services.Locations;
+using GameInterface.Services.Locations.Conversations;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.ObjectManager;
 using Missions;
@@ -71,6 +72,7 @@ public class LocationControllerWithdrawalStateTests
             Mock.Of<IObjectManager>(),
             Mock.Of<ICoopMissionComponent>(),
             session.Object,
+            Mock.Of<ILocationConversationAgentGuard>(),
             Mock.Of<ILocationAgentBindingMap>(),
             Mock.Of<ILocationPartyAgentMap>(),
             Mock.Of<ILocationPuppetRosterBinder>(),

--- a/source/E2E.Tests/Services/Locations/LocationPuppetSpawnerTests.cs
+++ b/source/E2E.Tests/Services/Locations/LocationPuppetSpawnerTests.cs
@@ -1,0 +1,83 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.Locations;
+using GameInterface.Services.Locations.Conversations;
+using GameInterface.Services.MapEvents;
+using GameInterface.Services.ObjectManager;
+using Missions;
+using Missions.Agents;
+using Missions.Agents.Handlers;
+using Missions.Locations;
+using Missions.Messages;
+using Moq;
+using System;
+using System.Threading;
+
+namespace E2E.Tests.Services.Locations;
+
+/// <summary>Checks receiver-side location puppet lifecycle ordering.</summary>
+public class LocationPuppetSpawnerTests
+{
+    [Fact]
+    public void RemoteCompanionDespawn_EndsReceiverConversationBeforeRegistryRemoval()
+    {
+        using var broker = new MessageBroker();
+        var agentId = Guid.NewGuid();
+        var agentInfo = new CoopAgentInfo("host", "host", "host", null, agentId, 0);
+        var registry = new Mock<INetworkAgentRegistry>();
+        registry.Setup(value => value.TryGetAgentInfo(agentId, out agentInfo)).Returns(true);
+
+        int order = 0;
+        var conversationAgentGuard = new Mock<ILocationConversationAgentGuard>();
+        conversationAgentGuard
+            .Setup(value => value.EndConversationWithAgent(null))
+            .Callback(() => Assert.Equal(0, order++));
+        registry
+            .Setup(value => value.RemoveAgent(agentId))
+            .Callback(() => Assert.Equal(1, order++))
+            .Returns(true);
+
+        var movementHandler = new Mock<IAgentMovementHandler>();
+        movementHandler.SetupGet(value => value.Interpolator).Returns(Mock.Of<IAgentPositionInterpolator>());
+        var missionComponent = new Mock<ICoopMissionComponent>();
+        missionComponent.SetupGet(value => value.AgentRegistry).Returns(registry.Object);
+        missionComponent.SetupGet(value => value.AgentMovementHandler).Returns(movementHandler.Object);
+
+        using var spawner = new LocationPuppetSpawner(
+            broker,
+            Mock.Of<IObjectManager>(),
+            missionComponent.Object,
+            Mock.Of<ILocationSession>(),
+            conversationAgentGuard.Object,
+            Mock.Of<ILocationAgentBindingMap>(),
+            Mock.Of<ILocationPartyAgentMap>(),
+            Mock.Of<ILocationPuppetRosterBinder>(),
+            Mock.Of<IBattleAgentBudget>(),
+            Mock.Of<ILocationAgentSpawnBatchCodec>(),
+            Mock.Of<ILocationAuthorityMigrator>(),
+            Mock.Of<ILocationControllerWithdrawalState>());
+
+        int previousGameThreadId = GameThread.Instance.GameThreadId;
+        GameThread.Instance.MarkGameThread();
+        try
+        {
+            var networkThread = new Thread(() => broker.Publish(this, new NetworkDespawnLocationAgents(
+                new[] { agentId },
+                new[] { (byte)LocationDespawnReason.Removed },
+                new[] { string.Empty })));
+            networkThread.Start();
+            networkThread.Join();
+
+            GameThread.Instance.Update(TimeSpan.Zero);
+
+            Assert.Equal(2, order);
+            conversationAgentGuard.Verify(value => value.EndConversationWithAgent(null), Times.Once);
+            registry.Verify(value => value.RemoveAgent(agentId), Times.Once);
+        }
+        finally
+        {
+            GameThread.Instance.DiscardQueuedActions();
+            GameThread.Instance.RestoreGameThread(previousGameThreadId);
+        }
+    }
+}

--- a/source/E2E.Tests/Services/Locations/LocationRemotePartySpawnOrderingTests.cs
+++ b/source/E2E.Tests/Services/Locations/LocationRemotePartySpawnOrderingTests.cs
@@ -1,0 +1,79 @@
+﻿using Common;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Locations;
+using Missions;
+using Missions.Locations;
+using Moq;
+using System;
+using System.Threading;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.MountAndBlade;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace E2E.Tests.Services.Locations;
+
+/// <summary>Checks remote party puppet identity ordering against the population replay.</summary>
+public class LocationRemotePartySpawnOrderingTests
+{
+    [Fact]
+    public void SpawnAndPopulationReplayInSameDrain_ResolverSeesRemotePuppet()
+    {
+        using var registry = new NetworkAgentRegistry(Mock.Of<IControllerIdProvider>());
+        var partyAgentMap = new LocationPartyAgentMap();
+        var partyPuppetRegistrar = new LocationPartyPuppetRegistrar();
+        var agentId = Guid.NewGuid();
+        var remotePuppet = (Agent)FormatterServices.GetUninitializedObject(typeof(Agent));
+        remotePuppet.Origin = (SimpleAgentOrigin)FormatterServices.GetUninitializedObject(typeof(SimpleAgentOrigin));
+        partyAgentMap.Record(agentId);
+        LocationNpcGate.BeginMission(
+            "settlement|tavern",
+            agent => registry.TryGetAgentInfo(agent, out var info) && partyAgentMap.Contains(info.AgentId));
+
+        bool registered = false;
+        bool resolvedDuringReplay = false;
+        Thread spawnThread = null;
+        int previousGameThreadId = GameThread.Instance.GameThreadId;
+        GameThread.Instance.MarkGameThread();
+        try
+        {
+            spawnThread = new Thread(() => GameThread.RunSafe(() =>
+            {
+                registered = partyPuppetRegistrar.TrySpawnAndRegister(
+                    () => remotePuppet,
+                    registry,
+                    "remote",
+                    agentId,
+                    out _);
+            }, blocking: true));
+            spawnThread.Start();
+            Assert.True(SpinWait.SpinUntil(
+                () => GameThread.Instance.QueueLength == 1,
+                TimeSpan.FromSeconds(2)));
+
+            var replayThread = new Thread(() => GameThread.RunSafe(() =>
+            {
+                resolvedDuringReplay = LocationNpcGate.IsPlayerPartyAgent(remotePuppet);
+            }));
+            replayThread.Start();
+            replayThread.Join();
+            Assert.True(SpinWait.SpinUntil(
+                () => GameThread.Instance.QueueLength == 2,
+                TimeSpan.FromSeconds(2)));
+
+            GameThread.Instance.Update(TimeSpan.Zero);
+            spawnThread.Join();
+
+            Assert.True(registered);
+            Assert.True(resolvedDuringReplay);
+        }
+        finally
+        {
+            if (GameThread.Instance.QueueLength > 0)
+                GameThread.Instance.Update(TimeSpan.Zero);
+            spawnThread?.Join(TimeSpan.FromSeconds(1));
+            GameThread.Instance.DiscardQueuedActions();
+            GameThread.Instance.RestoreGameThread(previousGameThreadId);
+            LocationNpcGate.EndMission();
+        }
+    }
+}

--- a/source/E2E.Tests/Services/MapEvents/MapEventUpdateAuthorityTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventUpdateAuthorityTests.cs
@@ -65,6 +65,22 @@ public class MapEventUpdateAuthorityTests : MapEventTestBase
         }, MapEventDisabledMethods);
     }
 
+    [Fact]
+    public void MapEvent_WithMissingLeaderAndRemainingParty_ServerUpdateRepairsLeader()
+    {
+        var context = CreateServerMapEvent();
+
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(context.MapEventId, out var mapEvent));
+            var expectedLeader = mapEvent.AttackerSide.Parties[0].Party;
+            mapEvent.AttackerSide.LeaderParty = null;
+
+            Assert.True(InvokeMapEventUpdatePrefix(mapEvent));
+            Assert.Same(expectedLeader, mapEvent.AttackerSide.LeaderParty);
+        }, MapEventDisabledMethods);
+    }
+
     private static void AddSyntheticMapEventParty(MapEventSide side, PartyBase party)
     {
         party._mapEventSide = side;

--- a/source/E2E.Tests/Services/MapEvents/MapEventUpdateAuthorityTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/MapEventUpdateAuthorityTests.cs
@@ -66,18 +66,25 @@ public class MapEventUpdateAuthorityTests : MapEventTestBase
     }
 
     [Fact]
-    public void MapEvent_WithMissingLeaderAndRemainingParty_ServerUpdateRepairsLeader()
+    public void MapEvent_WithStaleLeaderAndLockedAllocations_ServerUpdateRepairsSimulationSetup()
     {
         var context = CreateServerMapEvent();
 
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(context.MapEventId, out var mapEvent));
-            var expectedLeader = mapEvent.AttackerSide.Parties[0].Party;
-            mapEvent.AttackerSide.LeaderParty = null;
+            var side = mapEvent.AttackerSide;
+            var removedLeader = side.LeaderParty;
+            var expectedLeader = GameObjectCreator.CreateInitializedObject<MobileParty>().Party;
+            AddSyntheticMapEventParty(side, expectedLeader);
+
+            side._troopAllocationsLocked = true;
+            side._battleParties.RemoveAt(0);
+            removedLeader._mapEventSide = null;
 
             Assert.True(InvokeMapEventUpdatePrefix(mapEvent));
-            Assert.Same(expectedLeader, mapEvent.AttackerSide.LeaderParty);
+            Assert.Same(expectedLeader, side.LeaderParty);
+            Assert.False(side._troopAllocationsLocked);
         }, MapEventDisabledMethods);
     }
 

--- a/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
+++ b/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
@@ -1306,6 +1306,7 @@ public class VillageHostileActionTests : MapEventTestBase
                 var defenderParty = GameObjectCreator.CreateInitializedObject<MobileParty>();
                 defenderParty.MemberRoster.AddToCounts(defenderTroop, 1);
                 AddSyntheticMapEventParty(mapEvent.DefenderSide, defenderParty.Party);
+                mapEvent.DefenderSide.LeaderParty = defenderParty.Party;
 
                 Assert.True(mapEvent.IsActiveSlowVillageRaid());
                 Assert.True(mapEvent.DefenderSide.TroopCount > 0);
@@ -1313,6 +1314,7 @@ public class VillageHostileActionTests : MapEventTestBase
 
                 Assert.Null(defenderParty.Party.MapEventSide);
                 Assert.DoesNotContain(mapEvent.DefenderSide.Parties, party => party.Party == defenderParty.Party);
+                Assert.Same(settlement.Party, mapEvent.DefenderSide.LeaderParty);
                 Assert.Equal(0, mapEvent.DefenderSide.TroopCount);
 
                 var wasFinished = false;

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/KingdomPolicyDecisionSerializationTest.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecision/KingdomPolicyDecisionSerializationTest.cs
@@ -1,9 +1,14 @@
 ﻿using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.ObjectManager;
 using ProtoBuf;
+using Serilog;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
 using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
 
 namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
 {
@@ -29,6 +34,33 @@ namespace GameInterface.Tests.Services.Kingdoms.KingdomDecision
             Assert.Equal(kingdomPolicyDecisionData.PolicyObjectId, deserializedObj.PolicyObjectId);
             Assert.Equal(kingdomPolicyDecisionData.KingdomPolicies, deserializedObj.KingdomPolicies);
             Assert.Equal(kingdomPolicyDecisionData.IsInvertedDecision, deserializedObj.IsInvertedDecision);
+        }
+
+        [Fact]
+        public void EmptyPolicySnapshot_RoundTripReconstructsDecision()
+        {
+            var data = new KingdomPolicyDecisionData(
+                "ProposerClan", "Kingdom", 10, true, true, true, "PolicyObject1", true, new List<string>());
+            using var stream = new MemoryStream();
+            Serializer.Serialize<KingdomDecisionData>(stream, data);
+            stream.Position = 0;
+            var deserialized = Assert.IsType<KingdomPolicyDecisionData>(
+                Serializer.Deserialize<KingdomDecisionData>(stream));
+
+            var objectManager = new ObjectManager(new LoggerConfiguration().CreateLogger());
+            var proposerClan = (Clan)FormatterServices.GetUninitializedObject(typeof(Clan));
+            proposerClan.StringId = data.ProposerClanId;
+            var kingdom = (Kingdom)FormatterServices.GetUninitializedObject(typeof(Kingdom));
+            kingdom.StringId = data.KingdomId;
+            var policy = (PolicyObject)FormatterServices.GetUninitializedObject(typeof(PolicyObject));
+            policy.StringId = data.PolicyObjectId;
+            objectManager.AddExisting(proposerClan.StringId, proposerClan);
+            objectManager.AddExisting(kingdom.StringId, kingdom);
+            objectManager.AddExisting(policy.StringId, policy);
+
+            Assert.True(deserialized.TryGetKingdomDecision(objectManager, out var decision));
+            var policyDecision = Assert.IsType<KingdomPolicyDecision>(decision);
+            Assert.Empty(policyDecision._kingdomPolicies);
         }
 
         [Fact]

--- a/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
@@ -1,5 +1,10 @@
-﻿using GameInterface.Services.Locations.Patches;
+﻿using GameInterface.Services.Locations;
+using GameInterface.Services.Locations.Patches;
+using System;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.MountAndBlade;
 using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
 
 namespace GameInterface.Tests.Services.Locations;
 
@@ -95,18 +100,45 @@ public class LocationCompanionAuthorityPatchTests
                 suppressNativeSpawns));
     }
 
-    [Theory]
-    [InlineData(true, true, false)]
-    [InlineData(true, false, true)]
-    [InlineData(false, true, true)]
-    public void DelayedPopulationSimulation_SkipsOnlyOwnedPartyAgents(
-        bool isReplayingNativePopulation,
-        bool isOwnedPartyAgent,
-        bool expected)
+    [Fact]
+    public void DelayedPopulationSimulation_SkipsMainAgentRegardlessOfOrigin()
     {
-        Assert.Equal(expected,
-            LocationNativeSpawnSuppressionPatches.ShouldSimulateAgent(
-                isReplayingNativePopulation,
-                isOwnedPartyAgent));
+        var mainAgent = CreateAgentWithSimpleOrigin();
+
+        Assert.True(LocationNpcGate.IsPlayerPartyAgent(mainAgent, mainAgent));
+    }
+
+    [Fact]
+    public void DelayedPopulationSimulation_SkipsRegisteredRemotePartyPuppet()
+    {
+        var remotePartyPuppet = CreateAgentWithSimpleOrigin();
+        var ambientNpc = CreateAgentWithSimpleOrigin();
+        LocationNpcGate.BeginMission(
+            "settlement|tavern",
+            agent => ReferenceEquals(agent, remotePartyPuppet));
+
+        try
+        {
+            Assert.False(LocationNativeSpawnSuppressionPatches.ShouldSimulateAgent(
+                isReplayingNativePopulation: true,
+                remotePartyPuppet));
+            Assert.True(LocationNativeSpawnSuppressionPatches.ShouldSimulateAgent(
+                isReplayingNativePopulation: true,
+                ambientNpc));
+            Assert.True(LocationNativeSpawnSuppressionPatches.ShouldSimulateAgent(
+                isReplayingNativePopulation: false,
+                remotePartyPuppet));
+        }
+        finally
+        {
+            LocationNpcGate.EndMission();
+        }
+    }
+
+    private static Agent CreateAgentWithSimpleOrigin()
+    {
+        var agent = (Agent)FormatterServices.GetUninitializedObject(typeof(Agent));
+        agent.Origin = (SimpleAgentOrigin)FormatterServices.GetUninitializedObject(typeof(SimpleAgentOrigin));
+        return agent;
     }
 }

--- a/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
+++ b/source/GameInterface.Tests/Services/Locations/LocationCompanionAuthorityPatchTests.cs
@@ -94,4 +94,19 @@ public class LocationCompanionAuthorityPatchTests
                 isOwnedCompanion,
                 suppressNativeSpawns));
     }
+
+    [Theory]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    public void DelayedPopulationSimulation_SkipsOnlyOwnedPartyAgents(
+        bool isReplayingNativePopulation,
+        bool isOwnedPartyAgent,
+        bool expected)
+    {
+        Assert.Equal(expected,
+            LocationNativeSpawnSuppressionPatches.ShouldSimulateAgent(
+                isReplayingNativePopulation,
+                isOwnedPartyAgent));
+    }
 }

--- a/source/GameInterface.Tests/Services/Locations/LocationConversationAgentGuardTests.cs
+++ b/source/GameInterface.Tests/Services/Locations/LocationConversationAgentGuardTests.cs
@@ -1,0 +1,24 @@
+﻿using GameInterface.Services.Locations.Conversations;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace GameInterface.Tests.Services.Locations;
+
+/// <summary>Checks conversation-agent identity matching used before local and remote despawns.</summary>
+public class LocationConversationAgentGuardTests
+{
+    [Fact]
+    public void ConversationAgentMatch_UsesAgentIdentity()
+    {
+        var target = (Agent)FormatterServices.GetUninitializedObject(typeof(Agent));
+        var other = (Agent)FormatterServices.GetUninitializedObject(typeof(Agent));
+        var absent = (Agent)FormatterServices.GetUninitializedObject(typeof(Agent));
+        IAgent[] conversationAgents = { other, target };
+
+        Assert.True(LocationConversationAgentGuard.ContainsAgent(conversationAgents, target));
+        Assert.False(LocationConversationAgentGuard.ContainsAgent(conversationAgents, absent));
+        Assert.False(LocationConversationAgentGuard.ContainsAgent(conversationAgents, null));
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -23,6 +23,7 @@ using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Kingdoms.Patches;
 using GameInterface.Services.LiveTesting;
 using GameInterface.Services.Locations;
+using GameInterface.Services.Locations.Conversations;
 using GameInterface.Services.Locations.Hosting;
 using GameInterface.Services.MapEventParties;
 using GameInterface.Services.MapEvents;
@@ -91,6 +92,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<AwaitingAlternativeSolutionTroopsRegistry>().As<IAwaitingAlternativeSolutionTroopsRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<BattleHostRegistry>().As<IBattleHostRegistry>().InstancePerLifetimeScope();
         builder.RegisterType<LocationHostRegistry>().As<ILocationHostRegistry>().InstancePerLifetimeScope();
+        builder.RegisterType<LocationConversationAgentGuard>().As<ILocationConversationAgentGuard>().InstancePerDependency();
         builder.RegisterType<BattleAgentBudget>().As<IBattleAgentBudget>().InstancePerDependency();
         builder.RegisterType<NearbyPartyReinforcer>().As<INearbyPartyReinforcer>().InstancePerDependency();
         builder.RegisterType<SiegeMapEventLeaderReconciler>().As<ISiegeMapEventLeaderReconciler>().InstancePerDependency();

--- a/source/GameInterface/Services/Kingdoms/Data/KingdomPolicyDecisionData.cs
+++ b/source/GameInterface/Services/Kingdoms/Data/KingdomPolicyDecisionData.cs
@@ -42,14 +42,17 @@ namespace GameInterface.Services.Kingdoms.Data
             }
 
             List<PolicyObject> kingdomPolicies = new List<PolicyObject>();
-            foreach (string policyObjectId in KingdomPolicies)
+            if (KingdomPolicies != null)
             {
-                if (!objectManager.TryGetObject(policyObjectId, out PolicyObject kingdomPolicy))
+                foreach (string policyObjectId in KingdomPolicies)
                 {
-                    kingdomDecision = null;
-                    return false;
+                    if (!objectManager.TryGetObject(policyObjectId, out PolicyObject kingdomPolicy))
+                    {
+                        kingdomDecision = null;
+                        return false;
+                    }
+                    kingdomPolicies.Add(kingdomPolicy);
                 }
-                kingdomPolicies.Add(kingdomPolicy);
             }
 
             KingdomPolicyDecision kingdomPolicyDecision = (KingdomPolicyDecision)FormatterServices.GetUninitializedObject(typeof(KingdomPolicyDecision));

--- a/source/GameInterface/Services/Locations/Conversations/LocationConversationAgentGuard.cs
+++ b/source/GameInterface/Services/Locations/Conversations/LocationConversationAgentGuard.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using TaleWorlds.MountAndBlade;
+
+namespace GameInterface.Services.Locations.Conversations;
+
+/// <summary>Ends a local conversation before its mission agent is removed.</summary>
+public interface ILocationConversationAgentGuard
+{
+    void EndConversationWithAgent(Agent agent);
+}
+
+/// <inheritdoc cref="ILocationConversationAgentGuard"/>
+internal class LocationConversationAgentGuard : ILocationConversationAgentGuard
+{
+    public void EndConversationWithAgent(Agent agent)
+    {
+        var conversationManager = Campaign.Current?.ConversationManager;
+        if (conversationManager?.IsConversationInProgress != true ||
+            !ContainsAgent(conversationManager.ConversationAgents, agent))
+            return;
+
+        conversationManager.EndConversation();
+    }
+
+    internal static bool ContainsAgent(IEnumerable<IAgent> conversationAgents, Agent agent)
+    {
+        if (conversationAgents == null || agent == null) return false;
+
+        foreach (var conversationAgent in conversationAgents)
+        {
+            if (ReferenceEquals(conversationAgent, agent))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/source/GameInterface/Services/Locations/LocationNpcGate.cs
+++ b/source/GameInterface/Services/Locations/LocationNpcGate.cs
@@ -1,4 +1,4 @@
-using Common.Logging;
+﻿using Common.Logging;
 using Serilog;
 using System;
 
@@ -31,6 +31,9 @@ public static class LocationNpcGate
     // set and read on the same thread within a single spawn call.
     [ThreadStatic]
     private static bool _suppressCapture;
+
+    [ThreadStatic]
+    private static bool _isReplayingNativePopulation;
 
     /// <summary>True while a coop settlement location mission is active on this client.</summary>
     public static bool IsCoopLocationMissionActive
@@ -66,6 +69,13 @@ public static class LocationNpcGate
     {
         get => _suppressCapture;
         set => _suppressCapture = value;
+    }
+
+    /// <summary>True while the elected host replays the native population pass after party agents spawned.</summary>
+    public static bool IsReplayingNativePopulation
+    {
+        get => _isReplayingNativePopulation;
+        set => _isReplayingNativePopulation = value;
     }
 
     /// <summary>A coop location mission began on this client. Resets host confirmation.</summary>

--- a/source/GameInterface/Services/Locations/LocationNpcGate.cs
+++ b/source/GameInterface/Services/Locations/LocationNpcGate.cs
@@ -1,6 +1,9 @@
 ﻿using Common.Logging;
 using Serilog;
 using System;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.MountAndBlade;
 
 namespace GameInterface.Services.Locations;
 
@@ -25,6 +28,7 @@ public static class LocationNpcGate
 
     private static string _activeInstanceId;
     private static bool _localHostConfirmed;
+    private static Func<Agent, bool> _partyAgentResolver;
 
     // Set around a puppet Mission.SpawnAgent/SpawnMonster call so the location capture patch does not
     // re-capture (and re-broadcast) an agent that itself came off the wire. Thread-static because it is
@@ -78,8 +82,26 @@ public static class LocationNpcGate
         set => _isReplayingNativePopulation = value;
     }
 
+    /// <summary>True when the agent belongs to a local or replicated player party.</summary>
+    public static bool IsPlayerPartyAgent(Agent agent)
+        => IsPlayerPartyAgent(agent, Agent.Main);
+
+    internal static bool IsPlayerPartyAgent(Agent agent, Agent mainAgent)
+    {
+        if (agent == null) return false;
+        if (ReferenceEquals(agent, mainAgent)) return true;
+
+        var mainParty = PartyBase.MainParty;
+        if (mainParty != null && agent.Origin is PartyAgentOrigin origin && origin.Party == mainParty)
+            return true;
+
+        Func<Agent, bool> resolver;
+        lock (Gate) resolver = _partyAgentResolver;
+        return resolver?.Invoke(agent) == true;
+    }
+
     /// <summary>A coop location mission began on this client. Resets host confirmation.</summary>
-    public static void BeginMission(string instanceId)
+    public static void BeginMission(string instanceId, Func<Agent, bool> partyAgentResolver = null)
     {
         if (string.IsNullOrEmpty(instanceId)) throw new ArgumentException("instanceId is required", nameof(instanceId));
 
@@ -91,6 +113,7 @@ public static class LocationNpcGate
 
             _activeInstanceId = instanceId;
             _localHostConfirmed = false;
+            _partyAgentResolver = partyAgentResolver;
         }
     }
 
@@ -101,6 +124,7 @@ public static class LocationNpcGate
         {
             _activeInstanceId = null;
             _localHostConfirmed = false;
+            _partyAgentResolver = null;
         }
     }
 

--- a/source/GameInterface/Services/Locations/LocationNpcGate.cs
+++ b/source/GameInterface/Services/Locations/LocationNpcGate.cs
@@ -91,9 +91,12 @@ public static class LocationNpcGate
         if (agent == null) return false;
         if (ReferenceEquals(agent, mainAgent)) return true;
 
-        var mainParty = PartyBase.MainParty;
-        if (mainParty != null && agent.Origin is PartyAgentOrigin origin && origin.Party == mainParty)
-            return true;
+        if (agent.Origin is PartyAgentOrigin origin)
+        {
+            var mainParty = PartyBase.MainParty;
+            if (mainParty != null && origin.Party == mainParty)
+                return true;
+        }
 
         Func<Agent, bool> resolver;
         lock (Gate) resolver = _partyAgentResolver;

--- a/source/GameInterface/Services/Locations/Patches/LocationNativeSpawnSuppressionPatches.cs
+++ b/source/GameInterface/Services/Locations/Patches/LocationNativeSpawnSuppressionPatches.cs
@@ -1,7 +1,10 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 using SandBox;
 using SandBox.Missions.MissionLogics;
+using TaleWorlds.CampaignSystem.AgentOrigins;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements.Locations;
+using TaleWorlds.MountAndBlade;
 
 namespace GameInterface.Services.Locations.Patches;
 
@@ -51,6 +54,17 @@ internal class LocationNativeSpawnSuppressionPatches
 
     internal static bool ShouldAllowEnteringLocationSpawn(bool isOwnedCompanion, bool suppressNativeSpawns)
         => isOwnedCompanion || !suppressNativeSpawns;
+
+    [HarmonyPatch(nameof(MissionAgentHandler.SimulateAgent))]
+    [HarmonyPrefix]
+    [HarmonyPriority(Priority.High)]
+    private static bool SkipOwnedPartySimulation(Agent agent)
+        => ShouldSimulateAgent(
+            LocationNpcGate.IsReplayingNativePopulation,
+            agent?.Origin is PartyAgentOrigin origin && origin.Party == PartyBase.MainParty);
+
+    internal static bool ShouldSimulateAgent(bool isReplayingNativePopulation, bool isOwnedPartyAgent)
+        => !isReplayingNativePopulation || !isOwnedPartyAgent;
 
     [HarmonyPatch(nameof(MissionAgentHandler.SpawnWanderingAgentWithDelay))]
     [HarmonyPrefix]

--- a/source/GameInterface/Services/Locations/Patches/LocationNativeSpawnSuppressionPatches.cs
+++ b/source/GameInterface/Services/Locations/Patches/LocationNativeSpawnSuppressionPatches.cs
@@ -1,8 +1,6 @@
 ﻿using HarmonyLib;
 using SandBox;
 using SandBox.Missions.MissionLogics;
-using TaleWorlds.CampaignSystem.AgentOrigins;
-using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements.Locations;
 using TaleWorlds.MountAndBlade;
 
@@ -58,13 +56,11 @@ internal class LocationNativeSpawnSuppressionPatches
     [HarmonyPatch(nameof(MissionAgentHandler.SimulateAgent))]
     [HarmonyPrefix]
     [HarmonyPriority(Priority.High)]
-    private static bool SkipOwnedPartySimulation(Agent agent)
-        => ShouldSimulateAgent(
-            LocationNpcGate.IsReplayingNativePopulation,
-            agent?.Origin is PartyAgentOrigin origin && origin.Party == PartyBase.MainParty);
+    private static bool SkipPlayerPartySimulation(Agent agent)
+        => ShouldSimulateAgent(LocationNpcGate.IsReplayingNativePopulation, agent);
 
-    internal static bool ShouldSimulateAgent(bool isReplayingNativePopulation, bool isOwnedPartyAgent)
-        => !isReplayingNativePopulation || !isOwnedPartyAgent;
+    internal static bool ShouldSimulateAgent(bool isReplayingNativePopulation, Agent agent)
+        => !isReplayingNativePopulation || !LocationNpcGate.IsPlayerPartyAgent(agent);
 
     [HarmonyPatch(nameof(MissionAgentHandler.SpawnWanderingAgentWithDelay))]
     [HarmonyPrefix]

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -333,6 +333,9 @@ internal class MapEventPatches
         if (CallOriginalPolicy.IsOriginalAllowed())
             return true;
 
+        if (!RepairLeaderParties(__instance))
+            return false;
+
         if (__instance.IsRaidHostileAction())
         {
             RaidAiInterventionSuppression.SuppressJoinedDefenders(__instance);
@@ -350,6 +353,41 @@ internal class MapEventPatches
         // Prevents server from instantly finishing the battle and waits for client finish request
         if (__instance.InvolvedParties.Any(x => x.IsMobile && !x.MobileParty.IsControlledByThisInstance()))
             return false;
+
+        return true;
+    }
+
+    private static bool RepairLeaderParties(MapEvent mapEvent)
+    {
+        if (mapEvent._sides == null || mapEvent._sides.Length < 2 ||
+            mapEvent._sides[0] == null || mapEvent._sides[1] == null)
+            return false;
+
+        foreach (var side in mapEvent._sides)
+        {
+            if (side._battleParties == null)
+                return false;
+
+            var leaderParty = side.LeaderParty;
+            if (leaderParty != null &&
+                side._battleParties.Any(entry => ReferenceEquals(entry?.Party, leaderParty)))
+                continue;
+
+            var replacement = side._battleParties
+                .Select(entry => entry?.Party)
+                .FirstOrDefault(party => party != null);
+            if (replacement == null)
+                continue;
+
+            side.LeaderParty = replacement;
+            side._mapFaction = replacement.MapFaction;
+            side.CacheLeaderSimulationModifier();
+            Logger.Warning(
+                "Repaired missing or stale leader party on {Side} side of map event {MapEventId} using {PartyId}",
+                side.MissionSide,
+                mapEvent.StringId,
+                replacement.Id);
+        }
 
         return true;
     }

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -379,6 +379,7 @@ internal class MapEventPatches
             if (replacement == null)
                 continue;
 
+            side.InvalidateSimulationSetup();
             side.LeaderParty = replacement;
             side._mapFaction = replacement.MapFaction;
             side.CacheLeaderSimulationModifier();

--- a/source/GameInterface/Services/MapEvents/RaidAiInterventionSuppression.cs
+++ b/source/GameInterface/Services/MapEvents/RaidAiInterventionSuppression.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using GameInterface.Services.MapEventSides.Messages;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Messages.Behavior;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
@@ -70,16 +71,15 @@ internal static class RaidAiInterventionSuppression
         if (defenderSide == null)
             return;
 
-        for (int i = defenderSide._battleParties.Count - 1; i >= 0; i--)
+        var joinedDefenders = defenderSide.Parties.ToArray();
+        foreach (var mapEventParty in joinedDefenders)
         {
-            var mapEventParty = defenderSide._battleParties[i];
             var party = mapEventParty?.Party;
-            if (!ShouldSuppressParty(defenderSide, party))
+            if (!defenderSide._battleParties.Contains(mapEventParty) ||
+                !ShouldSuppressParty(defenderSide, party))
                 continue;
 
-            defenderSide._battleParties.RemoveAt(i);
-            defenderSide._mapEvent.RemoveInvolvedPartyInternal(mapEventParty);
-
+            defenderSide.RemovePartyInternal(party);
             if (party._mapEventSide == defenderSide)
                 party._mapEventSide = null;
 

--- a/source/Missions/Locations/LocationAuthorityMigrator.cs
+++ b/source/Missions/Locations/LocationAuthorityMigrator.cs
@@ -46,6 +46,7 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
     private readonly ILocationPartyAgentMap partyAgentMap;
     private readonly IMissionContext missionContext;
     private readonly GameInterface.Services.Locations.Conversations.ILocationNpcHoldRegistry holdRegistry;
+    private readonly GameInterface.Services.Locations.Conversations.ILocationConversationAgentGuard conversationAgentGuard;
 
     public LocationAuthorityMigrator(
         IMessageBroker messageBroker,
@@ -54,7 +55,8 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
         ILocationAgentBindingMap bindingMap,
         ILocationPartyAgentMap partyAgentMap,
         IMissionContext missionContext,
-        GameInterface.Services.Locations.Conversations.ILocationNpcHoldRegistry holdRegistry)
+        GameInterface.Services.Locations.Conversations.ILocationNpcHoldRegistry holdRegistry,
+        GameInterface.Services.Locations.Conversations.ILocationConversationAgentGuard conversationAgentGuard)
     {
         this.messageBroker = messageBroker;
         this.coopMissionComponent = coopMissionComponent;
@@ -63,6 +65,7 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
         this.partyAgentMap = partyAgentMap;
         this.missionContext = missionContext;
         this.holdRegistry = holdRegistry;
+        this.conversationAgentGuard = conversationAgentGuard;
 
         messageBroker.Subscribe<MissionPeerLeft>(Handle_PeerLeft);
         messageBroker.Subscribe<MissionPeerDisconnected>(Handle_PeerDisconnected);
@@ -107,6 +110,7 @@ public class LocationAuthorityMigrator : ILocationAuthorityMigrator
                 if (partyAgentMap.ShouldAdoptAsNpc(info.AgentId, hasNpcBinding)) continue;
 
                 var agent = info.Agent;
+                conversationAgentGuard.EndConversationWithAgent(agent);
                 coopMissionComponent.AgentMovementHandler.Interpolator.Forget(agent);
                 registry.RemoveAgent(info.AgentId);
 

--- a/source/Missions/Locations/LocationPartyPuppetRegistrar.cs
+++ b/source/Missions/Locations/LocationPartyPuppetRegistrar.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Locations;
+
+/// <summary>[Game thread] Spawns and registers a remote party puppet before returning.</summary>
+public interface ILocationPartyPuppetRegistrar
+{
+    bool TrySpawnAndRegister(
+        Func<Agent> spawnAgent,
+        INetworkAgentRegistry agentRegistry,
+        string controllerId,
+        Guid agentId,
+        out Agent agent);
+}
+
+/// <inheritdoc cref="ILocationPartyPuppetRegistrar"/>
+public class LocationPartyPuppetRegistrar : ILocationPartyPuppetRegistrar
+{
+    public bool TrySpawnAndRegister(
+        Func<Agent> spawnAgent,
+        INetworkAgentRegistry agentRegistry,
+        string controllerId,
+        Guid agentId,
+        out Agent agent)
+    {
+        agent = spawnAgent();
+        return agent != null && agentRegistry.TryRegisterAgent(controllerId, agentId, agent);
+    }
+}

--- a/source/Missions/Locations/LocationPopulationDirector.cs
+++ b/source/Missions/Locations/LocationPopulationDirector.cs
@@ -1,6 +1,7 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Messaging;
+using GameInterface.Services.Locations;
 using Missions.Messages;
 using SandBox;
 using SandBox.Missions.MissionLogics;
@@ -97,7 +98,15 @@ public class LocationPopulationDirector : ILocationPopulationDirector
             // The suppression gate lifted with the host confirmation, so these run natively; the
             // capture patches replicate everything they spawn. The seeded-RNG and civilian-count
             // patches wrap SpawnLocationCharacters exactly as they wrap the native AfterStart call.
-            agentHandler.SpawnLocationCharacters();
+            LocationNpcGate.IsReplayingNativePopulation = true;
+            try
+            {
+                agentHandler.SpawnLocationCharacters();
+            }
+            finally
+            {
+                LocationNpcGate.IsReplayingNativePopulation = false;
+            }
 
             SandBoxHelpers.MissionHelper.SpawnHorses();
             if (!Campaign.Current.IsNight)

--- a/source/Missions/Locations/LocationPuppetSpawner.cs
+++ b/source/Missions/Locations/LocationPuppetSpawner.cs
@@ -2,6 +2,7 @@
 using Common.Logging;
 using Common.Messaging;
 using GameInterface.Services.Locations;
+using GameInterface.Services.Locations.Conversations;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.ObjectManager;
 using Missions.Messages;
@@ -54,6 +55,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
     private readonly IObjectManager objectManager;
     private readonly ICoopMissionComponent coopMissionComponent;
     private readonly ILocationSession session;
+    private readonly ILocationConversationAgentGuard conversationAgentGuard;
     private readonly ILocationAgentBindingMap bindingMap;
     private readonly ILocationPartyAgentMap partyAgentMap;
     private readonly ILocationPuppetRosterBinder rosterBinder;
@@ -83,6 +85,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
         IObjectManager objectManager,
         ICoopMissionComponent coopMissionComponent,
         ILocationSession session,
+        ILocationConversationAgentGuard conversationAgentGuard,
         ILocationAgentBindingMap bindingMap,
         ILocationPartyAgentMap partyAgentMap,
         ILocationPuppetRosterBinder rosterBinder,
@@ -95,6 +98,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
         this.objectManager = objectManager;
         this.coopMissionComponent = coopMissionComponent;
         this.session = session;
+        this.conversationAgentGuard = conversationAgentGuard;
         this.bindingMap = bindingMap;
         this.partyAgentMap = partyAgentMap;
         this.rosterBinder = rosterBinder;
@@ -150,6 +154,7 @@ public class LocationPuppetSpawner : ILocationPuppetSpawner
                 if (!registry.TryGetAgentInfo(id, out var info)) continue;
 
                 var agent = info.Agent;
+                conversationAgentGuard.EndConversationWithAgent(agent);
 
                 // SR-026: a passage exit moved the entry between location rosters on the host —
                 // mirror it here (before the binding is forgotten) or a later promoted host holds

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -125,6 +125,9 @@ public class MissionModule : Module
         builder.RegisterType<LocationAgentSpawnBatchCodec>()
             .As<ILocationAgentSpawnBatchCodec>()
             .InstancePerLifetimeScope();
+        builder.RegisterType<LocationPartyPuppetRegistrar>()
+            .As<ILocationPartyPuppetRegistrar>()
+            .InstancePerDependency();
         builder.RegisterType<LocationControllerWithdrawalState>()
             .As<ILocationControllerWithdrawalState>()
             .InstancePerDependency();

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -44,6 +44,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     private readonly ILocationAuthorityMigrator authorityMigrator;
     private readonly ILocationPartyAgentMap partyAgentMap;
     private readonly ILocationConversationAgentGuard conversationAgentGuard;
+    private readonly ILocationPartyPuppetRegistrar partyPuppetRegistrar;
     //private readonly BoardGameManager boardGameManager;
 
     private string instanceId;
@@ -58,6 +59,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         ILocationConversationAgentGuard conversationAgentGuard,
         IBattleAgentBudget agentBudget,
         ILocationAgentSpawnBatchCodec spawnBatchCodec,
+        ILocationPartyPuppetRegistrar partyPuppetRegistrar,
         ILocationControllerWithdrawalState withdrawalState,
         IMissionContext missionContext,
         //BoardGameManager boardGameManager,
@@ -74,6 +76,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         this.controllerIdProvider = controllerIdProvider;
         this.hostRegistry = hostRegistry;
         this.conversationAgentGuard = conversationAgentGuard;
+        this.partyPuppetRegistrar = partyPuppetRegistrar;
         //this.boardGameManager = boardGameManager;
 
         // Composition-root style (mirrors CoopBattleController): the per-mission session and NPC
@@ -532,12 +535,22 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             return;
         }
 
-        var agentRegistry = coopMissionComponent.AgentRegistry;
-
         // Record party identity before dedupe. An ambient spawn batch from the elected host can race this
         // join record; even if that batch won and attached an NPC binding, migration must still despawn this
         // player/companion instead of adopting it as settlement population.
         partyAgentMap.Record(agentData.AgentId);
+
+        // Keep spawn and registration in one queued action. A host-authority population replay can be in
+        // the same game-thread drain and must not see the spawned puppet before the registry can identify it.
+        GameThread.RunSafe(
+            () => ProcessAgentOnGameThread(controllerId, agentData),
+            blocking: true,
+            context: nameof(ProcessAgent));
+    }
+
+    private void ProcessAgentOnGameThread(string controllerId, CoopAgentSpawnData agentData)
+    {
+        var agentRegistry = coopMissionComponent.AgentRegistry;
 
         // Dedupe across all peers: NAT punch can yield more than one connection to the same remote
         // client, delivering its join info multiple times. Only spawn one agent per id.
@@ -556,27 +569,39 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             agentData.IsPlayer == true ? "Player" : "Agent",
             characterObject?.Name?.ToString() ?? "<unresolved>", agentData.AgentId, controllerId);
 
-        Agent newAgent = SpawnAgent(
-            agentData.Position,
-            characterObject,
-            agentData.HasMount,
-            agentData.Health,
-            agentData.MissionEquipmentData,
-            agentData.HasCurrentEquipment ? agentData.CurrentEquipment : (AgentEquipmentData?)null);
+        bool registered = partyPuppetRegistrar.TrySpawnAndRegister(
+            () => SpawnAgentOnGameThread(
+                agentData.Position,
+                characterObject,
+                agentData.HasMount,
+                agentData.Health,
+                agentData.MissionEquipmentData,
+                agentData.HasCurrentEquipment ? agentData.CurrentEquipment : (AgentEquipmentData?)null),
+            agentRegistry,
+            controllerId,
+            agentData.AgentId,
+            out Agent newAgent);
 
-        if (newAgent == null)
+        if (!registered)
         {
-            Logger.Error("[LocationSync] Failed to spawn remote agent {AgentID} — removing agent.", agentData.AgentId);
-            agentRegistry.RemoveAgent(agentData.AgentId);
+            if (newAgent == null)
+            {
+                Logger.Error("[LocationSync] Failed to spawn remote agent {AgentID}", agentData.AgentId);
+            }
+            else
+            {
+                bool hideMount = newAgent.HasMount && newAgent.MountAgent != null && newAgent.MountAgent.IsActive();
+                newAgent.FadeOut(true, hideMount);
+                Logger.Error("[LocationSync] Failed to register remote agent {AgentID} — removed duplicate spawn", agentData.AgentId);
+            }
             return;
         }
 
-        agentRegistry.TryRegisterAgent(controllerId, agentData.AgentId, newAgent);
         Logger.Information("[LocationSync] Spawned + registered remote agent {AgentID} at {Pos} (mission '{Scene}')",
             agentData.AgentId, newAgent.Position, Mission.Current?.SceneName);
     }
 
-    public Agent SpawnAgent(
+    private Agent SpawnAgentOnGameThread(
         Vec3 startingPos,
         CharacterObject character,
         bool hasMount = false,
@@ -597,63 +622,53 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             return null;
         }
 
-        // HandleJoinInfo runs on the network thread. AgentBuildData's ctor (and SpawnAgent) touch
-        // TaleWorlds engine statics (Team.Invalid -> Team.Initialize -> Formation.Reset) that must run
-        // on the main thread, so build AND spawn entirely inside the game-loop closure — not just the
-        // final SpawnAgent call. Doing the ctor off-thread NREs intermittently (notably on rejoin).
-        Agent agent = null;
-        GameThread.RunSafe(() =>
+        try
         {
+            // The player may have left between receiving the join info and this running.
+            if (Mission.Current == null) return null;
+
+            // The owner sends the live mount state because companions can spawn mounted in village centers.
+            bool isVillage = Settlement.CurrentSettlement?.IsVillage == true;
+
+            AgentBuildData agentBuildData = new AgentBuildData(character);
+            agentBuildData.BodyProperties(character.GetBodyPropertiesMax());
+            agentBuildData.InitialPosition(startingPos);
+            agentBuildData.Team(Mission.Current.PlayerAllyTeam);
+            agentBuildData.InitialDirection(Vec2.Forward);
+            agentBuildData.NoHorses(ShouldDisableHorses(hasMount));
+            agentBuildData.Equipment(isVillage ? character.FirstBattleEquipment : character.FirstCivilianEquipment);
+            MissionEquipment missionEquipment = ResolveMissionEquipment(missionEquipmentData);
+            if (missionEquipment != null)
+                agentBuildData.MissionEquipment(missionEquipment);
+            agentBuildData.TroopOrigin(new SimpleAgentOrigin(character, -1, null, default));
+            agentBuildData.Controller(AgentControllerType.None);
+            agentBuildData.ClothingColor1(character.HeroObject.MapFaction.Color);
+            agentBuildData.ClothingColor2(character.HeroObject.MapFaction.Color2);
+
+            Agent agent;
+            // Remote party puppets are not host-owned NPCs and must not be captured for replication.
+            LocationNpcGate.SuppressCapture = true;
             try
             {
-                // The player may have left between receiving the join info and this running.
-                if (Mission.Current == null) return;
-
-                // The owner sends the live mount state because companions can spawn mounted in village centers.
-                bool isVillage = Settlement.CurrentSettlement?.IsVillage == true;
-
-                AgentBuildData agentBuildData = new AgentBuildData(character);
-                agentBuildData.BodyProperties(character.GetBodyPropertiesMax());
-                agentBuildData.InitialPosition(startingPos);
-                agentBuildData.Team(Mission.Current.PlayerAllyTeam);
-                agentBuildData.InitialDirection(Vec2.Forward);
-                agentBuildData.NoHorses(ShouldDisableHorses(hasMount));
-                agentBuildData.Equipment(isVillage ? character.FirstBattleEquipment : character.FirstCivilianEquipment);
-                MissionEquipment missionEquipment = ResolveMissionEquipment(missionEquipmentData);
-                if (missionEquipment != null)
-                    agentBuildData.MissionEquipment(missionEquipment);
-                agentBuildData.TroopOrigin(new SimpleAgentOrigin(character, -1, null, default));
-                agentBuildData.Controller(AgentControllerType.None);
-                agentBuildData.ClothingColor1(character.HeroObject.MapFaction.Color);
-                agentBuildData.ClothingColor2(character.HeroObject.MapFaction.Color2);
-
-                // Remote party puppets are not host-owned NPCs and must not be captured for replication.
-                LocationNpcGate.SuppressCapture = true;
-                try
-                {
-                    agent = Mission.Current.SpawnAgent(agentBuildData);
-                }
-                finally
-                {
-                    LocationNpcGate.SuppressCapture = false;
-                }
-
-                if (health > 0)
-                {
-                    agent.Health = health;
-                }
-                if (currentEquipment.HasValue)
-                    currentEquipment.Value.Apply(agent);
-                agent.FadeIn();
+                agent = Mission.Current.SpawnAgent(agentBuildData);
             }
-            catch (Exception ex)
+            finally
             {
-                Logger.Warning(ex, "[LocationSync] Build/spawn failed for character '{Name}'", character?.StringId ?? "<null>");
-                agent = null;
+                LocationNpcGate.SuppressCapture = false;
             }
-        }, blocking: true);
 
-        return agent;
+            if (health > 0)
+                agent.Health = health;
+            if (currentEquipment.HasValue)
+                currentEquipment.Value.Apply(agent);
+            agent.FadeIn();
+            return agent;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "[LocationSync] Build/spawn failed for character '{Name}'", character?.StringId ?? "<null>");
+            return null;
+        }
     }
 
     private MissionEquipmentData PackMissionEquipmentData(MissionEquipment equipment)

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -352,6 +352,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     {
         if (agent == null || !_ownedCompanionIds.TryGetValue(agent, out Guid agentId)) return false;
 
+        EndConversationWithAgent(agent);
         _ownedCompanionIds.Remove(agent);
         coopMissionComponent.AgentRegistry.RemoveAgent(agentId);
         network.SendAll(new NetworkDespawnLocationAgents(
@@ -360,6 +361,21 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
             new[] { string.Empty }));
         Logger.Information("[LocationSync] Despawned local companion {AgentId} ({Reason})", agentId, reason);
         return true;
+    }
+
+    private static void EndConversationWithAgent(Agent agent)
+    {
+        var conversationManager = Campaign.Current?.ConversationManager;
+        if (conversationManager?.IsConversationInProgress != true || conversationManager.ConversationAgents == null)
+            return;
+
+        foreach (var conversationAgent in conversationManager.ConversationAgents)
+        {
+            if (!ReferenceEquals(conversationAgent, agent)) continue;
+
+            conversationManager.EndConversation();
+            return;
+        }
     }
 
     internal static bool IsOwnPartyAgent(Agent agent)

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -43,6 +43,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     private readonly ILocationPopulationDirector populationDirector;
     private readonly ILocationAuthorityMigrator authorityMigrator;
     private readonly ILocationPartyAgentMap partyAgentMap;
+    private readonly ILocationConversationAgentGuard conversationAgentGuard;
     //private readonly BoardGameManager boardGameManager;
 
     private string instanceId;
@@ -54,6 +55,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         ILocationHostRegistry hostRegistry,
         ILocationPuppetRosterBinder rosterBinder,
         ILocationNpcHoldRegistry npcHoldRegistry,
+        ILocationConversationAgentGuard conversationAgentGuard,
         IBattleAgentBudget agentBudget,
         ILocationAgentSpawnBatchCodec spawnBatchCodec,
         ILocationControllerWithdrawalState withdrawalState,
@@ -71,6 +73,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         this.relayNetwork = relayNetwork;
         this.controllerIdProvider = controllerIdProvider;
         this.hostRegistry = hostRegistry;
+        this.conversationAgentGuard = conversationAgentGuard;
         //this.boardGameManager = boardGameManager;
 
         // Composition-root style (mirrors CoopBattleController): the per-mission session and NPC
@@ -87,8 +90,8 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         authorityMigrator = new LocationAuthorityMigrator(
             messageBroker, coopMissionComponent, session, bindingMap, partyAgentMap, missionContext, npcHoldRegistry);
         npcPuppetSpawner = new LocationPuppetSpawner(
-            messageBroker, objectManager, coopMissionComponent, session, bindingMap, partyAgentMap,
-            rosterBinder, agentBudget, spawnBatchCodec, authorityMigrator, withdrawalState);
+            messageBroker, objectManager, coopMissionComponent, session, conversationAgentGuard,
+            bindingMap, partyAgentMap, rosterBinder, agentBudget, spawnBatchCodec, authorityMigrator, withdrawalState);
         populationDirector = new LocationPopulationDirector(messageBroker, session, bindingMap, npcPuppetSpawner);
 
         messageBroker.Subscribe<PlayerEnteredLocation>(Handle_PlayerEnteredLocation);
@@ -352,7 +355,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
     {
         if (agent == null || !_ownedCompanionIds.TryGetValue(agent, out Guid agentId)) return false;
 
-        EndConversationWithAgent(agent);
+        conversationAgentGuard.EndConversationWithAgent(agent);
         _ownedCompanionIds.Remove(agent);
         coopMissionComponent.AgentRegistry.RemoveAgent(agentId);
         network.SendAll(new NetworkDespawnLocationAgents(
@@ -363,19 +366,12 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         return true;
     }
 
-    private static void EndConversationWithAgent(Agent agent)
+    private bool IsKnownPartyAgent(Agent agent)
     {
-        var conversationManager = Campaign.Current?.ConversationManager;
-        if (conversationManager?.IsConversationInProgress != true || conversationManager.ConversationAgents == null)
-            return;
+        if (IsOwnPartyAgent(agent)) return true;
 
-        foreach (var conversationAgent in conversationManager.ConversationAgents)
-        {
-            if (!ReferenceEquals(conversationAgent, agent)) continue;
-
-            conversationManager.EndConversation();
-            return;
-        }
+        return coopMissionComponent.AgentRegistry.TryGetAgentInfo(agent, out var info) &&
+               partyAgentMap.Contains(info.AgentId);
     }
 
     internal static bool IsOwnPartyAgent(Agent agent)
@@ -430,7 +426,7 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
 
         // Engage the NPC gate: native population spawning is suppressed on every client until the
         // server's host assignment confirms who runs it (SR-013).
-        LocationNpcGate.BeginMission(instanceId);
+        LocationNpcGate.BeginMission(instanceId, IsKnownPartyAgent);
 
         network.ConnectToInstance(instanceId);
         coopMissionComponent.AgentRegistry.Clear();

--- a/source/Missions/Taverns/CoopLocationsController.cs
+++ b/source/Missions/Taverns/CoopLocationsController.cs
@@ -91,7 +91,8 @@ public class CoopLocationsController : CoopMissionController, ILocationMissionBe
         npcReplicator = new LocationOwnedAgentReplicator(
             network, messageBroker, objectManager, coopMissionComponent, session, bindingMap, rosterBinder, spawnBatchCodec);
         authorityMigrator = new LocationAuthorityMigrator(
-            messageBroker, coopMissionComponent, session, bindingMap, partyAgentMap, missionContext, npcHoldRegistry);
+            messageBroker, coopMissionComponent, session, bindingMap, partyAgentMap, missionContext,
+            npcHoldRegistry, conversationAgentGuard);
         npcPuppetSpawner = new LocationPuppetSpawner(
             messageBroker, objectManager, coopMissionComponent, session, conversationAgentGuard,
             bindingMap, partyAgentMap, rosterBinder, agentBudget, spawnBatchCodec, authorityMigrator, withdrawalState);


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The delayed location population pass simulates already-spawned player companions. It can remove an active conversation partner and leave the conversation camera throwing every frame.

Empty kingdom policy snapshots are omitted by protobuf and deserialize as `null`, so policy decisions throw instead of reaching the client. Raid map events can also retain a missing or removed leader and throw from `MapEvent.Update` every server tick, including after loading the affected save.

## What is the new behavior?

Resolves #3284
Resolves #3265
Resolves #3187
Resolves #2984

Player-owned agents are excluded from the delayed population simulation, and an active conversation is ended before its companion is despawned. Empty policy snapshots reconstruct as an empty list. Map events repair stale leaders before updating, and raid intervention removal now uses the normal side bookkeeping path.

## How to test

- `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Release`
- `dotnet test source/E2E.Tests/E2E.Tests.csproj -c Release --filter "FullyQualifiedName~MapEventUpdateAuthorityTests|FullyQualifiedName~SlowRaidMapEvent_WithDefenderTroopsAndAiInterventionDisabled_ServerUpdateIsAllowed"`

## Bot Changelog Entry

- Fixed companion conversations crashing, kingdom policy votes freezing, and raids becoming permanently stuck.
