### PR TITLE
Fix stuck companion dialogue

### DIFF
--- a/deploy/ModuleData/global_strings.xml
+++ b/deploy/ModuleData/global_strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <strings>
     <string id="str_coop_server_managed_player_received_damage" text="{=!}Managing this option is disabled on clients; the server does this." />
+    <string id="coop_wanderer_alley_orders" text="Do you have any orders for your alley, {?PLAYER.GENDER}madam{?}sir{\?}" />
     <!-- Add other custom text here in the future-->
 </strings>

--- a/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using Helpers;
 using System;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
@@ -24,49 +23,89 @@ internal class LordConversationsWandererPatches
         if (targetSentence == null) return;
 
         // Vanilla incorrectly uses the NPC's gender to address the player
-        targetSentence.Text = new TextObject("{=EUBxMVXk}Do you have any orders for your alley, {?PLAYER.GENDER}madam{?}sir{\\?}");
+        targetSentence.Text = new TextObject("{=coop_wanderer_alley_orders}Do you have any orders for your alley, {?PLAYER.GENDER}madam{?}sir{\\?}");
     }
-
-    [ThreadStatic]
-    private static bool UseWandererIntroduction = false;
 
     /// <summary>
-    /// Use wanderer dialogue introduction regardless of recruited status.
-    /// After introduction, treat dialogue as a lord conversation by ConversationWandererOnConditionPrefix.
+    /// Wrap introduction conditions to use always wanderer dialogue for introductions.
+    /// In the context of introductions, conditions should be met the same as in vanilla
+    /// even when a wanderer has already been recruited.
     /// </summary>
+    [ThreadStatic]
+    private static int wandererIntroductionConditionDepth;
+    
     [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_meet_on_condition))]
     [HarmonyPrefix]
-    public static bool ConversationWandererMeetOnConditionPrefix(LordConversationsCampaignBehavior __instance, ref bool __result)
-    {
-        __result = IsNonPrisonerWanderer(CharacterObject.OneToOneConversationCharacter)
-            && __instance.ConversationUseMeetingDialogs();
+    public static void ConversationWandererMeetOnConditionPrefix() =>
+        EnterWandererIntroductionCondition();
 
-        if (__result)
-        {
-            UseWandererIntroduction = true;
-        }
-
-        return false;
-    }
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_meet_on_condition))]
+    [HarmonyFinalizer]
+    public static void ConversationWandererMeetOnConditionFinalizer() =>
+        ExitWandererIntroductionCondition();
 
     [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_meet_player_on_condition))]
     [HarmonyPrefix]
-    public static bool ConversationWandererMeetPlayerOnConditionPrefix(ref bool __result)
-    {
-        __result = UseWandererIntroduction;
-        return false;
-    }
+    public static void ConversationWandererMeetPlayerOnConditionPrefix() =>
+        EnterWandererIntroductionCondition();
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_meet_player_on_condition))]
+    [HarmonyFinalizer]
+    public static void ConversationWandererMeetPlayerOnConditionFinalizer() =>
+        ExitWandererIntroductionCondition();
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_introduction_on_condition))]
+    [HarmonyPrefix]
+    public static void ConversationWandererIntroductionOnConditionPrefix() =>
+        EnterWandererIntroductionCondition();
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_introduction_on_condition))]
+    [HarmonyFinalizer]
+    public static void ConversationWandererIntroductionOnConditionFinalizer() =>
+        ExitWandererIntroductionCondition();
 
     [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_generic_introduction_on_condition))]
     [HarmonyPrefix]
-    public static bool ConversationWandererGenericIntroductionOnConditionPostfix(ref bool __result)
+    public static void ConversationWandererGenericIntroductionOnConditionPrefix() =>
+        EnterWandererIntroductionCondition();
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_generic_introduction_on_condition))]
+    [HarmonyFinalizer]
+    public static void ConversationWandererGenericIntroductionOnConditionFinalizer() =>
+        ExitWandererIntroductionCondition();
+
+    /// <summary>
+    /// Don't load wanderer dialogue for companions of a different clan, instead treat the dialogue as a lord dialogue.
+    /// All companion dialogue in vanilla assumes they are a companion of the player in the conversation.
+    /// </summary>
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_on_condition))]
+    [HarmonyPrefix]
+    public static bool ConversationWandererOnConditionPrefix(ref bool __result)
     {
-        if (UseWandererIntroduction)
-        {
-            __result = true;
-            StringHelpers.SetCharacterProperties("CONVERSATION_CHARACTER", Hero.OneToOneConversationHero.CharacterObject, null, false);
-        }
+        __result = IsNonPrisonerWanderer(CharacterObject.OneToOneConversationCharacter)
+            && (wandererIntroductionConditionDepth > 0
+            || Hero.OneToOneConversationHero.CompanionOf == null
+            || Hero.OneToOneConversationHero.CompanionOf == Clan.PlayerClan);
+
         return false;
+    }
+
+    private static void EnterWandererIntroductionCondition()
+    {
+        wandererIntroductionConditionDepth++;
+    }
+
+    private static void ExitWandererIntroductionCondition()
+    {
+        wandererIntroductionConditionDepth--;
+    }
+
+    private static bool IsNonPrisonerWanderer(CharacterObject character)
+    {
+        return character != null
+            && character.IsHero
+            && character.Occupation == Occupation.Wanderer
+            && character.HeroObject.HeroState != Hero.CharacterStates.Prisoner;
     }
 
     /// <summary>
@@ -82,31 +121,6 @@ internal class LordConversationsWandererPatches
             && Hero.OneToOneConversationHero.Clan == Clan.PlayerClan;
 
         return false;
-    }
-
-    /// <summary>
-    /// Don't load wanderer dialogue for companions of a different clan, instead treat the dialogue as a lord dialogue.
-    /// All companion dialogue in vanilla assumes they are a companion of the player in the conversation.
-    /// </summary>
-    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_on_condition))]
-    [HarmonyPrefix]
-    public static bool ConversationWandererOnConditionPrefix(ref bool __result)
-    {
-        __result = UseWandererIntroduction || IsNonPrisonerWanderer(CharacterObject.OneToOneConversationCharacter)
-            && (Hero.OneToOneConversationHero.CompanionOf == null
-            || Hero.OneToOneConversationHero.CompanionOf == Clan.PlayerClan);
-
-        UseWandererIntroduction = false;
-
-        return false;
-    }
-
-    private static bool IsNonPrisonerWanderer(CharacterObject character)
-    {
-        return character != null
-            && character.IsHero
-            && character.Occupation == Occupation.Wanderer
-            && character.HeroObject.HeroState != Hero.CharacterStates.Prisoner;
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
@@ -27,7 +27,7 @@ internal class LordConversationsWandererPatches
     }
 
     /// <summary>
-    /// Wrap introduction conditions to use always wanderer dialogue for introductions.
+    /// Wrap introduction conditions to always use wanderer dialogue for introductions.
     /// In the context of introductions, conditions should be met the same as in vanilla
     /// even when a wanderer has already been recruited.
     /// </summary>

--- a/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
@@ -28,9 +28,6 @@ internal class LordConversationsWandererPatches
     }
 
     [ThreadStatic]
-    private static bool IsMeetingWanderer = false;
-
-    [ThreadStatic]
     private static bool UseWandererIntroduction = false;
 
     /// <summary>
@@ -46,7 +43,6 @@ internal class LordConversationsWandererPatches
 
         if (__result)
         {
-            IsMeetingWanderer = true;
             UseWandererIntroduction = true;
         }
 
@@ -57,7 +53,7 @@ internal class LordConversationsWandererPatches
     [HarmonyPrefix]
     public static bool ConversationWandererMeetPlayerOnConditionPrefix(ref bool __result)
     {
-        __result = IsMeetingWanderer;
+        __result = UseWandererIntroduction;
         return false;
     }
 
@@ -65,7 +61,7 @@ internal class LordConversationsWandererPatches
     [HarmonyPrefix]
     public static bool ConversationWandererGenericIntroductionOnConditionPostfix(ref bool __result)
     {
-        if (IsMeetingWanderer)
+        if (UseWandererIntroduction)
         {
             __result = true;
             StringHelpers.SetCharacterProperties("CONVERSATION_CHARACTER", Hero.OneToOneConversationHero.CharacterObject, null, false);

--- a/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
+++ b/source/GameInterface/Services/Heroes/Patches/LordConversationsWandererPatches.cs
@@ -1,14 +1,78 @@
 ﻿using HarmonyLib;
+using Helpers;
+using System;
+using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Localization;
 
 namespace GameInterface.Services.Heroes.Patches;
 
 [HarmonyPatch(typeof(LordConversationsCampaignBehavior))]
 internal class LordConversationsWandererPatches
 {
+    private const string AlleyDialogueId = "wanderer_job_status_1";
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.AddWandererConversations))]
+    [HarmonyPostfix]
+    public static void AddWandererConversationsPostfix()
+    {
+        var targetSentence = Campaign.Current.ConversationManager._sentences.FirstOrDefault(sentence => sentence.Id == AlleyDialogueId);
+
+        if (targetSentence == null) return;
+
+        // Vanilla incorrectly uses the NPC's gender to address the player
+        targetSentence.Text = new TextObject("{=EUBxMVXk}Do you have any orders for your alley, {?PLAYER.GENDER}madam{?}sir{\\?}");
+    }
+
+    [ThreadStatic]
+    private static bool IsMeetingWanderer = false;
+
+    [ThreadStatic]
+    private static bool UseWandererIntroduction = false;
+
+    /// <summary>
+    /// Use wanderer dialogue introduction regardless of recruited status.
+    /// After introduction, treat dialogue as a lord conversation by ConversationWandererOnConditionPrefix.
+    /// </summary>
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_meet_on_condition))]
+    [HarmonyPrefix]
+    public static bool ConversationWandererMeetOnConditionPrefix(LordConversationsCampaignBehavior __instance, ref bool __result)
+    {
+        __result = IsNonPrisonerWanderer(CharacterObject.OneToOneConversationCharacter)
+            && __instance.ConversationUseMeetingDialogs();
+
+        if (__result)
+        {
+            IsMeetingWanderer = true;
+            UseWandererIntroduction = true;
+        }
+
+        return false;
+    }
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_meet_player_on_condition))]
+    [HarmonyPrefix]
+    public static bool ConversationWandererMeetPlayerOnConditionPrefix(ref bool __result)
+    {
+        __result = IsMeetingWanderer;
+        return false;
+    }
+
+    [HarmonyPatch(nameof(LordConversationsCampaignBehavior.conversation_wanderer_generic_introduction_on_condition))]
+    [HarmonyPrefix]
+    public static bool ConversationWandererGenericIntroductionOnConditionPostfix(ref bool __result)
+    {
+        if (IsMeetingWanderer)
+        {
+            __result = true;
+            StringHelpers.SetCharacterProperties("CONVERSATION_CHARACTER", Hero.OneToOneConversationHero.CharacterObject, null, false);
+        }
+        return false;
+    }
+
     /// <summary>
     /// Override result to check if in the same clan rather than just checking if a player companion
     /// </summary>
@@ -32,14 +96,21 @@ internal class LordConversationsWandererPatches
     [HarmonyPrefix]
     public static bool ConversationWandererOnConditionPrefix(ref bool __result)
     {
-        __result = CharacterObject.OneToOneConversationCharacter != null
-            && CharacterObject.OneToOneConversationCharacter.IsHero
-            && CharacterObject.OneToOneConversationCharacter.Occupation == Occupation.Wanderer
-            && CharacterObject.OneToOneConversationCharacter.HeroObject.HeroState != Hero.CharacterStates.Prisoner
+        __result = UseWandererIntroduction || IsNonPrisonerWanderer(CharacterObject.OneToOneConversationCharacter)
             && (Hero.OneToOneConversationHero.CompanionOf == null
             || Hero.OneToOneConversationHero.CompanionOf == Clan.PlayerClan);
 
+        UseWandererIntroduction = false;
+
         return false;
+    }
+
+    private static bool IsNonPrisonerWanderer(CharacterObject character)
+    {
+        return character != null
+            && character.IsHero
+            && character.Occupation == Occupation.Wanderer
+            && character.HeroObject.HeroState != Hero.CharacterStates.Prisoner;
     }
 
     /// <summary>


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The previously changed companion dialogue to allow for hostile interactions made introductions of companions belonging to other players use a generic fall back introduction. This generic fall back would only work when the companion was not part of a kingdom though, resulting in stuck dialogue where pressing "continue" wouldn't do anything.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3272
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Wrap introduction conditions to allow wanderer introduction dialogue regardless of recruitment status to prevent using fallback dialogue that causes softlocks under certain conditions.

Also fixed a minor vanilla issue where alley dialogue incorrectly addresses the player using the NPC's gender instead of the player's.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed an issue where talking to another player's companion could cause a softlock.