### PR TITLE
Armytracker

### DIFF
--- a/source/E2E.Tests/Services/Armies/NetworkArmyFullyCreatedSecurityTests.cs
+++ b/source/E2E.Tests/Services/Armies/NetworkArmyFullyCreatedSecurityTests.cs
@@ -1,0 +1,49 @@
+﻿using Common.PacketHandlers;
+using Common.Serialization;
+using E2E.Tests.Environment;
+using GameInterface.Services.Armies.Messages;
+using TaleWorlds.CampaignSystem;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Armies;
+
+public class NetworkArmyFullyCreatedSecurityTests : IDisposable
+{
+    E2ETestEnvironment TestEnvironment { get; }
+
+    public NetworkArmyFullyCreatedSecurityTests(ITestOutputHelper output)
+    {
+        TestEnvironment = new E2ETestEnvironment(output);
+    }
+
+    public void Dispose()
+    {
+        TestEnvironment.Dispose();
+    }
+
+    [Fact]
+    public void ForgedClientNetworkArmyFullyCreated_IsDroppedBeforeBrokerDispatch()
+    {
+        // Arrange
+        var server = TestEnvironment.Server;
+        var forgingClient = TestEnvironment.Clients.First();
+
+        var armyId = "MyArmy";
+        server.CreateRegisteredObject<Army>(armyId);
+
+        var serializer = server.Resolve<ICommonSerializer>();
+        var forgedPacket = MessagePacket.Create(new NetworkArmyFullyCreated(armyId), serializer);
+
+        // Act
+        // A modified client sends the server-only command directly, as if it were a legitimate
+        // inbound packet from a connected peer, using a real (already-registered) army id.
+        server.SimulatePacket(forgingClient.NetPeer, forgedPacket);
+
+        // Assert
+        // MessagePacketHandler.PublishEvent must reject on the IServerToClientCommand check before
+        // the message ever reaches the broker, so ArmyHandler.HandleNetworkArmyFullyCreated (and
+        // CampaignEventDispatcher.OnArmyCreated) never runs, and nothing gets rebroadcast to clients.
+        Assert.Equal(0, server.InternalMessages.GetMessageCount<NetworkArmyFullyCreated>());
+        Assert.Equal(0, server.NetworkSentMessages.GetMessageCount<NetworkArmyFullyCreated>());
+    }
+}

--- a/source/E2E.Tests/Services/DefaultNotificationsBehavior/DefaultNotificationsBehaviorPatchesTests.cs
+++ b/source/E2E.Tests/Services/DefaultNotificationsBehavior/DefaultNotificationsBehaviorPatchesTests.cs
@@ -1,0 +1,98 @@
+﻿using Autofac;
+using E2E.Tests.Environment;
+using E2E.Tests.Environment.Instance;
+using E2E.Tests.Util;
+using GameInterface;
+using GameInterface.Services.UI.Notifications.Patches;
+using Moq;
+using SandBox.CampaignBehaviors;
+using TaleWorlds.CampaignSystem;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.DefaultNotificationsBehavior;
+
+public class DefaultNotificationsBehaviorPatchesTests : IDisposable
+{
+    private E2ETestEnvironment TestEnvironment { get; }
+    private EnvironmentInstance Server => TestEnvironment.Server;
+    private IEnumerable<EnvironmentInstance> Clients => TestEnvironment.Clients;
+    public DefaultNotificationsBehaviorPatchesTests(ITestOutputHelper output)
+    {
+        TestEnvironment = new E2ETestEnvironment(output);
+        ContainerProvider.Clear();
+    }
+
+    public void Dispose()
+    {
+        ContainerProvider.Clear();
+        TestEnvironment.Dispose();
+    }
+
+    [Fact]
+    public void Prefix_ActiveCoopContainer_SuppressesVanillaOnArmyCreatedNotification()
+    {
+        DefaultNotificationsCampaignBehavior instance = null;
+        using var container = BuildContainerWithGameInterface();
+
+        using (ContainerProvider.UseContainerThreadSafe(container))
+        {
+            bool runOriginal = DefaultNotificationsCampaignBehaviorPatches.OnArmyCreatedPrefix(
+                ref instance,
+                army: null);
+
+            Assert.False(runOriginal);
+        }
+    }
+
+    [Fact]
+    public void Prefix_NoActiveContainer_AllowsVanillaOnArmyCreatedNotification()
+    {
+        DefaultNotificationsCampaignBehavior instance = null;
+        bool runOriginal = DefaultNotificationsCampaignBehaviorPatches.OnArmyCreatedPrefix(
+            ref instance,
+            army: null);
+
+        Assert.True(runOriginal);
+    }
+
+    [Fact]
+    public void Prefix_OnServer_SuppressesVanilla()
+    {
+        Army army = null;
+        Server.Call(() =>
+        {
+            army = GameObjectCreator.CreateInitializedObject<Army>();
+
+            DefaultNotificationsCampaignBehavior instance = null;
+            bool runOriginal = DefaultNotificationsCampaignBehaviorPatches.OnArmyCreatedPrefix(
+                ref instance,
+                army);
+
+            Assert.False(runOriginal);
+        });
+    }
+
+    [Fact]
+    public void Prefix_AfterContainerClearedLikeDestroyContainerCore_AllowsVanilla()
+    {
+        DefaultNotificationsCampaignBehavior instance = null;
+        using var container = BuildContainerWithGameInterface();
+
+        using (ContainerProvider.UseContainerThreadSafe(container))
+        {
+            Assert.False(DefaultNotificationsCampaignBehaviorPatches.OnArmyCreatedPrefix(
+            ref instance, army: null));
+        }
+        ContainerProvider.Clear();
+
+        Assert.True(DefaultNotificationsCampaignBehaviorPatches.OnArmyCreatedPrefix(
+            ref instance, army: null));
+    }
+
+    private static IContainer BuildContainerWithGameInterface()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(new Mock<IGameInterface>().Object).As<IGameInterface>();
+        return builder.Build();
+    }
+}

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Messaging;
 using Common.Util;
 using Coop.Core.Client.Services.Kingdoms.Handlers;
 using Coop.Core.Client.Services.MobileParties.Messages;
@@ -11,6 +12,8 @@ using E2E.Tests.Util;
 using GameInterface.Services.Clans.Messages;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Messages;
+using GameInterface.Services.Heroes.Interfaces;
+using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.Kingdoms;
 using GameInterface.Services.Kingdoms.Commands;
 using GameInterface.Services.Kingdoms.Data;
@@ -18,6 +21,7 @@ using GameInterface.Services.Kingdoms.Extentions;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.Kingdoms.Patches;
 using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.MobileParties.Handlers;
 using GameInterface.Services.MobileParties.Messages.Behavior;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
@@ -26,18 +30,19 @@ using GameInterface.Services.Stances.Messages;
 using GameInterface.Services.UI.Notifications.Messages;
 using GameInterface.Services.Villages.Interfaces;
 using HarmonyLib;
+using SandBox.ViewModelCollection.Map.Tracker;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
-using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
-using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Diplomacy;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.ItemTypes;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Diplomacy;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Policies;
 using TaleWorlds.Core;
 using TaleWorlds.Core.ViewModelCollection.Information;
@@ -3120,6 +3125,154 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         });
     }
 
+    [Fact]
+    public void SwitchedPlayer_RefreshesPreExistingArmyTracker_AfterMainHeroWasStillWrongAtConstruction()
+    {
+        var client = TestEnvironment.Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+
+        var player = CreateSyncedPlayerContext(ControllerId, _ => false);
+        var kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        var armyId = TestEnvironment.CreateRegisteredObject<Army>();
+        ConfigureClanInKingdom(client, player.ClanId, kingdomId);
+        EnsureKingdomRegistered(client, kingdomId);
+
+        ConfigureArmyInKingdom(client, kingdomId, armyId);
+
+        // Throwaway clan, avoids EncyclopediaManager exception.
+        var throwawayClanId = TestEnvironment.CreateRegisteredObject<Clan>();
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(throwawayClanId, out var throwawayClan));
+            using (new AllowedThread())
+            {
+                Hero.MainHero.Clan = throwawayClan;
+                Campaign.Current.PlayerDefaultFaction = throwawayClan;
+            }
+        });
+
+        MapTrackerProvider provider = null;
+        client.Call(() =>
+        {
+            // MainHero still wrong at construction; reproduces the real bug.
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(player.HeroId, out var playerHero));
+            Assert.NotSame(playerHero, Hero.MainHero);
+
+            provider = new MapTrackerProvider();
+
+            Assert.True(client.ObjectManager.TryGetObject<Army>(armyId, out var army));
+            Assert.DoesNotContain(
+                provider.GetTrackers(),
+                tracker => ReferenceEquals(tracker.TrackedObject, army));
+        });
+
+        // Act: real switch, publishes SwitchedPlayer at the end.
+        client.Call(() =>
+        {
+            var heroInterface = client.Resolve<IHeroInterface>();
+            heroInterface.SwitchToPlayer(new Player(
+                ControllerId,
+                player.HeroId,
+                player.PartyId,
+                player.ClanId,
+                player.CharacterId));
+        }, new[] { AccessTools.Method(typeof(InteractionsInitializationHandler), "Handle", new[] { typeof(MessagePayload<PlayerHeroChanged>) }) });
+        GameThread.Run(() => { }, blocking: true);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Army>(armyId, out var army));
+            Assert.Contains(
+                provider.GetTrackers(),
+                tracker => ReferenceEquals(tracker.TrackedObject, army));
+        });
+    }
+
+    [Fact]
+    public void ArmyCreatedDuringSession_IsPickedUpByExistingClientMapTracker()
+    {
+        var client = TestEnvironment.Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+
+        var player = CreateSyncedPlayerContext(ControllerId, _ => false);
+        var kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        ConfigureClanInKingdom(player.ClanId, kingdomId);
+        EnsureKingdomRegisteredEverywhere(kingdomId);
+
+        var settlementId = CreateSyncedSettlement();
+
+        // Gather() needs a home settlement.
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(player.HeroId, out var hero));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+            using (new AllowedThread())
+            {
+                hero._homeSettlement = settlement;
+            }
+        });
+
+        var throwawayClanId = TestEnvironment.CreateRegisteredObject<Clan>();
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Clan>(throwawayClanId, out var throwawayClan));
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            using (new AllowedThread())
+            {
+                throwawayClan._kingdom = kingdom;
+                Hero.MainHero.Clan = throwawayClan;
+                Campaign.Current.PlayerDefaultFaction = throwawayClan;
+            }
+        });
+
+        // Provider exists before the army,
+        // testing the live ArmyCreated listener, not ResetTrackers.
+        MapTrackerProvider provider = null;
+        client.Call(() => provider = new MapTrackerProvider());
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            Assert.DoesNotContain(
+                provider.GetTrackers(),
+                tracker => kingdom.Armies.Contains(tracker.TrackedObject as Army));
+        });
+
+        // Act: CreateArmy on the server, which syncs the events to the clients through a postfix.
+        string armyId = null;
+        Server.Call(() =>
+        {
+            Assert.True(Server.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(player.HeroId, out var armyLeader));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
+
+            kingdom.CreateArmy(armyLeader, settlement, Army.ArmyTypes.Defender);
+
+            var army = Assert.Single(kingdom.Armies);
+            Assert.True(Server.ObjectManager.TryGetId(army, out armyId));
+        });
+        GameThread.Run(() => { }, blocking: true);
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Army>(armyId, out var army));
+            Assert.Contains(
+                provider.GetTrackers(),
+                tracker => ReferenceEquals(tracker.TrackedObject, army));
+        });
+    }
+    private static void ConfigureArmyInKingdom(EnvironmentInstance instance, string kingdomId, string armyId)
+    {
+        instance.Call(() =>
+        {
+            Assert.True(instance.ObjectManager.TryGetObject<Army>(armyId, out var army));
+            Assert.True(instance.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+
+            using (new AllowedThread())
+            {
+                army.Kingdom = kingdom;
+            }
+        });
+    }
     private static T GetObject<T>(EnvironmentInstance instance, string id) where T : class
     {
         Assert.True(instance.ObjectManager.TryGetObject<T>(id, out var value));

--- a/source/E2E.Tests/Util/GameObjectCreator.cs
+++ b/source/E2E.Tests/Util/GameObjectCreator.cs
@@ -70,6 +70,7 @@ internal class GameObjectCreator
         { typeof(SiegeEngineType), new SiegeEngineTypeBuilder() },
         { typeof(SiegeEngineConstructionProgress), new SiegeEngineConstructionProgressBuilder()  },
         { typeof(StanceLink), new StanceLinkBuilder() },
+        { typeof(Army), new ArmyBuilder() },
     };
 
     public static T CreateInitializedObject<T>()

--- a/source/E2E.Tests/Util/ObjectBuilders/ArmyBuilder.cs
+++ b/source/E2E.Tests/Util/ObjectBuilders/ArmyBuilder.cs
@@ -1,0 +1,14 @@
+﻿using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace E2E.Tests.Util.ObjectBuilders;
+
+internal class ArmyBuilder : IObjectBuilder
+{
+    public object Build()
+    {
+        var kingdom = GameObjectCreator.CreateInitializedObject<Kingdom>();
+        var mobileparty = GameObjectCreator.CreateInitializedObject<MobileParty>();
+        return new Army(kingdom, mobileparty, Army.ArmyTypes.Besieger);
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -34,8 +34,8 @@ using GameInterface.Services.Modules;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party;
 using GameInterface.Services.Players;
-using GameInterface.Services.Stances;
 using GameInterface.Services.SiegeEvents;
+using GameInterface.Services.Stances;
 using GameInterface.Services.Time;
 using GameInterface.Services.TroopRosters;
 using GameInterface.Services.TroopRosters.Logging;
@@ -44,6 +44,7 @@ using GameInterface.Services.UI.CoopOptions.Providers.ChatTab;
 using GameInterface.Services.UI.CoopOptions.Providers.KillFeedTab;
 using GameInterface.Services.UI.CoopOptions.Providers.MapTimeTab;
 using GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
+using GameInterface.Services.UI.Patches;
 using GameInterface.Services.Workshops;
 using GameInterface.Surrogates;
 using HarmonyLib;
@@ -132,6 +133,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<MainPartyBattleRewardsCache>().As<IMainPartyBattleRewardsCache>().InstancePerLifetimeScope();
         builder.RegisterType<PacketManager>().As<IPacketManager>().InstancePerLifetimeScope();
         builder.RegisterType<MapEventInitializationBarrierBinding>().InstancePerLifetimeScope().AutoActivate();
+        builder.RegisterType<MapTrackerProviderHolder>().As<IMapTrackerProviderHolder>().InstancePerLifetimeScope();
 
         builder.RegisterModule<ServiceModule>();
         builder.RegisterModule<ObjectManagerModule>();

--- a/source/GameInterface/Services/Armies/Handlers/ArmyHandler.cs
+++ b/source/GameInterface/Services/Armies/Handlers/ArmyHandler.cs
@@ -48,6 +48,8 @@ public class ArmyHandler : IHandler
         messageBroker.Subscribe<NetworkChangeClanInfluence>(HandleNetworkInfluencespent);
         messageBroker.Subscribe<SetArmyKingdom>(HandleSetArmyKingdom);
         messageBroker.Subscribe<NetworkSetArmyKingdom>(HandleNetworkSetArmyKingdom);
+        messageBroker.Subscribe<ArmyFullyCreated>(HandleArmyFullyCreated);
+        messageBroker.Subscribe<NetworkArmyFullyCreated>(HandleNetworkArmyFullyCreated);
     }
 
     public void Dispose()
@@ -66,6 +68,8 @@ public class ArmyHandler : IHandler
         messageBroker.Unsubscribe<NetworkChangeClanInfluence>(HandleNetworkInfluencespent);
         messageBroker.Unsubscribe<SetArmyKingdom>(HandleSetArmyKingdom);
         messageBroker.Unsubscribe<NetworkSetArmyKingdom>(HandleNetworkSetArmyKingdom);
+        messageBroker.Unsubscribe<ArmyFullyCreated>(HandleArmyFullyCreated);
+        messageBroker.Unsubscribe<NetworkArmyFullyCreated>(HandleNetworkArmyFullyCreated);
     }
 
     private void HandleAddMobilePartyInArmy(MessagePayload<MobilePartyInArmyAdded> obj)
@@ -279,6 +283,27 @@ public class ArmyHandler : IHandler
             {
                 army.Kingdom = kingdom;
             }
+        });
+    }
+
+    private void HandleArmyFullyCreated(MessagePayload<ArmyFullyCreated> payload)
+    {
+        var obj = payload.What;
+
+        if (!objectManager.TryGetIdWithLogging(obj.Army, out var armyId)) return;
+
+        network.SendAll(new NetworkArmyFullyCreated(armyId));
+    }
+
+    private void HandleNetworkArmyFullyCreated(MessagePayload<NetworkArmyFullyCreated> payload)
+    {
+        var obj = payload.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObject<Army>(obj.ArmyId, out var army)) return;
+
+            CampaignEventDispatcher.Instance.OnArmyCreated(army);
         });
     }
 }

--- a/source/GameInterface/Services/Armies/Messages/ArmyFullyCreated.cs
+++ b/source/GameInterface/Services/Armies/Messages/ArmyFullyCreated.cs
@@ -1,0 +1,14 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Armies.Messages;
+
+public readonly struct ArmyFullyCreated : IEvent
+{
+    public readonly Army Army;
+
+    public ArmyFullyCreated(Army army)
+    {
+        Army = army;
+    }
+}

--- a/source/GameInterface/Services/Armies/Messages/NetworkArmyFullyCreated.cs
+++ b/source/GameInterface/Services/Armies/Messages/NetworkArmyFullyCreated.cs
@@ -4,7 +4,7 @@ using ProtoBuf;
 namespace GameInterface.Services.Armies.Messages;
 
 [ProtoContract(SkipConstructor = true)]
-public readonly struct NetworkArmyFullyCreated : ICommand
+public readonly struct NetworkArmyFullyCreated : IServerToClientCommand
 {
     [ProtoMember(1)]
     public readonly string ArmyId;

--- a/source/GameInterface/Services/Armies/Messages/NetworkArmyFullyCreated.cs
+++ b/source/GameInterface/Services/Armies/Messages/NetworkArmyFullyCreated.cs
@@ -1,0 +1,16 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Armies.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+public readonly struct NetworkArmyFullyCreated : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string ArmyId;
+
+    public NetworkArmyFullyCreated(string armyId)
+    {
+        ArmyId = armyId;
+    }
+}

--- a/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
+++ b/source/GameInterface/Services/Heroes/Interfaces/HeroInterface.cs
@@ -13,6 +13,7 @@ using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.SiegeEvents.Interfaces;
+using GameInterface.Services.UI.Messages;
 using SandBox.View.Map.Managers;
 using Serilog;
 using System;
@@ -192,6 +193,7 @@ internal class HeroInterface : IHeroInterface
         // icons would stay revealed forever. Queued so it runs once the campaign state is entered
         // and the hero switched to above is the local main party.
         GameThread.RunSafe(partyVisibilitySweep.RebuildAroundMainParty);
+        MessageBroker.Instance.Publish(player, new SwitchedPlayer());
     }
 
     private void LogPlayerSwitchState(

--- a/source/GameInterface/Services/Kingdoms/Patches/KingdomPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/KingdomPatches.cs
@@ -1,5 +1,7 @@
 ﻿using Common;
+using Common.Messaging;
 using GameInterface.Policies;
+using GameInterface.Services.Armies.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Election;
@@ -60,6 +62,15 @@ namespace GameInterface.Services.Kingdoms.Patches
             }
 
             return true;
+        }
+        [HarmonyPatch(nameof(Kingdom.CreateArmy))]
+        [HarmonyPostfix]
+        public static void PostfixCreateArmy(Kingdom __instance, Hero armyLeader)
+        {
+            if (ModInformation.IsClient) return;
+            var army = armyLeader.PartyBelongedTo?.Army;
+            if (army == null) return;
+            MessageBroker.Instance.Publish(__instance, new ArmyFullyCreated(army));
         }
     }
 }

--- a/source/GameInterface/Services/UI/Handlers/MapTrackerProviderRefreshHandler.cs
+++ b/source/GameInterface/Services/UI/Handlers/MapTrackerProviderRefreshHandler.cs
@@ -1,0 +1,35 @@
+﻿using Common.Messaging;
+using GameInterface.Services.UI.Messages;
+using GameInterface.Services.UI.Patches;
+
+namespace GameInterface.Services.UI.Handlers;
+
+/// <summary>
+/// Handler for resetting the trackers after the mainhero has been properly set up
+/// </summary>
+internal class MapTrackerProviderRefreshHandler : IHandler
+{
+    private readonly IMessageBroker messageBroker;
+    private readonly IMapTrackerProviderHolder holder;
+
+    public MapTrackerProviderRefreshHandler(
+        IMessageBroker messageBroker,
+        IMapTrackerProviderHolder holder)
+    {
+        this.messageBroker = messageBroker;
+        this.holder = holder;
+
+        messageBroker.Subscribe<SwitchedPlayer>(Handle_SwitchedPlayer);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<SwitchedPlayer>(Handle_SwitchedPlayer);
+    }
+
+    private void Handle_SwitchedPlayer(MessagePayload<SwitchedPlayer> payload)
+    {
+        if (holder.Current == null) return;
+        holder.Current.ResetTrackers();
+    }
+}

--- a/source/GameInterface/Services/UI/Messages/SwitchedPlayer.cs
+++ b/source/GameInterface/Services/UI/Messages/SwitchedPlayer.cs
@@ -1,0 +1,7 @@
+﻿using Common.Messaging;
+
+namespace GameInterface.Services.UI.Messages;
+
+public readonly struct SwitchedPlayer : IEvent
+{
+}

--- a/source/GameInterface/Services/UI/Notifications/Patches/DefaultNotificationsCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/UI/Notifications/Patches/DefaultNotificationsCampaignBehaviorPatches.cs
@@ -255,13 +255,13 @@ internal class DefaultNotificationsCampaignBehaviorPatches
     }
 
     [HarmonyPatch(nameof(DefaultNotificationsCampaignBehavior.OnArmyCreated))]
-    [HarmonyPostfix]
-    public static void OnArmyCreatedPostfix(ref DefaultNotificationsCampaignBehavior __instance, Army army)
+    [HarmonyPrefix]
+    public static bool OnArmyCreatedPrefix(ref DefaultNotificationsCampaignBehavior __instance, Army army)
     {
-        if (ModInformation.IsClient) return;
-
+        if (ModInformation.IsClient) return false;
         var message = new NotifyArmyCreated(army, army.AiBehaviorObject);
         MessageBroker.Instance.Publish(__instance, message);
+        return false;
     }
 
     [HarmonyPatch(nameof(DefaultNotificationsCampaignBehavior.OnSiegeBombardmentHit))]

--- a/source/GameInterface/Services/UI/Notifications/Patches/DefaultNotificationsCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/UI/Notifications/Patches/DefaultNotificationsCampaignBehaviorPatches.cs
@@ -258,6 +258,7 @@ internal class DefaultNotificationsCampaignBehaviorPatches
     [HarmonyPrefix]
     public static bool OnArmyCreatedPrefix(ref DefaultNotificationsCampaignBehavior __instance, Army army)
     {
+        if (!ContainerProvider.TryResolve<IGameInterface>(out _)) return true;
         if (ModInformation.IsClient) return false;
         var message = new NotifyArmyCreated(army, army.AiBehaviorObject);
         MessageBroker.Instance.Publish(__instance, message);

--- a/source/GameInterface/Services/UI/Patches/MapTrackerProviderCapturePatch.cs
+++ b/source/GameInterface/Services/UI/Patches/MapTrackerProviderCapturePatch.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using SandBox.ViewModelCollection.Map.Tracker;
+namespace GameInterface.Services.UI.Patches;
+
+[HarmonyPatch(typeof(MapTrackerProvider))]
+[HarmonyPatch(MethodType.Constructor)]
+internal static class MapTrackerProviderCapturePatch
+{
+    [HarmonyPostfix]
+    static void Postfix(MapTrackerProvider __instance)
+    {
+        if (ContainerProvider.TryResolve<IMapTrackerProviderHolder>(out var holder))
+        {
+            holder.Current = __instance;
+        }
+    }
+}
+internal interface IMapTrackerProviderHolder
+{
+    MapTrackerProvider Current { get; set; }
+}
+
+internal class MapTrackerProviderHolder : IMapTrackerProviderHolder
+{
+    public MapTrackerProvider Current { get; set; }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ x ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Players couldn't see the maptracker of an army in their kingdom

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Players see a maptracker on the armies in their kingdom
Also works for late joining clients.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information
1: `MapTrackerProvider.ResetTrackers()` gets called before the mainhero is properly assigned, which causes late joining clients to always evaluating `army.Kingdom == Hero.MainHero.MapFaction` false.
2: `OnArmyCreated` was never sent to clients, thus it would never be added.
