### PR TITLE
Fix contested village raid hanging on the battle loading screen

### DIFF
--- a/source/E2E.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
+++ b/source/E2E.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
@@ -5,6 +5,7 @@ using Common.Network;
 using GameInterface;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.Players;
@@ -76,7 +77,8 @@ public class BattleMissionStartHandlerTests : MapEventTestBase
                 client.Resolve<IPlayerManager>(),
                 client.Resolve<INetwork>(),
                 client.Resolve<IMapEventLogger>(),
-                missionInitializerResolver);
+                missionInitializerResolver,
+                new Mock<IMapEventInitializationBarrier>().Object);
 
             try
             {
@@ -189,7 +191,8 @@ public class BattleMissionStartHandlerTests : MapEventTestBase
                     client.Resolve<IPlayerManager>(),
                     client.Resolve<INetwork>(),
                     client.Resolve<IMapEventLogger>(),
-                    missionInitializerResolver);
+                    missionInitializerResolver,
+                    new Mock<IMapEventInitializationBarrier>().Object);
 
                 messageBroker.Publish(this, new NetworkStartAttackMission(
                     mapEvent.MapEventId,

--- a/source/E2E.Tests/Services/SiegeEvents/SiegeAssaultLeaveTests.cs
+++ b/source/E2E.Tests/Services/SiegeEvents/SiegeAssaultLeaveTests.cs
@@ -6,6 +6,7 @@ using E2E.Tests.Environment.Instance;
 using E2E.Tests.Services.MapEvents;
 using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.Players;
@@ -141,7 +142,8 @@ public class SiegeAssaultLeaveTests : MapEventTestBase
                 Server.Resolve<IPlayerManager>(),
                 Server.Resolve<INetwork>(),
                 Server.Resolve<IMapEventLogger>(),
-                Server.Resolve<IBattleMissionInitializerResolver>());
+                Server.Resolve<IBattleMissionInitializerResolver>(),
+                Server.Resolve<IMapEventInitializationBarrier>());
 
             Assert.True(handler.RemoveWoundedNonInitiatorParties(mapEvent, initiatingPartyId));
         }, disabledMethods);
@@ -201,7 +203,8 @@ public class SiegeAssaultLeaveTests : MapEventTestBase
                 Server.Resolve<IPlayerManager>(),
                 Server.Resolve<INetwork>(),
                 Server.Resolve<IMapEventLogger>(),
-                Server.Resolve<IBattleMissionInitializerResolver>());
+                Server.Resolve<IBattleMissionInitializerResolver>(),
+                Server.Resolve<IMapEventInitializationBarrier>());
 
             Assert.True(handler.RemoveWoundedNonInitiatorParties(mapEvent, initiatingPartyId));
         }, disabledMethods);

--- a/source/GameInterface.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
@@ -8,11 +8,27 @@ namespace GameInterface.Tests.Services.MapEvents;
 public class BattleMissionStartHandlerTests
 {
     [Fact]
+    public void DecideDeferredOpenAction_ResolvesByMissionAndBattleState()
+    {
+        // Keep waiting while the battle is still valid, abandon the loading window once its graph is gone
+        // (the aborted contested-raid case), and clear once a mission has opened.
+        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Keep,
+            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: false, battleStillValid: true));
+        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Abandon,
+            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: false, battleStillValid: false));
+        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Clear,
+            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: true, battleStillValid: false));
+        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Clear,
+            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: true, battleStillValid: true));
+    }
+
+    [Fact]
     public void GetOrCreateMissionInitializerSnapshot_ReusesFirstBattleInitializer()
     {
         using var messageBroker = new MessageBroker();
         using var handler = new BattleMissionStartHandler(
             messageBroker,
+            null!,
             null!,
             null!,
             null!,

--- a/source/GameInterface.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
@@ -1,12 +1,56 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
+using Common.Util;
 using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.MapEvents.Initialization;
+using GameInterface.Services.MapEvents.Messages.Start;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.UI.Interfaces;
+using GameInterface.Tests.Bootstrap;
+using GameInterface.Tests.Services.SiegeEvents;
+using Moq;
+using System;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.MapEvents;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
+using TaleWorlds.Library;
 using Xunit;
 
 namespace GameInterface.Tests.Services.MapEvents;
 
-public class BattleMissionStartHandlerTests
+[Collection(nameof(CampaignCurrentCollection))]
+public sealed class BattleMissionStartHandlerTests : IDisposable
 {
+    private const string MapEventId = "map-event-1";
+    private const string InitiatingPartyId = "attacker-party-1";
+
+    private static readonly FieldInfo SidesField =
+        typeof(MapEvent).GetField("_sides", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static readonly FieldInfo BattlePartiesField =
+        typeof(MapEventSide).GetField("_battleParties", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static readonly FieldInfo MapEventField =
+        typeof(MapEventSide).GetField("_mapEvent", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private readonly MobileParty? previousMainParty;
+
+    static BattleMissionStartHandlerTests()
+    {
+        GameBootStrap.Initialize();
+    }
+
+    public BattleMissionStartHandlerTests()
+    {
+        previousMainParty = Campaign.Current?.MainParty;
+    }
+
+    public void Dispose()
+    {
+        if (Campaign.Current != null)
+            Campaign.Current.MainParty = previousMainParty;
+    }
+
     // The two missionOpen: true rows prove Clear wins regardless of battleStillValid, guarding
     // against a future reorder that would let a stale/invalid battle override an opened mission.
     [Theory]
@@ -32,6 +76,7 @@ public class BattleMissionStartHandlerTests
             null!,
             null!,
             null!,
+            null!,
             null!);
 
         var initial = new MissionInitializerRecord("battle_terrain_026")
@@ -51,5 +96,156 @@ public class BattleMissionStartHandlerTests
         Assert.Equal(first.SceneName, repeated.SceneName);
         Assert.Equal(1234, repeated.RandomTerrainSeed);
         Assert.Equal("battle_terrain_030", otherBattle.SceneName);
+    }
+
+    [Fact]
+    public void PendingBattle_DisposeDropsLoadingWindowAndGuardsDeferredCallback()
+    {
+        var window = new Mock<IGlobalLoadingWindow>();
+        var barrier = CreatePendingBarrier(out var capturedOpen);
+        using var messageBroker = new MessageBroker();
+        var handler = CreateHandler(messageBroker, CreateObjectManager(), barrier.Object, window.Object);
+        SetupMainPartyBattle();
+
+        DriveAttackMissionStart(messageBroker);
+
+        Assert.Equal(MapEventId, handler.DeferredAttackMissionMapEventId);
+        Assert.NotNull(capturedOpen.Value);
+        window.Verify(w => w.Enable(), Times.Once);
+        window.Verify(w => w.Disable(), Times.Never);
+
+        handler.Dispose();
+
+        Assert.Null(handler.DeferredAttackMissionMapEventId);
+        window.Verify(w => w.Disable(), Times.Once);
+
+        // The barrier callback fires after disposal; the disposed guard makes it a no-op, so the
+        // window is not touched again and no mission is opened on the dead handler.
+        capturedOpen.Value();
+
+        Assert.Null(handler.DeferredAttackMissionMapEventId);
+        window.Verify(w => w.Disable(), Times.Once);
+    }
+
+    [Fact]
+    public void PendingBattle_CommitRunsDeferredOpenInsteadOfImmediateOpen()
+    {
+        var window = new Mock<IGlobalLoadingWindow>();
+        var barrier = CreatePendingBarrier(out var capturedOpen);
+        using var messageBroker = new MessageBroker();
+        using var handler = CreateHandler(messageBroker, CreateObjectManager(), barrier.Object, window.Object);
+        SetupMainPartyBattle();
+
+        DriveAttackMissionStart(messageBroker);
+
+        Assert.Equal(MapEventId, handler.DeferredAttackMissionMapEventId);
+        window.Verify(w => w.Enable(), Times.Once);
+        barrier.Verify(b => b.RunAfterCommit(It.IsAny<MapEvent>(), It.IsAny<Action>()), Times.Once);
+        // The open was registered on the barrier, not opened immediately, so the window is still held.
+        window.Verify(w => w.Disable(), Times.Never);
+
+        // The battle ends before the queued open runs (the race TryGetValidBattle guards); the commit
+        // callback still fires and drives the open, which re-validates and drops the window.
+        Campaign.Current.MainParty = null;
+        capturedOpen.Value();
+
+        Assert.Null(handler.DeferredAttackMissionMapEventId);
+        window.Verify(w => w.Disable(), Times.Once);
+    }
+
+    private static Mock<IMapEventInitializationBarrier> CreatePendingBarrier(out DeferredOpen capturedOpen)
+    {
+        var open = new DeferredOpen();
+        capturedOpen = open;
+        var barrier = new Mock<IMapEventInitializationBarrier>();
+        barrier.Setup(b => b.IsPending(It.IsAny<MapEvent>())).Returns(true);
+        barrier.Setup(b => b.RunAfterCommit(It.IsAny<MapEvent>(), It.IsAny<Action>()))
+            .Callback<MapEvent, Action>((_, action) => open.Value = action);
+        return barrier;
+    }
+
+    private static IObjectManager CreateObjectManager()
+    {
+        var objectManager = new Mock<IObjectManager>();
+        string mapEventId = MapEventId;
+        objectManager.Setup(o => o.TryGetId(It.IsAny<object>(), out mapEventId)).Returns(true);
+        return objectManager.Object;
+    }
+
+    private static BattleMissionStartHandler CreateHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        IMapEventInitializationBarrier barrier,
+        IGlobalLoadingWindow window)
+    {
+        return new BattleMissionStartHandler(
+            messageBroker,
+            objectManager,
+            null!,
+            null!,
+            null!,
+            null!,
+            barrier,
+            window);
+    }
+
+    private static void DriveAttackMissionStart(IMessageBroker messageBroker)
+    {
+        var message = new NetworkStartAttackMission(
+            MapEventId,
+            new MissionInitializerRecord("battle_terrain_026"),
+            InitiatingPartyId);
+
+        int previousGameThreadId = GameThread.Instance.GameThreadId;
+        GameThread.Instance.MarkGameThread();
+        try
+        {
+            messageBroker.Publish(null, message);
+        }
+        finally
+        {
+            GameThread.Instance.RestoreGameThread(previousGameThreadId);
+        }
+    }
+
+    private static void SetupMainPartyBattle()
+    {
+        var playerParty = CreateMobileParty();
+        var enemyParty = CreateMobileParty();
+        var mapEvent = ObjectHelper.SkipConstructor<MapEvent>();
+        var attackerSide = CreateSide(mapEvent, CreateMapEventParty(playerParty));
+        var defenderSide = CreateSide(mapEvent, CreateMapEventParty(enemyParty));
+        SidesField.SetValue(mapEvent, new[] { defenderSide, attackerSide });
+        playerParty.Party._mapEventSide = attackerSide;
+        Campaign.Current.MainParty = playerParty;
+    }
+
+    private static MapEventSide CreateSide(MapEvent mapEvent, params MapEventParty[] parties)
+    {
+        var side = ObjectHelper.SkipConstructor<MapEventSide>();
+        BattlePartiesField.SetValue(side, new MBList<MapEventParty>(parties));
+        MapEventField.SetValue(side, mapEvent);
+        return side;
+    }
+
+    private static MapEventParty CreateMapEventParty(MobileParty mobileParty)
+    {
+        var mapEventParty = ObjectHelper.SkipConstructor<MapEventParty>();
+        mapEventParty.Party = mobileParty.Party;
+        return mapEventParty;
+    }
+
+    private static MobileParty CreateMobileParty()
+    {
+        var mobileParty = ObjectHelper.SkipConstructor<MobileParty>();
+        var party = ObjectHelper.SkipConstructor<PartyBase>();
+        party.MobileParty = mobileParty;
+        mobileParty.Party = party;
+        return mobileParty;
+    }
+
+    private sealed class DeferredOpen
+    {
+        public Action Value { get; set; }
     }
 }

--- a/source/GameInterface.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/MapEvents/BattleMissionStartHandlerTests.cs
@@ -7,19 +7,18 @@ namespace GameInterface.Tests.Services.MapEvents;
 
 public class BattleMissionStartHandlerTests
 {
-    [Fact]
-    public void DecideDeferredOpenAction_ResolvesByMissionAndBattleState()
+    // The two missionOpen: true rows prove Clear wins regardless of battleStillValid, guarding
+    // against a future reorder that would let a stale/invalid battle override an opened mission.
+    [Theory]
+    [InlineData(false, true, BattleMissionStartHandler.DeferredOpenAction.Keep)]
+    [InlineData(false, false, BattleMissionStartHandler.DeferredOpenAction.Abandon)]
+    [InlineData(true, false, BattleMissionStartHandler.DeferredOpenAction.Clear)]
+    [InlineData(true, true, BattleMissionStartHandler.DeferredOpenAction.Clear)]
+    public void DecideDeferredOpenAction_ResolvesByMissionAndBattleState(
+        bool missionOpen, bool battleStillValid, object expected)
     {
-        // Keep waiting while the battle is still valid, abandon the loading window once its graph is gone
-        // (the aborted contested-raid case), and clear once a mission has opened.
-        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Keep,
-            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: false, battleStillValid: true));
-        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Abandon,
-            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: false, battleStillValid: false));
-        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Clear,
-            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: true, battleStillValid: false));
-        Assert.Equal(BattleMissionStartHandler.DeferredOpenAction.Clear,
-            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen: true, battleStillValid: true));
+        Assert.Equal((BattleMissionStartHandler.DeferredOpenAction)expected,
+            BattleMissionStartHandler.DecideDeferredOpenAction(missionOpen, battleStillValid));
     }
 
     [Fact]

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleMissionStartHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleMissionStartHandler.cs
@@ -12,6 +12,7 @@ using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
+using GameInterface.Services.UI.Interfaces;
 using LiteNetLib;
 using Serilog;
 using System;
@@ -25,7 +26,6 @@ using TaleWorlds.CampaignSystem.MapEvents;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
-using TaleWorlds.Engine;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.ObjectSystem;
@@ -54,6 +54,7 @@ internal class BattleMissionStartHandler : IHandler
     private readonly IMapEventLogger mapEventLogger;
     private readonly IBattleMissionInitializerResolver missionInitializerResolver;
     private readonly IMapEventInitializationBarrier initializationBarrier;
+    private readonly IGlobalLoadingWindow loadingWindow;
     private static long attackMissionStartSequence;
 
     // Server-side: the complete mission initializer chosen once per map event and reused for late entrants.
@@ -69,6 +70,9 @@ internal class BattleMissionStartHandler : IHandler
     // Client-side, game-thread only: the map event whose attack-mission open is deferred until the battle
     // graph commits. Non-null means the loading window is up waiting for that commit.
     private string deferredAttackMissionMapEventId;
+    private bool disposed;
+
+    internal string DeferredAttackMissionMapEventId => deferredAttackMissionMapEventId;
 
     public BattleMissionStartHandler(
         IMessageBroker messageBroker,
@@ -77,7 +81,8 @@ internal class BattleMissionStartHandler : IHandler
         INetwork network,
         IMapEventLogger mapEventLogger,
         IBattleMissionInitializerResolver missionInitializerResolver,
-        IMapEventInitializationBarrier initializationBarrier)
+        IMapEventInitializationBarrier initializationBarrier,
+        IGlobalLoadingWindow loadingWindow)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -86,6 +91,7 @@ internal class BattleMissionStartHandler : IHandler
         this.mapEventLogger = mapEventLogger;
         this.missionInitializerResolver = missionInitializerResolver;
         this.initializationBarrier = initializationBarrier;
+        this.loadingWindow = loadingWindow;
 
         messageBroker.Subscribe<NetworkBattleStartRequest>(Handle_NetworkBattleStartRequest);
         messageBroker.Subscribe<NetworkStartAttackMission>(Handle_NetworkStartAttackMission);
@@ -96,6 +102,16 @@ internal class BattleMissionStartHandler : IHandler
 
     public void Dispose()
     {
+        disposed = true;
+
+        // A deferred open still holds the loading window up; drop it here so the window
+        // doesn't outlive the handler when the scope disposes before the barrier commits.
+        if (deferredAttackMissionMapEventId != null)
+        {
+            deferredAttackMissionMapEventId = null;
+            loadingWindow.Disable();
+        }
+
         messageBroker.Unsubscribe<NetworkBattleStartRequest>(Handle_NetworkBattleStartRequest);
         messageBroker.Unsubscribe<NetworkStartAttackMission>(Handle_NetworkStartAttackMission);
         messageBroker.Unsubscribe<NetworkStartSiegeMission>(Handle_NetworkStartSiegeMission);
@@ -460,7 +476,7 @@ internal class BattleMissionStartHandler : IHandler
             return;
         }
 
-        LoadingWindow.EnableGlobalLoadingWindow();
+        loadingWindow.Enable();
         LogAttackMissionLifecycle("queued", sequence, message.MapEventId);
 
         // Opening before the defender side graph commits leaves CoopTroopSupplier with no troops to deploy
@@ -480,13 +496,18 @@ internal class BattleMissionStartHandler : IHandler
 
     private void OpenQueuedAttackMission(NetworkStartAttackMission message, long sequence)
     {
+        // A barrier RunAfterCommit callback can fire after the scope disposed this handler; opening a
+        // mission on a dead handler is a no-op, and Dispose already dropped the loading window.
+        if (disposed)
+            return;
+
         deferredAttackMissionMapEventId = null;
         LogAttackMissionLifecycle("executing queued open", sequence, message.MapEventId);
         OpenAttackMission(message.MapEventId, message.MissionInitializer,
             message.InitiatingPartyId, sequence);
 
         if (MissionState.Current == null)
-            LoadingWindow.DisableGlobalLoadingWindow();
+            loadingWindow.Disable();
     }
 
     // A deferred open's RunAfterCommit callback is dropped when the barrier aborts and destroys the graph
@@ -506,7 +527,7 @@ internal class BattleMissionStartHandler : IHandler
         {
             case DeferredOpenAction.Abandon:
                 deferredAttackMissionMapEventId = null;
-                LoadingWindow.DisableGlobalLoadingWindow();
+                loadingWindow.Disable();
                 break;
             case DeferredOpenAction.Clear:
                 deferredAttackMissionMapEventId = null;

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleMissionStartHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleMissionStartHandler.cs
@@ -4,11 +4,13 @@ using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.MapEvents.Extensions;
+using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MapEvents.Messages.Leave;
 using GameInterface.Services.MapEvents.Messages.Start;
 using GameInterface.Services.MapEvents.Patches;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.PlayerCaptivityService.Messages;
 using GameInterface.Services.Players;
 using LiteNetLib;
 using Serilog;
@@ -51,6 +53,7 @@ internal class BattleMissionStartHandler : IHandler
     private readonly INetwork network;
     private readonly IMapEventLogger mapEventLogger;
     private readonly IBattleMissionInitializerResolver missionInitializerResolver;
+    private readonly IMapEventInitializationBarrier initializationBarrier;
     private static long attackMissionStartSequence;
 
     // Server-side: the complete mission initializer chosen once per map event and reused for late entrants.
@@ -63,13 +66,18 @@ internal class BattleMissionStartHandler : IHandler
     // container keeps syncing. Evicted with the terrain seed when the event finalizes.
     private readonly ConcurrentDictionary<string, NetworkStartSiegeMission> siegeMissionSnapshots = new ConcurrentDictionary<string, NetworkStartSiegeMission>();
 
+    // Client-side, game-thread only: the map event whose attack-mission open is deferred until the battle
+    // graph commits. Non-null means the loading window is up waiting for that commit.
+    private string deferredAttackMissionMapEventId;
+
     public BattleMissionStartHandler(
         IMessageBroker messageBroker,
         IObjectManager objectManager,
         IPlayerManager playerManager,
         INetwork network,
         IMapEventLogger mapEventLogger,
-        IBattleMissionInitializerResolver missionInitializerResolver)
+        IBattleMissionInitializerResolver missionInitializerResolver,
+        IMapEventInitializationBarrier initializationBarrier)
     {
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
@@ -77,11 +85,13 @@ internal class BattleMissionStartHandler : IHandler
         this.network = network;
         this.mapEventLogger = mapEventLogger;
         this.missionInitializerResolver = missionInitializerResolver;
+        this.initializationBarrier = initializationBarrier;
 
         messageBroker.Subscribe<NetworkBattleStartRequest>(Handle_NetworkBattleStartRequest);
         messageBroker.Subscribe<NetworkStartAttackMission>(Handle_NetworkStartAttackMission);
         messageBroker.Subscribe<NetworkStartSiegeMission>(Handle_NetworkStartSiegeMission);
         messageBroker.Subscribe<MapEventFinalized>(Handle_MapEventFinalized);
+        messageBroker.Subscribe<CampaignTick>(Handle_CampaignTick);
     }
 
     public void Dispose()
@@ -90,6 +100,7 @@ internal class BattleMissionStartHandler : IHandler
         messageBroker.Unsubscribe<NetworkStartAttackMission>(Handle_NetworkStartAttackMission);
         messageBroker.Unsubscribe<NetworkStartSiegeMission>(Handle_NetworkStartSiegeMission);
         messageBroker.Unsubscribe<MapEventFinalized>(Handle_MapEventFinalized);
+        messageBroker.Unsubscribe<CampaignTick>(Handle_CampaignTick);
     }
 
     /// <summary>The battle ended — drop its cached mission inputs (server-side; a no-op on a client's empty maps).</summary>
@@ -443,7 +454,7 @@ internal class BattleMissionStartHandler : IHandler
 
     private void ShowLoadingScreenAndQueueAttackMission(NetworkStartAttackMission message, long sequence)
     {
-        if (!TryGetValidBattle(nameof(NetworkStartAttackMission), message.MapEventId, out _))
+        if (!TryGetValidBattle(nameof(NetworkStartAttackMission), message.MapEventId, out var battle))
         {
             LogAttackMissionLifecycle("rejected before queue", sequence, message.MapEventId);
             return;
@@ -452,17 +463,55 @@ internal class BattleMissionStartHandler : IHandler
         LoadingWindow.EnableGlobalLoadingWindow();
         LogAttackMissionLifecycle("queued", sequence, message.MapEventId);
 
+        // Opening before the defender side graph commits leaves CoopTroopSupplier with no troops to deploy
+        // and the loading screen never clears, so wait for the barrier's commit while the event is pending.
+        if (initializationBarrier.IsPending(battle))
+        {
+            deferredAttackMissionMapEventId = message.MapEventId;
+            initializationBarrier.RunAfterCommit(battle, () => OpenQueuedAttackMission(message, sequence));
+            return;
+        }
+
         // MissionState enables the loading window only after building every mission behavior.
         // Defer that work one frame so the window is rendered before setup can stall the map.
-        GameThread.EnqueueSafe(() =>
-        {
-            LogAttackMissionLifecycle("executing queued open", sequence, message.MapEventId);
-            OpenAttackMission(message.MapEventId, message.MissionInitializer,
-                message.InitiatingPartyId, sequence);
+        GameThread.EnqueueSafe(() => OpenQueuedAttackMission(message, sequence),
+            context: nameof(Handle_NetworkStartAttackMission));
+    }
 
-            if (MissionState.Current == null)
+    private void OpenQueuedAttackMission(NetworkStartAttackMission message, long sequence)
+    {
+        deferredAttackMissionMapEventId = null;
+        LogAttackMissionLifecycle("executing queued open", sequence, message.MapEventId);
+        OpenAttackMission(message.MapEventId, message.MissionInitializer,
+            message.InitiatingPartyId, sequence);
+
+        if (MissionState.Current == null)
+            LoadingWindow.DisableGlobalLoadingWindow();
+    }
+
+    // A deferred open's RunAfterCommit callback is dropped when the barrier aborts and destroys the graph
+    // (a contested raid whose defense event never completes), which would strand the loading window; once
+    // the battle is gone, abandon the open so the client returns to the map instead of hanging.
+    private void Handle_CampaignTick(MessagePayload<CampaignTick> payload)
+    {
+        var deferredMapEventId = deferredAttackMissionMapEventId;
+        if (deferredMapEventId == null)
+            return;
+
+        bool missionOpen = MissionState.Current != null;
+        bool battleStillValid = !missionOpen &&
+            TryGetValidBattle(nameof(CampaignTick), deferredMapEventId, out _);
+
+        switch (DecideDeferredOpenAction(missionOpen, battleStillValid))
+        {
+            case DeferredOpenAction.Abandon:
+                deferredAttackMissionMapEventId = null;
                 LoadingWindow.DisableGlobalLoadingWindow();
-        }, context: nameof(Handle_NetworkStartAttackMission));
+                break;
+            case DeferredOpenAction.Clear:
+                deferredAttackMissionMapEventId = null;
+                break;
+        }
     }
 
     /// <summary>[Server] Snapshot the mission-defining siege inputs for one map event.</summary>
@@ -736,5 +785,23 @@ internal class BattleMissionStartHandler : IHandler
     {
         return !isPlayerWounded ||
                (localPartyId != null && string.Equals(localPartyId, initiatingPartyId, StringComparison.Ordinal));
+    }
+
+    internal enum DeferredOpenAction
+    {
+        Keep,
+        Clear,
+        Abandon,
+    }
+
+    /// <summary>[Client] Fate of a deferred attack-mission open re-checked on a later tick: keep waiting while
+    /// the battle is still valid, clear once a mission has opened, or abandon (dropping the loading window)
+    /// once the battle graph is gone.</summary>
+    internal static DeferredOpenAction DecideDeferredOpenAction(bool missionOpen, bool battleStillValid)
+    {
+        if (missionOpen)
+            return DeferredOpenAction.Clear;
+
+        return battleStillValid ? DeferredOpenAction.Keep : DeferredOpenAction.Abandon;
     }
 }

--- a/source/GameInterface/Services/UI/Interfaces/GlobalLoadingWindow.cs
+++ b/source/GameInterface/Services/UI/Interfaces/GlobalLoadingWindow.cs
@@ -1,0 +1,19 @@
+﻿using TaleWorlds.Engine;
+
+namespace GameInterface.Services.UI.Interfaces;
+
+// Raw seam over the engine's global loading window toggles. Deliberately does NOT touch
+// LoadingWindowPatches.ForceLoadingWindow the way ILoadingInterface does, so a Disable here
+// is not suppressed and the battle mission's own load-completion disable (MissionPatches)
+// still clears the window once the loaded battle is running.
+public interface IGlobalLoadingWindow : IGameAbstraction
+{
+    void Enable();
+    void Disable();
+}
+
+internal sealed class GlobalLoadingWindow : IGlobalLoadingWindow
+{
+    public void Enable() => LoadingWindow.EnableGlobalLoadingWindow();
+    public void Disable() => LoadingWindow.DisableGlobalLoadingWindow();
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Raiding a village that resists (militia and villagers fight back, so the raid becomes a defense battle) can hang the client on the battle loading screen while the campaign keeps ticking underneath. The client log floods with `Failed to get TroopRoster using MapEventParty_Created_<id>_(DiedInBattle|WoundedInBattle|RoutedInBattle)`. This is the raid counterpart of the siege battle-launch races (sibling of #3253).

`BattleMissionStartHandler` opens the attack mission as soon as `NetworkStartAttackMission` arrives, gated only by `TryGetValidBattle`, which checks the local party side membership but not that the opponent (defender) side graph has committed on the client. `CoopTroopSupplier` then has no defender parties to deploy, deployment never completes, and the loading window never clears.

## What is the new behavior?

`ShowLoadingScreenAndQueueAttackMission` checks `initializationBarrier.IsPending(battle)`. While the event is still pending it defers the open through `IMapEventInitializationBarrier.RunAfterCommit`, so the mission opens only after the defender `MapEventParty` graph commits and `CoopTroopSupplier` has real parties to deploy. Already-committed events open immediately as before, so field battles and other already-synced paths are unchanged.

A `CampaignTick` safety net abandons the deferred open and disables the loading window if the graph is aborted and destroyed (the `RunAfterCommit` callback is dropped in that case), so a never-committing event returns to the map instead of hanging. The decision is the pure `DecideDeferredOpenAction`, covered by a theory matrix in `BattleMissionStartHandlerTests`.

## Bot Changelog Entry

- Fixed the loading screen hanging when raiding a village that fights back.

## Other information

Scoped to the attack-mission open. It does not touch the encounter-menu "Attack!" gating (that belongs with #3253) or the tally-roster client registration gap behind the `Failed to get TroopRoster` spam.

Manual in-game validation is still pending: raid a resisting village as a client and confirm `Coop_client.log` shows `Attack mission queued` then a delayed `executing queued open` after the commit, no `Failed to get TroopRoster ... MapEventParty_Created_*` flood, and the defense mission loads. Unit tests pass: `dotnet test GameInterface.Tests --filter BattleMissionStartHandlerTests` (5 of 5).
