### PR TITLE
[1827] Add regression test for player->player vassal oath in settlements

### DIFF
--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Network;
 using Common.Messaging;
 using Common.Util;
 using Coop.Core.Client.Services.Kingdoms.Handlers;
@@ -20,6 +21,8 @@ using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Extentions;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.Kingdoms.Patches;
+using GameInterface.Services.Locations.Messages.Conversation;
+using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.MobileParties.Handlers;
 using GameInterface.Services.MobileParties.Messages.Behavior;
@@ -291,6 +294,55 @@ public class PlayerKingdomCreationFlowTests : IDisposable
 
         var rejected = Assert.Single(Server.NetworkSentMessages.GetMessages<VassalServiceResult>());
         Assert.False(rejected.Accepted);
+    }
+    
+    [Fact]
+    public void VassalServiceAccepted_DuringSettlementLocationConversation_JoinsKingdomAndReleasesConversationLock()
+    {
+        const string LocationId = "vassal_oath_settlement";
+
+        var client = Clients.First();
+        var joiner = CreateSyncedPlayerContext(ControllerId, client);
+        var ruler = CreateSyncedPlayerContext("SettlementVassalRuler", _ => false);
+        var kingdomId = TestEnvironment.CreateRegisteredObject<Kingdom>();
+        ConfigureClanInKingdom(ruler.ClanId, kingdomId);
+        SetClanTierEverywhere(joiner.ClanId, 2);
+
+        Server.Call(() => Server.Resolve<IPlayerManager>().SetPeer(ControllerId, client.NetPeer));
+
+        // The joiner walks up to the ruler's hero inside a settlement and opens a location conversation,
+        // exactly as LocationConversationPatches gates it for a synced hero met in a settlement.
+        Server.NetworkSentMessages.Clear();
+        client.Call(() => client.Resolve<INetwork>().SendAll(
+            new NetworkRequestLocationConversation(LocationId, ruler.CharacterId, generation: 1)));
+
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkAllowLocationConversation>());
+        var started = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerInteractionStarted>());
+        Assert.True(started.IsLocationInteraction);
+
+        // While that settlement conversation is still held, the joiner takes the oath to join the ruler's kingdom
+        Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
+        Server.NetworkSentMessages.Clear();
+        client.SimulateMessage(this, new VassalServiceAccepted(kingdom, grantRewards: false));
+
+        var request = Assert.Single(client.NetworkSentMessages.GetMessages<RequestVassalService>());
+        Assert.Equal(kingdomId, request.KingdomId);
+
+        var accepted = Assert.Single(Server.NetworkSentMessages.GetMessages<VassalServiceResult>());
+        Assert.True(accepted.Accepted);
+
+        Server.Call(() => AssertVassalMembership(Server, joiner.ClanId, kingdomId));
+        foreach (var instance in Clients)
+        {
+            instance.Call(() => AssertVassalMembership(instance, joiner.ClanId, kingdomId));
+        }
+
+        // The dialog concludes and the settlement conversation ends normally afterward
+        Server.NetworkSentMessages.Clear();
+        client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkLocationConversationEnded()));
+
+        var ended = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerInteractionEnded>());
+        Assert.True(ended.IsLocationInteraction);
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -9,8 +9,10 @@ using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.Core.Server.Services.Stances.Messages;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
+using E2E.Tests.Environment.MockEngine;
 using E2E.Tests.Util;
 using GameInterface.Services.Clans.Messages;
+using GameInterface.Services.Clans.Patches;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.Heroes.Interfaces;
@@ -21,6 +23,8 @@ using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Extentions;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.Kingdoms.Patches;
+using GameInterface.Services.Locations.Conversations;
+using GameInterface.Services.Locations.Conversations.Patches;
 using GameInterface.Services.Locations.Messages.Conversation;
 using GameInterface.Services.MapEvents.Messages.Conversation;
 using GameInterface.Services.MobileParties.Extensions;
@@ -33,6 +37,7 @@ using GameInterface.Services.Stances.Messages;
 using GameInterface.Services.UI.Notifications.Messages;
 using GameInterface.Services.Villages.Interfaces;
 using HarmonyLib;
+using SandBox.Conversation.MissionLogics;
 using SandBox.ViewModelCollection.Map.Tracker;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -43,6 +48,8 @@ using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Settlements.Locations;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Diplomacy;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.ItemTypes;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Diplomacy;
@@ -51,6 +58,7 @@ using TaleWorlds.Core;
 using TaleWorlds.Core.ViewModelCollection.Information;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
+using TaleWorlds.MountAndBlade;
 using Xunit.Abstractions;
 
 namespace E2E.Tests.Services.Kingdoms;
@@ -310,39 +318,197 @@ public class PlayerKingdomCreationFlowTests : IDisposable
 
         Server.Call(() => Server.Resolve<IPlayerManager>().SetPeer(ControllerId, client.NetPeer));
 
-        // The joiner walks up to the ruler's hero inside a settlement and opens a location conversation,
-        // exactly as LocationConversationPatches gates it for a synced hero met in a settlement.
-        Server.NetworkSentMessages.Clear();
-        client.Call(() => client.Resolve<INetwork>().SendAll(
-            new NetworkRequestLocationConversation(LocationId, ruler.CharacterId, generation: 1)));
+        var pendingField = AccessTools.Field(typeof(LocationConversationPatches), "pending");
+        var heldNpcKeyField = AccessTools.Field(typeof(LocationConversationPatches), "heldNpcKey");
+        var onAgentInteractionPrefix = AccessTools.Method(typeof(LocationConversationPatches), "OnAgentInteractionPrefix");
+        var onConversationEndPostfix = AccessTools.Method(typeof(LocationConversationPatches), "OnConversationEndPostfix");
+        // These are process-wide statics on LocationConversationPatches: in a real game only one client runs
+        // per process, but this harness runs several "clients" in one, so a previous test's leftovers could
+        // otherwise leak in here.
+        pendingField.SetValue(null, null);
+        heldNpcKeyField.SetValue(null, null);
 
-        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkAllowLocationConversation>());
-        var started = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerInteractionStarted>());
-        Assert.True(started.IsLocationInteraction);
+        using var fixture = new MissionEngineFixture();
+        var harmony = new Harmony($"e2e.vassal-oath-settlement.{Guid.NewGuid():N}");
+        harmony.Patch(
+            AccessTools.Method(typeof(Agent), nameof(Agent.IsEnemyOf)),
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(PlayerKingdomCreationFlowTests), nameof(NeverEnemiesPrefix))));
+        harmony.Patch(
+            AccessTools.PropertyGetter(typeof(MissionConversationLogic), nameof(MissionConversationLogic.Current)),
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(PlayerKingdomCreationFlowTests), nameof(GetMissionConversationLogicCurrentPrefix))));
+        harmony.Patch(
+            AccessTools.Method(typeof(MissionConversationLogic), nameof(MissionConversationLogic.StartConversation)),
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(PlayerKingdomCreationFlowTests), nameof(SuppressNativeStartConversationPrefix))));
+        harmony.Patch(
+            AccessTools.PropertyGetter(typeof(Hero), nameof(Hero.OneToOneConversationHero)),
+            prefix: new HarmonyMethod(AccessTools.Method(typeof(PlayerKingdomCreationFlowTests), nameof(GetOneToOneConversationHeroPrefix))));
 
-        // While that settlement conversation is still held, the joiner takes the oath to join the ruler's kingdom
-        Assert.True(client.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom));
-        Server.NetworkSentMessages.Clear();
-        client.SimulateMessage(this, new VassalServiceAccepted(kingdom, grantRewards: false));
-
-        var request = Assert.Single(client.NetworkSentMessages.GetMessages<RequestVassalService>());
-        Assert.Equal(kingdomId, request.KingdomId);
-
-        var accepted = Assert.Single(Server.NetworkSentMessages.GetMessages<VassalServiceResult>());
-        Assert.True(accepted.Accepted);
-
-        Server.Call(() => AssertVassalMembership(Server, joiner.ClanId, kingdomId));
-        foreach (var instance in Clients)
+        try
         {
-            instance.Call(() => AssertVassalMembership(instance, joiner.ClanId, kingdomId));
+            Agent joinerAgent = null;
+            Agent rulerAgent = null;
+
+            client.Call(() =>
+            {
+                var mock = fixture.CreateMission(client);
+
+                Assert.True(client.ObjectManager.TryGetObject<CharacterObject>(joiner.CharacterId, out var joinerCharacter));
+                Assert.True(client.ObjectManager.TryGetObject<CharacterObject>(ruler.CharacterId, out var rulerCharacter));
+                Assert.True(rulerCharacter.IsHero);
+
+                joinerAgent = mock.SpawnAgent(new AgentBuildData(joinerCharacter).Controller(AgentControllerType.Player));
+                rulerAgent = mock.SpawnAgent(new AgentBuildData(rulerCharacter).Controller(AgentControllerType.AI));
+                mock.MainAgent = joinerAgent;
+                Assert.True(AgentMirror.TryGet(rulerAgent, out var rulerMirror));
+                rulerMirror.Position = new Vec3(1f, 0f, 0f);
+
+                Assert.NotNull(Campaign.Current.ConversationManager);
+                MissionConversationLogicOverride = new MissionConversationLogic
+                {
+                    Mission = mock.Shell,
+                    ConversationManager = Campaign.Current.ConversationManager,
+                };
+
+                var location = ObjectHelper.SkipConstructor<Location>();
+                Assert.True(client.ObjectManager.AddExisting(LocationId, location));
+                CampaignMission.Current = new StubCampaignMission(location);
+                
+                new LocationConversationTracker(client.ObjectManager);
+            });
+            
+            Server.NetworkSentMessages.Clear();
+            client.Call(() =>
+            {
+                var vanillaAllowed = (bool)onAgentInteractionPrefix.Invoke(
+                    null, new object[] { MissionConversationLogicOverride, joinerAgent, rulerAgent });
+                Assert.False(vanillaAllowed);
+            });
+
+            Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkAllowLocationConversation>());
+            var started = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerInteractionStarted>());
+            Assert.True(started.IsLocationInteraction);
+
+            // The approval round-trip runs synchronously through the mock network, so StartApprovedConversation
+            // has already consumed `pending` and set `heldNpcKey` for real by the time control returns here.
+            Assert.Null(pendingField.GetValue(null));
+            Assert.Equal(LocationConversationTracker.ComposeKey(LocationId, ruler.CharacterId), heldNpcKeyField.GetValue(null));
+            Server.Call(() =>
+            {
+                Assert.True(Server.Resolve<LocationConversationTracker>().TryGetEngagement(client.NetPeer, out var lockedNpcKey));
+                Assert.Equal(LocationConversationTracker.ComposeKey(LocationId, ruler.CharacterId), lockedNpcKey);
+            });
+
+            // While that settlement conversation is still held, the joiner takes the oath to join the ruler's
+            // kingdom driven through the real dialogue-consequence patch.
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(ruler.HeroId, out var rulerHero));
+            OneToOneConversationHeroOverride = rulerHero;
+            Server.NetworkSentMessages.Clear();
+            client.Call(() =>
+            {
+                var behavior = new LordConversationsCampaignBehavior { _receivedVassalRewards = true };
+                var vanillaAllowed = VassalServiceConversationPatch.ConversationPlayerIsAcceptedAsVassalPrefix(behavior);
+                Assert.False(vanillaAllowed);
+            });
+
+            var request = Assert.Single(client.NetworkSentMessages.GetMessages<RequestVassalService>());
+            Assert.Equal(kingdomId, request.KingdomId);
+            Assert.False(request.GrantRewards);
+
+            var accepted = Assert.Single(Server.NetworkSentMessages.GetMessages<VassalServiceResult>());
+            Assert.True(accepted.Accepted);
+
+            Server.Call(() => AssertVassalMembership(Server, joiner.ClanId, kingdomId));
+            foreach (var instance in Clients)
+            {
+                instance.Call(() => AssertVassalMembership(instance, joiner.ClanId, kingdomId));
+            }
+
+            // The dialog concludes and the settlement conversation ends normally afterward.
+            Server.NetworkSentMessages.Clear();
+            client.Call(() => onConversationEndPostfix.Invoke(null, null));
+
+            Assert.Null(heldNpcKeyField.GetValue(null));
+            var ended = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerInteractionEnded>());
+            Assert.True(ended.IsLocationInteraction);
+            Server.Call(() =>
+            {
+                Assert.False(Server.Resolve<LocationConversationTracker>().TryGetEngagement(client.NetPeer, out _));
+            });
+
+            // Reacquire the SAME target: if the server's engagement tracker had not actually released it (only
+            // NetworkPlayerInteractionEnded had fired), this second request would come back denied instead.
+            Server.NetworkSentMessages.Clear();
+            client.Call(() =>
+            {
+                new LocationConversationTracker(client.ObjectManager);
+                var vanillaAllowed = (bool)onAgentInteractionPrefix.Invoke(
+                    null, new object[] { MissionConversationLogicOverride, joinerAgent, rulerAgent });
+                Assert.False(vanillaAllowed);
+            });
+
+            Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkAllowLocationConversation>());
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkLocationConversationDenied>());
         }
+        finally
+        {
+            harmony.UnpatchAll(harmony.Id);
+            MissionConversationLogicOverride = null;
+            OneToOneConversationHeroOverride = null;
+            pendingField.SetValue(null, null);
+            heldNpcKeyField.SetValue(null, null);
+            CampaignMission.Current = null;
+        }
+    }
 
-        // The dialog concludes and the settlement conversation ends normally afterward
-        Server.NetworkSentMessages.Clear();
-        client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkLocationConversationEnded()));
+    private static MissionConversationLogic MissionConversationLogicOverride;
+    private static Hero OneToOneConversationHeroOverride;
 
-        var ended = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPlayerInteractionEnded>());
-        Assert.True(ended.IsLocationInteraction);
+    private static bool GetMissionConversationLogicCurrentPrefix(ref MissionConversationLogic __result)
+    {
+        __result = MissionConversationLogicOverride;
+        return false;
+    }
+
+    private static bool GetOneToOneConversationHeroPrefix(ref Hero __result)
+    {
+        __result = OneToOneConversationHeroOverride;
+        return false;
+    }
+    
+    private static bool SuppressNativeStartConversationPrefix() => false;
+
+    private static bool NeverEnemiesPrefix(Agent __instance, ref bool __result)
+    {
+        if (!AgentMirror.TryGet(__instance, out _)) return true;
+        __result = false;
+        return false;
+    }
+    
+    private sealed class StubCampaignMission : ICampaignMission
+    {
+        public StubCampaignMission(Location location) => Location = location;
+
+        public GameState State => null;
+        public IMissionTroopSupplier AgentSupplier => null;
+        public Location Location { get; set; }
+        public Alley LastVisitedAlley { get; set; }
+        public MissionMode Mode => MissionMode.StartUp;
+        public void SetMissionMode(MissionMode newMode, bool atStart) { }
+        public void OnCloseEncounterMenu() { }
+        public bool AgentLookingAtAgent(IAgent agent1, IAgent agent2) => false;
+        public void OnCharacterLocationChanged(LocationCharacter locationCharacter, Location fromLocation, Location toLocation) { }
+        public void OnProcessSentence() { }
+        public void OnConversationContinue() { }
+        public bool CheckIfAgentCanFollow(IAgent agent) => false;
+        public void AddAgentFollowing(IAgent agent) { }
+        public bool CheckIfAgentCanUnFollow(IAgent agent) => false;
+        public void RemoveAgentFollowing(IAgent agent) { }
+        public void OnConversationPlay(string idleActionId, string idleFaceAnimId, string reactionId, string reactionFaceAnimId, string soundPath) { }
+        public void OnConversationStart(IAgent agent, bool setActionsInstantly) { }
+        public void OnConversationEnd(IAgent agent) { }
+        public void EndMission() { }
+        public void FadeOutCharacter(CharacterObject characterObject) { }
+        public void OnGameStateChanged() { }
     }
 
     [Fact]


### PR DESCRIPTION
issue #1827

## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Other... Please describe:
Added a regression test for issue https://github.com/Bannerlord-Coop-Team/BannerlordCoop/issues/1827 as I was not able to reproduce the issue. It seems to have been fixed.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information
