### PR TITLE
Give the kingdom decision screen an exit on every resolution path

### DIFF
--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecisionScreenLifecycleTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecisionScreenLifecycleTests.cs
@@ -1,0 +1,241 @@
+﻿using Autofac;
+using Common.Messaging;
+using Common.Util;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Patches;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using Moq;
+using System;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
+using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.ItemTypes;
+using TaleWorlds.Library;
+using Xunit;
+using CampaignKingdomDecision = TaleWorlds.CampaignSystem.Election.KingdomDecision;
+
+namespace GameInterface.Tests.Services.Kingdoms;
+
+/// <summary>
+/// The server owns kingdom decision resolution, so the patches never hand a decision screen back to
+/// native resolution, and the vote manager only closes screens whose decision the server already took.
+/// </summary>
+public class KingdomDecisionScreenLifecycleTests
+{
+    private const string KingdomId = "kingdom-1";
+    private const string OtherKingdomId = "kingdom-2";
+
+    private static readonly FieldInfo ElectionDecisionField = typeof(KingdomElection).GetField(
+        "_decision",
+        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+    [Fact]
+    public void ExecuteFinalSelection_EligiblePlayerVotes_LeavesResolutionToTheServer()
+    {
+        var decisionItem = ObjectHelper.SkipConstructor<SettlementDecisionItemVM>();
+        var voteManager = new Mock<IKingdomDecisionVoteManager>();
+        voteManager.Setup(manager => manager.IsLocalPlayerEligible(decisionItem)).Returns(true);
+        voteManager.Setup(manager => manager.TryPublishFinalVote(decisionItem)).Returns(true);
+
+        bool runOriginal = RunWithVoteManager(
+            voteManager.Object,
+            () => DecisionItemBaseVMPatches.ExecuteFinalSelectionPrefix(decisionItem));
+
+        Assert.False(runOriginal);
+        voteManager.Verify(manager => manager.TryPublishFinalVote(decisionItem), Times.Once);
+        voteManager.Verify(manager => manager.CloseDecisionItem(It.IsAny<DecisionItemBaseVM>()), Times.Never);
+    }
+
+    [Fact]
+    public void ExecuteFinalSelection_VoteCannotBeRouted_ClosesTheScreenInsteadOfResolvingLocally()
+    {
+        var decisionItem = ObjectHelper.SkipConstructor<SettlementDecisionItemVM>();
+        var voteManager = new Mock<IKingdomDecisionVoteManager>();
+        voteManager.Setup(manager => manager.IsLocalPlayerEligible(decisionItem)).Returns(true);
+        voteManager.Setup(manager => manager.TryPublishFinalVote(decisionItem)).Returns(false);
+
+        bool runOriginal = RunWithVoteManager(
+            voteManager.Object,
+            () => DecisionItemBaseVMPatches.ExecuteFinalSelectionPrefix(decisionItem));
+
+        Assert.False(runOriginal);
+        voteManager.Verify(manager => manager.TryPublishFinalVote(decisionItem), Times.Once);
+        voteManager.Verify(manager => manager.CloseDecisionItem(decisionItem), Times.Once);
+    }
+
+    [Fact]
+    public void ExecuteFinalSelection_IneligiblePlayer_ClosesTheScreenWithoutVoting()
+    {
+        var decisionItem = ObjectHelper.SkipConstructor<SettlementDecisionItemVM>();
+        var voteManager = new Mock<IKingdomDecisionVoteManager>();
+        voteManager.Setup(manager => manager.IsLocalPlayerEligible(decisionItem)).Returns(false);
+
+        bool runOriginal = RunWithVoteManager(
+            voteManager.Object,
+            () => DecisionItemBaseVMPatches.ExecuteFinalSelectionPrefix(decisionItem));
+
+        Assert.False(runOriginal);
+        voteManager.Verify(manager => manager.TryPublishFinalVote(It.IsAny<DecisionItemBaseVM>()), Times.Never);
+        voteManager.Verify(manager => manager.CloseDecisionItem(decisionItem), Times.Once);
+    }
+
+    [Fact]
+    public void RefreshWith_SuppressedDecision_DoesNotOpenAScreen()
+    {
+        var decisionsVm = ObjectHelper.SkipConstructor<KingdomDecisionsVM>();
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        var voteManager = new Mock<IKingdomDecisionVoteManager>();
+        voteManager.Setup(manager => manager.ShouldSuppressLocalDecision(decision)).Returns(true);
+
+        bool runOriginal = RunWithVoteManager(
+            voteManager.Object,
+            () => KingdomDecisionsVMPatches.RefreshWithPrefix(decisionsVm, decision));
+
+        Assert.False(runOriginal);
+        Assert.Null(decisionsVm.CurrentDecision);
+    }
+
+    [Fact]
+    public void RefreshWith_UnsuppressedDecision_RunsNativeRefresh()
+    {
+        var decisionsVm = ObjectHelper.SkipConstructor<KingdomDecisionsVM>();
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        var voteManager = new Mock<IKingdomDecisionVoteManager>();
+        voteManager.Setup(manager => manager.ShouldSuppressLocalDecision(decision)).Returns(false);
+
+        bool runOriginal = RunWithVoteManager(
+            voteManager.Object,
+            () => KingdomDecisionsVMPatches.RefreshWithPrefix(decisionsVm, decision));
+
+        Assert.True(runOriginal);
+    }
+
+    [Fact]
+    public void IsOrphanedSubmittedDecisionItem_SecondSubmittedScreenInTheKingdom_SurvivesWhileItsDecisionStands()
+    {
+        Kingdom kingdom = CreateKingdom();
+        CampaignKingdomDecision liveDecision = CreateDecision(kingdom);
+        CampaignKingdomDecision takenDecision = CreateDecision(kingdom);
+        kingdom._unresolvedDecisions.Add(liveDecision);
+
+        using var voteManager = CreateVoteManager(CreateObjectManager(kingdom));
+
+        Assert.True(voteManager.IsOrphanedSubmittedDecisionItem(CreateDecisionItem(takenDecision, true), KingdomId));
+        Assert.False(voteManager.IsOrphanedSubmittedDecisionItem(CreateDecisionItem(liveDecision, true), KingdomId));
+    }
+
+    [Fact]
+    public void IsOrphanedSubmittedDecisionItem_ScreenStillBeingVotedOn_IsLeftOpen()
+    {
+        Kingdom kingdom = CreateKingdom();
+        CampaignKingdomDecision takenDecision = CreateDecision(kingdom);
+
+        using var voteManager = CreateVoteManager(CreateObjectManager(kingdom));
+
+        Assert.False(voteManager.IsOrphanedSubmittedDecisionItem(CreateDecisionItem(takenDecision, false), KingdomId));
+    }
+
+    [Fact]
+    public void IsOrphanedSubmittedDecisionItem_ScreenForAnotherKingdom_IsLeftOpen()
+    {
+        Kingdom kingdom = CreateKingdom();
+        CampaignKingdomDecision takenDecision = CreateDecision(kingdom);
+
+        using var voteManager = CreateVoteManager(CreateObjectManager(kingdom));
+
+        Assert.False(voteManager.IsOrphanedSubmittedDecisionItem(CreateDecisionItem(takenDecision, true), OtherKingdomId));
+    }
+
+    [Fact]
+    public void IsLocalPlayerEligible_ScreenWithoutAnElection_IsNotEligible()
+    {
+        using var voteManager = CreateVoteManager(new Mock<IObjectManager>().Object);
+
+        Assert.False(voteManager.IsLocalPlayerEligible(null!));
+        Assert.False(voteManager.IsLocalPlayerEligible(ObjectHelper.SkipConstructor<SettlementDecisionItemVM>()));
+    }
+
+    [Fact]
+    public void IsLocalPlayerEligible_ElectionWithoutADecision_IsNotEligible()
+    {
+        using var voteManager = CreateVoteManager(new Mock<IObjectManager>().Object);
+        var decisionItem = ObjectHelper.SkipConstructor<SettlementDecisionItemVM>();
+        decisionItem.KingdomDecisionMaker = ObjectHelper.SkipConstructor<KingdomElection>();
+
+        Assert.False(voteManager.IsLocalPlayerEligible(decisionItem));
+    }
+
+    private static Kingdom CreateKingdom()
+    {
+        var kingdom = ObjectHelper.SkipConstructor<Kingdom>();
+        kingdom._unresolvedDecisions = new MBList<CampaignKingdomDecision>();
+        return kingdom;
+    }
+
+    private static CampaignKingdomDecision CreateDecision(Kingdom kingdom)
+    {
+        var decision = ObjectHelper.SkipConstructor<SettlementClaimantDecision>();
+        decision._kingdom = kingdom;
+        return decision;
+    }
+
+    private static DecisionItemBaseVM CreateDecisionItem(CampaignKingdomDecision decision, bool finalSelectionDone)
+    {
+        var election = ObjectHelper.SkipConstructor<KingdomElection>();
+        // the election constructor needs a live campaign and _decision is readonly, so seed the field
+        ElectionDecisionField.SetValue(election, decision);
+
+        var decisionItem = ObjectHelper.SkipConstructor<SettlementDecisionItemVM>();
+        decisionItem.KingdomDecisionMaker = election;
+        decisionItem._finalSelectionDone = finalSelectionDone;
+        return decisionItem;
+    }
+
+    private static IObjectManager CreateObjectManager(Kingdom kingdom)
+    {
+        var objectManager = new Mock<IObjectManager>();
+        string kingdomId = KingdomId;
+        objectManager.Setup(manager => manager.TryGetId(kingdom, out kingdomId)).Returns(true);
+        return objectManager.Object;
+    }
+
+    private static KingdomDecisionVoteManager CreateVoteManager(IObjectManager objectManager)
+    {
+        return new KingdomDecisionVoteManager(
+            new Mock<IPlayerManager>().Object,
+            objectManager,
+            new Mock<IMessageBroker>().Object,
+            new Mock<IKingdomDecisionOutcomeResolver>().Object,
+            new Mock<IKingdomDecisionOutcomeOrder>().Object,
+            new Mock<IKingdomDecisionRoundPresentation>().Object);
+    }
+
+    private static bool RunWithVoteManager(IKingdomDecisionVoteManager voteManager, Func<bool> act)
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(voteManager).As<IKingdomDecisionVoteManager>();
+        using var container = builder.Build();
+
+        bool hadPreviousContainer = ContainerProvider.TryGetContainer(out var previousContainer);
+        try
+        {
+            using (ContainerProvider.UseContainerThreadSafe(container))
+            {
+                return act();
+            }
+        }
+        finally
+        {
+            if (hadPreviousContainer)
+            {
+                ContainerProvider.SetContainer(previousContainer);
+            }
+            else
+            {
+                ContainerProvider.Clear();
+            }
+        }
+    }
+}

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -44,7 +44,7 @@ namespace GameInterface.Services.Kingdoms
         bool ShouldSuppressLocalDecision(KingdomDecision decision);
         bool ShouldDisableResolveDecision(KingdomDecision decision);
         bool HasLocalPlayerSubmittedVote(KingdomDecision decision);
-        bool ShouldBlockLocalResolution(DecisionItemBaseVM decisionItem);
+        bool IsLocalPlayerEligible(DecisionItemBaseVM decisionItem);
         void RegisterDecisionItem(DecisionItemBaseVM decisionItem);
         void UnregisterDecisionItem(DecisionItemBaseVM decisionItem);
         bool HandleVoteRequest(string controllerId, KingdomDecisionVoteData voteData);
@@ -213,7 +213,9 @@ namespace GameInterface.Services.Kingdoms
 
             if (!TryCreateVoteData(decisionItem, out KingdomDecisionVoteData voteData, isFinal: true))
             {
-                Logger.Warning("Unable to publish final kingdom decision vote from the local decision UI.");
+                Logger.Warning(
+                    "Unable to route the final kingdom decision vote for {DecisionType}, so the screen closes without recording one.",
+                    decisionItem.KingdomDecisionMaker?._decision?.GetType().Name);
                 return false;
             }
 
@@ -393,18 +395,11 @@ namespace GameInterface.Services.Kingdoms
                    roundClan.HasFinalVote;
         }
 
-        public bool ShouldBlockLocalResolution(DecisionItemBaseVM decisionItem)
+        public bool IsLocalPlayerEligible(DecisionItemBaseVM decisionItem)
         {
             if (decisionItem == null || decisionItem.KingdomDecisionMaker == null) return false;
-            KingdomDecision decision = decisionItem.KingdomDecisionMaker._decision;
-            if (decision == null || Clan.PlayerClan == null) return false;
 
-            if (DecisionStates.TryGetValue(decision, out KingdomDecisionVoteState state) && state.HasRoundSnapshot)
-            {
-                return Clan.PlayerClan.Kingdom == decision.Kingdom;
-            }
-
-            return IsLocalPlayerEligible(decision);
+            return IsLocalPlayerEligible(decisionItem.KingdomDecisionMaker._decision);
         }
 
         public void RegisterDecisionItem(DecisionItemBaseVM decisionItem)
@@ -574,7 +569,12 @@ namespace GameInterface.Services.Kingdoms
         {
             if (!TryGetDecision(kingdomId, decisionIndex, out KingdomDecision decision))
             {
+                Logger.Warning(
+                    "Resolved decision {DecisionIndex} for kingdom {KingdomId} is missing from the local unresolved decisions, so it cant be concluded here.",
+                    decisionIndex,
+                    kingdomId);
                 PublishDecisionNotification(notificationText);
+                CloseOrphanedDecisionItems(kingdomId);
                 return;
             }
             KingdomDecisionVoteState state = GetOrCreateState(decision);
@@ -588,7 +588,13 @@ namespace GameInterface.Services.Kingdoms
                 outcomeKey);
             if (!outcomeResolver.TryGetOutcome(voteData, state.Election, objectManager, out DecisionOutcome outcome))
             {
+                Logger.Warning(
+                    "Resolved outcome {OutcomeIndex} for kingdom {KingdomId} decision {DecisionIndex} has no local match, so it cant be concluded here.",
+                    outcomeIndex,
+                    kingdomId,
+                    decisionIndex);
                 PublishDecisionNotification(notificationText);
+                CloseOrphanedDecisionItems(kingdomId);
                 return;
             }
 
@@ -683,12 +689,39 @@ namespace GameInterface.Services.Kingdoms
 
         private void CloseDecision(KingdomDecision decision)
         {
-            foreach (DecisionItemBaseVM decisionItem in ActiveDecisionItems
-                         .Where(item => item?.KingdomDecisionMaker?._decision == decision)
-                         .ToList())
+            CloseDecisionItems(item => item?.KingdomDecisionMaker?._decision == decision);
+        }
+
+        private void CloseOrphanedDecisionItems(string kingdomId)
+        {
+            if (string.IsNullOrWhiteSpace(kingdomId)) return;
+
+            CloseDecisionItems(item => IsOrphanedSubmittedDecisionItem(item, kingdomId));
+        }
+
+        // A resolve that cant be matched to a local decision still has to close a screen whose final vote is
+        // already in, otherwise that screen has no exit left. The decision also has to be gone from the kingdom,
+        // otherwise a second submitted screen closes while the server is still working on it.
+        internal bool IsOrphanedSubmittedDecisionItem(DecisionItemBaseVM decisionItem, string kingdomId)
+        {
+            return decisionItem != null &&
+                   decisionItem._finalSelectionDone &&
+                   IsDecisionItemForKingdom(decisionItem, kingdomId) &&
+                   !IsDecisionUnresolved(decisionItem.KingdomDecisionMaker?._decision);
+        }
+
+        private void CloseDecisionItems(Func<DecisionItemBaseVM, bool> predicate)
+        {
+            foreach (DecisionItemBaseVM decisionItem in ActiveDecisionItems.Where(predicate).ToList())
             {
                 CloseDecisionItem(decisionItem);
             }
+        }
+
+        private bool IsDecisionItemForKingdom(DecisionItemBaseVM decisionItem, string kingdomId)
+        {
+            return TryGetKingdomId(decisionItem.KingdomDecisionMaker?._decision?.Kingdom, out string itemKingdomId) &&
+                   itemKingdomId == kingdomId;
         }
 
         private void RemoveDecisionState(KingdomDecision decision)

--- a/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/KingdomDecisionVMPatches.cs
@@ -76,7 +76,7 @@ namespace GameInterface.Services.Kingdoms.Patches
         // Bypass vanilla's single-clan shortcut so the receiving player gets the normal peace decision UI and vote.
         [HarmonyPatch(typeof(KingdomDecisionsVM), nameof(KingdomDecisionsVM.RefreshWith))]
         [HarmonyPrefix]
-        private static bool RefreshWithPrefix(KingdomDecisionsVM __instance, KingdomDecision decision)
+        internal static bool RefreshWithPrefix(KingdomDecisionsVM __instance, KingdomDecision decision)
         {
             if ((CoopKingdomElection.IsPendingPlayerPeaceOffer(decision) || CoopKingdomElection.IsPendingPlayerAllianceOffer(decision)) && decision.IsSingleClanDecision())
             {
@@ -87,7 +87,10 @@ namespace GameInterface.Services.Kingdoms.Patches
                 __instance.CurrentDecision.SetDoneInputKey(__instance.DoneInputKey);
                 return false;
             }
-            return true;
+
+            // KingdomManagementVM.ForceDecideDecision reaches RefreshWith without going through HandleDecision,
+            // so gate a suppressed decision here too, otherwise it opens a screen the local clan cant vote on.
+            return !TryGetVoteManager(out var voteManager) || !voteManager.ShouldSuppressLocalDecision(decision);
         }
     }
 
@@ -105,12 +108,18 @@ namespace GameInterface.Services.Kingdoms.Patches
 
         [HarmonyPatch(nameof(DecisionItemBaseVM.ExecuteFinalSelection))]
         [HarmonyPrefix]
-        private static bool ExecuteFinalSelectionPrefix(DecisionItemBaseVM __instance)
+        internal static bool ExecuteFinalSelectionPrefix(DecisionItemBaseVM __instance)
         {
             if (!KingdomDecisionsVMPatches.TryGetVoteManager(out var voteManager)) return true;
-            if (!voteManager.ShouldBlockLocalResolution(__instance)) return true;
 
-            voteManager.TryPublishFinalVote(__instance);
+            if (voteManager.IsLocalPlayerEligible(__instance) && voteManager.TryPublishFinalVote(__instance))
+            {
+                return false;
+            }
+
+            // native resolution applies an AI outcome locally for a clan that cant vote and records an abstain
+            // nobody picked when the vote wont route, so close the screen instead of falling through to it
+            voteManager.CloseDecisionItem(__instance);
             return false;
         }
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The client kingdom decision screen has exactly one exit, a server resolve message, and several paths skip it. A failed final vote publish is discarded and the screen stays open with every option disabled. A vassal whose clan is not in the round snapshot gets a screen where every click silently fails and Done does nothing. A server resolve that cannot be matched to a local decision publishes the notification but never closes the screen. The player ends up on a locked modal with ESC dead and `coop.unstuck` does not help.

## What is the new behavior?

Resolves #3300

The Done click publishes the final vote when the local player is eligible and the vote routes, and otherwise closes the decision item instead of falling through to native resolution. Falling through was not an option: native `ApplySelection` on an ineligible clan applies an AI picked outcome locally, and for a claimant preliminary decision that outcome publishes a new decision back to the server. The `RefreshWith` path is now gated by the same suppression check as `HandleDecision`, with the pending peace and alliance offer bypass running first so an offer target still gets its screen. When a resolve cannot be matched, submitted screens whose decision left the unresolved list are closed and the miss is logged as a desync signal.

Manual check: on the server `coop.debug.kingdom.add_decision`, on a client `coop.debug.kingdom.open_decision`, pick an option and confirm. Before, the screen locks. After, it closes, and `coop.debug.kingdom.screen_state` shows `decisionActive=False`.

## Bot Changelog Entry

- Fixed the kingdom decision screen locking up and blocking all input after voting.

## Other information

Unit tests cover the patch prefixes and the orphan close predicate, including the case where one submitted screen belongs to a still unresolved decision and survives. The `RegisterDecisionItem` early out from branch 3268 is deliberately not duplicated here.
