### PR TITLE
docs: fix typo propery -> property

### DIFF
--- a/source/GameInterface/AutoSync/README.md
+++ b/source/GameInterface/AutoSync/README.md
@@ -1,7 +1,7 @@
 # Dynamic Sync
 
 1. [Collects]() all classes that inherit [IAutoSync]()
-2. Each field/propery/collection added from the IAutoSync class is stored in the [AutoSyncRegistry]()
+2. Each field/property/collection added from the IAutoSync class is stored in the [AutoSyncRegistry]()
 
 
 There are 4 different types of data


### PR DESCRIPTION
One-word typo fix in `source/GameInterface/AutoSync/README.md:4`: "Each field/propery/co..." → "property".
