### PR TITLE
Hold kingdom voting rounds while an eligible voter is in a battle

### DIFF
--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomDecisionVoteManagerTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomDecisionVoteManagerTests.cs
@@ -1,0 +1,122 @@
+﻿using Common.Messaging;
+using Common.Util;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using Moq;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Kingdoms;
+
+public class KingdomDecisionVoteManagerTests : IDisposable
+{
+    private static readonly ICollection<string> NoFinalVotes = new HashSet<string>();
+
+    private readonly Mock<IObjectManager> objectManager = new();
+    private readonly KingdomDecisionVoteManager manager;
+
+    public KingdomDecisionVoteManagerTests()
+    {
+        manager = new KingdomDecisionVoteManager(
+            Mock.Of<IPlayerManager>(),
+            objectManager.Object,
+            Mock.Of<IMessageBroker>(),
+            Mock.Of<IKingdomDecisionOutcomeResolver>(),
+            Mock.Of<IKingdomDecisionOutcomeOrder>(),
+            Mock.Of<IKingdomDecisionRoundPresentation>(),
+            Mock.Of<IKingdomVotingRoundClock>());
+    }
+
+    public void Dispose()
+    {
+        manager.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void IsPendingVoter_HoldsForAVoterWhoseClanStillOwesAVote()
+    {
+        Player voter = PlayerInClan("voter", "clan_a");
+
+        Assert.True(manager.IsPendingVoter(new[] { "clan_a" }, NoFinalVotes, null, voter));
+    }
+
+    [Fact]
+    public void IsPendingVoter_DoesNotHoldForAClanThatAlreadyCastItsFinalVote()
+    {
+        Player voter = PlayerInClan("voter", "clan_a");
+
+        Assert.False(manager.IsPendingVoter(new[] { "clan_a" }, FinalVotesFor("clan_a"), null, voter));
+        objectManager.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void IsPendingVoter_DoesNotHoldOnceEveryEligibleClanHasVoted()
+    {
+        Player voter = PlayerInClan("voter", "clan_a");
+
+        Assert.False(manager.IsPendingVoter(
+            new[] { "clan_a", "clan_b" },
+            FinalVotesFor("clan_a", "clan_b"),
+            null,
+            voter));
+        objectManager.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void IsPendingVoter_StillHoldsForAnEligibleClanThatHasNotVoted()
+    {
+        string[] eligibleClanIds = { "clan_a", "clan_b" };
+        ICollection<string> finalVotes = FinalVotesFor("clan_a");
+
+        Assert.False(manager.IsPendingVoter(eligibleClanIds, finalVotes, null, PlayerInClan("voted", "clan_a")));
+        Assert.True(manager.IsPendingVoter(eligibleClanIds, finalVotes, null, PlayerInClan("pending", "clan_b")));
+    }
+
+    [Fact]
+    public void IsPendingVoter_ResolvesAVoterRegisteredUnderANonCanonicalClanId()
+    {
+        RegisterClan("registered_clan_a", "clan_a");
+        Player voter = PlayerInClan("voter", "registered_clan_a");
+
+        Assert.True(manager.IsPendingVoter(new[] { "clan_a" }, NoFinalVotes, null, voter));
+        Assert.False(manager.IsPendingVoter(new[] { "clan_a" }, FinalVotesFor("clan_a"), null, voter));
+    }
+
+    [Fact]
+    public void IsPendingVoter_DoesNotHoldForAPlayerOutsideTheEligibleClans()
+    {
+        RegisterClan("clan_b", "clan_b");
+        Player outsider = PlayerInClan("outsider", "clan_b");
+
+        Assert.False(manager.IsPendingVoter(new[] { "clan_a" }, NoFinalVotes, null, outsider));
+    }
+
+    [Fact]
+    public void IsPendingVoter_DoesNotHoldForAPlayerWithNoClan()
+    {
+        Assert.False(manager.IsPendingVoter(new[] { "clan_a" }, NoFinalVotes, null, PlayerInClan("wanderer", null)));
+        Assert.False(manager.IsPendingVoter(new[] { "clan_a" }, NoFinalVotes, null, null));
+    }
+
+    private static Player PlayerInClan(string controllerId, string clanId)
+    {
+        return new Player(controllerId, null, $"{controllerId}-party", clanId, null);
+    }
+
+    private static ICollection<string> FinalVotesFor(params string[] clanIds)
+    {
+        return new HashSet<string>(clanIds);
+    }
+
+    private void RegisterClan(string registeredClanId, string canonicalClanId)
+    {
+        Clan clan = ObjectHelper.SkipConstructor<Clan>();
+        objectManager.Setup(objects => objects.TryGetObject(registeredClanId, out clan)).Returns(true);
+        objectManager.Setup(objects => objects.TryGetId(clan, out canonicalClanId)).Returns(true);
+    }
+}

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomVotingRoundClockTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomVotingRoundClockTests.cs
@@ -1,0 +1,155 @@
+﻿using GameInterface.Services.Kingdoms;
+using System;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Kingdoms;
+
+public class KingdomVotingRoundClockTests
+{
+    private static readonly DateTime RoundStartedUtc = new(2026, 8, 25, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan RoundDuration = KingdomDecisionVoteManager.VotingRoundDuration;
+    private static readonly TimeSpan HoldMaximum = KingdomDecisionVoteManager.VotingRoundBattleHoldMaximum;
+    private static readonly DateTime HoldLimitUtc = RoundStartedUtc + HoldMaximum;
+
+    private static readonly Func<bool> AVoterIsInBattle = () => true;
+    private static readonly Func<bool> NoVoterIsInBattle = () => false;
+
+    private readonly KingdomVotingRoundClock clock = new();
+
+    [Fact]
+    public void CreateDeadline_EndsOneVotingRoundAfterTheRoundStarts()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(60), RoundDuration);
+        Assert.Equal(TimeSpan.FromMinutes(4), HoldMaximum);
+        Assert.Equal(RoundStartedUtc + RoundDuration, clock.CreateDeadline(RoundStartedUtc));
+    }
+
+    [Fact]
+    public void TryExtendDeadline_DoesNotHoldWhenNoVoterIsInBattle()
+    {
+        DateTime deadline = clock.CreateDeadline(RoundStartedUtc);
+
+        Assert.Null(clock.TryExtendDeadline(deadline, deadline, RoundStartedUtc, NoVoterIsInBattle));
+    }
+
+    [Fact]
+    public void TryExtendDeadline_HoldsForAnotherRoundWhileAVoterIsInBattle()
+    {
+        DateTime deadline = clock.CreateDeadline(RoundStartedUtc);
+
+        DateTime? held = clock.TryExtendDeadline(deadline, deadline, RoundStartedUtc, AVoterIsInBattle);
+
+        Assert.Equal(deadline + RoundDuration, held);
+    }
+
+    [Fact]
+    public void TryExtendDeadline_ClampsTheLastHoldToTheBattleHoldMaximum()
+    {
+        DateTime deadline = HoldLimitUtc - TimeSpan.FromSeconds(10);
+
+        DateTime? held = clock.TryExtendDeadline(deadline, deadline, RoundStartedUtc, AVoterIsInBattle);
+
+        Assert.Equal(HoldLimitUtc, held);
+    }
+
+    [Fact]
+    public void TryExtendDeadline_StopsHoldingOnceTheBattleHoldMaximumIsReached()
+    {
+        Assert.Null(clock.TryExtendDeadline(HoldLimitUtc, HoldLimitUtc, RoundStartedUtc, AVoterIsInBattle));
+        Assert.Null(clock.TryExtendDeadline(
+            HoldLimitUtc + TimeSpan.FromSeconds(1),
+            HoldLimitUtc + TimeSpan.FromSeconds(1),
+            RoundStartedUtc,
+            AVoterIsInBattle));
+    }
+
+    [Fact]
+    public void TryExtendDeadline_NeverHoldsPastTheBattleHoldMaximum()
+    {
+        DateTime deadline = clock.CreateDeadline(RoundStartedUtc);
+        int holds = 0;
+
+        while (clock.TryExtendDeadline(deadline, deadline, RoundStartedUtc, AVoterIsInBattle) is DateTime held)
+        {
+            Assert.True(held > deadline);
+            Assert.True(held <= HoldLimitUtc);
+            deadline = held;
+            holds++;
+        }
+
+        Assert.Equal(HoldLimitUtc, deadline);
+        Assert.Equal(3, holds);
+    }
+
+    [Fact]
+    public void TryExtendDeadline_DoesNotMoveADeadlineThatIsAlreadyFurtherOut()
+    {
+        DateTime deadline = RoundStartedUtc + TimeSpan.FromSeconds(200);
+        DateTime utcNow = RoundStartedUtc + TimeSpan.FromSeconds(100);
+
+        Assert.Null(clock.TryExtendDeadline(utcNow, deadline, RoundStartedUtc, AVoterIsInBattle));
+    }
+
+    [Fact]
+    public void TryExtendDeadline_MeasuresTheHoldFromTheLateTickRatherThanTheMissedDeadline()
+    {
+        DateTime deadline = clock.CreateDeadline(RoundStartedUtc);
+        DateTime utcNow = deadline + TimeSpan.FromSeconds(30);
+
+        DateTime? held = clock.TryExtendDeadline(utcNow, deadline, RoundStartedUtc, AVoterIsInBattle);
+
+        Assert.Equal(utcNow + RoundDuration, held);
+    }
+
+    [Fact]
+    public void TryExtendDeadline_ClampsALateTickThatIsStillInsideTheBattleHoldMaximum()
+    {
+        DateTime deadline = HoldLimitUtc - TimeSpan.FromSeconds(60);
+        DateTime utcNow = HoldLimitUtc - TimeSpan.FromSeconds(40);
+
+        DateTime? held = clock.TryExtendDeadline(utcNow, deadline, RoundStartedUtc, AVoterIsInBattle);
+
+        Assert.Equal(HoldLimitUtc, held);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(60)]
+    public void TryExtendDeadline_NeverReturnsADeadlineThatHasAlreadyPassed(int secondsPastTheHoldMaximum)
+    {
+        DateTime deadline = HoldLimitUtc - TimeSpan.FromSeconds(1);
+        DateTime utcNow = HoldLimitUtc + TimeSpan.FromSeconds(secondsPastTheHoldMaximum);
+
+        Assert.Null(clock.TryExtendDeadline(utcNow, deadline, RoundStartedUtc, AVoterIsInBattle));
+    }
+
+    [Fact]
+    public void TryExtendDeadline_LooksForBattlesWhileAHoldIsStillPossible()
+    {
+        DateTime deadline = clock.CreateDeadline(RoundStartedUtc);
+        int battleScans = 0;
+
+        clock.TryExtendDeadline(deadline, deadline, RoundStartedUtc, () =>
+        {
+            battleScans++;
+            return true;
+        });
+
+        Assert.Equal(1, battleScans);
+    }
+
+    [Fact]
+    public void TryExtendDeadline_DoesNotLookForBattlesOncePastTheBattleHoldMaximum()
+    {
+        int battleScans = 0;
+
+        DateTime? held = clock.TryExtendDeadline(HoldLimitUtc, HoldLimitUtc, RoundStartedUtc, () =>
+        {
+            battleScans++;
+            return true;
+        });
+
+        Assert.Null(held);
+        Assert.Equal(0, battleScans);
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -147,6 +147,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<KingdomDecisionOutcomeResolver>().AsSelf().As<IKingdomDecisionOutcomeResolver>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomDecisionOutcomeOrder>().AsSelf().As<IKingdomDecisionOutcomeOrder>().InstancePerDependency();
         builder.RegisterType<KingdomDecisionRoundPresentation>().AsSelf().As<IKingdomDecisionRoundPresentation>().InstancePerDependency();
+        builder.RegisterType<KingdomVotingRoundClock>().AsSelf().As<IKingdomVotingRoundClock>().InstancePerDependency();
         builder.RegisterType<KingdomDecisionVoteManager>().AsSelf().As<IKingdomDecisionVoteManager>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomMembershipState>().AsSelf().As<IKingdomMembershipState>().InstancePerLifetimeScope();
         builder.RegisterType<ClientClanStrengthRefresher>().As<IClientClanStrengthRefresher>().InstancePerDependency();

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -5,6 +5,8 @@ using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Extentions;
 using GameInterface.Services.Kingdoms.Messages;
+using GameInterface.Services.MapEvents.Handlers;
+using GameInterface.Services.Missions;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
 using GameInterface.Services.Players.Data;
@@ -17,6 +19,7 @@ using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.ViewModelCollection;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions;
 using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.ItemTypes;
@@ -68,6 +71,7 @@ namespace GameInterface.Services.Kingdoms
     public class KingdomDecisionVoteManager : IKingdomDecisionVoteManager, IDisposable
     {
         internal static readonly TimeSpan VotingRoundDuration = TimeSpan.FromSeconds(60);
+        internal static readonly TimeSpan VotingRoundBattleHoldMaximum = TimeSpan.FromMinutes(4);
         private static readonly TimeSpan VotingRoundTickInterval = TimeSpan.FromSeconds(1);
         private static readonly ILogger Logger = LogManager.GetLogger(typeof(KingdomDecisionVoteManager));
         private readonly Dictionary<KingdomDecision, KingdomDecisionVoteState> DecisionStates = new Dictionary<KingdomDecision, KingdomDecisionVoteState>();
@@ -82,6 +86,7 @@ namespace GameInterface.Services.Kingdoms
         private readonly IKingdomDecisionOutcomeResolver outcomeResolver;
         private readonly IKingdomDecisionOutcomeOrder outcomeOrder;
         private readonly IKingdomDecisionRoundPresentation roundPresentation;
+        private readonly IKingdomVotingRoundClock votingRoundClock;
         private readonly Timer votingRoundTimer;
         private int isDisposed;
 
@@ -91,7 +96,8 @@ namespace GameInterface.Services.Kingdoms
             IMessageBroker messageBroker,
             IKingdomDecisionOutcomeResolver outcomeResolver,
             IKingdomDecisionOutcomeOrder outcomeOrder,
-            IKingdomDecisionRoundPresentation roundPresentation)
+            IKingdomDecisionRoundPresentation roundPresentation,
+            IKingdomVotingRoundClock votingRoundClock)
         {
             this.playerManager = playerManager;
             this.objectManager = objectManager;
@@ -99,6 +105,7 @@ namespace GameInterface.Services.Kingdoms
             this.outcomeResolver = outcomeResolver;
             this.outcomeOrder = outcomeOrder;
             this.roundPresentation = roundPresentation;
+            this.votingRoundClock = votingRoundClock;
 
             if (ModInformation.IsServer)
             {
@@ -451,6 +458,8 @@ namespace GameInterface.Services.Kingdoms
 
             KingdomDecisionVoteState state = GetOrCreateState(decision);
             RefreshEligibleClanIds(state, decision);
+            // A deadline held by TryResolveExpiredRound is only published on the paths below that reach
+            // PublishRoundStatus; the refused ones wait for the next 1s tick to publish it.
             if (state.IsResolved || TryResolveExpiredRound(state, DateTime.UtcNow)) return false;
             if (!state.EligibleClanIds.Contains(voterClanId)) return false;
             if (!ApplyVote(state, voterClanId, voterClan, voteData)) return false;
@@ -1386,9 +1395,10 @@ namespace GameInterface.Services.Kingdoms
             TryGetKingdomId(decision.Kingdom, out string kingdomId);
             TryGetDecisionIndex(decision, out int decisionIndex);
             HashSet<string> eligibleClanIds = GetEligibleClanIds(decision);
+            DateTime roundStartedUtc = DateTime.UtcNow;
             DateTime? deadlineUtc = ModInformation.IsServer && eligibleClanIds.Count > 0
-                ? DateTime.UtcNow + VotingRoundDuration
-                : null;
+                ? votingRoundClock.CreateDeadline(roundStartedUtc)
+                : (DateTime?)null;
             Dictionary<string, KingdomDecisionRoundClanStatusData> roundClans = ModInformation.IsServer
                 ? CreateRoundClanStatuses(decision, eligibleClanIds)
                 : new Dictionary<string, KingdomDecisionRoundClanStatusData>();
@@ -1397,6 +1407,7 @@ namespace GameInterface.Services.Kingdoms
                 decisionIndex,
                 decision,
                 eligibleClanIds,
+                roundStartedUtc,
                 deadlineUtc,
                 roundClans);
         }
@@ -1461,7 +1472,7 @@ namespace GameInterface.Services.Kingdoms
             }
 
             Player[] clanPlayers = playerManager.Players
-                .Where(player => player.ClanId == clanId || PlayerBelongsToClan(player, decision.Kingdom, clanId))
+                .Where(player => PlayerVotesForClan(player, decision.Kingdom, clanId))
                 .ToArray();
             string playerNames = string.Join(", ", clanPlayers
                 .Select(GetPlayerDisplayName)
@@ -1476,6 +1487,15 @@ namespace GameInterface.Services.Kingdoms
                 string.IsNullOrWhiteSpace(playerNames) ? clanName : playerNames,
                 hasFinalVote,
                 isConnected);
+        }
+
+        // The id a player registered with is not always the canonical clan id, so a raw mismatch still
+        // has to be resolved through the object manager before the player is ruled out.
+        private bool PlayerVotesForClan(Player player, Kingdom kingdom, string clanId)
+        {
+            if (player == null) return false;
+
+            return player.ClanId == clanId || PlayerBelongsToClan(player, kingdom, clanId);
         }
 
         private bool PlayerBelongsToClan(Player player, Kingdom kingdom, string canonicalClanId)
@@ -1686,6 +1706,22 @@ namespace GameInterface.Services.Kingdoms
         {
             if (!state.RoundDeadlineUtc.HasValue || utcNow < state.RoundDeadlineUtc.Value) return false;
 
+            DateTime? heldDeadlineUtc = votingRoundClock.TryExtendDeadline(
+                utcNow,
+                state.RoundDeadlineUtc.Value,
+                state.RoundStartedUtc,
+                () => AnyEligibleVoterInBattle(state));
+            if (heldDeadlineUtc.HasValue)
+            {
+                state.ExtendRoundDeadline(heldDeadlineUtc.Value);
+                Logger.Information(
+                    "Kingdom decision voting deadline for {KingdomId} decision {DecisionIndex} held until {HeldDeadline} because an eligible voter is in a battle",
+                    state.KingdomId,
+                    state.DecisionIndex,
+                    heldDeadlineUtc.Value);
+                return false;
+            }
+
             Logger.Information(
                 "Kingdom decision voting deadline reached for {KingdomId} decision {DecisionIndex}; resolving with {FinalVotes}/{EligibleClans} final clan votes",
                 state.KingdomId,
@@ -1695,6 +1731,46 @@ namespace GameInterface.Services.Kingdoms
             ApplyMissingAbstentions(state);
             ResolveDecision(state);
             return true;
+        }
+
+        // [Server] The mission registry is only registered in the server container, so it is resolved here
+        // instead of injected: this manager is also built in the client container where that type is missing.
+        private bool AnyEligibleVoterInBattle(KingdomDecisionVoteState state)
+        {
+            if (ModInformation.IsClient || playerManager == null || objectManager == null) return false;
+            if (!ContainerProvider.TryResolve<IMissionMembershipRegistry>(out IMissionMembershipRegistry missionRegistry)) return false;
+
+            Kingdom kingdom = state.Decision?.Kingdom;
+            return BattleHandler.CountConnectedPlayersInMapEvents(
+                playerManager.Players,
+                playerManager.IsConnected,
+                player => IsPendingVoter(state.EligibleClanIds, state.FinalVotes.Keys, kingdom, player) &&
+                          IsPlayerInBattle(player, missionRegistry)) > 0;
+        }
+
+        /// <summary>
+        /// Whether the player still owes a vote for one of the eligible clans. A clan that already cast its
+        /// final vote is skipped, otherwise its battle would hold a round it can no longer change.
+        /// </summary>
+        internal bool IsPendingVoter(
+            IEnumerable<string> eligibleClanIds,
+            ICollection<string> finalVoteClanIds,
+            Kingdom kingdom,
+            Player player)
+        {
+            return eligibleClanIds.Any(clanId =>
+                !finalVoteClanIds.Contains(clanId) && PlayerVotesForClan(player, kingdom, clanId));
+        }
+
+        // Mission membership is also true in a tavern or a tournament, so the party's map event is what makes it
+        // a battle. Sharing the fast-forward predicate keeps a slow village raid, which leaves the raider free on
+        // the map, out of both.
+        private bool IsPlayerInBattle(Player player, IMissionMembershipRegistry missionRegistry)
+        {
+            if (!missionRegistry.IsControllerInMission(player.ControllerId)) return false;
+            if (!objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty)) return false;
+
+            return BattleHandler.IsFastForwardBlockingMapEvent(playerParty.MapEvent);
         }
 
         private static bool IsDecisionUnresolved(KingdomDecision decision)
@@ -2024,6 +2100,7 @@ namespace GameInterface.Services.Kingdoms
             public Dictionary<string, KingdomDecisionRoundClanStatusData> RoundClans { get; }
             public string[] OrderedOutcomeKeys { get; private set; }
             public KingdomDecisionRoundStatusData LastPublishedRoundStatus { get; set; }
+            public DateTime RoundStartedUtc { get; }
             public DateTime? RoundDeadlineUtc { get; private set; }
             public bool IsResolved { get; set; }
             public bool HasRoundSnapshot => RoundClans.Count > 0;
@@ -2035,6 +2112,7 @@ namespace GameInterface.Services.Kingdoms
                 int decisionIndex,
                 KingdomDecision decision,
                 HashSet<string> eligibleClanIds,
+                DateTime roundStartedUtc,
                 DateTime? roundDeadlineUtc,
                 Dictionary<string, KingdomDecisionRoundClanStatusData> roundClans)
             {
@@ -2046,6 +2124,7 @@ namespace GameInterface.Services.Kingdoms
                 EligibleClanIds = eligibleClanIds;
                 Votes = new Dictionary<string, AppliedKingdomDecisionVote>();
                 FinalVotes = new Dictionary<string, AppliedKingdomDecisionVote>();
+                RoundStartedUtc = roundStartedUtc;
                 RoundDeadlineUtc = roundDeadlineUtc;
                 RoundClans = roundClans ?? new Dictionary<string, KingdomDecisionRoundClanStatusData>();
                 OrderedOutcomeKeys = Array.Empty<string>();
@@ -2055,6 +2134,11 @@ namespace GameInterface.Services.Kingdoms
             {
                 KingdomId = kingdomId;
                 DecisionIndex = decisionIndex;
+            }
+
+            public void ExtendRoundDeadline(DateTime roundDeadlineUtc)
+            {
+                RoundDeadlineUtc = roundDeadlineUtc;
             }
 
             public void RefreshEligibleClanIds(HashSet<string> eligibleClanIds)

--- a/source/GameInterface/Services/Kingdoms/KingdomVotingRoundClock.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomVotingRoundClock.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace GameInterface.Services.Kingdoms
+{
+    public interface IKingdomVotingRoundClock
+    {
+        DateTime CreateDeadline(DateTime utcNow);
+
+        /// <summary>
+        /// Returns the deadline an expired round should be held to, or null when it should resolve now.
+        /// <paramref name="anyVoterInBattle"/> is only evaluated while a hold is still possible.
+        /// </summary>
+        DateTime? TryExtendDeadline(
+            DateTime utcNow,
+            DateTime deadline,
+            DateTime roundStartedUtc,
+            Func<bool> anyVoterInBattle);
+    }
+
+    internal class KingdomVotingRoundClock : IKingdomVotingRoundClock
+    {
+        public DateTime CreateDeadline(DateTime utcNow)
+        {
+            return utcNow + KingdomDecisionVoteManager.VotingRoundDuration;
+        }
+
+        // A voter locked in a battle cannot open the kingdom screen, so an expired round is held one more
+        // duration at a time. The hold is capped from the round start, otherwise an afk voter in a battle
+        // would keep the decision queued forever.
+        public DateTime? TryExtendDeadline(
+            DateTime utcNow,
+            DateTime deadline,
+            DateTime roundStartedUtc,
+            Func<bool> anyVoterInBattle)
+        {
+            // The cap is checked first because the battle lookup scans every connected player.
+            DateTime holdLimitUtc = roundStartedUtc + KingdomDecisionVoteManager.VotingRoundBattleHoldMaximum;
+            if (deadline >= holdLimitUtc) return null;
+            if (!anyVoterInBattle()) return null;
+
+            DateTime extendedUtc = utcNow + KingdomDecisionVoteManager.VotingRoundDuration;
+            if (extendedUtc > holdLimitUtc) extendedUtc = holdLimitUtc;
+
+            // A tick that ran late can clamp back to a deadline that has already passed, which would
+            // hold the round without ever moving it forward.
+            return extendedUtc > deadline && extendedUtc > utcNow ? extendedUtc : (DateTime?)null;
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
+++ b/source/GameInterface/Services/MapEvents/Handlers/BattleHandler.cs
@@ -328,7 +328,7 @@ internal class BattleHandler : IHandler
         return players.Count(player => isConnected(player) && isInBlockingMapEvent(player));
     }
 
-    private static bool IsFastForwardBlockingMapEvent(MapEvent mapEvent, MapEvent excluding = null)
+    internal static bool IsFastForwardBlockingMapEvent(MapEvent mapEvent, MapEvent excluding = null)
     {
         return mapEvent != null &&
                mapEvent != excluding &&


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Kingdom decision voting rounds expire on a 60 second wall clock. A player locked inside a battle mission cannot open the kingdom screen, so the round expires, the clan is abstained, and the decision resolves by AI votes. On a live dedicated server this ended a war by peace vote while the affected player was in the middle of a siege, and the inquiry popup tells the player they have dozens of in game hours while the real window is one real minute.

## What is the new behavior?

The round deadline extends while a connected voter who still owes a vote is inside a fast forward blocking map event, in 60 second steps, capped at 4 minutes measured from round start so an afk voter cannot wedge the kingdom queue. Voters whose clan already cast its final vote never hold the round, disconnected voters never hold the round, and taverns and tournaments never hold the round. Deadline changes ride the existing round status replication, so there is no new network message. Battle detection reuses the `BattleHandler` helpers.

The 4 minute cap is a tradeoff stated openly: an ordinary field battle fits inside it, a long siege does not, so a besieging voter can still be cut off and abstained. Keying the hold off mission exit would cover that case at the cost of trusting a mission to always end. Maintainer input is welcome on which tradeoff is right and on whether 4 minutes is the number to keep.

Manual check: two clients in one kingdom, server runs `coop.debug.kingdom.add_decision`, client A enters a looter battle and stays in it. The countdown resets past 60 seconds while A fights, resolves normally once A leaves, and past 4 minutes from round start it resolves with A abstaining. Kill A mid battle and the round resolves at the next expiry.

## Bot Changelog Entry

- Kingdom decision votes now wait for players who are fighting a battle instead of resolving without them.

## Other information

The deadline arithmetic lives in a pure `KingdomVotingRoundClock` with unit tests for the cap and boundary behavior; the voter scan only runs when a hold is still possible.
