### PR TITLE
Fix governors forming parties

### DIFF
--- a/source/GameInterface/Services/Heroes/Patches/HeroSpawnCampaignBehaviorPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/HeroSpawnCampaignBehaviorPatches.cs
@@ -32,8 +32,8 @@ internal class HeroSpawnCampaignBehaviorPatches
 
     [HarmonyPatch(nameof(HeroSpawnCampaignBehavior.OnNonBanditClanDailyTick))]
     [HarmonyPrefix]
-    public static bool OnNonBanditClanDailyTickPrefix() => 
-        ModInformation.IsServer || CallOriginalPolicy.IsOriginalAllowed();
+    public static bool OnNonBanditClanDailyTickPrefix(Clan clan) =>
+        CallOriginalPolicy.IsOriginalAllowed() || (ModInformation.IsServer && !clan.IsPlayerClan());
 
     [HarmonyPatch(nameof(HeroSpawnCampaignBehavior.OnHeroComesOfAge))]
     [HarmonyPrefix]


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On dedicated servers its possible that the `TrySpawnHeroesAndPartiesPrefix` that is supposed to block forming parties for player clans isn't being used because of inlining.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3334 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Block the calling tick `OnNonBanditClanDailyTick` directly.