### PR TITLE
Prevent siege assaults from invalidating peace barters

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/PlayerPartyInteractionFlowTests.cs
@@ -2588,6 +2588,69 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             AssertPeaceMade(environmentClient, playerClanId, targetClanId);
     }
 
+    [Fact]
+    public void NpcPeaceBarter_BesiegerWithQueuedAssault_DoesNotLoseEncounterBeforeSubmission()
+    {
+        const int initialPlayerGold = 1_000_000;
+        const int offeredGold = 500_000;
+
+        var client = Clients.First();
+        client.Resolve<IControllerIdProvider>().SetControllerId("PlayerOne");
+        var (playerHeroId, playerMobilePartyId) = CreatePlayerPartyWithRegisteredLeader("PlayerOne");
+        var playerPartyId = GetPartyBaseId(Server, playerMobilePartyId);
+        var (targetHeroId, targetMobilePartyId, targetPartyId) = CreateAiPartyWithRegisteredLeader();
+        var siege = CreateSyncedSiege(targetMobilePartyId);
+        MakePartiesHostile(playerPartyId, targetPartyId);
+
+        Server.Resolve<IPlayerManager>().SetPeer("PlayerOne", client.NetPeer);
+        Server.Call(() =>
+        {
+            new GoldBarterBehavior().RegisterEvents();
+
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(playerHeroId, out var playerHero));
+            Assert.True(Server.ObjectManager.TryGetObject<Hero>(targetHeroId, out var targetHero));
+            Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(targetMobilePartyId, out var targetParty));
+            Assert.True(Server.ObjectManager.TryGetObject<Settlement>(siege.SettlementId, out var settlement));
+
+            playerHero.Gold = initialPlayerGold;
+            VillageHostileFactionStanceHelper.ApplyWarStance(playerHero.MapFaction, targetHero.MapFaction);
+            targetParty.SetShortTermBehavior(AiBehavior.AssaultSettlement, settlement.Party);
+            Assert.True(ConversationPartyHold.TryEngage(
+                Server.Resolve<ConversationPartyTracker>(),
+                client.NetPeer,
+                playerPartyId,
+                targetParty,
+                targetPartyId,
+                engagerIsDefender: true));
+
+            Assert.Equal(AiBehavior.AssaultSettlement, targetParty.ShortTermBehavior);
+            Assert.False(InvokeEncounterPrefix("Prefix", targetParty, settlement));
+            Assert.Null(targetParty.MapEvent);
+            Assert.Null(settlement.Party.MapEvent);
+        });
+
+        Server.NetworkSentMessages.Clear();
+        client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkRequestPeaceBarter(
+            targetHeroId,
+            PeaceConversationContext.MapParty,
+            targetPartyId,
+            new[]
+            {
+                new PeaceBarterTerm(
+                    PeaceBarterTermType.Gold,
+                    playerHeroId,
+                    objectId: null,
+                    itemModifierId: null,
+                    itemModifierNull: true,
+                    amount: offeredGold),
+            },
+            requestId: "besieger-peace-success")));
+
+        var result = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPeaceBarterResult>());
+        Assert.True(result.Accepted, result.Reason);
+        Assert.Equal("besieger-peace-success", result.RequestId);
+    }
+
     [Theory]
     [InlineData(false, false)]
     [InlineData(true, false)]
@@ -3468,7 +3531,8 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
         }, MapEventDisabledMethods);
     }
 
-    private (string SiegeEventId, string SettlementId, string LeaderPartyId) CreateSyncedSiege()
+    private (string SiegeEventId, string SettlementId, string LeaderPartyId) CreateSyncedSiege(
+        string? leaderMobilePartyId = null)
     {
         var siegeCreationDisabledMethods = new[]
         {
@@ -3477,7 +3541,7 @@ public class PlayerPartyInteractionFlowTests : MapEventTestBase
             AccessTools.Method(typeof(Settlement), nameof(Settlement.InitializeSiegeEventSide)),
         };
         var settlementId = TestEnvironment.CreateRegisteredObject<Settlement>();
-        var leaderMobilePartyId = TestEnvironment.CreateRegisteredObject<MobileParty>();
+        leaderMobilePartyId ??= TestEnvironment.CreateRegisteredObject<MobileParty>();
         var leaderPartyId = GetPartyBaseId(Server, leaderMobilePartyId);
 
         string? siegeEventId = null;

--- a/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
+++ b/source/GameInterface/Services/MapEvents/ConversationPartyHold.cs
@@ -153,8 +153,10 @@ internal static class ConversationPartyHold
 
     /// <summary>True when the party is held in a player's conversation (and not already in a battle).</summary>
     public static bool IsInPlayerConversation(MobileParty party)
+        => IsInPlayerConversation(ConversationPartyTracker.Instance, party);
+
+    internal static bool IsInPlayerConversation(ConversationPartyTracker tracker, MobileParty party)
     {
-        var tracker = ConversationPartyTracker.Instance;
         if (tracker == null || tracker.IsEmpty) return false;
 
         if (party?.Party == null || party.MapEvent != null) return false;

--- a/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/EncounterManagerPatches.cs
@@ -33,6 +33,13 @@ internal class EncounterManagerPatches
         if (IsPendingParty(attackerParty?.Party))
             return false;
 
+        // A besieger can already have AssaultSettlement queued when its conversation hold disables the AI.
+        // Suppress that pending encounter until the conversation releases the party.
+        if (ModInformation.IsServer &&
+            ContainerProvider.TryResolve<ConversationPartyTracker>(out var conversationPartyTracker) &&
+            ConversationPartyHold.IsInPlayerConversation(conversationPartyTracker, attackerParty))
+            return false;
+
         if (IsAwaitingMissionExit(attackerParty?.Party))
             return false;
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other

## What is the current behavior?

Follow-up to #3013 and #3190. A besieging lord can already have an assault queued when the conversation hold disables its AI. Vanilla can then start the siege encounter while the peace barter is open, invalidating the server-side conversation context.

## What is the new behavior?

Settlement encounters are deferred while the acting party is held in a player conversation. Releasing the conversation lets the party resume normally. An end-to-end regression covers a besieger with a queued assault and verifies that the peace barter completes.

## Bot Changelog Entry

- Peace negotiations with besieging lords no longer fail when a siege assault was about to begin.

## Other information

Targeted coverage passed: 9 NPC peace flow tests, 5 rejected barter completion tests, and 3 conversation tracker tests.