### PR TITLE
Keep client kingdom decision queues aligned with the server

### DIFF
--- a/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
+++ b/source/Coop.Core/Client/Services/Kingdoms/Handlers/ClientKingdomHandler.cs
@@ -151,12 +151,14 @@ public class ClientKingdomHandler : IHandler
         var payload = obj.What;
         if (!TryGetKingdomId(payload.Kingdom, out var kingdomId)) return;
 
+        // A client proposal never carries a queue-vs-resolve answer, the server decides that for everyone.
         var data = kingdomDecisionDataConverter.Convert(payload.Decision);
         var message = new NetworkAddDecision(
             kingdomId,
             data,
             payload.IgnoreInfluenceCost,
-            payload.RandomNumber);
+            payload.RandomNumber,
+            wasQueued: null);
         network.SendAll(message);
     }
 
@@ -388,21 +390,16 @@ public class ClientKingdomHandler : IHandler
     private void HandleNetworkAddDecision(MessagePayload<NetworkAddDecision> obj)
     {
         var payload = obj.What;
-        if (!ShouldApplyNetworkDecision(payload.KingdomId)) return;
 
-        var message = new AddDecision(payload.KingdomId, payload.Data, payload.IgnoreInfluenceCost, payload.RandomNumber);
+        // Every kingdom's queue is mirrored on every client, otherwise a clan that joins a kingdom mid
+        // session keeps a shorter list than the server and every later decision index is off by one.
+        var message = new AddDecision(
+            payload.KingdomId,
+            payload.Data,
+            payload.IgnoreInfluenceCost,
+            payload.RandomNumber,
+            payload.WasQueued);
         messageBroker.Publish(this, message);
-    }
-
-    private bool ShouldApplyNetworkDecision(string kingdomId)
-    {
-        if (string.IsNullOrWhiteSpace(kingdomId)) return false;
-        if (!objectManager.TryGetObject(kingdomId, out Kingdom kingdom)) return true;
-        if (!playerManager.TryGetPlayer(controllerIdProvider.ControllerId, out var player)) return true;
-        if (string.IsNullOrWhiteSpace(player.ClanId)) return false;
-        if (!objectManager.TryGetObject(player.ClanId, out Clan clan)) return false;
-
-        return clan.Kingdom == kingdom;
     }
 
     private void HandleDestroyKingdom(MessagePayload<DestroyKingdom> obj)

--- a/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
+++ b/source/Coop.Core/Server/Services/Kingdoms/Handlers/ServerKingdomHandler.cs
@@ -254,23 +254,17 @@ public class ServerKingdomHandler : IHandler
     {
         var payload = obj.What;
 
+        // A proposing client is not authority on queue-vs-resolve, so the server applies the proposal with
+        // no answer attached. That apply publishes DecisionAdded, and HandleLocalDecisionAdded broadcasts
+        // the server's answer from there, so there is no second relay to send here.
         messageBroker.Publish(
             this,
-            new AddDecision(payload.KingdomId, payload.Data, payload.IgnoreInfluenceCost, payload.RandomNumber));
-
-        var message = new NetworkAddDecision(
-            payload.KingdomId,
-            payload.Data,
-            payload.IgnoreInfluenceCost,
-            payload.RandomNumber);
-
-        if (obj.Who is NetPeer peer)
-        {
-            network.SendAllBut(peer, message);
-            return;
-        }
-
-        network.SendAll(message);
+            new AddDecision(
+                payload.KingdomId,
+                payload.Data,
+                payload.IgnoreInfluenceCost,
+                payload.RandomNumber,
+                wasQueued: null));
     }
 
     private void HandleLocalKingdomPolicyChanged(MessagePayload<KingdomPolicyChanged> obj)
@@ -301,7 +295,12 @@ public class ServerKingdomHandler : IHandler
         if (!TryGetKingdomId(payload.Kingdom, out var kingdomId)) return;
 
         var data = kingdomDecisionDataConverter.Convert(payload.Decision);
-        var message = new NetworkAddDecision(kingdomId, data, payload.IgnoreInfluenceCost, payload.RandomNumber);
+        var message = new NetworkAddDecision(
+            kingdomId,
+            data,
+            payload.IgnoreInfluenceCost,
+            payload.RandomNumber,
+            payload.WasQueued);
         network.SendAll(message);
     }
 

--- a/source/Coop.Core/Server/Services/Kingdoms/Messages/NetworkAddDecision.cs
+++ b/source/Coop.Core/Server/Services/Kingdoms/Messages/NetworkAddDecision.cs
@@ -20,12 +20,25 @@ namespace Coop.Core.Server.Services.Kingdoms.Messages
         [ProtoMember(4)]
         public float RandomNumber { get; }
 
-        public NetworkAddDecision(string kingdomId, KingdomDecisionData data, bool ignoreInfluenceCost, float randomNumber)
+        /// <summary>
+        /// Whether the server queued the decision in <c>Kingdom._unresolvedDecisions</c> instead of resolving
+        /// it in place. Null when the server has no answer for this add, the receiver then decides locally.
+        /// </summary>
+        [ProtoMember(5)]
+        public bool? WasQueued { get; }
+
+        public NetworkAddDecision(
+            string kingdomId,
+            KingdomDecisionData data,
+            bool ignoreInfluenceCost,
+            float randomNumber,
+            bool? wasQueued)
         {
             KingdomId = kingdomId;
             Data = data;
             IgnoreInfluenceCost = ignoreInfluenceCost;
             RandomNumber = randomNumber;
+            WasQueued = wasQueued;
         }
     }
 }

--- a/source/Coop.IntegrationTests/Environment/TestEnvironment.cs
+++ b/source/Coop.IntegrationTests/Environment/TestEnvironment.cs
@@ -28,6 +28,7 @@ public class TestEnvironment
     private static readonly object ContainerBuildLock = new object();
 
     private readonly TestNetworkRouter networkOrchestrator;
+    private readonly Action<ContainerBuilder>? configureInstance;
 
     public readonly ILogger Logger = LogManager.GetLogger<TestEnvironment>();
 
@@ -36,8 +37,14 @@ public class TestEnvironment
     /// Constructor for TestEnvironment
     /// </summary>
     /// <param name="numClients">Number of clients to create, defaults to 2 clients</param>
-    public TestEnvironment(int numClients = 2)
+    /// <param name="configureInstance">
+    /// Runs last against every instance's container builder, so a test can replace a registration that
+    /// needs game state the headless environment does not have. Registered per instance, never shared.
+    /// </param>
+    public TestEnvironment(int numClients = 2, Action<ContainerBuilder>? configureInstance = null)
     {
+        this.configureInstance = configureInstance;
+
         // Setup test network
         networkOrchestrator = new TestNetworkRouter();
 
@@ -118,6 +125,8 @@ public class TestEnvironment
             .SingleInstance();
 
         RegisterMock<ISettlementInterface>(builder);
+
+        configureInstance?.Invoke(builder);
 
         return builder;
     }

--- a/source/Coop.IntegrationTests/Kingdoms/KingdomAddDecisionTest.cs
+++ b/source/Coop.IntegrationTests/Kingdoms/KingdomAddDecisionTest.cs
@@ -1,8 +1,11 @@
 ﻿using Coop.Core.Server.Services.Kingdoms.Messages;
 using Coop.IntegrationTests.Environment;
 using Coop.IntegrationTests.Environment.Instance;
+using GameInterface.Services.Entity;
 using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Messages;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Election;
 namespace Coop.IntegrationTests.Kingdoms
@@ -28,7 +31,7 @@ namespace Coop.IntegrationTests.Kingdoms
                 client.CreateRegisteredObject<Kingdom>("kingdom1");
             }
             var decision = CreateDecision(TestEnvironment.Server);
-            var triggerMessage = new DecisionAdded(kingdom, decision, false, 0.5f);
+            var triggerMessage = new DecisionAdded(kingdom, decision, false, 0.5f, wasQueued: true);
             var server = TestEnvironment.Server;
             // Act
             server.SimulateMessage(this, triggerMessage);
@@ -41,6 +44,11 @@ namespace Coop.IntegrationTests.Kingdoms
                 Assert.Equal(1, client.InternalMessages.GetMessageCount<AddDecision>());
             }
         }
+
+        /// <summary>
+        /// A proposal reaches the server as an add with no answer attached, and the receive handler sends
+        /// nothing itself. The broadcast comes from the server's own apply, so nobody is sent two adds.
+        /// </summary>
         [Fact]
         public void ClientKingdom_AddDecision_Publishes_ServerCommand()
         {
@@ -50,16 +58,92 @@ namespace Coop.IntegrationTests.Kingdoms
             var kingdom = client1.CreateRegisteredObject<Kingdom>("kingdom1");
             server.CreateRegisteredObject<Kingdom>("kingdom1");
             var decision = CreateDecision(client1);
-            var triggerMessage = new DecisionAdded(kingdom, decision, false, 0f);
+            var triggerMessage = new DecisionAdded(kingdom, decision, false, 0f, wasQueued: null);
             // Act
             client1.SimulateMessage(this, triggerMessage);
             // Assert
             Assert.Equal(1, client1.NetworkSentMessages.GetMessageCount<NetworkAddDecision>());
             Assert.Equal(1, server.InternalMessages.GetMessageCount<NetworkAddDecision>());
-            Assert.Equal(1, server.InternalMessages.GetMessageCount<AddDecision>());
-            Assert.Equal(0, client1.InternalMessages.GetMessageCount<AddDecision>());
-            Assert.Equal(1, TestEnvironment.Clients.Skip(1).First().InternalMessages.GetMessageCount<AddDecision>());
+            Assert.Single(
+                server.InternalMessages.GetMessages<AddDecision>(),
+                message => message.WasQueued == null);
+            Assert.Empty(server.NetworkSentMessages.GetMessages<NetworkAddDecision>());
         }
+        /// <summary>
+        /// A clan outside the kingdom still mirrors that kingdom's queue, otherwise its
+        /// _unresolvedDecisions stays shorter than the server's and every later decision index is off.
+        /// </summary>
+        [Fact]
+        public void ServerKingdom_AddDecision_Publishes_ClientWithClanOutsideKingdom()
+        {
+            var server = TestEnvironment.Server;
+            var kingdom = server.CreateRegisteredObject<Kingdom>("kingdom1");
+            foreach (var client in TestEnvironment.Clients)
+            {
+                client.CreateRegisteredObject<Kingdom>("kingdom1");
+            }
+            var outsideClient = TestEnvironment.Clients.First();
+            PlaceControllerClanOutsideKingdom(outsideClient);
+            var decision = CreateDecision(server);
+
+            server.SimulateMessage(this, new DecisionAdded(kingdom, decision, false, 0.5f, wasQueued: true));
+
+            Assert.Equal(1, outsideClient.InternalMessages.GetMessageCount<AddDecision>());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ServerKingdom_AddDecision_Forwards_ServerQueueAnswer(bool wasQueued)
+        {
+            var server = TestEnvironment.Server;
+            var kingdom = server.CreateRegisteredObject<Kingdom>("kingdom1");
+            foreach (var client in TestEnvironment.Clients)
+            {
+                client.CreateRegisteredObject<Kingdom>("kingdom1");
+            }
+            var decision = CreateDecision(server);
+
+            server.SimulateMessage(this, new DecisionAdded(kingdom, decision, false, 0.5f, wasQueued));
+
+            Assert.Single(
+                server.NetworkSentMessages.GetMessages<NetworkAddDecision>(),
+                message => message.WasQueued == wasQueued);
+            foreach (EnvironmentInstance client in TestEnvironment.Clients)
+            {
+                Assert.Single(
+                    client.InternalMessages.GetMessages<AddDecision>(),
+                    message => message.WasQueued == wasQueued);
+            }
+        }
+
+        /// <summary>
+        /// A client proposal is a request, the server decides queue-vs-resolve for everyone.
+        /// </summary>
+        [Fact]
+        public void ClientKingdom_AddDecision_DoesNotSend_LocalQueueAnswer()
+        {
+            var client1 = TestEnvironment.Clients.First();
+            var kingdom = client1.CreateRegisteredObject<Kingdom>("kingdom1");
+            TestEnvironment.Server.CreateRegisteredObject<Kingdom>("kingdom1");
+            var decision = CreateDecision(client1);
+
+            client1.SimulateMessage(this, new DecisionAdded(kingdom, decision, false, 0f, wasQueued: true));
+
+            Assert.Single(
+                client1.NetworkSentMessages.GetMessages<NetworkAddDecision>(),
+                message => message.WasQueued == null);
+        }
+
+        private static void PlaceControllerClanOutsideKingdom(EnvironmentInstance client)
+        {
+            client.Resolve<IControllerIdProvider>().SetControllerId("player1");
+            client.Resolve<IPlayerManager>().AddPlayer(
+                new Player("player1", "hero1", "party1", "clan1", "character1"));
+            var otherKingdom = client.CreateRegisteredObject<Kingdom>("kingdom_other");
+            client.CreateRegisteredObject<Clan>("clan1")._kingdom = otherKingdom;
+        }
+
         private static KingdomDecision CreateDecision(EnvironmentInstance instance)
         {
             instance.CreateRegisteredObject<Clan>("clan1");

--- a/source/Coop.IntegrationTests/Kingdoms/KingdomDecisionQueueAlignmentTest.cs
+++ b/source/Coop.IntegrationTests/Kingdoms/KingdomDecisionQueueAlignmentTest.cs
@@ -1,0 +1,191 @@
+﻿using Autofac;
+using Common.Util;
+using Coop.Core.Server.Services.Kingdoms.Messages;
+using Coop.IntegrationTests.Environment;
+using Coop.IntegrationTests.Environment.Instance;
+using GameInterface.Services.Entity;
+using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
+using GameInterface.Services.Kingdoms.Messages;
+using GameInterface.Services.Kingdoms.Patches;
+using GameInterface.Services.Players;
+using GameInterface.Services.Players.Data;
+using Moq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Election;
+using TaleWorlds.Library;
+
+namespace Coop.IntegrationTests.Kingdoms;
+
+/// <summary>
+/// Guards the invariant the decision index messages depend on: every instance's
+/// <c>Kingdom._unresolvedDecisions</c> holds the same decisions in the same order as the server's.
+/// Asserts the lists themselves, not the messages that carry them.
+/// </summary>
+/// <remarks>
+/// Two collaborators need live campaign state the headless environment does not have, so they are
+/// stubbed: <see cref="IKingdomDecisionVoteManager"/> (its RegisterDecision builds a vanilla election
+/// that reads stances and heroes) and the campaign event dispatcher (given no receivers). Everything
+/// between the vanilla AddDecision patch and each instance's list is the real path.
+/// </remarks>
+[Collection(KingdomSyncGameThreadCollection.Name)]
+public class KingdomDecisionQueueAlignmentTest : IDisposable
+{
+    private const string KingdomId = "kingdom1";
+    private const string ProposerClanId = "clan1";
+    private const string ControllerId = "player1";
+
+    private readonly Campaign previousCampaign;
+
+    internal TestEnvironment TestEnvironment { get; }
+
+    public KingdomDecisionQueueAlignmentTest()
+    {
+        previousCampaign = Campaign.Current;
+        Campaign.Current = ObjectHelper.SkipConstructor<Campaign>();
+        Campaign.Current.CampaignEventDispatcher = new CampaignEventDispatcher(Array.Empty<CampaignEventReceiver>());
+        TestEnvironment = new TestEnvironment(configureInstance: StubVoteManager);
+    }
+
+    public void Dispose()
+    {
+        Campaign.Current = previousCampaign;
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// The proposing side is the server here, which is the only side that decides queue-vs-resolve.
+    /// One client's clan sits in another kingdom, the case the removed membership filter used to drop.
+    /// </summary>
+    [Fact]
+    public void ServerQueue_IsMirrored_OnEveryClient_AfterMixedAddAndResolve()
+    {
+        var server = TestEnvironment.Server;
+        var outsideClient = TestEnvironment.Clients.First();
+        var insideClient = TestEnvironment.Clients.Skip(1).First();
+        RegisterKingdomEverywhere();
+        PlaceControllerClanOutsideKingdom(outsideClient);
+
+        AddDecisionOnServer("kingdom2");
+        AddDecisionOnServer("kingdom3");
+        ResolveDecisionOnServer(index: 0);
+        AddDecisionOnServer("kingdom4");
+
+        AssertQueue(server, "kingdom3", "kingdom4");
+        AssertQueue(outsideClient, "kingdom3", "kingdom4");
+        AssertQueue(insideClient, "kingdom3", "kingdom4");
+    }
+
+    /// <summary>
+    /// A client applying the server's answer must not re-announce it, otherwise the server treats the
+    /// mirrored add as a fresh proposal and the two sides trade the same decision forever.
+    /// </summary>
+    [Fact]
+    public void MirroredAdd_IsNotProposedBackToTheServer()
+    {
+        RegisterKingdomEverywhere();
+
+        AddDecisionOnServer("kingdom2");
+
+        foreach (var client in TestEnvironment.Clients)
+        {
+            Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkAddDecision>());
+        }
+    }
+
+    /// <summary>
+    /// A decision the server resolved in place never entered its queue, so no client may queue it either.
+    /// The client must also not re-run the election: that second evaluation would re-apply outcome actions
+    /// the server already replicated, and here it throws because the vanilla election reads campaign state.
+    /// </summary>
+    [Fact]
+    public void ClientQueue_SkipsDecision_TheServerResolvedInPlace()
+    {
+        RegisterKingdomEverywhere();
+        var client = TestEnvironment.Clients.First();
+
+        client.SimulateMessage(this, new AddDecision(
+            KingdomId,
+            CreateDecisionData("kingdom2"),
+            ignoreInfluenceCost: true,
+            randomNumber: 0.5f,
+            wasQueued: false));
+
+        Assert.Empty(client.GetRegisteredObject<Kingdom>(KingdomId)._unresolvedDecisions);
+    }
+
+    private void AddDecisionOnServer(string targetKingdomId)
+    {
+        var server = TestEnvironment.Server;
+        server.Call(() =>
+        {
+            var kingdom = server.GetRegisteredObject<Kingdom>(KingdomId);
+            Assert.True(CreateDecisionData(targetKingdomId)
+                .TryGetKingdomDecision(server.ObjectManager, out var decision));
+            KingdomPatches.AddDecisionPrefix(kingdom, decision, ignoreInfluenceCost: true);
+        });
+    }
+
+    /// <summary>
+    /// Drives the server side of a resolve. The patch prefix returns true so vanilla removes the entry,
+    /// and Harmony is not installed in this environment, so the original call is made here instead.
+    /// </summary>
+    private void ResolveDecisionOnServer(int index)
+    {
+        var server = TestEnvironment.Server;
+        server.Call(() =>
+        {
+            var kingdom = server.GetRegisteredObject<Kingdom>(KingdomId);
+            var decision = kingdom._unresolvedDecisions[index];
+            Assert.True(KingdomPatches.RemoveDecisionPrefix(kingdom, decision));
+            kingdom._unresolvedDecisions.Remove(decision);
+        });
+    }
+
+    private static void AssertQueue(EnvironmentInstance instance, params string[] expectedTargetKingdomIds)
+    {
+        var decisions = instance.GetRegisteredObject<Kingdom>(KingdomId)._unresolvedDecisions;
+        Assert.Equal(expectedTargetKingdomIds.Length, decisions.Count);
+        for (int index = 0; index < expectedTargetKingdomIds.Length; index++)
+        {
+            var decision = Assert.IsType<DeclareWarDecision>(decisions[index]);
+            Assert.Same(
+                instance.GetRegisteredObject<Kingdom>(expectedTargetKingdomIds[index]),
+                decision.FactionToDeclareWarOn);
+        }
+    }
+
+    private void RegisterKingdomEverywhere()
+    {
+        foreach (var instance in TestEnvironment.Clients.Prepend(TestEnvironment.Server))
+        {
+            var kingdom = instance.CreateRegisteredObject<Kingdom>(KingdomId);
+            kingdom._unresolvedDecisions = new MBList<KingdomDecision>();
+            instance.CreateRegisteredObject<Clan>(ProposerClanId)._kingdom = kingdom;
+            instance.CreateRegisteredObject<Kingdom>("kingdom2");
+            instance.CreateRegisteredObject<Kingdom>("kingdom3");
+            instance.CreateRegisteredObject<Kingdom>("kingdom4");
+        }
+    }
+
+    private static void PlaceControllerClanOutsideKingdom(EnvironmentInstance client)
+    {
+        client.Resolve<IControllerIdProvider>().SetControllerId(ControllerId);
+        client.Resolve<IPlayerManager>().AddPlayer(
+            new Player(ControllerId, "hero1", "party1", ProposerClanId, "character1"));
+        client.GetRegisteredObject<Clan>(ProposerClanId)._kingdom =
+            client.CreateRegisteredObject<Kingdom>("kingdom_other");
+    }
+
+    private static KingdomDecisionData CreateDecisionData(string targetKingdomId)
+    {
+        return new DeclareWarDecisionData(ProposerClanId, KingdomId, 0, false, false, false, targetKingdomId);
+    }
+
+    private static void StubVoteManager(ContainerBuilder builder)
+    {
+        var voteManager = new Mock<IKingdomDecisionVoteManager>();
+        voteManager.Setup(manager => manager.HasEligiblePlayerClan(It.IsAny<KingdomDecision>())).Returns(true);
+        builder.RegisterInstance(voteManager.Object).As<IKingdomDecisionVoteManager>().SingleInstance();
+    }
+}

--- a/source/Coop.IntegrationTests/Kingdoms/KingdomNetworkMessageSerializationTest.cs
+++ b/source/Coop.IntegrationTests/Kingdoms/KingdomNetworkMessageSerializationTest.cs
@@ -1,6 +1,6 @@
-﻿using Coop.Core.Server.Services.Kingdoms.Messages;
+﻿using Common.Serialization;
+using Coop.Core.Server.Services.Kingdoms.Messages;
 using GameInterface.Services.Kingdoms.Data;
-using ProtoBuf;
 using TaleWorlds.CampaignSystem.Election;
 
 namespace Coop.IntegrationTests.Kingdoms;
@@ -111,6 +111,30 @@ public class KingdomNetworkMessageSerializationTest
         Assert.Equal("The council has reached a decision.", copy.NotificationText);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [InlineData(null)]
+    public void NetworkAddDecision_RoundTripsQueueAnswer(bool? wasQueued)
+    {
+        var original = new NetworkAddDecision(
+            "Kingdom_empire",
+            new DeclareWarDecisionData("Clan_realclan", "Kingdom_empire", 5, false, true, false, "Kingdom_vlandia"),
+            ignoreInfluenceCost: true,
+            randomNumber: 0.25f,
+            wasQueued: wasQueued);
+
+        var copy = RoundTrip(original);
+
+        Assert.Equal("Kingdom_empire", copy.KingdomId);
+        Assert.True(copy.IgnoreInfluenceCost);
+        Assert.Equal(0.25f, copy.RandomNumber);
+        Assert.Equal(wasQueued, copy.WasQueued);
+        var data = Assert.IsType<DeclareWarDecisionData>(copy.Data);
+        Assert.Equal("Clan_realclan", data.ProposerClanId);
+        Assert.Equal("Kingdom_vlandia", data.FactionToDeclareWarOnId);
+    }
+
     [Fact]
     public void NetworkRequestChangeKingdomName_RoundTrips()
     {
@@ -134,12 +158,15 @@ public class KingdomNetworkMessageSerializationTest
         Assert.Equal("Kingdom_empire", copy.KingdomId);
     }
 
+    /// <summary>
+    /// Goes through the production serializer so the round trip exercises the runtime model
+    /// <see cref="ProtoBufSerializer.ConfigureRuntimeModel()"/> installs, not protobuf-net's defaults.
+    /// </summary>
     private static T RoundTrip<T>(T original)
     {
-        using var stream = new MemoryStream();
-        Serializer.Serialize(stream, original);
-        stream.Position = 0;
-        return Serializer.Deserialize<T>(stream);
+        ProtoBufSerializer.ConfigureRuntimeModel();
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        return serializer.Deserialize<T>(serializer.Serialize(original!));
     }
 
     private static void AssertVoteData(KingdomDecisionVoteData expected, KingdomDecisionVoteData actual)

--- a/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
+++ b/source/E2E.Tests/Services/Kingdoms/PlayerKingdomCreationFlowTests.cs
@@ -2648,7 +2648,7 @@ public class PlayerKingdomCreationFlowTests : IDisposable
         Assert.NotNull(decisionData);
         Server.SimulateMessage(
             this,
-            new NetworkAddDecision(kingdomId, decisionData, ignoreInfluenceCost: false, randomNumber: 0.5f));
+            new NetworkAddDecision(kingdomId, decisionData, ignoreInfluenceCost: false, randomNumber: 0.5f, wasQueued: null));
         Server.Call(() =>
         {
             Assert.True(Server.ObjectManager.TryGetObject<Clan>(player1.ClanId, out var proposerClan));

--- a/source/GameInterface.Tests/Services/Kingdoms/KingdomHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Kingdoms/KingdomHandlerTests.cs
@@ -1,6 +1,8 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
 using Common.Util;
 using GameInterface.Services.Kingdoms;
+using GameInterface.Services.Kingdoms.Data;
 using GameInterface.Services.Kingdoms.Handlers;
 using GameInterface.Services.Kingdoms.Messages;
 using GameInterface.Services.ObjectManager;
@@ -9,6 +11,8 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Election;
 using TaleWorlds.Library;
@@ -19,6 +23,18 @@ namespace GameInterface.Tests.Services.Kingdoms;
 
 public class KingdomHandlerTests
 {
+    private const string KingdomId = "kingdom-id";
+    private const string ProposerClanId = "clan-id";
+    private const string TargetKingdomId = "target-kingdom-id";
+
+    static KingdomHandlerTests()
+    {
+        // Coop.Tests starts and continuously pumps a dedicated game-loop thread from a [ModuleInitializer]
+        // (TestGameLoopPump); force that initializer to run so the pump is up when this class runs in
+        // isolation. RunModuleConstructor is idempotent.
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
     [Fact]
     public void TryGetCulture_UsesObjectManager()
     {
@@ -253,6 +269,99 @@ public class KingdomHandlerTests
         Assert.Equal("kingdom name was empty", reason);
     }
     
+    [Fact]
+    public void AddDecision_ResolvesEveryLookupOnTheGameThread()
+    {
+        Assert.True(GameThread.Instance.IsInitialized, "game-loop pump was not initialized");
+        Assert.False(GameThread.Instance.IsGameThread);
+
+        var lookupThreadIds = new List<int>();
+        var objectManager = CreateDecisionObjectManager(
+            () => lookupThreadIds.Add(Thread.CurrentThread.ManagedThreadId));
+        var kingdomInterface = new Mock<IKingdomInterface>();
+        var handler = CreateHandler<AddDecision>(objectManager, kingdomInterface.Object);
+
+        int gameThreadId = 0;
+        GameThread.Run(() => gameThreadId = Thread.CurrentThread.ManagedThreadId, blocking: true);
+
+        handler(new MessagePayload<AddDecision>(this, CreateAddDecision(wasQueued: true)));
+
+        Assert.NotEmpty(lookupThreadIds);
+        Assert.All(lookupThreadIds, threadId => Assert.Equal(gameThreadId, threadId));
+    }
+
+    [Fact]
+    public void AddDecision_ForwardsTheServerQueueAnswerToTheKingdomInterface()
+    {
+        var objectManager = CreateDecisionObjectManager();
+        var kingdomInterface = new Mock<IKingdomInterface>();
+        var handler = CreateHandler<AddDecision>(objectManager, kingdomInterface.Object);
+
+        handler(new MessagePayload<AddDecision>(this, CreateAddDecision(wasQueued: false)));
+
+        kingdomInterface.Verify(
+            gameInterface => gameInterface.RunAddDecision(
+                It.IsAny<Kingdom>(),
+                It.IsAny<CampaignKingdomDecision>(),
+                false,
+                0.25f,
+                false),
+            Times.Once);
+    }
+
+    [Fact]
+    public void AddDecision_MissingKingdom_DoesNotAdd()
+    {
+        var objectManager = new Mock<IObjectManager>();
+        Kingdom missingKingdom = null!;
+        objectManager.Setup(manager => manager.TryGetObjectWithLogging(KingdomId, out missingKingdom)).Returns(false);
+        var kingdomInterface = new Mock<IKingdomInterface>();
+        var handler = CreateHandler<AddDecision>(objectManager.Object, kingdomInterface.Object);
+
+        handler(new MessagePayload<AddDecision>(this, CreateAddDecision(wasQueued: true)));
+
+        kingdomInterface.Verify(
+            gameInterface => gameInterface.RunAddDecision(
+                It.IsAny<Kingdom>(),
+                It.IsAny<CampaignKingdomDecision>(),
+                It.IsAny<bool>(),
+                It.IsAny<float>(),
+                It.IsAny<bool?>()),
+            Times.Never);
+    }
+
+    private static AddDecision CreateAddDecision(bool wasQueued)
+    {
+        var data = new DeclareWarDecisionData(ProposerClanId, KingdomId, 0, false, false, false, TargetKingdomId);
+        return new AddDecision(KingdomId, data, false, 0.25f, wasQueued);
+    }
+
+    /// <summary>
+    /// Resolves everything <see cref="DeclareWarDecisionData.TryGetKingdomDecision"/> needs, optionally
+    /// reporting each lookup so a test can observe which thread it ran on.
+    /// </summary>
+    private static IObjectManager CreateDecisionObjectManager(Action onLookup = null)
+    {
+        var objectManager = new Mock<IObjectManager>();
+        Kingdom kingdom = ObjectHelper.SkipConstructor<Kingdom>();
+        Kingdom targetKingdom = ObjectHelper.SkipConstructor<Kingdom>();
+        Clan proposerClan = ObjectHelper.SkipConstructor<Clan>();
+
+        objectManager.Setup(manager => manager.TryGetObjectWithLogging(KingdomId, out kingdom))
+            .Callback(() => onLookup?.Invoke())
+            .Returns(true);
+        objectManager.Setup(manager => manager.TryGetObject(KingdomId, out kingdom))
+            .Callback(() => onLookup?.Invoke())
+            .Returns(true);
+        objectManager.Setup(manager => manager.TryGetObject(TargetKingdomId, out targetKingdom))
+            .Callback(() => onLookup?.Invoke())
+            .Returns(true);
+        objectManager.Setup(manager => manager.TryGetObject(ProposerClanId, out proposerClan))
+            .Callback(() => onLookup?.Invoke())
+            .Returns(true);
+        return objectManager.Object;
+    }
+
     private static KingdomHandler CreateHandler(IObjectManager objectManager)
     {
         return new KingdomHandler(
@@ -270,20 +379,32 @@ public class KingdomHandlerTests
         IKingdomDecisionVoteManager voteManager,
         IKingdomInterface kingdomInterface)
     {
-        Action<MessagePayload<RemoveDecision>> removeDecisionHandler = null!;
+        return CreateHandler<RemoveDecision>(objectManager, kingdomInterface, voteManager);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="KingdomHandler"/> against mocked collaborators and returns the delegate it
+    /// subscribed for <typeparamref name="T"/>, so a test can drive that one handler directly.
+    /// </summary>
+    private static Action<MessagePayload<T>> CreateHandler<T>(
+        IObjectManager objectManager,
+        IKingdomInterface kingdomInterface,
+        IKingdomDecisionVoteManager voteManager = null) where T : IMessage
+    {
+        Action<MessagePayload<T>> subscribedHandler = null!;
         var messageBroker = new Mock<IMessageBroker>();
         messageBroker
-            .Setup(broker => broker.Subscribe(It.IsAny<Action<MessagePayload<RemoveDecision>>>()!))
-            .Callback<Action<MessagePayload<RemoveDecision>>>(handler => removeDecisionHandler = handler);
+            .Setup(broker => broker.Subscribe(It.IsAny<Action<MessagePayload<T>>>()!))
+            .Callback<Action<MessagePayload<T>>>(handler => subscribedHandler = handler);
         _ = new KingdomHandler(
             messageBroker.Object,
             objectManager,
             new Mock<IPlayerManager>().Object,
-            voteManager,
+            voteManager ?? new Mock<IKingdomDecisionVoteManager>().Object,
             new Mock<IKingdomMembershipState>().Object,
             kingdomInterface,
             new Mock<IKingdomCreator>().Object);
-        return removeDecisionHandler;
+        return subscribedHandler;
     }
 
     private static bool TryGetCulture(KingdomHandler handler, string cultureId, out CultureObject culture)

--- a/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
+++ b/source/GameInterface/Services/Kingdoms/Handlers/KingdomHandler.cs
@@ -499,19 +499,25 @@ public class KingdomHandler : IHandler
     {
         var payload = obj.What;
 
-        if (!objectManager.TryGetObject(payload.KingdomId, out Kingdom kingdom))
+        // The lookups belong inside the closure, otherwise they can run before the registration a
+        // preceding handler queued on the game thread and the add is dropped while removes still apply.
+        RunKingdomMutation(() =>
         {
-            Logger.Debug("Kingdom not found in KingdomDecisionHandler with KingdomId: {id}", payload.KingdomId);
-            return;
-        }
+            if (!objectManager.TryGetObjectWithLogging(payload.KingdomId, out Kingdom kingdom)) return;
 
-        if (!payload.Data.TryGetKingdomDecision(objectManager, out KingdomDecision kingdomDecision))
-        {
-            Logger.Warning("KingdomDecision could not be deserialized in KingdomDecisionHandler.");
-            return;
-        }
+            if (!payload.Data.TryGetKingdomDecision(objectManager, out KingdomDecision kingdomDecision))
+            {
+                Logger.Warning("KingdomDecision could not be deserialized in KingdomDecisionHandler.");
+                return;
+            }
 
-        kingdomInterface.RunAddDecision(kingdom, kingdomDecision, payload.IgnoreInfluenceCost, payload.RandomNumber);
+            kingdomInterface.RunAddDecision(
+                kingdom,
+                kingdomDecision,
+                payload.IgnoreInfluenceCost,
+                payload.RandomNumber,
+                payload.WasQueued);
+        });
     }
 
     private static void RunKingdomMutation(Action action)

--- a/source/GameInterface/Services/Kingdoms/KingdomInterface.cs
+++ b/source/GameInterface/Services/Kingdoms/KingdomInterface.cs
@@ -15,8 +15,8 @@ public interface IKingdomInterface : IGameAbstraction
     bool RemoveDecisionPrefix(Kingdom kingdom, KingdomDecision kingdomDecision);
     bool AddPolicyPrefix(Kingdom kingdom, PolicyObject policy);
     bool RemovePolicyPrefix(Kingdom kingdom, PolicyObject policy);
-    float AddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float? randomFloat = null, bool applyInfluenceCost = true);
-    void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat);
+    KingdomDecisionAddResult AddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float? randomFloat, bool applyInfluenceCost, bool? wasQueued);
+    void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat, bool? wasQueued);
     void RemoveDecision(Kingdom kingdom, KingdomDecision kingdomDecision);
     void ChangeKingdomPolicy(Kingdom kingdom, PolicyObject policy, bool isAdd);
 }
@@ -32,14 +32,14 @@ internal class KingdomInterface : IKingdomInterface
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
         if (ModInformation.IsClient)
         {
-            float clientRandomNumber = AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, applyInfluenceCost: false);
+            // A client only proposes, the same shape RemoveDecisionPrefix uses. The decision is applied
+            // when the server broadcasts its answer back, otherwise the proposer holds an optimistic copy
+            // that the broadcast then adds a second time and every later decision index is off by one.
             MessageBroker.Instance.Publish(kingdom,
-                new DecisionAdded(kingdom, kingdomDecision, ignoreInfluenceCost, clientRandomNumber));
+                new DecisionAdded(kingdom, kingdomDecision, ignoreInfluenceCost, randomNumber: default, wasQueued: null));
             return false;
         }
-        float randomNumber = AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, applyInfluenceCost: true);
-        MessageBroker.Instance.Publish(kingdom,
-            new DecisionAdded(kingdom, kingdomDecision, ignoreInfluenceCost, randomNumber));
+        ApplyAndAnnounce(kingdom, kingdomDecision, ignoreInfluenceCost, randomFloat: null, wasQueued: null);
         return false;
     }
     public bool RemoveDecisionPrefix(Kingdom kingdom, KingdomDecision kingdomDecision)
@@ -78,12 +78,13 @@ internal class KingdomInterface : IKingdomInterface
         }
         return true;
     }
-    public float AddDecision(
+    public KingdomDecisionAddResult AddDecision(
         Kingdom kingdom,
         KingdomDecision kingdomDecision,
         bool ignoreInfluenceCost,
-        float? randomFloat = null,
-        bool applyInfluenceCost = true)
+        float? randomFloat,
+        bool applyInfluenceCost,
+        bool? wasQueued)
     {
         KingdomRegistry.EnsureRuntimeCollections(kingdom);
         if (applyInfluenceCost && !ignoreInfluenceCost)
@@ -92,24 +93,49 @@ internal class KingdomInterface : IKingdomInterface
             int influenceCost = kingdomDecision.GetInfluenceCost(proposerClan);
             ChangeClanInfluenceAction.Apply(proposerClan, (float)(-(float)influenceCost));
         }
-        bool hasEligiblePlayerClan = decisionVoteManager.HasEligiblePlayerClan(kingdomDecision);
-        CampaignEventDispatcher.Instance.OnKingdomDecisionAdded(kingdomDecision, hasEligiblePlayerClan);
-        if (!hasEligiblePlayerClan)
+        // Take the server's answer when it sent one. Eligibility also filters on player connectivity on the
+        // server, so re-deciding here offsets _unresolvedDecisions and every later index based message.
+        bool queueDecision = wasQueued ?? decisionVoteManager.HasEligiblePlayerClan(kingdomDecision);
+        CampaignEventDispatcher.Instance.OnKingdomDecisionAdded(kingdomDecision, queueDecision);
+        if (!queueDecision)
         {
+            // Only the server elects. On a client the answer means "this one never entered the queue",
+            // because a second evaluation there re-applies outcome actions the server already replicated.
+            if (ModInformation.IsClient) return new KingdomDecisionAddResult(default, false);
+
             CoopKingdomElection election = new CoopKingdomElection(kingdomDecision, randomFloat);
             election.StartElectionCoop();
-            return election.RandomFloat;
+            return new KingdomDecisionAddResult(election.RandomFloat, false);
         }
         kingdom._unresolvedDecisions.Add(kingdomDecision);
         decisionVoteManager.RegisterDecision(kingdomDecision);
-        return default;
+        return new KingdomDecisionAddResult(default, true);
     }
-    public void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat)
+    public void RunAddDecision(Kingdom kingdom, KingdomDecision kingdomDecision, bool ignoreInfluenceCost, float randomFloat, bool? wasQueued)
     {
         RunKingdomMutation(() =>
         {
-            AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, randomFloat, ModInformation.IsServer);
+            if (ModInformation.IsServer)
+            {
+                // This is a client's proposal being applied, and announcing the apply is what carries the
+                // server's queue answer out to every client, the proposer included, in one broadcast.
+                ApplyAndAnnounce(kingdom, kingdomDecision, ignoreInfluenceCost, randomFloat, wasQueued);
+                return;
+            }
+            // Only the server charges influence, the client mirrors the cost the server replicates.
+            AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, randomFloat, applyInfluenceCost: false, wasQueued);
         });
+    }
+    private void ApplyAndAnnounce(
+        Kingdom kingdom,
+        KingdomDecision kingdomDecision,
+        bool ignoreInfluenceCost,
+        float? randomFloat,
+        bool? wasQueued)
+    {
+        var result = AddDecision(kingdom, kingdomDecision, ignoreInfluenceCost, randomFloat, applyInfluenceCost: true, wasQueued);
+        MessageBroker.Instance.Publish(kingdom,
+            new DecisionAdded(kingdom, kingdomDecision, ignoreInfluenceCost, result.RandomNumber, result.WasQueued));
     }
     public void RemoveDecision(Kingdom kingdom, KingdomDecision kingdomDecision)
     {
@@ -147,5 +173,21 @@ internal class KingdomInterface : IKingdomInterface
             return;
         }
         GameThread.RunSafe(action, blocking: true, context: nameof(KingdomInterface));
+    }
+}
+/// <summary>
+/// Outcome of a single <c>Kingdom.AddDecision</c> apply.
+/// </summary>
+public readonly struct KingdomDecisionAddResult
+{
+    public readonly float RandomNumber;
+    /// <summary>
+    /// True when the decision was queued in <c>Kingdom._unresolvedDecisions</c>, false when it was resolved in place.
+    /// </summary>
+    public readonly bool WasQueued;
+    public KingdomDecisionAddResult(float randomNumber, bool wasQueued)
+    {
+        RandomNumber = randomNumber;
+        WasQueued = wasQueued;
     }
 }

--- a/source/GameInterface/Services/Kingdoms/Messages/AddDecision.cs
+++ b/source/GameInterface/Services/Kingdoms/Messages/AddDecision.cs
@@ -14,12 +14,23 @@ namespace GameInterface.Services.Kingdoms.Messages
 
         public float RandomNumber { get; }
 
-        public AddDecision(string kingdomId, KingdomDecisionData data, bool ignoreInfluenceCost, float randomNumber)
+        /// <summary>
+        /// The server's queue-vs-resolve answer, or null when the receiver has to decide locally.
+        /// </summary>
+        public bool? WasQueued { get; }
+
+        public AddDecision(
+            string kingdomId,
+            KingdomDecisionData data,
+            bool ignoreInfluenceCost,
+            float randomNumber,
+            bool? wasQueued)
         {
             KingdomId = kingdomId;
             Data = data;
             IgnoreInfluenceCost = ignoreInfluenceCost;
             RandomNumber = randomNumber;
+            WasQueued = wasQueued;
         }
     }
 }

--- a/source/GameInterface/Services/Kingdoms/Messages/DecisionAdded.cs
+++ b/source/GameInterface/Services/Kingdoms/Messages/DecisionAdded.cs
@@ -11,11 +11,17 @@ public readonly struct DecisionAdded : IEvent
     public readonly KingdomDecision Decision;
     public readonly bool IgnoreInfluenceCost;
     public readonly float RandomNumber;
-    public DecisionAdded(Kingdom kingdom, KingdomDecision decision, bool ignoreInfluenceCost, float randomNumber)
+    /// <summary>
+    /// True when the decision was queued in <c>Kingdom._unresolvedDecisions</c>, false when it was resolved in place.
+    /// Null when the publisher only proposed the decision and is waiting for the server to answer.
+    /// </summary>
+    public readonly bool? WasQueued;
+    public DecisionAdded(Kingdom kingdom, KingdomDecision decision, bool ignoreInfluenceCost, float randomNumber, bool? wasQueued)
     {
         Kingdom = kingdom;
         Decision = decision;
         IgnoreInfluenceCost = ignoreInfluenceCost;
         RandomNumber = randomNumber;
+        WasQueued = wasQueued;
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Kingdom decision network messages address decisions by their index in `Kingdom._unresolvedDecisions`, and clients can drift from the server in two ways. Adds are filtered by local kingdom membership while removes and resolves are not, so a clan that joins a kingdom mid session has a shorter list than the server forever. And every machine re evaluates queue versus resolve locally, while only the server filters eligibility on connectivity, so a disconnected registered player makes server and client disagree deterministically. Any divergence permanently offsets every later index based vote, resolve and remove until relog, which is the stuck vote loop in #3171.

## What is the new behavior?

Resolves #3171

Clients now mirror every kingdom's decision adds, so the lists cannot diverge by filtering. The server's queue versus resolve answer travels on `NetworkAddDecision` as a nullable field, so a message from a build without the field falls back to today's local evaluation and mixed versions degrade gracefully. A proposing client only proposes, matching what `RemoveDecisionPrefix` already does, and applies the decision once the server's single `DecisionAdded` broadcast arrives, so exactly one apply happens per machine. Clients never run an election for a decision the server resolved in place, which that branch would otherwise now do for every AI kingdom on every client, locally deducting influence and dispatching foreign kingdom map notices. Decision lookups in the add handler resolve on the game thread and a miss is logged instead of silently dropped.

What remains open: the proposer sees its decision after one round trip rather than instantly, and kingdom decisions still have no stable synced id, so index addressing survives. A server minted decision id is the follow up that would remove both, and it should land after branch 3268 which adds the save data shape it needs.

Manual check: server and every client run `coop.debug.kingdom.list_kingdom_decisions` for the same kingdom after joins, leaves and resolves; the listings must match line for line, including on a client whose clan is outside that kingdom.

## Bot Changelog Entry

- Fixed kingdom votes and decisions getting out of sync and sticking until relog.

## Other information

An integration test asserts list count and per index identity on the server and both clients after a mixed add and resolve sequence with one client's clan outside the kingdom. The serialization round trip covers the nullable field in all three states through the runtime model the mod actually configures.
