### PR TITLE
Fix bug report consent, saves, and archive eviction

### DIFF
--- a/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
+++ b/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
@@ -4,8 +4,10 @@ using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.BugReporting;
 using GameInterface.Services.BugReporting.Messages;
+using GameInterface.Services.Heroes;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Players;
+using GameInterface.Services.Save.Patches;
 using GameInterface.Services.UI.BugReporting;
 using Moq;
 using System;
@@ -17,6 +19,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using TaleWorlds.SaveSystem;
 using Xunit;
 
 namespace GameInterface.Tests.Services.BugReporting;
@@ -179,12 +182,12 @@ public class CoopLogBugReportTests : IDisposable
     }
 
     [Fact]
-    public void ServerSaveProvider_PersistsAndReturnsTheCampaignSave()
+    public void ServerSaveProvider_ReturnsTheCampaignSaveFileData()
     {
         var saveData = Encoding.UTF8.GetBytes("campaign save");
         var saveInterface = new Mock<ISaveInterface>();
         saveInterface
-            .Setup(value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName))
+            .Setup(value => value.SaveCurrentGameAsFileData(BugReportServerSaveProvider.SaveName))
             .Returns(new SaveResults(true, saveData, "campaign-id"));
         var provider = new BugReportServerSaveProvider(saveInterface.Object, Mock.Of<Serilog.ILogger>());
 
@@ -194,8 +197,35 @@ public class CoopLogBugReportTests : IDisposable
         Assert.Equal("coop_bug_report.sav", save.FileName);
         Assert.Equal(saveData, save.Data);
         saveInterface.Verify(
-            value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName),
+            value => value.SaveCurrentGameAsFileData(BugReportServerSaveProvider.SaveName),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task ServerSaveSnapshot_DoesNotOverwriteExistingSavePair()
+    {
+        Directory.CreateDirectory(tempRoot);
+        var campaignPath = Path.Combine(tempRoot, "coop_bug_report.sav");
+        var sessionPath = Path.Combine(tempRoot, "coop_bug_report.json");
+        var existingCampaign = Encoding.UTF8.GetBytes("existing campaign");
+        var existingSession = Encoding.UTF8.GetBytes("existing session");
+        File.WriteAllBytes(campaignPath, existingCampaign);
+        File.WriteAllBytes(sessionPath, existingSession);
+        var driver = new CoopFileInMemSaveDriver();
+        var gameData = new GameData(
+            new byte[] { 1 },
+            new byte[] { 2 },
+            new[] { new byte[] { 3 } },
+            new[] { new byte[] { 4 } });
+
+        await driver.Save(BugReportServerSaveProvider.SaveName, 1, new MetaData(), gameData);
+
+        Assert.Equal(existingCampaign, File.ReadAllBytes(campaignPath));
+        Assert.Equal(existingSession, File.ReadAllBytes(sessionPath));
+        Assert.NotEmpty(driver.Data);
+        Assert.Equal(gameData.Header, driver.Load(BugReportServerSaveProvider.SaveName).GameData.Header);
+        Assert.False(SavePatches.ShouldPublishGameSaved(driver));
+        Assert.True(SavePatches.ShouldPublishGameSaved(new FileDriver()));
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
+++ b/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
@@ -4,6 +4,7 @@ using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.BugReporting;
 using GameInterface.Services.BugReporting.Messages;
+using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Players;
 using GameInterface.Services.UI.BugReporting;
 using Moq;
@@ -61,6 +62,7 @@ public class CoopLogBugReportTests : IDisposable
         Directory.CreateDirectory(tempRoot);
         var logBytes = Compress("client diagnostic\n");
         var serverLogBytes = Compress("server diagnostic\n");
+        var serverSaveBytes = Encoding.UTF8.GetBytes("server save data");
         var requestId = Guid.NewGuid().ToString("N");
         using var builder = new BugReportArchiveBuilder(tempRoot);
         var contents = new BugReportArchiveContents(
@@ -74,6 +76,7 @@ public class CoopLogBugReportTests : IDisposable
             new CollectedBugReportServerLog(
                 serverLogBytes,
                 Encoding.UTF8.GetByteCount("server diagnostic\n")),
+            new CollectedBugReportServerSave("coop_bug_report.sav", serverSaveBytes),
             DateTimeOffset.UtcNow,
             new[] { new CollectedBugReportLog(2, logBytes, Encoding.UTF8.GetByteCount("client diagnostic\n")) },
             expectedClients: 3,
@@ -105,6 +108,13 @@ public class CoopLogBugReportTests : IDisposable
         using (var serverLogReader = new StreamReader(serverLogEntry.Open()))
         {
             Assert.Equal("server diagnostic\n", serverLogReader.ReadToEnd());
+        }
+        var serverSaveEntry = Assert.IsType<ZipArchiveEntry>(archive.GetEntry("server/coop_bug_report.sav"));
+        using (var saveData = new MemoryStream())
+        {
+            using var saveStream = serverSaveEntry.Open();
+            saveStream.CopyTo(saveData);
+            Assert.Equal(serverSaveBytes, saveData.ToArray());
         }
         var logEntry = Assert.Single(archive.Entries, entry => entry.FullName.StartsWith("clients/"));
         Assert.Equal("clients/client-02.log", logEntry.FullName);
@@ -156,6 +166,7 @@ public class CoopLogBugReportTests : IDisposable
             Mock.Of<IPlayerManager>(),
             Mock.Of<IBugReportLogSharingPreference>(),
             snapshotProvider.Object,
+            Mock.Of<IBugReportServerSaveProvider>(),
             Mock.Of<IBugReportArchiveBuilder>(),
             new BugReportLogValidator(),
             Mock.Of<IBugReportUploader>(),
@@ -165,6 +176,26 @@ public class CoopLogBugReportTests : IDisposable
 
         Assert.NotNull(contents.ServerLog);
         Assert.Equal(compressed, contents.ServerLog.CompressedData);
+    }
+
+    [Fact]
+    public void ServerSaveProvider_PersistsAndReturnsTheCampaignSave()
+    {
+        var saveData = Encoding.UTF8.GetBytes("campaign save");
+        var saveInterface = new Mock<ISaveInterface>();
+        saveInterface
+            .Setup(value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName))
+            .Returns(new SaveResults(true, saveData, "campaign-id"));
+        var provider = new BugReportServerSaveProvider(saveInterface.Object, Mock.Of<Serilog.ILogger>());
+
+        var captured = provider.TryCapture(out var save);
+
+        Assert.True(captured);
+        Assert.Equal("coop_bug_report.sav", save.FileName);
+        Assert.Equal(saveData, save.Data);
+        saveInterface.Verify(
+            value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName),
+            Times.Once);
     }
 
     [Fact]
@@ -267,7 +298,7 @@ public class CoopLogBugReportTests : IDisposable
     }
 
     [Fact]
-    public async Task Uploader_PostsJsonWithReporterServerLogAndClientLogs()
+    public async Task Uploader_UploadsServerSaveThenPostsJsonWithLogs()
     {
         var handler = new RecordingHttpHandler();
         using var httpClient = new HttpClient(handler);
@@ -280,6 +311,7 @@ public class CoopLogBugReportTests : IDisposable
             authorizationToken);
         var serverLog = Compress("server diagnostic\n");
         var clientLog = Compress("client diagnostic\n");
+        var serverSave = Encoding.UTF8.GetBytes("server campaign save");
         var report = new BugReportArchiveContents(
             Guid.NewGuid().ToString("N"),
             "network-client-1",
@@ -291,6 +323,7 @@ public class CoopLogBugReportTests : IDisposable
             new CollectedBugReportServerLog(
                 serverLog,
                 Encoding.UTF8.GetByteCount("server diagnostic\n")),
+            new CollectedBugReportServerSave("coop_bug_report.sav", serverSave),
             DateTimeOffset.UtcNow,
             new[] { new CollectedBugReportLog(
                 1,
@@ -308,6 +341,13 @@ public class CoopLogBugReportTests : IDisposable
         Assert.Equal(publishableKey, handler.ApiKey);
         Assert.Equal("Bearer " + authorizationToken, handler.Authorization);
         Assert.Equal(report.RequestId, handler.IdempotencyKey);
+        Assert.Equal(serverSave, handler.ServerSaveBody);
+        Assert.Equal("server-save", handler.ServerSaveArtifact);
+        Assert.Equal(report.RequestId, handler.ServerSaveReportId);
+        Assert.Equal("coop_bug_report.sav", handler.ServerSaveFileName);
+        Assert.Equal(publishableKey, handler.ServerSaveApiKey);
+        Assert.Equal("Bearer " + authorizationToken, handler.ServerSaveAuthorization);
+        Assert.Equal(report.RequestId + "-server-save", handler.ServerSaveIdempotencyKey);
         using var json = JsonDocument.Parse(handler.Body);
         var root = json.RootElement;
         Assert.Equal("network-client-1", root.GetProperty("reportingClientNetworkId").GetString());
@@ -321,6 +361,42 @@ public class CoopLogBugReportTests : IDisposable
         Assert.Equal(
             Convert.ToBase64String(clientLog),
             root.GetProperty("clientLogs")[0].GetProperty("data").GetString());
+        Assert.Equal(2, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal("server-save", root.GetProperty("serverSave").GetProperty("artifact").GetString());
+        Assert.Equal(serverSave.Length, root.GetProperty("serverSave").GetProperty("length").GetInt64());
+    }
+
+    [Fact]
+    public async Task Uploader_DoesNotPostReportWhenServerSaveUploadFails()
+    {
+        var handler = new RecordingHttpHandler { FailServerSaveUpload = true };
+        using var httpClient = new HttpClient(handler);
+        using var uploader = new BugReportUploader(
+            httpClient,
+            "https://bug-reports.example.test/api/v1/reports",
+            "test-publishable-key",
+            "server-bound-token");
+        var report = new BugReportArchiveContents(
+            Guid.NewGuid().ToString("N"),
+            "network-client-1",
+            Array.Empty<string>(),
+            Array.Empty<BugReportSubmission>(),
+            null,
+            new CollectedBugReportServerSave(
+                "coop_bug_report.sav",
+                Encoding.UTF8.GetBytes("server campaign save")),
+            DateTimeOffset.UtcNow,
+            Array.Empty<CollectedBugReportLog>(),
+            expectedClients: 0,
+            declinedClients: 0,
+            failedClients: 0,
+            timedOutClients: 0);
+
+        var result = await uploader.UploadAsync(report, CancellationToken.None);
+
+        Assert.False(result.Uploaded);
+        Assert.Null(handler.Body);
+        Assert.NotNull(handler.ServerSaveBody);
     }
 
     [Fact]
@@ -348,12 +424,16 @@ public class CoopLogBugReportTests : IDisposable
     }
 
     [Fact]
-    public void Uploader_EnforcesCompressedReportLimitBeforeJsonEncoding()
+    public void Uploader_EnforcesAttachmentLimitsBeforeSending()
     {
         Assert.True(BugReportUploader.IsWithinCompressedLogLimit(
             BugReportUploader.MaximumCompressedReportBytes));
         Assert.False(BugReportUploader.IsWithinCompressedLogLimit(
             (long)BugReportUploader.MaximumCompressedReportBytes + 1));
+        Assert.True(BugReportUploader.IsWithinServerSaveLimit(
+            BugReportUploader.MaximumServerSaveBytes));
+        Assert.False(BugReportUploader.IsWithinServerSaveLimit(
+            (long)BugReportUploader.MaximumServerSaveBytes + 1));
     }
 
     public void Dispose()
@@ -377,6 +457,7 @@ public class CoopLogBugReportTests : IDisposable
             "network-client-1",
             Array.Empty<string>(),
             Array.Empty<BugReportSubmission>(),
+            null,
             null,
             DateTimeOffset.UtcNow,
             Array.Empty<CollectedBugReportLog>(),
@@ -412,16 +493,53 @@ public class CoopLogBugReportTests : IDisposable
         public string ApiKey { get; private set; }
         public string Authorization { get; private set; }
         public string IdempotencyKey { get; private set; }
+        public byte[] ServerSaveBody { get; private set; }
+        public string ServerSaveArtifact { get; private set; }
+        public string ServerSaveReportId { get; private set; }
+        public string ServerSaveFileName { get; private set; }
+        public string ServerSaveApiKey { get; private set; }
+        public string ServerSaveAuthorization { get; private set; }
+        public string ServerSaveIdempotencyKey { get; private set; }
+        public bool FailServerSaveUpload { get; set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            ContentType = request.Content.Headers.ContentType.ToString();
-            ApiKey = string.Join(string.Empty, request.Headers.GetValues("apikey"));
-            Authorization = request.Headers.Authorization?.ToString();
-            IdempotencyKey = string.Join(string.Empty, request.Headers.GetValues("Idempotency-Key"));
-            Body = await request.Content.ReadAsStringAsync();
+            if (request.Method == HttpMethod.Put)
+            {
+                ServerSaveBody = await request.Content.ReadAsByteArrayAsync();
+                ServerSaveArtifact = string.Join(
+                    string.Empty,
+                    request.Headers.GetValues("X-Bug-Report-Artifact"));
+                ServerSaveReportId = string.Join(
+                    string.Empty,
+                    request.Headers.GetValues("X-Bug-Report-Id"));
+                ServerSaveFileName = string.Join(
+                    string.Empty,
+                    request.Headers.GetValues("X-Bug-Report-File-Name"));
+                ServerSaveApiKey = string.Join(string.Empty, request.Headers.GetValues("apikey"));
+                ServerSaveAuthorization = request.Headers.Authorization?.ToString();
+                ServerSaveIdempotencyKey = string.Join(
+                    string.Empty,
+                    request.Headers.GetValues("Idempotency-Key"));
+                if (FailServerSaveUpload)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        Content = new StringContent("save rejected"),
+                    };
+                }
+            }
+            else
+            {
+                ContentType = request.Content.Headers.ContentType.ToString();
+                ApiKey = string.Join(string.Empty, request.Headers.GetValues("apikey"));
+                Authorization = request.Headers.Authorization?.ToString();
+                IdempotencyKey = string.Join(string.Empty, request.Headers.GetValues("Idempotency-Key"));
+                Body = await request.Content.ReadAsStringAsync();
+            }
+
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("accepted"),

--- a/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
+++ b/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
@@ -189,6 +189,36 @@ public class CoopLogBugReportTests : IDisposable
     }
 
     [Fact]
+    public void Archive_SkipsLockedOldestReportWhenEnforcingQuota()
+    {
+        Directory.CreateDirectory(tempRoot);
+        string lockedPath = null;
+        bool DeleteUnlessLocked(string path)
+        {
+            if (string.Equals(path, lockedPath, StringComparison.OrdinalIgnoreCase)) return false;
+            File.Delete(path);
+            return true;
+        }
+
+        using var builder = new BugReportArchiveBuilder(
+            tempRoot,
+            maximumPendingArchiveCount: 2,
+            maximumPendingArchiveBytes: long.MaxValue,
+            deleteArchive: DeleteUnlessLocked);
+        lockedPath = builder.Create(CreateEmptyArchiveContents());
+        File.SetLastWriteTimeUtc(lockedPath, DateTime.UtcNow.AddMinutes(-2));
+        var removablePath = builder.Create(CreateEmptyArchiveContents());
+        File.SetLastWriteTimeUtc(removablePath, DateTime.UtcNow.AddMinutes(-1));
+
+        var newPath = builder.Create(CreateEmptyArchiveContents());
+
+        Assert.True(File.Exists(lockedPath));
+        Assert.False(File.Exists(removablePath));
+        Assert.True(File.Exists(newPath));
+        Assert.Equal(2, Directory.GetFiles(tempRoot, "bug_report_*.zip").Length);
+    }
+
+    [Fact]
     public void Archive_RejectsReportLargerThanPendingByteQuota()
     {
         Directory.CreateDirectory(tempRoot);

--- a/source/GameInterface.Tests/Services/UI/BugReportConsentTests.cs
+++ b/source/GameInterface.Tests/Services/UI/BugReportConsentTests.cs
@@ -67,6 +67,23 @@ public class BugReportConsentTests
     }
 
     [Fact]
+    public void ExplicitEnablePrompt_DoesNotEnableSharingUntilDisclosureIsAccepted()
+    {
+        var store = new TestOptionsStore();
+        var preference = new BugReportLogSharingPreference(store);
+        var coordinator = new BugReportConsentCoordinator(store, _ => { });
+        InquiryData inquiry = null;
+
+        coordinator.ShowPrompt(value => inquiry = value);
+
+        Assert.NotNull(inquiry);
+        Assert.Contains("public GitHub issue", inquiry.Text);
+        Assert.False(preference.IsEnabled());
+        inquiry.AffirmativeAction();
+        Assert.True(preference.IsEnabled());
+    }
+
+    [Fact]
     public void MissingDecision_DefaultsToDisabled()
     {
         var preference = new BugReportLogSharingPreference(new TestOptionsStore());

--- a/source/GameInterface.Tests/Services/UI/BugReportConsentTests.cs
+++ b/source/GameInterface.Tests/Services/UI/BugReportConsentTests.cs
@@ -16,7 +16,9 @@ public class BugReportConsentTests
     {
         Assert.Contains("sent to the dedicated server", BugReportConsentCoordinator.PromptText);
         Assert.Contains("IP addresses", BugReportConsentCoordinator.PromptText);
-        Assert.Contains("Saves, configuration files, and memory dumps are not included",
+        Assert.Contains("current campaign save", BugReportConsentCoordinator.PromptText);
+        Assert.Contains("campaign save is still included", BugReportConsentCoordinator.PromptText);
+        Assert.Contains("Client saves, configuration files, and memory dumps are not included",
             BugReportConsentCoordinator.PromptText);
         Assert.Contains("cancel this bug report", BugReportSubmissionConsent.PromptText);
         Assert.Contains("public GitHub issue", BugReportConsentCoordinator.PromptText);
@@ -25,6 +27,9 @@ public class BugReportConsentTests
         Assert.Contains("public GitHub issue", BugReportSubmissionConsent.PromptText);
         Assert.Contains("publicly accessible links", BugReportSubmissionConsent.PromptText);
         Assert.Contains("remote deletion or expiry is not guaranteed", BugReportSubmissionConsent.PromptText);
+        Assert.Contains("current campaign save", BugReportSubmissionConsent.PromptText);
+        Assert.Contains("Client saves, configuration files, and memory dumps are not included",
+            BugReportSubmissionConsent.PromptText);
     }
 
     [Theory]
@@ -48,14 +53,18 @@ public class BugReportConsentTests
     }
 
     [Fact]
-    public void LegacyConsentWithoutPublicDisclosure_IsDisabledAndPromptedAgain()
+    public void ConsentWithoutServerSaveDisclosure_IsDisabledAndPromptedAgain()
     {
         var store = new TestOptionsStore();
         var options = store.LoadOrDefault();
         options.SetSection(
             BugReportConsentCoordinator.TabId,
             BugReportConsentCoordinator.SectionId,
-            new BugReportConsentOptions { ShareBugReportLogs = true });
+            new BugReportConsentOptions
+            {
+                ShareBugReportLogs = true,
+                DisclosureVersion = 2,
+            });
         store.Save(options);
         var coordinator = new BugReportConsentCoordinator(store, _ => { });
         InquiryData inquiry = null;

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -87,6 +87,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<BugReportService>().As<IBugReportService>().InstancePerLifetimeScope().AutoActivate();
         builder.RegisterType<BugReportOverlay>().As<IBugReportOverlay>().InstancePerLifetimeScope();
         builder.RegisterType<CoopLogSnapshotProvider>().As<ICoopLogSnapshotProvider>().InstancePerDependency();
+        builder.RegisterType<BugReportServerSaveProvider>().As<IBugReportServerSaveProvider>().InstancePerDependency();
         builder.RegisterType<BugReportArchiveBuilder>().As<IBugReportArchiveBuilder>().InstancePerDependency();
         builder.RegisterType<BugReportLogValidator>().As<IBugReportLogValidator>().InstancePerDependency();
         builder.RegisterType<BugReportUploader>().As<IBugReportUploader>().InstancePerDependency();

--- a/source/GameInterface/Services/BugReporting/BugReportArchiveBuilder.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportArchiveBuilder.cs
@@ -56,6 +56,19 @@ public sealed class CollectedBugReportServerLog
     }
 }
 
+/// <summary>Contains the persistent server campaign save captured for a diagnostic report.</summary>
+public sealed class CollectedBugReportServerSave
+{
+    public string FileName { get; }
+    public byte[] Data { get; }
+
+    public CollectedBugReportServerSave(string fileName, byte[] data)
+    {
+        FileName = fileName;
+        Data = data;
+    }
+}
+
 /// <summary>Contains the logs and metadata written to a diagnostic archive.</summary>
 public sealed class BugReportArchiveContents
 {
@@ -64,6 +77,7 @@ public sealed class BugReportArchiveContents
     public IReadOnlyCollection<string> Triggers { get; }
     public IReadOnlyCollection<BugReportSubmission> Submissions { get; }
     public CollectedBugReportServerLog ServerLog { get; }
+    public CollectedBugReportServerSave ServerSave { get; }
     public DateTimeOffset StartedAt { get; }
     public IReadOnlyCollection<CollectedBugReportLog> Logs { get; }
     public int ExpectedClients { get; }
@@ -77,6 +91,7 @@ public sealed class BugReportArchiveContents
         IReadOnlyCollection<string> triggers,
         IReadOnlyCollection<BugReportSubmission> submissions,
         CollectedBugReportServerLog serverLog,
+        CollectedBugReportServerSave serverSave,
         DateTimeOffset startedAt,
         IReadOnlyCollection<CollectedBugReportLog> logs,
         int expectedClients,
@@ -89,6 +104,7 @@ public sealed class BugReportArchiveContents
         Triggers = triggers ?? Array.Empty<string>();
         Submissions = submissions ?? Array.Empty<BugReportSubmission>();
         ServerLog = serverLog;
+        ServerSave = serverSave;
         StartedAt = startedAt;
         Logs = logs ?? Array.Empty<CollectedBugReportLog>();
         ExpectedClients = expectedClients;
@@ -105,6 +121,7 @@ public sealed class BugReportArchiveContents
             Triggers,
             Submissions,
             serverLog,
+            ServerSave,
             StartedAt,
             Logs,
             ExpectedClients,
@@ -123,6 +140,7 @@ public sealed class BugReportArchiveContents
             Triggers,
             Submissions,
             ServerLog,
+            ServerSave,
             StartedAt,
             logs,
             ExpectedClients,
@@ -225,6 +243,7 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
                 WriteManifest(archive, contents);
                 AddSubmissions(archive, contents.Submissions);
                 if (contents.ServerLog != null) AddServerLog(archive, contents.ServerLog);
+                if (contents.ServerSave != null) AddServerSave(archive, contents.ServerSave);
                 foreach (var log in contents.Logs.OrderBy(item => item.ClientNumber))
                 {
                     AddLog(archive, log);
@@ -358,12 +377,13 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
         writer.WriteLine("Started: " + contents.StartedAt.ToString("O", CultureInfo.InvariantCulture));
         writer.WriteLine("Packaged: " + DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
         writer.WriteLine("Player submissions: " + contents.Submissions.Count.ToString(CultureInfo.InvariantCulture));
+        writer.WriteLine("Server save included: " + (contents.ServerSave != null ? "yes" : "no"));
         writer.WriteLine("Expected clients: " + contents.ExpectedClients.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Logs included: " + contents.Logs.Count.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Clients declined: " + contents.DeclinedClients.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Clients failed: " + contents.FailedClients.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Clients timed out: " + contents.TimedOutClients.ToString(CultureInfo.InvariantCulture));
-        writer.WriteLine("Only current BannerlordCoop server and client logs are included; saves, configs, and dumps are excluded.");
+        writer.WriteLine("The current server campaign save and current BannerlordCoop logs are included; client saves, configs, and dumps are excluded.");
     }
 
     private static void AddSubmissions(
@@ -387,6 +407,21 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
             writer.Write(submission.Description);
             index++;
         }
+    }
+
+    private static void AddServerSave(ZipArchive archive, CollectedBugReportServerSave save)
+    {
+        if (save.Data == null || save.Data.Length == 0)
+            throw new InvalidDataException("The collected server save was empty.");
+        if (string.IsNullOrWhiteSpace(save.FileName) ||
+            !string.Equals(Path.GetFileName(save.FileName), save.FileName, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException("The collected server save had an invalid file name.");
+        }
+
+        var entry = archive.CreateEntry("server/" + save.FileName, CompressionLevel.NoCompression);
+        using var destination = entry.Open();
+        destination.Write(save.Data, 0, save.Data.Length);
     }
 
     private static void AddServerLog(ZipArchive archive, CollectedBugReportServerLog log)

--- a/source/GameInterface/Services/BugReporting/BugReportArchiveBuilder.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportArchiveBuilder.cs
@@ -149,6 +149,7 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
     private readonly int maximumPendingArchiveCount;
     private readonly long maximumPendingArchiveBytes;
     private readonly TimeSpan pendingArchiveRetention;
+    private readonly Func<string, bool> deleteArchive;
     private readonly object archiveGate = new object();
     private readonly Timer cleanupTimer;
     private int disposed;
@@ -166,7 +167,8 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
         int maximumPendingArchiveCount = MaximumPendingArchiveCount,
         long maximumPendingArchiveBytes = MaximumPendingArchiveBytes,
         TimeSpan? pendingArchiveRetention = null,
-        TimeSpan? cleanupInterval = null)
+        TimeSpan? cleanupInterval = null,
+        Func<string, bool> deleteArchive = null)
     {
         if (string.IsNullOrWhiteSpace(outputDirectory))
             throw new ArgumentException("Output directory cannot be empty.", nameof(outputDirectory));
@@ -183,6 +185,7 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
         this.maximumPendingArchiveCount = maximumPendingArchiveCount;
         this.maximumPendingArchiveBytes = maximumPendingArchiveBytes;
         this.pendingArchiveRetention = pendingArchiveRetention ?? PendingArchiveRetention;
+        this.deleteArchive = deleteArchive ?? DeleteArchive;
         RunCleanup();
         var interval = cleanupInterval ?? CleanupInterval;
         cleanupTimer = new Timer(_ => RunCleanup(), null, interval, interval);
@@ -233,23 +236,31 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
         }
         catch
         {
-            TryDelete(archivePath);
+            TryDeleteArchive(archivePath);
             throw;
         }
     }
 
-    private static void TryDelete(string path)
+    private bool TryDeleteArchive(string path)
     {
         try
         {
-            File.Delete(path);
+            return deleteArchive(path);
         }
         catch (IOException)
         {
+            return false;
         }
         catch (UnauthorizedAccessException)
         {
+            return false;
         }
+    }
+
+    private static bool DeleteArchive(string path)
+    {
+        File.Delete(path);
+        return true;
     }
 
     private void RunCleanup()
@@ -285,7 +296,7 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
         {
             try
             {
-                if (File.GetLastWriteTimeUtc(path) < cutoff) File.Delete(path);
+                if (File.GetLastWriteTimeUtc(path) < cutoff) TryDeleteArchive(path);
             }
             catch (IOException)
             {
@@ -310,14 +321,20 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
             throw new InvalidDataException("The diagnostic archive exceeds the pending storage quota.");
 
         var totalBytes = archives.Sum(file => file.Length);
-        while (archives.Count > maximumPendingArchiveCount ||
-               totalBytes > maximumPendingArchiveBytes)
+        var evictionCandidates = archives
+            .Where(file => !ReferenceEquals(file, newArchive))
+            .ToList();
+        foreach (var archive in evictionCandidates)
         {
-            var archive = archives.FirstOrDefault(file => !ReferenceEquals(file, newArchive));
-            if (archive == null) break;
+            if (archives.Count <= maximumPendingArchiveCount &&
+                totalBytes <= maximumPendingArchiveBytes)
+            {
+                break;
+            }
 
             var length = archive.Length;
-            archive.Delete();
+            if (!TryDeleteArchive(archive.FullName)) continue;
+
             totalBytes -= length;
             archives.Remove(archive);
         }

--- a/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace GameInterface.Services.BugReporting;
 
-/// <summary>Creates the persistent server campaign save attached to a diagnostic report.</summary>
+/// <summary>Creates the native-format server campaign save attached to a diagnostic report.</summary>
 public interface IBugReportServerSaveProvider
 {
     bool TryCapture(out CollectedBugReportServerSave save);
@@ -31,7 +31,7 @@ public class BugReportServerSaveProvider : IBugReportServerSaveProvider
         save = null;
         try
         {
-            var result = saveInterface.SaveCurrentGameToFile(SaveName);
+            var result = saveInterface.SaveCurrentGameAsFileData(SaveName);
             if (!result.Success || result.Data == null || result.Data.Length == 0)
             {
                 logger.Warning("The server campaign save for the diagnostic bug report could not be created");

--- a/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
@@ -1,0 +1,50 @@
+﻿using GameInterface.Services.Heroes.Interfaces;
+using Serilog;
+using System;
+
+namespace GameInterface.Services.BugReporting;
+
+/// <summary>Creates the persistent server campaign save attached to a diagnostic report.</summary>
+public interface IBugReportServerSaveProvider
+{
+    bool TryCapture(out CollectedBugReportServerSave save);
+}
+
+/// <inheritdoc />
+public class BugReportServerSaveProvider : IBugReportServerSaveProvider
+{
+    internal const string SaveName = "coop_bug_report";
+
+    private readonly ISaveInterface saveInterface;
+    private readonly ILogger logger;
+
+    public BugReportServerSaveProvider(ISaveInterface saveInterface, ILogger logger)
+    {
+        if (saveInterface == null) throw new ArgumentNullException(nameof(saveInterface));
+        if (logger == null) throw new ArgumentNullException(nameof(logger));
+        this.saveInterface = saveInterface;
+        this.logger = logger;
+    }
+
+    public bool TryCapture(out CollectedBugReportServerSave save)
+    {
+        save = null;
+        try
+        {
+            var result = saveInterface.SaveCurrentGameToFile(SaveName);
+            if (!result.Success || result.Data == null || result.Data.Length == 0)
+            {
+                logger.Warning("The server campaign save for the diagnostic bug report could not be created");
+                return false;
+            }
+
+            save = new CollectedBugReportServerSave(SaveName + ".sav", result.Data);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            logger.Warning(exception, "Creating the server campaign save for the diagnostic bug report failed");
+            return false;
+        }
+    }
+}

--- a/source/GameInterface/Services/BugReporting/BugReportService.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportService.cs
@@ -42,6 +42,7 @@ internal class BugReportService : IBugReportService, IDisposable
     private readonly IPlayerManager playerManager;
     private readonly IBugReportLogSharingPreference logSharingPreference;
     private readonly ICoopLogSnapshotProvider logSnapshotProvider;
+    private readonly IBugReportServerSaveProvider serverSaveProvider;
     private readonly IBugReportArchiveBuilder archiveBuilder;
     private readonly IBugReportLogValidator logValidator;
     private readonly IBugReportUploader uploader;
@@ -60,6 +61,7 @@ internal class BugReportService : IBugReportService, IDisposable
         IPlayerManager playerManager,
         IBugReportLogSharingPreference logSharingPreference,
         ICoopLogSnapshotProvider logSnapshotProvider,
+        IBugReportServerSaveProvider serverSaveProvider,
         IBugReportArchiveBuilder archiveBuilder,
         IBugReportLogValidator logValidator,
         IBugReportUploader uploader,
@@ -70,6 +72,7 @@ internal class BugReportService : IBugReportService, IDisposable
         this.playerManager = playerManager;
         this.logSharingPreference = logSharingPreference;
         this.logSnapshotProvider = logSnapshotProvider;
+        this.serverSaveProvider = serverSaveProvider;
         this.archiveBuilder = archiveBuilder;
         this.logValidator = logValidator;
         this.uploader = uploader;
@@ -264,6 +267,16 @@ internal class BugReportService : IBugReportService, IDisposable
                 null,
                 CollectionTimeout,
                 Timeout.InfiniteTimeSpan);
+        }
+
+        try
+        {
+            if (serverSaveProvider.TryCapture(out var serverSave))
+                collection.ServerSave = serverSave;
+        }
+        catch (Exception exception)
+        {
+            Logger.Warning(exception, "Capturing the server campaign save for a bug report failed");
         }
 
         Logger.Information(
@@ -585,6 +598,7 @@ internal class BugReportService : IBugReportService, IDisposable
                 collection.Triggers.OrderBy(trigger => trigger).ToArray(),
                 collection.Submissions.ToArray(),
                 null,
+                collection.ServerSave,
                 collection.StartedAt,
                 logs,
                 collection.Clients.Count,
@@ -631,6 +645,7 @@ internal class BugReportService : IBugReportService, IDisposable
         }
 
         if (contents.ServerLog == null &&
+            contents.ServerSave == null &&
             contents.Logs.Count == 0 &&
             contents.Submissions.Count == 0)
         {
@@ -656,7 +671,11 @@ internal class BugReportService : IBugReportService, IDisposable
         if (upload.Uploaded)
         {
             Logger.Information("Uploaded diagnostic bug report {RequestId}", contents.RequestId);
-            SendResult(finalized, "The bug report and available diagnostic logs were submitted.");
+            SendResult(
+                finalized,
+                contents.ServerSave != null
+                    ? "The bug report, server save, and available diagnostic logs were submitted."
+                    : "The bug report and available diagnostic logs were submitted, but the server save could not be created.");
             return;
         }
 
@@ -798,6 +817,7 @@ internal class BugReportService : IBugReportService, IDisposable
         public Dictionary<NetPeer, ClientCollection> Clients { get; }
         public HashSet<NetPeer> Requesters { get; } = new HashSet<NetPeer>();
         public Timer Timer { get; set; }
+        public CollectedBugReportServerSave ServerSave { get; set; }
         public bool Finalizing { get; set; }
         public long BufferedBytes { get; set; }
 

--- a/source/GameInterface/Services/BugReporting/BugReportUploader.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportUploader.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -11,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace GameInterface.Services.BugReporting;
 
-/// <summary>Posts diagnostic bug reports as JSON when an endpoint is configured.</summary>
+/// <summary>Uploads the server save as a raw artifact, then posts diagnostic report metadata as JSON.</summary>
 public interface IBugReportUploader
 {
     bool IsConfigured { get; }
@@ -28,6 +29,7 @@ public class BugReportUploader : IBugReportUploader, IDisposable
     public const string PublishableKeyEnvironmentVariable = "BANNERLORDCOOP_BUG_REPORT_PUBLISHABLE_KEY";
     public const string AuthorizationTokenEnvironmentVariable = "BANNERLORDCOOP_BUG_REPORT_TOKEN";
     internal const int MaximumCompressedReportBytes = 10 * 1024 * 1024;
+    internal const int MaximumServerSaveBytes = 48 * 1024 * 1024;
 
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
@@ -90,7 +92,30 @@ public class BugReportUploader : IBugReportUploader, IDisposable
             return new BugReportUploadResult(
                 false,
                 true,
-                "The bug report exceeds the upload size limit.");
+                "The bug report logs exceed the upload size limit.");
+        }
+
+        if (report.ServerSave != null)
+        {
+            if (string.IsNullOrWhiteSpace(report.ServerSave.FileName) ||
+                !string.Equals(
+                    Path.GetFileName(report.ServerSave.FileName),
+                    report.ServerSave.FileName,
+                    StringComparison.Ordinal))
+            {
+                return new BugReportUploadResult(false, true, "The server campaign save had an invalid file name.");
+            }
+
+            if (!IsWithinServerSaveLimit(report.ServerSave.Data?.LongLength ?? 0))
+            {
+                return new BugReportUploadResult(
+                    false,
+                    true,
+                    "The server campaign save exceeds the upload size limit.");
+            }
+
+            var saveUpload = await UploadServerSaveAsync(report, cancellationToken).ConfigureAwait(false);
+            if (!saveUpload.Uploaded) return saveUpload;
         }
 
         var json = JsonSerializer.Serialize(CreateRequest(report), JsonOptions);
@@ -98,9 +123,7 @@ public class BugReportUploader : IBugReportUploader, IDisposable
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json"),
         };
-        request.Headers.TryAddWithoutValidation("apikey", supabasePublishableKey);
-        request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + authorizationToken);
-        request.Headers.TryAddWithoutValidation("Idempotency-Key", report.RequestId);
+        AddRequestHeaders(request, report.RequestId);
         using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var details = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
@@ -124,6 +147,46 @@ public class BugReportUploader : IBugReportUploader, IDisposable
     internal static bool IsWithinCompressedLogLimit(long compressedBytes)
     {
         return compressedBytes >= 0 && compressedBytes <= MaximumCompressedReportBytes;
+    }
+
+    internal static bool IsWithinServerSaveLimit(long saveBytes)
+    {
+        return saveBytes > 0 && saveBytes <= MaximumServerSaveBytes;
+    }
+
+    private async Task<BugReportUploadResult> UploadServerSaveAsync(
+        BugReportArchiveContents report,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Put, endpoint)
+        {
+            Content = new ByteArrayContent(report.ServerSave.Data),
+        };
+        request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
+            "application/octet-stream");
+        request.Headers.TryAddWithoutValidation("X-Bug-Report-Artifact", "server-save");
+        request.Headers.TryAddWithoutValidation("X-Bug-Report-Id", report.RequestId);
+        request.Headers.TryAddWithoutValidation("X-Bug-Report-File-Name", report.ServerSave.FileName);
+        AddRequestHeaders(request, report.RequestId + "-server-save");
+
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var details = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+            return new BugReportUploadResult(true, true, details);
+
+        return new BugReportUploadResult(
+            false,
+            true,
+            string.IsNullOrWhiteSpace(details)
+                ? "The server-save endpoint returned " + ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + "."
+                : details);
+    }
+
+    private void AddRequestHeaders(HttpRequestMessage request, string idempotencyKey)
+    {
+        request.Headers.TryAddWithoutValidation("apikey", supabasePublishableKey);
+        request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + authorizationToken);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
     }
 
     private static long GetCompressedLogBytes(BugReportArchiveContents report)
@@ -158,6 +221,11 @@ public class BugReportUploader : IBugReportUploader, IDisposable
                 submission.Summary,
                 submission.Description))
             .ToArray();
+        var serverSave = report.ServerSave == null
+            ? null
+            : new BugReportJsonServerSave(
+                report.ServerSave.FileName,
+                report.ServerSave.Data.LongLength);
 
         return new BugReportJsonRequest(
             report.RequestId,
@@ -171,6 +239,7 @@ public class BugReportUploader : IBugReportUploader, IDisposable
             ModInformation.Commit,
             ModInformation.BuildVersion,
             serverLog,
+            serverSave,
             clientLogs,
             submissions,
             report.ExpectedClients,
@@ -198,7 +267,7 @@ public sealed class BugReportUploadResult
 /// <summary>Defines the versioned JSON payload posted to the bug-report endpoint.</summary>
 internal sealed class BugReportJsonRequest
 {
-    public int SchemaVersion => 1;
+    public int SchemaVersion => 2;
     public string ReportId { get; }
     public string ReportingClientNetworkId { get; }
     public string Summary { get; }
@@ -210,6 +279,7 @@ internal sealed class BugReportJsonRequest
     public string Commit { get; }
     public string BuildVersion { get; }
     public BugReportJsonLog ServerLog { get; }
+    public BugReportJsonServerSave ServerSave { get; }
     public IReadOnlyCollection<BugReportJsonClientLog> ClientLogs { get; }
     public IReadOnlyCollection<BugReportJsonSubmission> Submissions { get; }
     public int ExpectedClients { get; }
@@ -229,6 +299,7 @@ internal sealed class BugReportJsonRequest
         string commit,
         string buildVersion,
         BugReportJsonLog serverLog,
+        BugReportJsonServerSave serverSave,
         IReadOnlyCollection<BugReportJsonClientLog> clientLogs,
         IReadOnlyCollection<BugReportJsonSubmission> submissions,
         int expectedClients,
@@ -247,6 +318,7 @@ internal sealed class BugReportJsonRequest
         Commit = commit;
         BuildVersion = buildVersion;
         ServerLog = serverLog;
+        ServerSave = serverSave;
         ClientLogs = clientLogs;
         Submissions = submissions;
         ExpectedClients = expectedClients;
@@ -269,6 +341,20 @@ internal sealed class BugReportJsonLog
         FileName = fileName;
         UncompressedLength = uncompressedLength;
         Data = data;
+    }
+}
+
+/// <summary>Describes the raw server-save artifact uploaded before the JSON report.</summary>
+internal sealed class BugReportJsonServerSave
+{
+    public string FileName { get; }
+    public string Artifact => "server-save";
+    public long Length { get; }
+
+    public BugReportJsonServerSave(string fileName, long length)
+    {
+        FileName = fileName;
+        Length = length;
     }
 }
 

--- a/source/GameInterface/Services/GameDebug/Commands/BugReportLogSharingCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/BugReportLogSharingCommand.cs
@@ -3,6 +3,8 @@ using GameInterface.Services.UI.BugReporting;
 using GameInterface.Services.UI.CoopOptions;
 using System;
 using System.Collections.Generic;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
@@ -26,26 +28,26 @@ public class BugReportLogSharingCommand
                 : "Diagnostic bug-report log sharing is disabled.";
         }
 
-        bool enabled;
         if (args[0].Equals("enable", StringComparison.OrdinalIgnoreCase))
         {
-            enabled = true;
+            if (InformationManager.IsAnyInquiryActive())
+                return "Close the current prompt before enabling diagnostic bug-report log sharing.";
+
+            var consent = new BugReportConsentCoordinator(
+                store,
+                exception => InformationManager.DisplayMessage(new InformationMessage(
+                    "[Bug Report] Could not save the log-sharing preference: " + exception.Message)));
+            consent.ShowPrompt(inquiry => InformationManager.ShowInquiry(inquiry));
+            return "Review the diagnostic log-sharing privacy prompt and choose Allow to enable it.";
         }
-        else if (args[0].Equals("disable", StringComparison.OrdinalIgnoreCase))
-        {
-            enabled = false;
-        }
-        else
-        {
+
+        if (!args[0].Equals("disable", StringComparison.OrdinalIgnoreCase))
             return "Usage: coop.bug_report_log_sharing status|enable|disable";
-        }
 
         try
         {
-            preference.SetEnabled(enabled);
-            return enabled
-                ? "Diagnostic bug-report log sharing enabled."
-                : "Diagnostic bug-report log sharing disabled.";
+            preference.SetEnabled(false);
+            return "Diagnostic bug-report log sharing disabled.";
         }
         catch (Exception exception)
         {

--- a/source/GameInterface/Services/Save/CoopInMemSaveDriver.cs
+++ b/source/GameInterface/Services/Save/CoopInMemSaveDriver.cs
@@ -1,4 +1,9 @@
-﻿using TaleWorlds.SaveSystem;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using TaleWorlds.Library;
+using TaleWorlds.SaveSystem;
 
 namespace GameInterface.Services.Heroes;
 
@@ -21,4 +26,56 @@ internal class CoopInMemSaveDriver : InMemDriver
             return _data;
         }
     }
+}
+
+/// <summary>Produces a native FileDriver-format campaign save without writing to the user save directory.</summary>
+internal class CoopFileInMemSaveDriver : ISaveDriver
+{
+    private byte[] data = Array.Empty<byte>();
+
+    public byte[] Data => data;
+
+    public Task<SaveResultWithMessage> Save(string saveName, int version, MetaData metaData, GameData gameData)
+    {
+        using var stream = new MemoryStream();
+        metaData.Add("Version", version.ToString());
+        metaData.Serialize(stream);
+        using (var output = new DeflateStream(stream, CompressionLevel.Fastest, leaveOpen: true))
+        using (var writer = new System.IO.BinaryWriter(output))
+        {
+            GameData.Write(writer, gameData);
+        }
+
+        data = stream.ToArray();
+        return Task.FromResult(SaveResultWithMessage.Default);
+    }
+
+    public MetaData LoadMetaData(string saveName)
+    {
+        using var stream = new MemoryStream(data);
+        return MetaData.Deserialize(stream);
+    }
+
+    public LoadData Load(string saveName)
+    {
+        using var stream = new MemoryStream(data);
+        var metaData = MetaData.Deserialize(stream);
+        using var input = new DeflateStream(stream, CompressionMode.Decompress);
+        using var reader = new System.IO.BinaryReader(input);
+        return new LoadData(metaData, GameData.Read(reader));
+    }
+
+    public SaveGameFileInfo[] GetSaveGameFileInfos() => Array.Empty<SaveGameFileInfo>();
+
+    public string[] GetSaveGameFileNames() => Array.Empty<string>();
+
+    public bool Delete(string saveName)
+    {
+        data = Array.Empty<byte>();
+        return true;
+    }
+
+    public bool IsSaveGameFileExists(string saveName) => false;
+
+    public bool IsWorkingAsync() => false;
 }

--- a/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
+++ b/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
@@ -12,6 +12,7 @@ namespace GameInterface.Services.Heroes.Interfaces;
 public interface ISaveInterface : IGameAbstraction
 {
     SaveResults SaveCurrentGame();
+    SaveResults SaveCurrentGameToFile(string saveName);
 }
 
 internal class SaveInterface : ISaveInterface
@@ -20,24 +21,48 @@ internal class SaveInterface : ISaveInterface
 
     public SaveResults SaveCurrentGame()
     {
-        // Validation
+        var saveDriver = new CoopInMemSaveDriver();
+        var result = SaveCurrentGame("TransferSave", saveDriver);
+        return new SaveResults(
+            result.Success,
+            result.Success ? saveDriver.Data : Array.Empty<byte>(),
+            result.CampaignId);
+    }
+
+    public SaveResults SaveCurrentGameToFile(string saveName)
+    {
+        if (string.IsNullOrWhiteSpace(saveName))
+            throw new ArgumentException("Save name cannot be empty.", nameof(saveName));
+
+        var saveDriver = new FileDriver();
+        var result = SaveCurrentGame(saveName, saveDriver);
+        if (!result.Success) return result;
+
+        var data = FileHelper.GetFileContent(FileDriver.GetSaveFilePath(saveName + ".sav"));
+        if (data == null || data.Length == 0) return ReportSaveFailure("saved game file");
+
+        return new SaveResults(true, data, result.CampaignId);
+    }
+
+    private SaveResults SaveCurrentGame(string saveName, ISaveDriver saveDriver)
+    {
         if (Game.Current == null) return ReportSaveFailure(nameof(Game.Current));
         if (Campaign.Current == null) return ReportSaveFailure(nameof(Campaign.Current));
         if (Campaign.Current.SaveHandler == null) return ReportSaveFailure(nameof(Campaign.Current.SaveHandler));
 
-        // Logic
         var saveHandler = Campaign.Current.SaveHandler;
         var dataArgs = saveHandler.GetSaveMetaData();
         var metaData = MBSaveLoad.GetSaveMetaData(dataArgs);
         EnsureUsableGameVersion(metaData);
 
-        // Required to properly transfer campaign behaviors
         CampaignEventDispatcher.Instance.OnBeforeSave();
 
-        var saveDriver = new CoopInMemSaveDriver();
-        Game.Current.Save(metaData, "TransferSave", saveDriver, (SaveResult) => { });
-
-        return new SaveResults(true, saveDriver.Data, Campaign.Current?.UniqueGameId);
+        var saveResult = SaveResult.GeneralFailure;
+        Game.Current.Save(metaData, saveName, saveDriver, result => saveResult = result);
+        return new SaveResults(
+            saveResult == SaveResult.Success,
+            Array.Empty<byte>(),
+            Campaign.Current?.UniqueGameId);
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
+++ b/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
@@ -12,7 +12,7 @@ namespace GameInterface.Services.Heroes.Interfaces;
 public interface ISaveInterface : IGameAbstraction
 {
     SaveResults SaveCurrentGame();
-    SaveResults SaveCurrentGameToFile(string saveName);
+    SaveResults SaveCurrentGameAsFileData(string saveName);
 }
 
 internal class SaveInterface : ISaveInterface
@@ -29,19 +29,16 @@ internal class SaveInterface : ISaveInterface
             result.CampaignId);
     }
 
-    public SaveResults SaveCurrentGameToFile(string saveName)
+    public SaveResults SaveCurrentGameAsFileData(string saveName)
     {
         if (string.IsNullOrWhiteSpace(saveName))
             throw new ArgumentException("Save name cannot be empty.", nameof(saveName));
 
-        var saveDriver = new FileDriver();
+        var saveDriver = new CoopFileInMemSaveDriver();
         var result = SaveCurrentGame(saveName, saveDriver);
-        if (!result.Success) return result;
+        if (!result.Success || saveDriver.Data.Length == 0) return ReportSaveFailure("saved game data");
 
-        var data = FileHelper.GetFileContent(FileDriver.GetSaveFilePath(saveName + ".sav"));
-        if (data == null || data.Length == 0) return ReportSaveFailure("saved game file");
-
-        return new SaveResults(true, data, result.CampaignId);
+        return new SaveResults(true, saveDriver.Data, result.CampaignId);
     }
 
     private SaveResults SaveCurrentGame(string saveName, ISaveDriver saveDriver)

--- a/source/GameInterface/Services/Save/Patches/SavePatches.cs
+++ b/source/GameInterface/Services/Save/Patches/SavePatches.cs
@@ -6,20 +6,27 @@ using GameInterface.Services.Save.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
+using TaleWorlds.SaveSystem;
 
 namespace GameInterface.Services.Save.Patches;
 
 [HarmonyPatch(typeof(Game), "Save")]
 class SavePatches
 {
-    static bool Prefix(Game __instance, ref string saveName)
+    static bool Prefix(Game __instance, ref string saveName, ISaveDriver driver)
     {
-        if (ModInformation.IsServer)
+        if (ModInformation.IsServer && ShouldPublishGameSaved(driver))
         {
             MessageBroker.Instance.Publish(__instance, new GameSaved(saveName));
         }
 
         return true;
+    }
+
+    internal static bool ShouldPublishGameSaved(ISaveDriver driver)
+    {
+        // GameSaved writes the co-op session sidecar, so only publish it for a normal campaign save.
+        return driver is FileDriver;
     }
 }
 

--- a/source/GameInterface/Services/UI/BugReporting/BugReportConsentCoordinator.cs
+++ b/source/GameInterface/Services/UI/BugReporting/BugReportConsentCoordinator.cs
@@ -10,18 +10,20 @@ public class BugReportConsentCoordinator
 {
     public const string TabId = "BugReporting";
     public const string SectionId = "BugReportLogSharingConsent";
-    public const int CurrentDisclosureVersion = 2;
+    public const int CurrentDisclosureVersion = 3;
     public const string PromptTitle = "Share Co-op Diagnostic Logs?";
     public const string PromptText =
         "When the dedicated server creates a diagnostic bug report, allow this client's current " +
         "BannerlordCoop log to be sent to the dedicated server, packaged with logs from other consenting " +
         "clients, and submitted to BannerlordCoop's bug-report service? Reports create a public GitHub " +
-        "issue containing the reporting player's network ID. Included server and client logs are uploaded " +
-        "to publicly accessible links, and remote deletion or expiry is not guaranteed. Reports may be triggered " +
-        "automatically by recovery actions such as the coop unstuck command. Logs may contain " +
+        "issue containing the reporting player's network ID. The server also creates and uploads its current " +
+        "campaign save for every report. The save and included server and client logs are uploaded to publicly " +
+        "accessible links, and remote deletion or expiry is not guaranteed. Reports may be triggered " +
+        "automatically by recovery actions such as the coop unstuck command. The server save and logs may contain " +
         "player names, Steam IDs, IP addresses, file paths, and gameplay or network details. Runtime " +
-        "command arguments and common credential values are redacted. Saves, configuration files, " +
-        "and memory dumps are not included. Choose No thanks to keep this client's log local. " +
+        "command arguments and common credential values are redacted from logs. Client saves, configuration " +
+        "files, and memory dumps are not included. Choose No thanks to keep this client's log local; the server " +
+        "campaign save is still included. " +
         "Change this later with coop.bug_report_log_sharing enable or disable.";
 
     private readonly ICoopOptionsStore optionsStore;

--- a/source/GameInterface/Services/UI/BugReporting/BugReportConsentCoordinator.cs
+++ b/source/GameInterface/Services/UI/BugReporting/BugReportConsentCoordinator.cs
@@ -48,6 +48,13 @@ public class BugReportConsentCoordinator
         if (decision.HasValue) return;
 
         promptShown = true;
+        ShowPrompt(showInquiry);
+    }
+
+    public void ShowPrompt(Action<InquiryData> showInquiry)
+    {
+        if (showInquiry == null) throw new ArgumentNullException(nameof(showInquiry));
+
         showInquiry(new InquiryData(
             PromptTitle,
             PromptText,

--- a/source/GameInterface/Services/UI/BugReporting/BugReportSubmissionConsent.cs
+++ b/source/GameInterface/Services/UI/BugReporting/BugReportSubmissionConsent.cs
@@ -18,11 +18,12 @@ public class BugReportSubmissionConsent : IBugReportSubmissionConsent
     public const string PromptText =
         "Submitting this report sends your network ID, summary, and description to the dedicated " +
         "server and BannerlordCoop's bug-report service. The reporting network ID is published in a " +
-        "public GitHub issue. Included server and client logs are uploaded to publicly accessible links, " +
-        "and remote deletion or expiry is not guaranteed. Allowing also enables sharing this client's " +
-        "current BannerlordCoop log with the report. Logs may contain player names, Steam IDs, IP " +
-        "addresses, file paths, and gameplay or network details. Runtime command arguments and " +
-        "common credential values are redacted. Saves, configuration files, and memory dumps are " +
+        "public GitHub issue. The server creates and uploads its current campaign save with the report. " +
+        "The save and included server and client logs are uploaded to publicly accessible links, and remote " +
+        "deletion or expiry is not guaranteed. Allowing also enables sharing this client's current " +
+        "BannerlordCoop log with the report. The server save and logs may contain player names, Steam IDs, " +
+        "IP addresses, file paths, and gameplay or network details. Runtime command arguments and common " +
+        "credential values are redacted from logs. Client saves, configuration files, and memory dumps are " +
         "not included. Choose Allow to enable diagnostic log sharing and submit this report. " +
         "Choose No thanks to cancel this bug report. Change log sharing later with " +
         "coop.bug_report_log_sharing enable or disable.";


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

`coop.bug_report_log_sharing enable` can save consent without displaying the current privacy disclosure. Pending archive quota enforcement stops when the oldest ZIP cannot be deleted. Bug reports also omit the server campaign save.

## What is the new behavior?

The enable command displays the current disclosure before saving consent, and quota enforcement skips undeletable archives and tries later candidates.

Each accepted bug report snapshots the server's current campaign as native `.sav` data in memory without writing to the normal Game Saves directory or creating a co-op session sidecar. The save is included in fallback ZIPs and uploaded before the JSON report. Existing consent is invalidated so the new public server-save disclosure is shown.

The ingestion endpoint receives:

1. An authenticated raw `PUT` with `X-Bug-Report-Artifact: server-save`, the report/file headers, and the save body.
2. The authenticated schema-v2 JSON `POST`, whose `serverSave` field identifies the uploaded artifact.

The endpoint must store the PUT by report id before accepting the matching JSON report.

Tested with:

- `dotnet test source/CoopUnitTests.slnf -c Release --no-build --no-restore`
- `dotnet test source/E2E.Tests/E2E.Tests.csproj -c Release --filter "FullyQualifiedName~UnstuckCommandTests"`

## Bot Changelog Entry

- Bug reports now save and upload the current server campaign, and log sharing shows the updated privacy disclosure before being enabled.
