### PR TITLE
Add minimum war duration and peace offer spam guards for player wars

### DIFF
--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -194,5 +194,20 @@
     // Toggle players being allowed to join battles when wounded
     // Default is true
     "playerWoundedBattleEntry": true,
+
+    // Minimum number of in-game days a war involving a player faction must last before
+    // AI clans are allowed to propose peace for it.
+    // On a dedicated server an AI peace vote resolves without meaningful player input, so
+    // without this a player war can be voted away the day after it was declared.
+    // Players can always propose peace themselves, whatever this is set to.
+    // Wars between two AI factions are never held back.
+    // (Default) 0: vanilla, AI clans may propose peace as soon as the war starts.
+    "minimumWarDurationDays": 0,
+
+    // In-game days an AI clan waits before proposing peace again to a faction pair that turned
+    // the last offer down. An offer that expires unanswered counts as a refusal.
+    // One decline holds the pair back in both directions, and only AI proposals are affected.
+    // (Default) 0: vanilla, a declined offer may be re-proposed the next day.
+    "peaceDeclineCooldownDays": 0,
   }
 }

--- a/source/Coop.IntegrationTests/Serialization/ModConfigNetworkMessageSerializationTest.cs
+++ b/source/Coop.IntegrationTests/Serialization/ModConfigNetworkMessageSerializationTest.cs
@@ -76,6 +76,8 @@ namespace Coop.IntegrationTests.Serialization
                 LooterPartySizeMultiplier = 0.33f,
                 ShowPlayerNameplates = true,
                 PlayerWoundedBattleEntry = false,
+                MinimumWarDurationDays = 30,
+                PeaceDeclineCooldownDays = 3,
             });
 
             var copy = RoundTrip(new NetworkLoadModConfig(options)).ModOptions;
@@ -91,6 +93,8 @@ namespace Coop.IntegrationTests.Serialization
             Assert.Equal(0.25f, copy.MaximumLootersMultiplier);
             Assert.Equal(0.33f, copy.LooterPartySizeMultiplier);
             Assert.False(copy.PlayerWoundedBattleEntry);
+            Assert.Equal(30, copy.MinimumWarDurationDays);
+            Assert.Equal(3, copy.PeaceDeclineCooldownDays);
 
             // Keys the operator left absent still resolve to the documented defaults, not to zero.
             Assert.True(copy.FastForwardEnabled);
@@ -118,6 +122,8 @@ namespace Coop.IntegrationTests.Serialization
             LooterPartySizeMultiplier = 0f,
             ShowPlayerNameplates = false,
             PlayerWoundedBattleEntry = false,
+            MinimumWarDurationDays = 0,
+            PeaceDeclineCooldownDays = 0,
         });
 
         private static void AssertAllOptionsOff(ModOptions copy)
@@ -139,6 +145,8 @@ namespace Coop.IntegrationTests.Serialization
             Assert.Equal(0f, copy.LooterPartySizeMultiplier);
             Assert.False(copy.ShowPlayerNameplates);
             Assert.False(copy.PlayerWoundedBattleEntry);
+            Assert.Equal(0, copy.MinimumWarDurationDays);
+            Assert.Equal(0, copy.PeaceDeclineCooldownDays);
         }
 
         private static T RoundTrip<T>(T original)

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -306,6 +306,8 @@ public class ModConfigTests : IDisposable
         Assert.Equal(1f, options.MaximumLootersMultiplier);
         Assert.Equal(LordDefectionRetryMode.Vanilla, options.LordDefectionRetries);
         Assert.True(options.ShowPlayerNameplates);
+        Assert.Equal(0, options.MinimumWarDurationDays);
+        Assert.Equal(0, options.PeaceDeclineCooldownDays);
     }
 
     /// <summary>

--- a/source/GameInterface.Tests/Services/Kingdoms/AiPeaceProposalGateTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/AiPeaceProposalGateTests.cs
@@ -1,0 +1,324 @@
+﻿using GameInterface.Services.Kingdoms;
+using GameInterface.Services.StanceLinks;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.Library;
+using TaleWorlds.ObjectSystem;
+using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace GameInterface.Tests.Services.Kingdoms;
+
+/// <summary>
+/// The rules that decide whether an AI clan may propose peace, exercised without the campaign
+/// statics the live gate reads: the minimum war duration, the post-decline cooldown, and the
+/// mirrored-offer duplicate guard. The cooldown state is per instance, so each test gets its own
+/// gate and nothing here depends on test ordering or on tests running one at a time.
+/// </summary>
+public sealed class AiPeaceProposalGateTests
+{
+    private const string FactionPairKey = "kingdom_a_kingdom_b";
+    private const int CooldownDays = 3;
+
+    private readonly AiPeaceProposalGate gate = new AiPeaceProposalGate();
+
+    /// <summary>Zero is the vanilla-faithful default and must never hold a proposal back, not even
+    /// on the day the war was declared.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(30)]
+    public void MinimumOfZero_NeverBlocks(double warAgeInDays)
+    {
+        Assert.False(AiPeaceProposalGate.IsWarTooYoung(warAgeInDays, minimumWarDurationDays: 0, involvesPlayerFaction: true));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(29)]
+    [InlineData(29.9)]
+    public void WarYoungerThanTheMinimum_IsBlocked(double warAgeInDays)
+    {
+        Assert.True(AiPeaceProposalGate.IsWarTooYoung(warAgeInDays, minimumWarDurationDays: 30, involvesPlayerFaction: true));
+    }
+
+    /// <summary>The boundary is inclusive: a war that has run exactly the minimum is old enough.</summary>
+    [Theory]
+    [InlineData(30)]
+    [InlineData(31)]
+    public void WarAtOrPastTheMinimum_IsNotBlocked(double warAgeInDays)
+    {
+        Assert.False(AiPeaceProposalGate.IsWarTooYoung(warAgeInDays, minimumWarDurationDays: 30, involvesPlayerFaction: true));
+    }
+
+    /// <summary>AI-vs-AI wars stay vanilla however high the minimum is set.</summary>
+    [Fact]
+    public void WarWithoutAPlayerFaction_IsNeverBlocked()
+    {
+        Assert.False(AiPeaceProposalGate.IsWarTooYoung(0, minimumWarDurationDays: 30, involvesPlayerFaction: false));
+    }
+
+    /// <summary>A war that is not running reads as unbounded age, so it cannot be blocked.</summary>
+    [Fact]
+    public void UnboundedWarAge_IsNotBlocked()
+    {
+        Assert.False(AiPeaceProposalGate.IsWarTooYoung(double.MaxValue, minimumWarDurationDays: 30, involvesPlayerFaction: true));
+    }
+
+    [Fact]
+    public void PairWithNoRecordedDecline_IsNotOnCooldown()
+    {
+        Assert.False(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays: 100, CooldownDays));
+    }
+
+    /// <summary>Zero is the vanilla-faithful default: a declined offer may be re-proposed at once.</summary>
+    [Fact]
+    public void CooldownOfZero_NeverBlocks()
+    {
+        gate.RecordDecline(FactionPairKey, nowInDays: 100, CooldownDays);
+
+        Assert.False(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays: 100, cooldownDays: 0));
+    }
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData(101)]
+    [InlineData(102.9)]
+    public void DeclinedOffer_BlocksUntilTheCooldownElapses(double nowInDays)
+    {
+        gate.RecordDecline(FactionPairKey, nowInDays: 100, CooldownDays);
+
+        Assert.True(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays, CooldownDays));
+    }
+
+    [Theory]
+    [InlineData(103)]
+    [InlineData(150)]
+    public void DeclinedOffer_StopsBlockingOnceTheCooldownElapses(double nowInDays)
+    {
+        gate.RecordDecline(FactionPairKey, nowInDays: 100, CooldownDays);
+
+        Assert.False(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays, CooldownDays));
+    }
+
+    [Fact]
+    public void DeclineCooldown_IsPerFactionPair()
+    {
+        gate.RecordDecline(FactionPairKey, nowInDays: 100, CooldownDays);
+
+        Assert.False(gate.IsWithinDeclineCooldown("kingdom_c_kingdom_d", nowInDays: 100, CooldownDays));
+    }
+
+    /// <summary>A later decline restarts the cooldown rather than keeping the first one's expiry.</summary>
+    [Fact]
+    public void SecondDecline_RestartsTheCooldown()
+    {
+        gate.RecordDecline(FactionPairKey, nowInDays: 100, CooldownDays);
+        gate.RecordDecline(FactionPairKey, nowInDays: 104, CooldownDays);
+
+        Assert.True(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays: 106, CooldownDays));
+        Assert.False(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays: 107, CooldownDays));
+    }
+
+    /// <summary>Recording a decline drops the pairs whose cooldown has run out, so the query stays a
+    /// pure read and the dictionary cannot grow for the whole session.</summary>
+    [Fact]
+    public void RecordingADecline_DropsThePairsWhoseCooldownHasElapsed()
+    {
+        gate.RecordDecline(FactionPairKey, nowInDays: 100, CooldownDays);
+        gate.RecordDecline("kingdom_c_kingdom_d", nowInDays: 200, CooldownDays);
+
+        Assert.False(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays: 100, CooldownDays));
+    }
+
+    [Fact]
+    public void ClearDeclineCooldowns_DropsEveryRecordedDecline()
+    {
+        gate.RecordDecline(FactionPairKey, nowInDays: 100, CooldownDays);
+
+        gate.ClearDeclineCooldowns();
+
+        Assert.False(gate.IsWithinDeclineCooldown(FactionPairKey, nowInDays: 100, CooldownDays));
+    }
+
+    /// <summary>The cooldown is keyed by the shared faction-pair key, so which side proposed does
+    /// not matter: a decline recorded for A/B has to block B/A too.</summary>
+    [Fact]
+    public void FactionPairKey_IsTheSameInBothDirections()
+    {
+        var factionA = CreateFaction("kingdom_a", 1u);
+        var factionB = CreateFaction("kingdom_b", 2u);
+
+        Assert.Equal(
+            StanceLinkHandler.GetStanceLinkKey(factionA, factionB),
+            StanceLinkHandler.GetStanceLinkKey(factionB, factionA));
+    }
+
+    [Fact]
+    public void DeclineRecordedInOneDirection_BlocksTheOther()
+    {
+        var factionA = CreateFaction("kingdom_a", 1u);
+        var factionB = CreateFaction("kingdom_b", 2u);
+
+        gate.RecordDecline(StanceLinkHandler.GetStanceLinkKey(factionA, factionB), nowInDays: 100, CooldownDays);
+
+        Assert.True(gate.IsWithinDeclineCooldown(
+            StanceLinkHandler.GetStanceLinkKey(factionB, factionA),
+            nowInDays: 101,
+            CooldownDays));
+    }
+
+    [Fact]
+    public void KingdomWithNoDecisionList_HasNoPendingMirroredOffer()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u, withDecisionList: false);
+
+        Assert.False(AiPeaceProposalGate.HasPendingMirroredOffer(targetKingdom, proposingKingdom));
+    }
+
+    [Fact]
+    public void ClanTargetFaction_HasNoPendingMirroredOffer()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+
+        Assert.False(AiPeaceProposalGate.HasPendingMirroredOffer(CreateFaction("clan_a", 3u), proposingKingdom));
+    }
+
+    /// <summary>Only the mirrored offers count. An offer the target itself authored is a normal
+    /// proposal and must not suppress the incoming one.</summary>
+    [Fact]
+    public void OfferTheTargetAuthoredItself_IsNotAPendingMirroredOffer()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u);
+        AddPeaceDecision(targetKingdom, proposingKingdom, isProposedByOpponent: false);
+
+        Assert.False(AiPeaceProposalGate.HasPendingMirroredOffer(targetKingdom, proposingKingdom));
+    }
+
+    /// <summary>A mirrored offer aimed at some third kingdom says nothing about this pair.</summary>
+    [Fact]
+    public void MirroredOfferForAnotherFaction_IsNotAPendingMirroredOffer()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u);
+        var otherKingdom = CreateKingdom("kingdom_c", 3u);
+        AddPeaceDecision(targetKingdom, otherKingdom, isProposedByOpponent: true);
+
+        Assert.False(AiPeaceProposalGate.HasPendingMirroredOffer(targetKingdom, proposingKingdom));
+    }
+
+    [Fact]
+    public void MirroredOfferFromTheProposer_IsAPendingMirroredOffer()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u);
+        AddPeaceDecision(targetKingdom, proposingKingdom, isProposedByOpponent: true);
+
+        Assert.True(AiPeaceProposalGate.HasPendingMirroredOffer(targetKingdom, proposingKingdom));
+    }
+
+    /// <summary>The arguments are the target first, then the proposer. Swapping them looks in the
+    /// proposer's own queue, which is not where a mirrored offer is ever held.</summary>
+    [Fact]
+    public void PendingMirroredOffer_IsNotFoundWithTheArgumentsSwapped()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u);
+        AddPeaceDecision(targetKingdom, proposingKingdom, isProposedByOpponent: true);
+
+        Assert.False(AiPeaceProposalGate.HasPendingMirroredOffer(proposingKingdom, targetKingdom));
+    }
+
+    [Fact]
+    public void NullFaction_ShortCircuitsTheComposedGate()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+
+        Assert.False(gate.IsPeaceProposalBlocked(null, proposingKingdom, out var blockingRuleWithoutProposer));
+        Assert.Equal(PeaceProposalBlock.None, blockingRuleWithoutProposer);
+
+        Assert.False(gate.IsPeaceProposalBlocked(proposingKingdom, null, out var blockingRuleWithoutTarget));
+        Assert.Equal(PeaceProposalBlock.None, blockingRuleWithoutTarget);
+    }
+
+    /// <summary>Both configurable rules are off by default, so the composed gate only reports the
+    /// mirrored-offer guard.</summary>
+    [Fact]
+    public void ComposedGate_ReportsThePendingMirroredOfferRule()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u);
+        AddPeaceDecision(targetKingdom, proposingKingdom, isProposedByOpponent: true);
+
+        Assert.True(gate.IsPeaceProposalBlocked(proposingKingdom, targetKingdom, out var blockingRule));
+        Assert.Equal(PeaceProposalBlock.PendingMirroredOffer, blockingRule);
+    }
+
+    [Fact]
+    public void ComposedGate_DoesNotBlockAPairWithNothingPending()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u);
+
+        Assert.False(gate.IsPeaceProposalBlocked(proposingKingdom, targetKingdom, out var blockingRule));
+        Assert.Equal(PeaceProposalBlock.None, blockingRule);
+    }
+
+    /// <summary>Only a mirrored MakePeace decision starts a cooldown. Anything else the sweep hands
+    /// over has to leave the recorded declines untouched.</summary>
+    [Fact]
+    public void RecordDeclinedOffer_IgnoresDecisionsThatAreNotMirroredPeaceOffers()
+    {
+        var proposingKingdom = CreateKingdom("kingdom_a", 1u);
+        var targetKingdom = CreateKingdom("kingdom_b", 2u);
+        string factionPairKey = StanceLinkHandler.GetStanceLinkKey(targetKingdom, proposingKingdom);
+
+        gate.RecordDeclinedOffer(null);
+        gate.RecordDeclinedOffer(CreatePeaceDecision(targetKingdom, proposingKingdom, isProposedByOpponent: false));
+
+        Assert.False(gate.IsWithinDeclineCooldown(factionPairKey, nowInDays: 0, CooldownDays));
+    }
+
+    private static void AddPeaceDecision(Kingdom kingdom, IFaction factionToMakePeaceWith, bool isProposedByOpponent)
+    {
+        kingdom._unresolvedDecisions.Add(CreatePeaceDecision(kingdom, factionToMakePeaceWith, isProposedByOpponent));
+    }
+
+    /// <summary>Both offer fields are readonly on the game type, so they are set the same way
+    /// <c>MakePeaceKingdomDecisionData</c> sets them when it rebuilds a received decision.</summary>
+    private static MakePeaceKingdomDecision CreatePeaceDecision(Kingdom kingdom, IFaction factionToMakePeaceWith, bool isProposedByOpponent)
+    {
+        var decision = (MakePeaceKingdomDecision)FormatterServices.GetUninitializedObject(typeof(MakePeaceKingdomDecision));
+        decision._kingdom = kingdom;
+        GetDecisionField(nameof(MakePeaceKingdomDecision.FactionToMakePeaceWith)).SetValue(decision, factionToMakePeaceWith);
+        GetDecisionField("_isProposedByOpponent").SetValue(decision, isProposedByOpponent);
+        return decision;
+    }
+
+    private static FieldInfo GetDecisionField(string name) => typeof(MakePeaceKingdomDecision).GetField(
+        name,
+        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+    private static Kingdom CreateKingdom(string stringId, uint id, bool withDecisionList = true)
+    {
+        var kingdom = (Kingdom)FormatterServices.GetUninitializedObject(typeof(Kingdom));
+        kingdom.StringId = stringId;
+        kingdom.Id = new MBGUID(id);
+        if (withDecisionList)
+        {
+            kingdom._unresolvedDecisions = new MBList<TaleWorlds.CampaignSystem.Election.KingdomDecision>();
+        }
+
+        return kingdom;
+    }
+
+    private static IFaction CreateFaction(string stringId, uint id)
+    {
+        var clan = (Clan)FormatterServices.GetUninitializedObject(typeof(Clan));
+        clan.StringId = stringId;
+        clan.Id = new MBGUID(id);
+        return clan;
+    }
+}

--- a/source/GameInterface/Configuration/ModConfigData.cs
+++ b/source/GameInterface/Configuration/ModConfigData.cs
@@ -124,6 +124,10 @@ public sealed class ModOptionsData
 
     public bool? ShowPlayerNameplates { get; set; }
 
+    public int? MinimumWarDurationDays { get; set; }
+
+    public int? PeaceDeclineCooldownDays { get; set; }
+
     [JsonExtensionData]
     public IDictionary<string, JToken> UnknownKeys { get; set; }
 }

--- a/source/GameInterface/Configuration/ModConfigProvider.cs
+++ b/source/GameInterface/Configuration/ModConfigProvider.cs
@@ -60,6 +60,10 @@ public readonly struct ModOptions
     public readonly bool ShowPlayerNameplates { get; } = true;
     [ProtoMember(20)]
     public readonly bool PlayerWoundedBattleEntry { get; } = true;
+    [ProtoMember(21)]
+    public readonly int MinimumWarDurationDays { get; } = 0;
+    [ProtoMember(22)]
+    public readonly int PeaceDeclineCooldownDays { get; } = 0;
 
     public ModOptions(ModOptionsData modOptionsData)
     {
@@ -83,5 +87,7 @@ public readonly struct ModOptions
         EnablePlayerClanMemberExecutions = modOptionsData.EnablePlayerClanMemberExecutions ?? EnablePlayerClanMemberExecutions;
         ShowPlayerNameplates = modOptionsData.ShowPlayerNameplates ?? ShowPlayerNameplates;
         PlayerWoundedBattleEntry = modOptionsData.PlayerWoundedBattleEntry ?? PlayerWoundedBattleEntry;
+        MinimumWarDurationDays = modOptionsData.MinimumWarDurationDays ?? MinimumWarDurationDays;
+        PeaceDeclineCooldownDays = modOptionsData.PeaceDeclineCooldownDays ?? PeaceDeclineCooldownDays;
     }
 }

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -142,6 +142,8 @@ public class GameInterfaceModule : Module
         builder.RegisterType<LiveTestCommandDispatcher>().As<ILiveTestCommandDispatcher>().InstancePerDependency();
         builder.RegisterType<CoopModulePathResolver>().As<ICoopModulePathResolver>().InstancePerDependency();
         builder.RegisterType<FixedTownNpcService>().AsSelf().InstancePerLifetimeScope();
+        // Holds the peace decline cooldowns, so it must be one instance per session, not per resolve.
+        builder.RegisterType<AiPeaceProposalGate>().AsSelf().As<IAiPeaceProposalGate>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomCreationSettlementTracker>().AsSelf().As<IKingdomCreationSettlementTracker>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomCreator>().AsSelf().As<IKingdomCreator>().InstancePerLifetimeScope();
         builder.RegisterType<KingdomDecisionOutcomeResolver>().AsSelf().As<IKingdomDecisionOutcomeResolver>().InstancePerLifetimeScope();

--- a/source/GameInterface/Services/Kingdoms/AiPeaceProposalGate.cs
+++ b/source/GameInterface/Services/Kingdoms/AiPeaceProposalGate.cs
@@ -1,0 +1,194 @@
+﻿using GameInterface.Configuration;
+using GameInterface.Services.Kingdoms.Extentions;
+using GameInterface.Services.StanceLinks;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+
+namespace GameInterface.Services.Kingdoms
+{
+    /// <summary>Which rule held an AI peace proposal back, if any.</summary>
+    public enum PeaceProposalBlock
+    {
+        None,
+        WarTooYoung,
+        DeclineCooldown,
+        PendingMirroredOffer,
+    }
+
+    /// <summary>
+    /// Decides whether an AI clan may propose peace for a war right now. Two configurable rules sit
+    /// on top of vanilla and are off by default: a minimum duration for wars a player faction is in,
+    /// and a cooldown after the target declined the last offer. The third rule always applies and
+    /// only suppresses a duplicate of an offer that is still unanswered. The player's own
+    /// propose-peace path is never gated by any of this.
+    /// </summary>
+    public interface IAiPeaceProposalGate
+    {
+        bool IsPeaceProposalBlocked(IFaction proposingFaction, IFaction targetFaction, out PeaceProposalBlock blockingRule);
+
+        /// <summary>Starts the cooldown for a mirrored offer the target did not accept. An offer that
+        /// expires unanswered counts the same as an explicit refusal.</summary>
+        void RecordDeclinedOffer(KingdomDecision decision);
+
+        /// <summary>Drops every recorded decline. The cooldowns describe one campaign's diplomacy and
+        /// must not carry into the next one loaded in the same process.</summary>
+        void ClearDeclineCooldowns();
+    }
+
+    public class AiPeaceProposalGate : IAiPeaceProposalGate
+    {
+        private readonly object declineLock = new object();
+        private readonly Dictionary<string, double> declineDayByFactionPair = new Dictionary<string, double>();
+
+        public bool IsPeaceProposalBlocked(IFaction proposingFaction, IFaction targetFaction, out PeaceProposalBlock blockingRule)
+        {
+            blockingRule = PeaceProposalBlock.None;
+            if (proposingFaction == null || targetFaction == null) return false;
+
+            if (IsWarWithinMinimumDuration(proposingFaction, targetFaction))
+            {
+                blockingRule = PeaceProposalBlock.WarTooYoung;
+            }
+            else if (IsWithinDeclineCooldown(proposingFaction, targetFaction))
+            {
+                blockingRule = PeaceProposalBlock.DeclineCooldown;
+            }
+            else if (HasPendingMirroredOffer(targetFaction, proposingFaction))
+            {
+                blockingRule = PeaceProposalBlock.PendingMirroredOffer;
+            }
+
+            return blockingRule != PeaceProposalBlock.None;
+        }
+
+        public void RecordDeclinedOffer(KingdomDecision decision)
+        {
+            int cooldownDays = ConfiguredCooldownDays;
+            if (cooldownDays <= 0) return;
+            if (decision is not MakePeaceKingdomDecision { _isProposedByOpponent: true } peaceDecision) return;
+            if (peaceDecision.Kingdom == null || peaceDecision.FactionToMakePeaceWith == null) return;
+
+            RecordDecline(
+                StanceLinkHandler.GetStanceLinkKey(peaceDecision.Kingdom, peaceDecision.FactionToMakePeaceWith),
+                CampaignTime.Now.ToDays,
+                cooldownDays);
+        }
+
+        public void ClearDeclineCooldowns()
+        {
+            lock (declineLock)
+            {
+                declineDayByFactionPair.Clear();
+            }
+        }
+
+        /// <summary>
+        /// The war-duration rule with no campaign statics in it. A minimum of 0 keeps vanilla
+        /// behaviour, and a war with no player faction in it is never held back.
+        /// </summary>
+        internal static bool IsWarTooYoung(double warAgeInDays, int minimumWarDurationDays, bool involvesPlayerFaction)
+        {
+            if (minimumWarDurationDays <= 0) return false;
+            if (!involvesPlayerFaction) return false;
+
+            return warAgeInDays < minimumWarDurationDays;
+        }
+
+        /// <summary>
+        /// True when <paramref name="targetFaction"/> still holds an unanswered offer mirrored from
+        /// <paramref name="proposingFaction"/>. The vanilla duplicate guard compares proposer map
+        /// factions, which never matches a mirrored offer because its proposer is the target's own
+        /// ruling clan, so the same offer would otherwise be re-authored every day.
+        /// </summary>
+        internal static bool HasPendingMirroredOffer(IFaction targetFaction, IFaction proposingFaction)
+        {
+            if (targetFaction is not Kingdom targetKingdom || targetKingdom._unresolvedDecisions == null) return false;
+
+            return targetKingdom.UnresolvedDecisions
+                .OfType<MakePeaceKingdomDecision>()
+                .Any(existing => existing._isProposedByOpponent
+                                 && existing.FactionToMakePeaceWith == proposingFaction);
+        }
+
+        /// <summary>
+        /// Records a decline and drops the ones that have already run out. Pruning happens here so
+        /// the query stays a pure read, otherwise every pair that ever declined stays in here.
+        /// </summary>
+        internal void RecordDecline(string factionPairKey, double nowInDays, int cooldownDays)
+        {
+            lock (declineLock)
+            {
+                PruneElapsedCooldowns(nowInDays, cooldownDays);
+                declineDayByFactionPair[factionPairKey] = nowInDays;
+            }
+        }
+
+        /// <summary>
+        /// The key is the shared faction-pair key, so one decline holds the pair back in both
+        /// directions: neither side re-offers until the cooldown runs out.
+        /// </summary>
+        internal bool IsWithinDeclineCooldown(string factionPairKey, double nowInDays, int cooldownDays)
+        {
+            if (cooldownDays <= 0) return false;
+
+            lock (declineLock)
+            {
+                if (!declineDayByFactionPair.TryGetValue(factionPairKey, out double declinedOnDay)) return false;
+
+                return nowInDays - declinedOnDay < cooldownDays;
+            }
+        }
+
+        private static int ConfiguredCooldownDays => ModConfigProvider.ModOptions.PeaceDeclineCooldownDays;
+
+        private void PruneElapsedCooldowns(double nowInDays, int cooldownDays)
+        {
+            var elapsed = declineDayByFactionPair
+                .Where(entry => nowInDays - entry.Value >= cooldownDays)
+                .Select(entry => entry.Key)
+                .ToList();
+
+            foreach (string factionPairKey in elapsed)
+            {
+                declineDayByFactionPair.Remove(factionPairKey);
+            }
+        }
+
+        private static bool IsWarWithinMinimumDuration(IFaction proposingFaction, IFaction targetFaction)
+        {
+            int minimumWarDurationDays = ModConfigProvider.ModOptions.MinimumWarDurationDays;
+            // Early out so the default-off gate never reads campaign state.
+            if (minimumWarDurationDays <= 0) return false;
+
+            return IsWarTooYoung(
+                GetWarAgeInDays(proposingFaction, targetFaction),
+                minimumWarDurationDays,
+                proposingFaction.IsPlayerFaction() || targetFaction.IsPlayerFaction());
+        }
+
+        /// <summary>Days this war has run, or <see cref="double.MaxValue"/> when the two are not at war.</summary>
+        private static double GetWarAgeInDays(IFaction faction1, IFaction faction2)
+        {
+            if (!faction1.IsAtWarWith(faction2)) return double.MaxValue;
+
+            StanceLink stance = faction1.GetStanceWith(faction2);
+            if (stance == null) return double.MaxValue;
+
+            return CampaignTime.Now.ToDays - stance._warStartDate.ToDays;
+        }
+
+        private bool IsWithinDeclineCooldown(IFaction faction1, IFaction faction2)
+        {
+            int cooldownDays = ConfiguredCooldownDays;
+            // Early out so the default-off gate never reads campaign state.
+            if (cooldownDays <= 0) return false;
+
+            return IsWithinDeclineCooldown(
+                StanceLinkHandler.GetStanceLinkKey(faction1, faction2),
+                CampaignTime.Now.ToDays,
+                cooldownDays);
+        }
+    }
+}

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -72,7 +72,11 @@ public class KingdomDebugCommand
     private static readonly string AddKingdomPolicyDecisionUsage = "Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> KingdomPolicyDecision <policyId> <isInvertedDecision>";
     private static readonly string AddSettlementClaimantDecisionUsage = "Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> SettlementClaimantDecision <settlementId> <capturerHeroId> <clanToExcludeId>";
     private static readonly string AddSettlementClaimantPreliminaryDecisionUsage = "Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> SettlementClaimantPreliminaryDecision <SettlementId>";
-    private static readonly string AddMakePeaceKingdomDecisionUsage = "Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> MakePeaceKingdomDecision <factionId> <dailyTribute> <applyResults>";
+    private static readonly string AddMakePeaceKingdomDecisionUsage =
+@"Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> MakePeaceKingdomDecision <factionId> <dailyTribute> <dailyTributeDurationInDays> <applyResults>
+Example: coop.debug.kingdom.add_decision empire_s clan_empire_south_1 true MakePeaceKingdomDecision vlandia 50 30 true
+  Pethros proposes that the Southern Empire make peace with Vlandia, paying 50 tribute a day for 30 days.
+  Run coop.debug.kingdom.list for the kingdom ids and coop.debug.kingdom.info <kingdomId> for its clans.";
     private static readonly string AddAcceptCallToWarAgreementDecisionUsage = "Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> AcceptCallToWarAgreementDecision <callingKingdomId> <kingdomToCallToWarAgainstId>";
     private static readonly string AddProposeCallToWarAgreementDecisionUsage = "Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> ProposeCallToWarAgreementDecision <calledKingdomId> <kingdomToCallToWarAgainstId>";
     private static readonly string AddStartAllianceDecisionUsage = "Usage: coop.debug.kingdom.add_decision <kingdomId> <proposerClanId> <ignoreInfluenceCost> StartAllianceDecision <kingdomToStartAllianceWithId>";
@@ -90,7 +94,7 @@ public class KingdomDebugCommand
             { nameof(ProposeCallToWarAgreementDecision), TryGetProposeCallToWarAgreementDecision },
             { nameof(StartAllianceDecision), TryGetStartAllianceDecision },
             { nameof(TradeAgreementDecision), TryGetTradeAgreementDecision },
-            //{ nameof(MakePeaceKingdomDecision), TryGetMakePeaceKingdomDecision },
+            { nameof(MakePeaceKingdomDecision), TryGetMakePeaceKingdomDecision },
         };
 
 
@@ -1558,6 +1562,7 @@ public class KingdomDebugCommand
     [CommandLineArgumentFunction("add_decision", "coop.debug.kingdom")]
     public static string AddDecision(List<string> args)
     {
+        if (ModInformation.IsClient) return "Command can only be run on the server.";
         if (args.Count < 4)
         {
             return AddBasicUsage;
@@ -1971,53 +1976,60 @@ public class KingdomDebugCommand
     /// <param name="kingdomDecision">kingdom decision result.</param>
     /// <param name="message">message result.</param>
     /// <returns>True if kingdomdecision is successfully returned, else false.</returns>
+    private static bool TryGetMakePeaceKingdomDecision(IObjectManager objectManager, List<string> args, Clan proposerClan, out KingdomDecision kingdomDecision, out string message)
+    {
+        if (args.Count < 8)
+        {
+            kingdomDecision = null;
+            message = AddMakePeaceKingdomDecisionUsage;
+            return false;
+        }
 
-    //private static bool TryGetMakePeaceKingdomDecision(IObjectManager objectManager, List<string> args, Clan proposerClan, out KingdomDecision kingdomDecision, out string message)
-    //{
-    //    if (args.Count < 7)
-    //    {
-    //        kingdomDecision = null;
-    //        message = AddMakePeaceKingdomDecisionUsage;
-    //        return false;
-    //    }
+        string factionId = args[4];
+        string dailyTribute = args[5];
+        string dailyTributeDuration = args[6];
+        string applyResults = args[7];
 
-    //    string factionId = args[4];
-    //    string dailyTribute = args[5];
-    //    string applyResults = args[6];
+        if (!objectManager.TryGetObject(factionId, out Kingdom kingdom) & !objectManager.TryGetObject(factionId, out Clan clanFaction))
+        {
+            kingdomDecision = null;
+            message = $"Argument5: Faction is not found by Id: {factionId}";
+            return false;
+        }
 
-    //    if (!objectManager.TryGetObject(factionId, out Kingdom kingdom) & !objectManager.TryGetObject(factionId, out Clan clan))
-    //    {
-    //        kingdomDecision = null;
-    //        message = $"Argument5: Faction is not found by Id: {factionId}";
-    //        return false;
-    //    }
+        IFaction faction;
+        if (kingdom != null)
+        {
+            faction = kingdom;
+        }
+        else
+        {
+            faction = clanFaction;
+        }
 
-    //    IFaction faction;
-    //    if (kingdom != null)
-    //    {
-    //        faction = kingdom;
-    //    }
-    //    else
-    //    {
-    //        faction = clan;
-    //    }
+        if (!int.TryParse(dailyTribute, out int dailyTributeToBePaid))
+        {
+            kingdomDecision = null;
+            message = $"Argument6: The given value is not an integer value: {dailyTribute}";
+            return false;
+        }
 
-    //    if (!int.TryParse(dailyTribute, out int dailyTributeToBePaid))
-    //    {
-    //        kingdomDecision = null;
-    //        message = $"Argument6: The given value is not an integer value: {dailyTribute}";
-    //        return false;
-    //    }
+        if (!int.TryParse(dailyTributeDuration, out int dailyTributeDurationInDays))
+        {
+            kingdomDecision = null;
+            message = $"Argument7: The given value is not an integer value: {dailyTributeDuration}";
+            return false;
+        }
 
-    //    if (!bool.TryParse(applyResults, out bool applyResult))
-    //    {
-    //        kingdomDecision = null;
-    //        message = $"Argument7: The given value is not a boolean value: {applyResults}";
-    //        return false;
-    //    }
+        if (!bool.TryParse(applyResults, out bool applyResult))
+        {
+            kingdomDecision = null;
+            message = $"Argument8: The given value is not a boolean value: {applyResults}";
+            return false;
+        }
 
-    //    kingdomDecision = new MakePeaceKingdomDecision(proposerClan, faction, dailyTributeToBePaid, applyResult);
-    //    message = string.Empty;
-    //    return true;
-    //}
+        kingdomDecision = new MakePeaceKingdomDecision(proposerClan, faction, dailyTributeToBePaid, dailyTributeDurationInDays, applyResult);
+        message = string.Empty;
+        return true;
+    }
 }

--- a/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
+++ b/source/GameInterface/Services/Kingdoms/Extentions/CoopKingdomElection.cs
@@ -157,12 +157,12 @@ namespace GameInterface.Services.Kingdoms.Extentions
                 return true;
             }
 
+            // Only the exact-duplicate guard belongs here. The AI proposer rules run on the
+            // DailyTickClan path; applying them again here would swallow a player authored offer
+            // after its influence was already spent and leave the pending flag stuck on.
             Kingdom proposingKingdom = peaceDecision.Kingdom;
-            bool offerAlreadyPending = playerKingdom.UnresolvedDecisions
-                .OfType<MakePeaceKingdomDecision>()
-                .Any(existing => existing._isProposedByOpponent
-                                 && existing.FactionToMakePeaceWith == proposingKingdom);
-            if (offerAlreadyPending || playerKingdom.RulingClan == null)
+            if (AiPeaceProposalGate.HasPendingMirroredOffer(playerKingdom, proposingKingdom)
+                || playerKingdom.RulingClan == null)
             {
                 return true;
             }

--- a/source/GameInterface/Services/Kingdoms/Handlers/AiPeaceProposalGateResetHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/AiPeaceProposalGateResetHandler.cs
@@ -1,0 +1,39 @@
+﻿using Common.Messaging;
+using GameInterface.Services.GameState.Messages;
+
+namespace GameInterface.Services.Kingdoms.Handlers;
+
+/// <summary>
+/// Clears the AI peace decline cooldowns whenever a campaign starts, loads, or is left. The gate
+/// lives for the whole session container, so without this a cooldown recorded in one campaign would
+/// still hold peace proposals back in the next campaign loaded in the same process.
+/// </summary>
+internal class AiPeaceProposalGateResetHandler : IHandler
+{
+    private readonly IMessageBroker messageBroker;
+    private readonly IAiPeaceProposalGate peaceProposalGate;
+
+    public AiPeaceProposalGateResetHandler(
+        IMessageBroker messageBroker,
+        IAiPeaceProposalGate peaceProposalGate)
+    {
+        this.messageBroker = messageBroker;
+        this.peaceProposalGate = peaceProposalGate;
+
+        messageBroker.Subscribe<GameLoadStarted>(Handle_Reset);
+        messageBroker.Subscribe<CampaignReady>(Handle_Reset);
+        messageBroker.Subscribe<MainMenuEntered>(Handle_Reset);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<GameLoadStarted>(Handle_Reset);
+        messageBroker.Unsubscribe<CampaignReady>(Handle_Reset);
+        messageBroker.Unsubscribe<MainMenuEntered>(Handle_Reset);
+    }
+
+    private void Handle_Reset<T>(MessagePayload<T> payload) where T : IMessage
+    {
+        peaceProposalGate.ClearDeclineCooldowns();
+    }
+}

--- a/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomDecisionVoteManager.cs
@@ -82,6 +82,7 @@ namespace GameInterface.Services.Kingdoms
         private readonly IKingdomDecisionOutcomeResolver outcomeResolver;
         private readonly IKingdomDecisionOutcomeOrder outcomeOrder;
         private readonly IKingdomDecisionRoundPresentation roundPresentation;
+        private readonly IAiPeaceProposalGate peaceProposalGate;
         private readonly Timer votingRoundTimer;
         private int isDisposed;
 
@@ -91,7 +92,8 @@ namespace GameInterface.Services.Kingdoms
             IMessageBroker messageBroker,
             IKingdomDecisionOutcomeResolver outcomeResolver,
             IKingdomDecisionOutcomeOrder outcomeOrder,
-            IKingdomDecisionRoundPresentation roundPresentation)
+            IKingdomDecisionRoundPresentation roundPresentation,
+            IAiPeaceProposalGate peaceProposalGate)
         {
             this.playerManager = playerManager;
             this.objectManager = objectManager;
@@ -99,6 +101,7 @@ namespace GameInterface.Services.Kingdoms
             this.outcomeResolver = outcomeResolver;
             this.outcomeOrder = outcomeOrder;
             this.roundPresentation = roundPresentation;
+            this.peaceProposalGate = peaceProposalGate;
 
             if (ModInformation.IsServer)
             {
@@ -1031,7 +1034,12 @@ namespace GameInterface.Services.Kingdoms
 
             if (state.Decision is MakePeaceKingdomDecision decision)
             {
-                if (decision.Kingdom is Kingdom playerKingdom && playerKingdom.IsPlayerKingdom() 
+                if (chosenOutcome is not MakePeaceKingdomDecision.MakePeaceDecisionOutcome { ShouldPeaceBeDeclared: true })
+                {
+                    peaceProposalGate?.RecordDeclinedOffer(decision);
+                }
+
+                if (decision.Kingdom is Kingdom playerKingdom && playerKingdom.IsPlayerKingdom()
                     && decision.FactionToMakePeaceWith is Kingdom playerkingdom2 && playerkingdom2.IsPlayerKingdom())
                 {
                     messageBroker?.Publish(state.Decision, new PeaceOfferPendingStatusChanged(

--- a/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
+++ b/source/GameInterface/Services/Kingdoms/Patches/CoopKingdomDecisionProposalBehaviorPatch.cs
@@ -111,6 +111,17 @@ namespace GameInterface.Services.Kingdoms.Patches
 
             if (kingdomDecision == null) return false;
 
+            // Held back if the war is younger than the configured minimum, if the last offer to
+            // this pair was declined, or if a mirrored offer is still unanswered.
+            if (kingdomDecision is MakePeaceKingdomDecision proposedPeace
+                && ContainerProvider.TryResolve<IAiPeaceProposalGate>(out var peaceProposalGate)
+                && peaceProposalGate.IsPeaceProposalBlocked(clan.MapFaction, proposedPeace.FactionToMakePeaceWith, out var blockingRule))
+            {
+                Logger.Debug("Held back {ProposingFaction} peace proposal to {TargetFaction}: {BlockingRule}",
+                    clan.MapFaction?.StringId, proposedPeace.FactionToMakePeaceWith?.StringId, blockingRule);
+                return false;
+            }
+
             // Cross-kingdom duplicate guard (vanilla, player-deref-free): skip if an equivalent
             // war/peace decision is already pending.
             foreach (KingdomDecision existing in __instance._kingdomDecisionsList)
@@ -192,6 +203,11 @@ namespace GameInterface.Services.Kingdoms.Patches
                                 kingdom.RemoveDecision(decision);
                                 if (decision is MakePeaceKingdomDecision d)
                                 {
+                                    if (ContainerProvider.TryResolve<IAiPeaceProposalGate>(out var peaceProposalGate))
+                                    {
+                                        peaceProposalGate.RecordDeclinedOffer(d);
+                                    }
+
                                     MessageBroker.Instance.Publish(null, new PeaceOfferPendingStatusChanged(
                                         (Kingdom)d.FactionToMakePeaceWith,
                                         d.Kingdom,


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

On a dedicated server an AI peace vote resolves without meaningful player input, so a war involving a player faction can be voted away the day after it was declared. Separately, a declined enemy peace offer is proposed again endlessly: the duplicate guard compares proposer map factions, which never matches the mirrored offer sitting in the target kingdom whose proposer is the target's own ruling clan. That repeat spam is what makes the decision prompt non interactive in #3156.

## What is the new behavior?

Resolves #3156

Two new server options in mod config, both defaulting to 0 so a fresh install behaves exactly like vanilla. `minimumWarDurationDays` holds AI clans back from proposing peace for a war a player faction is in until the war has run that many in game days. `peaceDeclineCooldownDays` holds an AI clan back from proposing again to a faction pair that turned the last offer down, with an offer that expires unanswered counting as a refusal. Neither rule touches the player's own propose peace path, and wars between two AI factions are never held back. The third rule always applies and is the actual #3156 fix: an AI clan no longer authors a mirrored peace offer while the previous one is still sitting unanswered in the target kingdom. A debug entry for `MakePeaceKingdomDecision` in `coop.debug.kingdom.add_decision` is re enabled with the current constructor signature so the flow can be driven manually.

One thing worth a maintainer confirming before merge: the war age reads `StanceLink._warStartDate`, and it is not established here whether that field resets when two factions declare war on each other a second time. If it carries the first war's date over, a re declared war would read as older than it is and the minimum would not hold it back. The gate fails open in that case, so the worst outcome is vanilla behaviour.

Manual check: set `minimumWarDurationDays` to 30, declare war with `coop.debug.kingdom.declare_war`, advance 10 days and `coop.debug.kingdom.list_kingdom_decisions` shows no peace decision while the player's own propose peace stays enabled, past 30 days the AI proposal reappears.

## Bot Changelog Entry

- Added server options to delay AI peace offers in player wars and to stop repeated peace offer spam after a declined offer.

## Other information

The decline cooldown is in memory only and resets on campaign load, which is fail open. The gate logic is a DI registered service with the pure rules unit tested; at default settings it reads no campaign state at all.
