### PR TITLE
Update MBBodyPropertyRegistry

### DIFF
--- a/source/GameInterface/Services/MBBodyProperties/MBBodyPropertyRegistry.cs
+++ b/source/GameInterface/Services/MBBodyProperties/MBBodyPropertyRegistry.cs
@@ -5,8 +5,8 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
+using TaleWorlds.ObjectSystem;
 
 namespace GameInterface.Services.MBBodyProperties;
 internal class MBBodyPropertyRegistry : AutoRegistryBase<MBBodyProperty>
@@ -16,17 +16,16 @@ internal class MBBodyPropertyRegistry : AutoRegistryBase<MBBodyProperty>
     {
     }
 
-    public override IEnumerable<MethodBase> Constructors => new MethodBase[] {
-        AccessTools.Constructor(typeof(MBBodyProperty))
-    };
+    public override IEnumerable<MethodBase> Constructors =>
+        AccessTools.GetDeclaredConstructors(typeof(MBBodyProperty));
 
     public override IEnumerable<MethodBase> DestroyMethods => Array.Empty<MethodBase>();
 
     public override void RegisterAllObjects()
     {
-        foreach (CharacterObject character in CharacterObject.All.DistinctBy(c => c.BodyPropertyRange))
+        foreach (var bodyProperty in MBObjectManager.Instance.GetObjectTypeList<MBBodyProperty>())
         {
-            RegisterExistingObject(character.StringId, character.BodyPropertyRange);
+            RegisterExistingObject(bodyProperty.StringId, bodyProperty);
         }
     }
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`MBBodyPropertyRegistry` uses `CharacterObject` string ids instead of `MBBodyProperty.StringId`. This may be causing several failed object resolutions such as the one below obtained by entering a tavern:

<img width="1183" height="48" alt="image" src="https://github.com/user-attachments/assets/7c725586-278e-4db6-a727-1c499d1c1e10" />


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Updated `MBBodyPropertyRegistry` to use `MBBodyProperty.StringId` as the base id instead.