### PR TITLE
Reduce reliable battle message backlog

### DIFF
--- a/UIMovies/CoopOptionsUIMovie.xml
+++ b/UIMovies/CoopOptionsUIMovie.xml
@@ -14,7 +14,7 @@
                        HorizontalAlignment="Center" MarginBottom="24" StackLayout.LayoutMethod="HorizontalLeftToRight">
               <ItemTemplate>
                 <ButtonWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed"
-                              SuggestedWidth="210" SuggestedHeight="58" Brush="Header.Tab.Center"
+                              SuggestedWidth="168" SuggestedHeight="58" Brush="Header.Tab.Center"
                               Command.Click="ExecuteSelection" IsSelected="@IsSelected" UpdateChildrenStates="true">
                   <Children>
                     <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
@@ -263,6 +263,65 @@
 			            </ItemTemplate>
 			        </ListPanel>
 			    </Children>
+			</ListPanel>
+			<ListPanel DataSource="{NetworkTab}" IsVisible="@IsSelected" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+			           LayoutImp.LayoutMethod="VerticalTopToBottom">
+			  <Children>
+			    <ListPanel DataSource="{Sections}" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+			               LayoutImp.LayoutMethod="VerticalTopToBottom">
+			      <ItemTemplate>
+			        <ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+			                   LayoutImp.LayoutMethod="VerticalTopToBottom">
+			          <Children>
+			            <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="48"
+			                        Brush="Clan.TabControl.Text" Brush.FontSize="36"
+			                        Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+			                        Text="@TitleText"/>
+			            <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="82"
+			                        Brush="Clan.TabControl.Text" Brush.FontSize="22" Brush.FontColor="#B8B8B8FF"
+			                        Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+			                        Text="@DescriptionText"/>
+
+			            <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="640" HeightSizePolicy="Fixed" SuggestedHeight="76"
+			                       HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
+			              <Children>
+			                <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="320" HeightSizePolicy="StretchToParent"
+			                            Brush="Clan.TabControl.Text" Brush.FontSize="28"
+			                            Brush.TextHorizontalAlignment="Right" Brush.TextVerticalAlignment="Center"
+			                            MarginRight="24" Text="@UploadText"/>
+			                <FloatInputTextWidget WidthSizePolicy="Fixed" SuggestedWidth="180" HeightSizePolicy="Fixed" SuggestedHeight="52"
+			                                      VerticalAlignment="Center" Brush="ScoreboardPanels_2" Brush.AlphaFactor="0.75"
+			                                      Brush.FontSize="28" Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+			                                      FloatText="@MovementUploadMiBPerSecond" MinFloat="0.01" MaxFloat="1024"
+			                                      EnableClamp="true" MaxLength="8"/>
+			                <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="90" HeightSizePolicy="StretchToParent"
+			                            MarginLeft="18" Brush="Clan.TabControl.Text" Brush.FontSize="24"
+			                            Brush.TextVerticalAlignment="Center" Text="@UnitText"/>
+			              </Children>
+			            </ListPanel>
+
+			            <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="640" HeightSizePolicy="Fixed" SuggestedHeight="76"
+			                       HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
+			              <Children>
+			                <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="320" HeightSizePolicy="StretchToParent"
+			                            Brush="Clan.TabControl.Text" Brush.FontSize="28"
+			                            Brush.TextHorizontalAlignment="Right" Brush.TextVerticalAlignment="Center"
+			                            MarginRight="24" Text="@DownloadText"/>
+			                <FloatInputTextWidget WidthSizePolicy="Fixed" SuggestedWidth="180" HeightSizePolicy="Fixed" SuggestedHeight="52"
+			                                      VerticalAlignment="Center" Brush="ScoreboardPanels_2" Brush.AlphaFactor="0.75"
+			                                      Brush.FontSize="28" Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+			                                      FloatText="@MovementDownloadMiBPerSecond" MinFloat="0.01" MaxFloat="1024"
+			                                      EnableClamp="true" MaxLength="8"/>
+			                <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="90" HeightSizePolicy="StretchToParent"
+			                            MarginLeft="18" Brush="Clan.TabControl.Text" Brush.FontSize="24"
+			                            Brush.TextVerticalAlignment="Center" Text="@UnitText"/>
+			              </Children>
+			            </ListPanel>
+			          </Children>
+			        </ListPanel>
+			      </ItemTemplate>
+			    </ListPanel>
+			  </Children>
 			</ListPanel>
 
             <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"

--- a/deploy/mod-config.default.json
+++ b/deploy/mod-config.default.json
@@ -73,12 +73,6 @@
     // Toggle auto allocation of perks for members of player clans.
     "autoAllocateClanMemberPerks": false
   },
-  "network": {
-    // Total compressed movement payload this client may send and receive per second.
-    // These are local per-client limits; the dedicated server does not originate mission movement.
-    "movementOutgoingMiBPerSecond": 1.0,
-    "movementIncomingMiBPerSecond": 1.0,
-  },
   "modOptions": {
     // Total human troops initially allocated across both sides of a battle.
     // Valid range: 200-1000. Default is 1000.

--- a/source/Common.Tests/Network/ReliableMessageBatcherTests.cs
+++ b/source/Common.Tests/Network/ReliableMessageBatcherTests.cs
@@ -1,0 +1,152 @@
+﻿using Common.Network;
+using Common.PacketHandlers;
+using Common.Serialization;
+
+namespace Common.Tests.Network;
+
+/// <summary>Regression coverage for reliable message batching and ordering barriers.</summary>
+public class ReliableMessageBatcherTests
+{
+    private readonly ICommonSerializer serializer =
+        new ProtoBufSerializer(new SerializableTypeMapper());
+
+    [Fact]
+    public void Send_SubBudgetMessages_DoesNotSendUntilFlush()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var sent = new List<byte[]>();
+
+        batcher.Send("peer", Payload(30, 1), (_, data) => sent.Add(data));
+        batcher.Send("peer", Payload(30, 2), (_, data) => sent.Add(data));
+
+        Assert.Empty(sent);
+
+        batcher.Flush("peer", (_, data) => sent.Add(data));
+
+        Assert.Single(sent);
+    }
+
+    [Fact]
+    public void Flush_MultipleMessages_SendsOneAggregateInOriginalOrder()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var first = Payload(30, 1);
+        var second = Payload(30, 2);
+        var sent = new List<byte[]>();
+
+        batcher.Send("peer", first, (_, data) => sent.Add(data));
+        batcher.Send("peer", second, (_, data) => sent.Add(data));
+        batcher.Flush("peer", (_, data) => sent.Add(data));
+
+        var aggregate = Assert.IsType<AggregateMessagePacket>(
+            serializer.Deserialize<IPacket>(Assert.Single(sent)));
+        Assert.Equal(2, aggregate.Messages.Length);
+        Assert.Equal(first, aggregate.Messages[0]);
+        Assert.Equal(second, aggregate.Messages[1]);
+    }
+
+    [Fact]
+    public void Flush_SingleMessage_SendsBarePayload()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var payload = Payload(30, 1);
+        var sent = new List<byte[]>();
+
+        batcher.Send("peer", payload, (_, data) => sent.Add(data));
+        batcher.Flush("peer", (_, data) => sent.Add(data));
+
+        Assert.Same(payload, Assert.Single(sent));
+    }
+
+    [Fact]
+    public void Send_Overflow_SendsPreviousBatchBeforeOverflowingMessage()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var first = Payload(60, 1);
+        var second = Payload(60, 2);
+        var sent = new List<byte[]>();
+
+        batcher.Send("peer", first, (_, data) => sent.Add(data));
+        batcher.Send("peer", second, (_, data) => sent.Add(data));
+        batcher.Flush("peer", (_, data) => sent.Add(data));
+
+        Assert.Equal(2, sent.Count);
+        Assert.Same(first, sent[0]);
+        Assert.Same(second, sent[1]);
+    }
+
+    [Fact]
+    public void Send_OversizedMessage_FlushesEarlierMessagesBeforeBarePayload()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var buffered = Payload(30, 1);
+        var oversized = Payload(100, 2);
+        var sent = new List<byte[]>();
+
+        batcher.Send("peer", buffered, (_, data) => sent.Add(data));
+        batcher.Send("peer", oversized, (_, data) => sent.Add(data));
+
+        Assert.Equal(2, sent.Count);
+        Assert.Same(buffered, sent[0]);
+        Assert.Same(oversized, sent[1]);
+    }
+
+    [Fact]
+    public void SendImmediate_FlushesEarlierMessagesBeforeImmediatePayload()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var first = Payload(30, 1);
+        var second = Payload(30, 2);
+        var immediate = Payload(10, 3);
+        var sent = new List<byte[]>();
+
+        batcher.Send("peer", first, (_, data) => sent.Add(data));
+        batcher.Send("peer", second, (_, data) => sent.Add(data));
+        batcher.SendImmediate("peer", immediate, (_, data) => sent.Add(data));
+
+        Assert.Equal(2, sent.Count);
+        var aggregate = Assert.IsType<AggregateMessagePacket>(
+            serializer.Deserialize<IPacket>(sent[0]));
+        Assert.Equal(first, aggregate.Messages[0]);
+        Assert.Equal(second, aggregate.Messages[1]);
+        Assert.Same(immediate, sent[1]);
+    }
+
+    [Fact]
+    public void FlushThen_SendsBufferedMessagesBeforeBarrier()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var order = new List<string>();
+
+        batcher.Send("peer", Payload(30), (_, _) => order.Add("messages"));
+        batcher.FlushThen(
+            "peer",
+            (_, _) => order.Add("messages"),
+            () => order.Add("barrier"));
+
+        Assert.Equal(new[] { "messages", "barrier" }, order);
+    }
+
+    [Fact]
+    public void FlushAll_PrunesDisconnectedDestination()
+    {
+        var batcher = new ReliableMessageBatcher<string>(serializer, 100);
+        var sentDestinations = new List<string>();
+
+        batcher.Send("connected", Payload(30), (_, _) => { });
+        batcher.Send("disconnected", Payload(30), (_, _) => { });
+        batcher.FlushAll(
+            destination => destination == "connected",
+            (destination, _) => sentDestinations.Add(destination));
+        batcher.Flush(
+            "disconnected",
+            (destination, _) => sentDestinations.Add(destination));
+
+        Assert.Equal(new[] { "connected" }, sentDestinations);
+    }
+
+    private static byte[] Payload(int size, byte fill = 0)
+    {
+        return Enumerable.Repeat(fill, size).ToArray();
+    }
+}

--- a/source/Common/Network/MessageAggregationBuffer.cs
+++ b/source/Common/Network/MessageAggregationBuffer.cs
@@ -1,15 +1,16 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Common.Network;
 
 /// <summary>
-/// Accumulates serialized message payloads destined for one peer until they fill a byte budget,
+/// Accumulates serialized message payloads for one destination until they fill a byte budget,
 /// so many small reliable messages leave as a few full packets instead of one packet each.
 /// </summary>
 /// <remarks>
 /// LiteNetLib's reliable channel caps unacked packets in flight (not bytes), so per-peer throughput
 /// is proportional to packet fullness; this buffer is what keeps world-sync bursts under that cap.
-/// Not thread-safe by itself — the owner locks around each call (see <c>CoopNetworkBase</c>), which
+/// Not thread-safe by itself — the owner locks around each call (see
+/// <see cref="ReliableMessageBatcher{TDestination}"/>), which
 /// also guarantees returned batches are sent in the order they were drained.
 /// </remarks>
 public class MessageAggregationBuffer
@@ -21,8 +22,8 @@ public class MessageAggregationBuffer
 
     /// <param name="budgetBytes">
     /// Combined payload size to aim for per batch. Callers pick it so a batch plus its envelope
-    /// framing fits one datagram at the link's LiteNetLib-negotiated packet size — see
-    /// <c>CoopNetworkBase.AggregationBudgetBytes</c> for the concrete numbers and rationale.
+    /// framing fits one datagram at the link's LiteNetLib-negotiated packet size. The shared
+    /// <see cref="ReliableMessageBatcher{TDestination}"/> supplies the production budget.
     /// </param>
     public MessageAggregationBuffer(int budgetBytes)
     {

--- a/source/Common/Network/ReliableMessageBatcher.cs
+++ b/source/Common/Network/ReliableMessageBatcher.cs
@@ -1,0 +1,243 @@
+﻿using Common.PacketHandlers;
+using Common.Serialization;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Common.Network;
+
+/// <summary>Batches reliable messages independently for each logical destination.</summary>
+public interface IReliableMessageBatcher<TDestination> where TDestination : class
+{
+    int BudgetBytes { get; }
+    event Action<AggregateMessagePacket, int> AggregateSent;
+    void Send(
+        TDestination destination,
+        byte[] messagePayload,
+        Action<TDestination, byte[]> sendReliableOrdered);
+    void SendImmediate(
+        TDestination destination,
+        byte[] messagePayload,
+        Action<TDestination, byte[]> sendReliableOrdered);
+    void Flush(
+        TDestination destination,
+        Action<TDestination, byte[]> sendReliableOrdered);
+    void FlushThen(
+        TDestination destination,
+        Action<TDestination, byte[]> sendReliableOrdered,
+        Action sendAfterFlush);
+    void FlushAll(
+        Func<TDestination, bool> isConnected,
+        Action<TDestination, byte[]> sendReliableOrdered);
+    void Remove(TDestination destination);
+    void Clear();
+}
+
+/// <summary>
+/// Batches small serialized messages per destination so LiteNetLib's fixed reliable packet window
+/// carries full datagrams instead of one small message per slot.
+/// </summary>
+public class ReliableMessageBatcher<TDestination> : IReliableMessageBatcher<TDestination>
+    where TDestination : class
+{
+    /// <summary>
+    /// Leaves room for the aggregate envelope and LiteNetLib framing within its discovered MTU.
+    /// </summary>
+    public const int DefaultBudgetBytes = 1200;
+
+    private sealed class DestinationBuffer
+    {
+        public readonly object Lock = new object();
+        public readonly MessageAggregationBuffer Buffer;
+
+        public DestinationBuffer(int budgetBytes)
+        {
+            Buffer = new MessageAggregationBuffer(budgetBytes);
+        }
+    }
+
+    private readonly ICommonSerializer serializer;
+    private readonly ConcurrentDictionary<TDestination, DestinationBuffer> pendingMessages =
+        new ConcurrentDictionary<TDestination, DestinationBuffer>();
+
+    public int BudgetBytes { get; }
+    public event Action<AggregateMessagePacket, int> AggregateSent;
+
+    public ReliableMessageBatcher(ICommonSerializer serializer)
+        : this(serializer, DefaultBudgetBytes)
+    {
+    }
+
+    public ReliableMessageBatcher(ICommonSerializer serializer, int budgetBytes)
+    {
+        if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+        if (budgetBytes <= 0) throw new ArgumentOutOfRangeException(nameof(budgetBytes));
+
+        this.serializer = serializer;
+        BudgetBytes = budgetBytes;
+    }
+
+    public void Send(
+        TDestination destination,
+        byte[] messagePayload,
+        Action<TDestination, byte[]> sendReliableOrdered)
+    {
+        ValidateSend(destination, messagePayload, sendReliableOrdered);
+
+        DestinationBuffer destinationBuffer = GetBuffer(destination);
+        lock (destinationBuffer.Lock)
+        {
+            if (messagePayload.Length >= BudgetBytes)
+            {
+                SendDrainedBatch(
+                    destination,
+                    destinationBuffer.Buffer.Drain(),
+                    sendReliableOrdered);
+                sendReliableOrdered(destination, messagePayload);
+                return;
+            }
+
+            SendDrainedBatch(
+                destination,
+                destinationBuffer.Buffer.Append(messagePayload),
+                sendReliableOrdered);
+        }
+    }
+
+    public void SendImmediate(
+        TDestination destination,
+        byte[] messagePayload,
+        Action<TDestination, byte[]> sendReliableOrdered)
+    {
+        ValidateSend(destination, messagePayload, sendReliableOrdered);
+
+        DestinationBuffer destinationBuffer = GetBuffer(destination);
+        lock (destinationBuffer.Lock)
+        {
+            SendDrainedBatch(
+                destination,
+                destinationBuffer.Buffer.Drain(),
+                sendReliableOrdered);
+            sendReliableOrdered(destination, messagePayload);
+        }
+    }
+
+    public void Flush(
+        TDestination destination,
+        Action<TDestination, byte[]> sendReliableOrdered)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (sendReliableOrdered == null) throw new ArgumentNullException(nameof(sendReliableOrdered));
+        if (!pendingMessages.TryGetValue(destination, out DestinationBuffer destinationBuffer)) return;
+
+        lock (destinationBuffer.Lock)
+        {
+            SendDrainedBatch(
+                destination,
+                destinationBuffer.Buffer.Drain(),
+                sendReliableOrdered);
+        }
+    }
+
+    public void FlushThen(
+        TDestination destination,
+        Action<TDestination, byte[]> sendReliableOrdered,
+        Action sendAfterFlush)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (sendReliableOrdered == null) throw new ArgumentNullException(nameof(sendReliableOrdered));
+        if (sendAfterFlush == null) throw new ArgumentNullException(nameof(sendAfterFlush));
+
+        DestinationBuffer destinationBuffer = GetBuffer(destination);
+        lock (destinationBuffer.Lock)
+        {
+            SendDrainedBatch(
+                destination,
+                destinationBuffer.Buffer.Drain(),
+                sendReliableOrdered);
+            sendAfterFlush();
+        }
+    }
+
+    public void FlushAll(
+        Func<TDestination, bool> isConnected,
+        Action<TDestination, byte[]> sendReliableOrdered)
+    {
+        if (isConnected == null) throw new ArgumentNullException(nameof(isConnected));
+        if (sendReliableOrdered == null) throw new ArgumentNullException(nameof(sendReliableOrdered));
+
+        foreach (KeyValuePair<TDestination, DestinationBuffer> entry in pendingMessages)
+        {
+            if (!isConnected(entry.Key))
+            {
+                Remove(entry.Key);
+                continue;
+            }
+
+            Flush(entry.Key, sendReliableOrdered);
+        }
+    }
+
+    public void Remove(TDestination destination)
+    {
+        if (destination == null) return;
+        if (!pendingMessages.TryRemove(destination, out DestinationBuffer destinationBuffer)) return;
+
+        lock (destinationBuffer.Lock)
+        {
+            destinationBuffer.Buffer.Drain();
+        }
+    }
+
+    public void Clear()
+    {
+        foreach (TDestination destination in pendingMessages.Keys)
+        {
+            Remove(destination);
+        }
+    }
+
+    private static void ValidateSend(
+        TDestination destination,
+        byte[] messagePayload,
+        Action<TDestination, byte[]> sendReliableOrdered)
+    {
+        if (destination == null) throw new ArgumentNullException(nameof(destination));
+        if (messagePayload == null) throw new ArgumentNullException(nameof(messagePayload));
+        if (sendReliableOrdered == null) throw new ArgumentNullException(nameof(sendReliableOrdered));
+    }
+
+    private DestinationBuffer GetBuffer(TDestination destination)
+    {
+        return pendingMessages.GetOrAdd(
+            destination,
+            _ => new DestinationBuffer(BudgetBytes));
+    }
+
+    private void SendDrainedBatch(
+        TDestination destination,
+        List<byte[]> payloads,
+        Action<TDestination, byte[]> sendReliableOrdered)
+    {
+        if (payloads == null) return;
+
+        if (payloads.Count == 1)
+        {
+            sendReliableOrdered(destination, payloads[0]);
+            return;
+        }
+
+        var envelope = new AggregateMessagePacket(payloads.ToArray());
+        byte[] data = serializer.Serialize(envelope);
+        sendReliableOrdered(destination, data);
+
+        if (AggregateSent == null) return;
+
+        int framingOverhead = data.Length;
+        foreach (byte[] payload in payloads)
+        {
+            framingOverhead -= payload.Length;
+        }
+        AggregateSent(envelope, framingOverhead);
+    }
+}

--- a/source/Coop.Core/Client/CoopClient.cs
+++ b/source/Coop.Core/Client/CoopClient.cs
@@ -47,7 +47,9 @@ public class CoopClient : CoopNetworkBase, ICoopClient
         IPacketManager packetManager,
         IMessagePacketHandler messagePacketHandler,
         ICommonSerializer serializer,
-        CancellationTokenSource sessionCancellation) : base(config, serializer, sessionCancellation)
+        IReliableMessageBatcher<NetPeer> reliableMessageBatcher,
+        CancellationTokenSource sessionCancellation)
+        : base(config, serializer, reliableMessageBatcher, sessionCancellation)
     {
         this.messageBroker = messageBroker;
         this.packetManager = packetManager;

--- a/source/Coop.Core/Common/CommonModule.cs
+++ b/source/Coop.Core/Common/CommonModule.cs
@@ -31,6 +31,9 @@ public abstract class CommonModule : Module
 
         #region Network
         builder.RegisterType<NetworkConfig>().As<INetworkConfig>().InstancePerLifetimeScope();
+        builder.RegisterGeneric(typeof(ReliableMessageBatcher<>))
+            .As(typeof(IReliableMessageBatcher<>))
+            .InstancePerDependency();
         #endregion
 
         #region Communication

--- a/source/Coop.Core/Common/Network/CoopNetworkBase.cs
+++ b/source/Coop.Core/Common/Network/CoopNetworkBase.cs
@@ -8,7 +8,6 @@ using Common.Util;
 using Coop.Core.Common.Network.Packets;
 using LiteNetLib;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -31,6 +30,7 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
 
     // Profiles outbound packets; dumps per-type counts and byte totals every 10 seconds (server only).
     private readonly PacketProfiler packetProfiler = new PacketProfiler(TimeSpan.FromSeconds(10));
+    private readonly IReliableMessageBatcher<NetPeer> reliableMessageBatcher;
 
     // Guard against repeated container and explicit disposal.
     private int disposed;
@@ -40,11 +40,17 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
     protected CoopNetworkBase(
         INetworkConfig configuration,
         ICommonSerializer serializer,
+        IReliableMessageBatcher<NetPeer> reliableMessageBatcher,
         CancellationTokenSource sessionCancellation)
     {
+        if (reliableMessageBatcher == null)
+            throw new ArgumentNullException(nameof(reliableMessageBatcher));
+
         Config = configuration;
         this.serializer = serializer;
         this.sessionCancellation = sessionCancellation;
+        this.reliableMessageBatcher = reliableMessageBatcher;
+        this.reliableMessageBatcher.AggregateSent += RecordAggregateSent;
 
         netManager = new NetManager(this)
         {
@@ -104,7 +110,9 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
         // Wake blocking game-thread marshals before waiting for the poll callback to return.
         sessionCancellation.Cancel();
         poller.StopAndWait(Timeout.InfiniteTimeSpan);
+        reliableMessageBatcher.AggregateSent -= RecordAggregateSent;
         packetProfiler.Dispose();
+        reliableMessageBatcher.Clear();
         netManager.Stop();
     }
 
@@ -186,15 +194,10 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
             // envelope's framing overhead is recorded separately when a batch actually leaves.
             packetProfiler.Record(packet, payload.Length);
 
-            if (immediate || payload.Length >= AggregationBudgetBytes)
-            {
-                // Keep the reliable stream's order: everything buffered was logically sent first.
-                FlushPeerMessages(netPeer);
-                netPeer.Send(payload, packet.DeliveryMethod);
-                return;
-            }
-
-            EnqueueMessage(netPeer, payload);
+            if (immediate)
+                reliableMessageBatcher.SendImmediate(netPeer, payload, SendReliableMessagePayload);
+            else
+                reliableMessageBatcher.Send(netPeer, payload, SendReliableMessagePayload);
             return;
         }
 
@@ -208,7 +211,11 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
         if (packet.DeliveryMethod == DeliveryMethod.ReliableOrdered ||
             packet.DeliveryMethod == DeliveryMethod.ReliableUnordered)
         {
-            FlushPeerMessages(netPeer);
+            reliableMessageBatcher.FlushThen(
+                netPeer,
+                SendReliableMessagePayload,
+                () => netPeer.Send(data, GetChannel(packet), packet.DeliveryMethod));
+            return;
         }
 
         netPeer.Send(data, GetChannel(packet), packet.DeliveryMethod);
@@ -225,94 +232,26 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
 
     private static byte GetChannel(IPacket packet) => packet is GameSaveDataPacket or GameSaveDataChunkPacket ? BulkChannel : (byte)0;
 
-    #region Message aggregation
-
-    /// <summary>
-    /// Combined payload budget per aggregate batch. LiteNetLib's reliable channel caps unacked
-    /// packets — not bytes — in flight (a hardcoded 64-packet window in 1.3.1), so per-peer
-    /// throughput scales with packet fullness.
-    /// </summary>
-    /// <remarks>
-    /// Why 1200: a LiteNetLib connection starts at InitialMtu (1024B) and probes upward ("MTU
-    /// discovery") to MaxPacketSize (1432B = Ethernet 1500 minus IP/UDP/LiteNetLib headers),
-    /// normally settling at 1432 within seconds. 1200B of payload plus envelope framing (~10-30B
-    /// protobuf + 4B channeled header) fits one 1432B datagram — one packet, one window slot. On a
-    /// link still at 1024 (pre-discovery, or a path that never upgrades) the envelope splits into
-    /// two reliable fragments — two window slots, still ~10x fewer than one packet per message.
-    /// </remarks>
-    public const int AggregationBudgetBytes = 1200;
-
-    private sealed class PeerMessageBuffer
-    {
-        public readonly object Lock = new object();
-        public readonly MessageAggregationBuffer Buffer = new MessageAggregationBuffer(AggregationBudgetBytes);
-    }
-
-    private readonly ConcurrentDictionary<NetPeer, PeerMessageBuffer> pendingMessages =
-        new ConcurrentDictionary<NetPeer, PeerMessageBuffer>();
-
-    private void EnqueueMessage(NetPeer netPeer, byte[] payload)
-    {
-        var peerBuffer = pendingMessages.GetOrAdd(netPeer, _ => new PeerMessageBuffer());
-        lock (peerBuffer.Lock)
-        {
-            var overflow = peerBuffer.Buffer.Append(payload);
-            // Sending under the peer's lock keeps batches in enqueue order on the reliable stream.
-            if (overflow != null) SendBatch(netPeer, overflow);
-        }
-    }
-
-    private void FlushPeerMessages(NetPeer netPeer)
-    {
-        if (pendingMessages.TryGetValue(netPeer, out var peerBuffer) == false) return;
-
-        lock (peerBuffer.Lock)
-        {
-            var batch = peerBuffer.Buffer.Drain();
-            if (batch != null) SendBatch(netPeer, batch);
-        }
-    }
-
     /// <summary>
     /// Sends every peer's buffered messages and prunes buffers of disconnected peers. Normally called
     /// from the network update; the join-save path also calls it while the poll thread is blocked.
     /// </summary>
     public void FlushPendingMessages()
     {
-        foreach (var entry in pendingMessages)
-        {
-            if (entry.Key.ConnectionState != ConnectionState.Connected)
-            {
-                pendingMessages.TryRemove(entry.Key, out _);
-                continue;
-            }
-
-            FlushPeerMessages(entry.Key);
-        }
+        reliableMessageBatcher.FlushAll(
+            peer => peer.ConnectionState == ConnectionState.Connected,
+            SendReliableMessagePayload);
     }
 
-    private void SendBatch(NetPeer netPeer, List<byte[]> payloads)
+    private void RecordAggregateSent(AggregateMessagePacket packet, int framingOverhead)
     {
-        // A batch of one goes bare — the historical wire format — sparing the envelope overhead.
-        if (payloads.Count == 1)
-        {
-            netPeer.Send(payloads[0], DeliveryMethod.ReliableOrdered);
-            return;
-        }
-
-        var envelope = new AggregateMessagePacket(payloads.ToArray());
-        byte[] data = serializer.Serialize(envelope);
-
-        // Inner messages were profiled at their logical send; record only the framing overhead here,
-        // which also makes the number of wire packets aggregation produced visible in the profile.
-        int framingOverhead = data.Length;
-        foreach (var payload in payloads) framingOverhead -= payload.Length;
-        packetProfiler.Record(envelope, framingOverhead);
-
-        netPeer.Send(data, envelope.DeliveryMethod);
+        packetProfiler.Record(packet, framingOverhead);
     }
 
-    #endregion
+    private static void SendReliableMessagePayload(NetPeer netPeer, byte[] payload)
+    {
+        netPeer.Send(payload, DeliveryMethod.ReliableOrdered);
+    }
 
     public void Send(NetPeer netPeer, IMessage message)
     {

--- a/source/Coop.Core/Server/CoopServer.cs
+++ b/source/Coop.Core/Server/CoopServer.cs
@@ -64,7 +64,9 @@ public class CoopServer : CoopNetworkBase, ICoopServer
         Lazy<IOverloadedPeerManager> overloadedPeerManager,
         ISendCoalescer coalescer,
         ICommonSerializer serializer,
-        CancellationTokenSource sessionCancellation) : base(configuration, serializer, sessionCancellation)
+        IReliableMessageBatcher<NetPeer> reliableMessageBatcher,
+        CancellationTokenSource sessionCancellation)
+        : base(configuration, serializer, reliableMessageBatcher, sessionCancellation)
     {
         // Dependancy assignment
         this.messageBroker = messageBroker;

--- a/source/Coop.IntegrationTests/Missions/MissionDisconnectDetectionTests.cs
+++ b/source/Coop.IntegrationTests/Missions/MissionDisconnectDetectionTests.cs
@@ -152,6 +152,7 @@ public class MissionDisconnectDetectionTests
         var serializer = new Mock<ICommonSerializer>();
         var messageBroker = new Mock<IMessageBroker>();
         var packetManager = new Mock<IPacketManager>();
+        var messagePacketHandler = new Mock<IMessagePacketHandler>();
         var controllerIdProvider = new Mock<IControllerIdProvider>();
         var steamBridge = new Mock<ISteamMissionBridge>();
         var movementPacketCompressor = new Mock<IMovementPacketCompressor>();
@@ -163,9 +164,11 @@ public class MissionDisconnectDetectionTests
             serializer.Object,
             messageBroker.Object,
             packetManager.Object,
+            messagePacketHandler.Object,
             controllerIdProvider.Object,
             steamBridge.Object,
-            movementPacketCompressor.Object);
+            movementPacketCompressor.Object,
+            new ReliableMessageBatcher<string>(serializer.Object));
 
         var droppedPeer = CreatePeer(new IPEndPoint(IPAddress.Loopback, 55001), 1);
 

--- a/source/Coop.Tests/Network/CoopNetworkBaseTests.cs
+++ b/source/Coop.Tests/Network/CoopNetworkBaseTests.cs
@@ -23,8 +23,14 @@ public class CoopNetworkBaseTests
         config.SetupGet(value => value.NetworkPollInterval).Returns(TimeSpan.FromMilliseconds(25));
         config.SetupGet(value => value.UpdateTime).Returns(TimeSpan.FromMilliseconds(15));
 
+        ICommonSerializer serializer = Mock.Of<ICommonSerializer>();
+        var reliableMessageBatcher = new ReliableMessageBatcher<NetPeer>(serializer);
         using var sessionCancellation = new CancellationTokenSource();
-        using var network = new TestNetwork(config.Object, Mock.Of<ICommonSerializer>(), sessionCancellation);
+        using var network = new TestNetwork(
+            config.Object,
+            serializer,
+            reliableMessageBatcher,
+            sessionCancellation);
 
         Assert.Equal(60_000, network.AppliedDisconnectTimeout);
     }
@@ -34,8 +40,9 @@ public class CoopNetworkBaseTests
         public TestNetwork(
             INetworkConfig config,
             ICommonSerializer serializer,
+            IReliableMessageBatcher<NetPeer> reliableMessageBatcher,
             CancellationTokenSource sessionCancellation)
-            : base(config, serializer, sessionCancellation)
+            : base(config, serializer, reliableMessageBatcher, sessionCancellation)
         {
         }
 

--- a/source/E2E.Tests/Environment/MockEngine/MirrorAgent.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MirrorAgent.cs
@@ -19,6 +19,7 @@ public sealed class MirrorAgent
     public bool IsActive { get; set; } = true;
     public bool IsHuman { get; set; } = true;
     public bool WasKilled { get; set; }
+    public int BloodBurstCalls { get; set; }
     public int OnFleeingCalls { get; set; }
     public bool IsAiPaused { get; set; }
     public int DeathAction { get; set; } = -1;

--- a/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
@@ -79,6 +79,7 @@ public sealed class MissionEngineFixture : IDisposable
         Prefix(typeof(Agent), "get_Equipment", nameof(Agent_get_Equipment));
         Prefix(typeof(Agent), "get_Name", nameof(Agent_get_Name));
         Prefix(typeof(Agent), nameof(Agent.IsActive), nameof(Agent_IsActive));
+        Prefix(typeof(Agent), nameof(Agent.CreateBloodBurstAtLimb), nameof(Agent_CreateBloodBurstAtLimb));
         Prefix(typeof(Agent), nameof(Agent.OnFleeing), nameof(Agent_OnFleeing));
         // Puppet classification (LocationPvpBlockPatch): human/mount/rider resolve via the mirror.
         Prefix(typeof(Agent), "get_IsHuman", nameof(Agent_get_IsHuman));
@@ -443,6 +444,13 @@ public sealed class MissionEngineFixture : IDisposable
     {
         if (!AgentMirror.TryGet(__instance, out var m)) return true;
         __result = m.IsActive;
+        return false;
+    }
+
+    private static bool Agent_CreateBloodBurstAtLimb(Agent __instance)
+    {
+        if (!AgentMirror.TryGet(__instance, out var m)) return true;
+        m.BloodBurstCalls++;
         return false;
     }
 

--- a/source/E2E.Tests/Services/Missions/BattleDamageCodecTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDamageCodecTests.cs
@@ -1,0 +1,181 @@
+﻿using Common.PacketHandlers;
+using Common.Serialization;
+using GameInterface.Surrogates;
+using Missions.Battles;
+using Missions.Messages;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace E2E.Tests.Services.Missions;
+
+/// <summary>Regression coverage for compact routed-damage engine struct encoding.</summary>
+public class BattleDamageCodecTests
+{
+    [Fact]
+    public void EncodeDecode_RoundTripsFullEngineStructDataUnderPacketBudget()
+    {
+        var blow = new Blow(17)
+        {
+            GlobalPosition = new Vec3(1f, 2f, 3f),
+            Direction = new Vec3(4f, 5f, 6f),
+            SwingDirection = new Vec3(7f, 8f, 9f),
+            InflictedDamage = 41,
+            SelfInflictedDamage = 2,
+            BaseMagnitude = 13f,
+            DefenderStunPeriod = 0.4f,
+            AttackerStunPeriod = 0.5f,
+            AbsorbedByArmor = 6f,
+            MovementSpeedDamageModifier = 1.2f,
+            StrikeType = StrikeType.Thrust,
+            AttackType = AgentAttackType.Bash,
+            BlowFlag = BlowFlags.CanDismount | BlowFlags.KnockBack,
+            BoneIndex = 3,
+            VictimBodyPart = BoneBodyPartType.ShoulderRight,
+            DamageType = DamageTypes.Pierce,
+            NoIgnore = true,
+            DamageCalculated = true,
+            DamagedPercentage = 0.75f,
+        };
+        blow.WeaponRecord = new BlowWeaponRecord
+        {
+            StartingPosition = new Vec3(10f, 11f, 12f),
+            CurrentPosition = new Vec3(13f, 14f, 15f),
+            Velocity = new Vec3(16f, 17f, 18f),
+            ItemFlags = ItemFlags.Civilian,
+            WeaponFlags = WeaponFlags.RangedWeapon,
+            WeaponClass = WeaponClass.Arrow,
+            BoneNoToAttach = 4,
+            AffectorWeaponSlotOrMissileIndex = 42,
+            Weight = 1.5f,
+            _isMissile = true,
+            _isMaterialMetal = true,
+        };
+
+        Vec3 weaponRotUp = new Vec3(1f, 2f, 3f);
+        Vec3 weaponBlowDir = new Vec3(4f, 5f, 6f);
+        Vec3 collisionPosition = new Vec3(7f, 8f, 9f);
+        Vec3 missileVelocity = new Vec3(10f, 11f, 12f);
+        Vec3 missileStartingPosition = new Vec3(13f, 14f, 15f);
+        Vec3 victimVelocity = new Vec3(16f, 17f, 18f);
+        Vec3 collisionNormal = new Vec3(19f, 20f, 21f);
+        Vec3 lastBoneRotUp = new Vec3(22f, 23f, 24f);
+        Vec3 lastBoneSwingDir = new Vec3(25f, 26f, 27f);
+        var collisionData = new AttackCollisionData(
+            true, false, true, false, true, false, true, false, true, false, true, false, true,
+            CombatCollisionResult.StrikeAgent,
+            42,
+            (int)StrikeType.Thrust,
+            (int)DamageTypes.Pierce,
+            3,
+            BoneBodyPartType.ShoulderRight,
+            5,
+            Agent.UsageDirection.AttackBegin,
+            30,
+            CombatHitResultFlags.HitWithArm,
+            0.5f,
+            0.8f,
+            0.7f,
+            1.1f,
+            50f,
+            20f,
+            0.2f,
+            0.3f,
+            weaponRotUp,
+            weaponBlowDir,
+            collisionPosition,
+            missileVelocity,
+            missileStartingPosition,
+            victimVelocity,
+            collisionNormal,
+            lastBoneRotUp,
+            lastBoneSwingDir);
+        collisionData.BaseMagnitude = 13f;
+        collisionData.MovementSpeedDamageModifier = 1.2f;
+        collisionData.AbsorbedByArmor = 6;
+        collisionData.InflictedDamage = 41;
+        collisionData.SelfInflictedDamage = 2;
+        collisionData.IsShieldBroken = true;
+        collisionData.IsSneakAttack = true;
+
+        var codec = new BattleDamageCodec();
+        BattleDamageData encoded = codec.Encode(in blow, in collisionData);
+
+        new SurrogateCollection();
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        byte[] messagePayload = MessagePacket.Create(
+            new NetworkApplyBattleDamage(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                encoded,
+                isMissile: true),
+            serializer).Data;
+        Assert.InRange(messagePayload.Length, 1, 1199);
+        Assert.True(codec.TryDecode(encoded, out Blow decodedBlow, out AttackCollisionData decodedCollision));
+        BattleDamageData reencoded = codec.Encode(in decodedBlow, in decodedCollision);
+
+        Assert.Equal(serializer.Serialize(encoded), serializer.Serialize(reencoded));
+        Assert.Equal(blow.BlowFlag, decodedBlow.BlowFlag);
+        Assert.Equal(blow.WeaponRecord.Velocity, decodedBlow.WeaponRecord.Velocity);
+        Assert.True(decodedBlow.WeaponRecord.IsMissile);
+        Assert.Equal(collisionData.AttackBlockedWithShield, decodedCollision.AttackBlockedWithShield);
+        Assert.Equal(collisionData.CorrectSideShieldBlock, decodedCollision.CorrectSideShieldBlock);
+        Assert.Equal(collisionData.IsAlternativeAttack, decodedCollision.IsAlternativeAttack);
+        Assert.Equal(collisionData.IsColliderAgent, decodedCollision.IsColliderAgent);
+        Assert.Equal(collisionData.CollidedWithShieldOnBack, decodedCollision.CollidedWithShieldOnBack);
+        Assert.Equal(collisionData.IsMissile, decodedCollision.IsMissile);
+        Assert.Equal(collisionData.MissileBlockedWithWeapon, decodedCollision.MissileBlockedWithWeapon);
+        Assert.Equal(collisionData.MissileHasPhysics, decodedCollision.MissileHasPhysics);
+        Assert.Equal(collisionData.EntityExists, decodedCollision.EntityExists);
+        Assert.Equal(collisionData.ThrustTipHit, decodedCollision.ThrustTipHit);
+        Assert.Equal(collisionData.MissileGoneUnderWater, decodedCollision.MissileGoneUnderWater);
+        Assert.Equal(collisionData.MissileGoneOutOfBorder, decodedCollision.MissileGoneOutOfBorder);
+        Assert.Equal(collisionData.CollidedWithLastBoneSegment, decodedCollision.CollidedWithLastBoneSegment);
+        Assert.Equal(collisionData.CollisionResult, decodedCollision.CollisionResult);
+        Assert.Equal(collisionData.AffectorWeaponSlotOrMissileIndex, decodedCollision.AffectorWeaponSlotOrMissileIndex);
+        Assert.Equal(collisionData.StrikeType, decodedCollision.StrikeType);
+        Assert.Equal(collisionData.DamageType, decodedCollision.DamageType);
+        Assert.Equal(collisionData.CollisionBoneIndex, decodedCollision.CollisionBoneIndex);
+        Assert.Equal(collisionData.VictimHitBodyPart, decodedCollision.VictimHitBodyPart);
+        Assert.Equal(collisionData.AttackBoneIndex, decodedCollision.AttackBoneIndex);
+        Assert.Equal(collisionData.AttackDirection, decodedCollision.AttackDirection);
+        Assert.Equal(collisionData.PhysicsMaterialIndex, decodedCollision.PhysicsMaterialIndex);
+        Assert.Equal(collisionData.CollisionHitResultFlags, decodedCollision.CollisionHitResultFlags);
+        Assert.Equal(collisionData.AttackProgress, decodedCollision.AttackProgress);
+        Assert.Equal(collisionData.CollisionDistanceOnWeapon, decodedCollision.CollisionDistanceOnWeapon);
+        Assert.Equal(collisionData.AttackerStunPeriod, decodedCollision.AttackerStunPeriod);
+        Assert.Equal(collisionData.DefenderStunPeriod, decodedCollision.DefenderStunPeriod);
+        Assert.Equal(collisionData.MissileTotalDamage, decodedCollision.MissileTotalDamage);
+        Assert.Equal(collisionData.MissileStartingBaseSpeed, decodedCollision.MissileStartingBaseSpeed);
+        Assert.Equal(collisionData.ChargeVelocity, decodedCollision.ChargeVelocity);
+        Assert.Equal(collisionData.FallSpeed, decodedCollision.FallSpeed);
+        Assert.Equal(collisionData.WeaponRotUp, decodedCollision.WeaponRotUp);
+        Assert.Equal(collisionData.WeaponBlowDir, decodedCollision.WeaponBlowDir);
+        Assert.Equal(collisionData.CollisionGlobalPosition, decodedCollision.CollisionGlobalPosition);
+        Assert.Equal(collisionData.MissileVelocity, decodedCollision.MissileVelocity);
+        Assert.Equal(collisionData.MissileStartingPosition, decodedCollision.MissileStartingPosition);
+        Assert.Equal(collisionData.VictimAgentCurVelocity, decodedCollision.VictimAgentCurVelocity);
+        Assert.Equal(collisionData.CollisionGlobalNormal, decodedCollision.CollisionGlobalNormal);
+        Assert.Equal(collisionData.LastBoneSegmentRotUp, decodedCollision.LastBoneSegmentRotUp);
+        Assert.Equal(collisionData.LastBoneSegmentSwingDir, decodedCollision.LastBoneSegmentSwingDir);
+        Assert.Equal(collisionData.BaseMagnitude, decodedCollision.BaseMagnitude);
+        Assert.Equal(collisionData.MovementSpeedDamageModifier, decodedCollision.MovementSpeedDamageModifier);
+        Assert.Equal(collisionData.AbsorbedByArmor, decodedCollision.AbsorbedByArmor);
+        Assert.Equal(collisionData.InflictedDamage, decodedCollision.InflictedDamage);
+        Assert.Equal(collisionData.SelfInflictedDamage, decodedCollision.SelfInflictedDamage);
+        Assert.Equal(collisionData.IsShieldBroken, decodedCollision.IsShieldBroken);
+        Assert.Equal(collisionData.IsSneakAttack, decodedCollision.IsSneakAttack);
+    }
+
+    [Fact]
+    public void TryDecode_MissingOwnedData_ReturnsFalse()
+    {
+        var codec = new BattleDamageCodec();
+        Blow blow = default;
+        AttackCollisionData collisionData = default;
+        BattleDamageData valid = codec.Encode(in blow, in collisionData);
+        var invalid = new BattleDamageData(null, valid.Collision);
+
+        Assert.False(codec.TryDecode(invalid, out _, out _));
+    }
+}

--- a/source/E2E.Tests/Services/Missions/BattleDamageDataMapperTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDamageDataMapperTests.cs
@@ -10,10 +10,10 @@ using TaleWorlds.MountAndBlade;
 namespace E2E.Tests.Services.Missions;
 
 /// <summary>Regression coverage for compact routed-damage engine struct encoding.</summary>
-public class BattleDamageCodecTests
+public class BattleDamageDataMapperTests
 {
     [Fact]
-    public void EncodeDecode_RoundTripsFullEngineStructDataUnderPacketBudget()
+    public void PackResolve_RoundTripsFullEngineStructDataUnderPacketBudget()
     {
         var blow = new Blow(17)
         {
@@ -98,8 +98,8 @@ public class BattleDamageCodecTests
         collisionData.IsShieldBroken = true;
         collisionData.IsSneakAttack = true;
 
-        var codec = new BattleDamageCodec();
-        BattleDamageData encoded = codec.Encode(in blow, in collisionData);
+        var mapper = new BattleDamageDataMapper();
+        BattleDamageData encoded = mapper.Pack(in blow, in collisionData);
 
         new SurrogateCollection();
         var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
@@ -111,8 +111,8 @@ public class BattleDamageCodecTests
                 isMissile: true),
             serializer).Data;
         Assert.InRange(messagePayload.Length, 1, 1199);
-        Assert.True(codec.TryDecode(encoded, out Blow decodedBlow, out AttackCollisionData decodedCollision));
-        BattleDamageData reencoded = codec.Encode(in decodedBlow, in decodedCollision);
+        Assert.True(mapper.TryResolve(encoded, out Blow decodedBlow, out AttackCollisionData decodedCollision));
+        BattleDamageData reencoded = mapper.Pack(in decodedBlow, in decodedCollision);
 
         Assert.Equal(serializer.Serialize(encoded), serializer.Serialize(reencoded));
         Assert.Equal(blow.BlowFlag, decodedBlow.BlowFlag);
@@ -168,14 +168,14 @@ public class BattleDamageCodecTests
     }
 
     [Fact]
-    public void TryDecode_MissingOwnedData_ReturnsFalse()
+    public void TryResolve_MissingOwnedData_ReturnsFalse()
     {
-        var codec = new BattleDamageCodec();
+        var mapper = new BattleDamageDataMapper();
         Blow blow = default;
         AttackCollisionData collisionData = default;
-        BattleDamageData valid = codec.Encode(in blow, in collisionData);
+        BattleDamageData valid = mapper.Pack(in blow, in collisionData);
         var invalid = new BattleDamageData(null, valid.Collision);
 
-        Assert.False(codec.TryDecode(invalid, out _, out _));
+        Assert.False(mapper.TryResolve(invalid, out _, out _));
     }
 }

--- a/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
@@ -56,9 +56,14 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
 
             var blow = new Blow(0) { InflictedDamage = 40, DamageType = DamageTypes.Pierce };
             var collisionData = new AttackCollisionData { InflictedDamage = 40 };
+            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
             client.Resolve<IMessageBroker>().Publish(
                 this,
-                new NetworkApplyBattleDamage(victimId, Guid.Empty, blow, collisionData));
+                new NetworkApplyBattleDamage(
+                    victimId,
+                    Guid.Empty,
+                    damageData,
+                    blow.IsMissile));
 
             Assert.True(AgentMirror.TryGet(agent, out var mirror));
             Assert.Equal(expectedHealth, mirror.Health);
@@ -92,7 +97,15 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
             blow.WeaponRecord._isMissile = true;
             blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex = 999;
 
-            client.Resolve<IMessageBroker>().Publish(this, new NetworkApplyBattleDamage(victimId, Guid.Empty, blow, default));
+            AttackCollisionData collisionData = default;
+            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
+            client.Resolve<IMessageBroker>().Publish(
+                this,
+                new NetworkApplyBattleDamage(
+                    victimId,
+                    Guid.Empty,
+                    damageData,
+                    blow.IsMissile));
 
             var field = typeof(CoopBattleController).GetField("damageRouter", BindingFlags.Instance | BindingFlags.NonPublic);
             var router = Assert.IsAssignableFrom<IBattleDamageRouter>(field?.GetValue(controller));
@@ -132,13 +145,15 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
                 InflictedDamage = 10,
                 DamageType = DamageTypes.Pierce
             };
+            AttackCollisionData collisionData = default;
+            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
             client.Resolve<IMessageBroker>().Publish(
                 this,
                 new NetworkApplyBattleDamage(
                     riderId,
                     Guid.Empty,
-                    blow,
-                    default));
+                    damageData,
+                    blow.IsMissile));
 
             Assert.Null(rider.MountAgent);
             Assert.Null(mount.RiderAgent);

--- a/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDamageMirrorTests.cs
@@ -56,7 +56,7 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
 
             var blow = new Blow(0) { InflictedDamage = 40, DamageType = DamageTypes.Pierce };
             var collisionData = new AttackCollisionData { InflictedDamage = 40 };
-            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
+            var damageData = client.Resolve<IBattleDamageDataMapper>().Pack(in blow, in collisionData);
             client.Resolve<IMessageBroker>().Publish(
                 this,
                 new NetworkApplyBattleDamage(
@@ -98,7 +98,7 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
             blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex = 999;
 
             AttackCollisionData collisionData = default;
-            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
+            var damageData = client.Resolve<IBattleDamageDataMapper>().Pack(in blow, in collisionData);
             client.Resolve<IMessageBroker>().Publish(
                 this,
                 new NetworkApplyBattleDamage(
@@ -146,7 +146,7 @@ public class BattleDamageMirrorTests : MissionTestEnvironment
                 DamageType = DamageTypes.Pierce
             };
             AttackCollisionData collisionData = default;
-            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
+            var damageData = client.Resolve<IBattleDamageDataMapper>().Pack(in blow, in collisionData);
             client.Resolve<IMessageBroker>().Publish(
                 this,
                 new NetworkApplyBattleDamage(

--- a/source/E2E.Tests/Services/Missions/BattleHeroDamageSyncTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleHeroDamageSyncTests.cs
@@ -54,7 +54,7 @@ public class BattleHeroDamageSyncTests : MissionTestEnvironment
             // The hero takes a 30-damage hit, routed to its owner (this client).
             var blow = new Blow(0) { InflictedDamage = 30, DamageType = DamageTypes.Pierce };
             AttackCollisionData collisionData = default;
-            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
+            var damageData = client.Resolve<IBattleDamageDataMapper>().Pack(in blow, in collisionData);
             client.Resolve<IMessageBroker>().Publish(
                 this,
                 new NetworkApplyBattleDamage(

--- a/source/E2E.Tests/Services/Missions/BattleHeroDamageSyncTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleHeroDamageSyncTests.cs
@@ -53,7 +53,15 @@ public class BattleHeroDamageSyncTests : MissionTestEnvironment
 
             // The hero takes a 30-damage hit, routed to its owner (this client).
             var blow = new Blow(0) { InflictedDamage = 30, DamageType = DamageTypes.Pierce };
-            client.Resolve<IMessageBroker>().Publish(this, new NetworkApplyBattleDamage(heroAgentId, Guid.Empty, blow, default));
+            AttackCollisionData collisionData = default;
+            var damageData = client.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
+            client.Resolve<IMessageBroker>().Publish(
+                this,
+                new NetworkApplyBattleDamage(
+                    heroAgentId,
+                    Guid.Empty,
+                    damageData,
+                    blow.IsMissile));
 
             // The blow landed on the agent (in-mission health 100 -> 70)...
             Assert.True(AgentMirror.TryGet(agent, out var mirror));

--- a/source/E2E.Tests/Services/Missions/BattleMessageBatchingTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleMessageBatchingTests.cs
@@ -48,7 +48,7 @@ public class BattleMessageBatchingTests : MissionTestEnvironment
         var controllerIdProvider = new Mock<IControllerIdProvider>();
         var steamBridge = new Mock<ISteamMissionBridge>();
         var compressor = new MovementPacketCompressor(serializer);
-        var damageCodec = new BattleDamageCodec();
+        var damageDataMapper = new BattleDamageDataMapper();
         var relayedPackets = new List<RelayPacket>();
         relayNetwork
             .Setup(network => network.SendAll(It.IsAny<IPacket>()))
@@ -71,7 +71,7 @@ public class BattleMessageBatchingTests : MissionTestEnvironment
         var logicalPayloads = new List<byte[]>(logicalMessageCount);
         for (int i = 0; i < logicalMessageCount; i++)
         {
-            IMessage message = CreateBattleMessage(i, damageCodec);
+            IMessage message = CreateBattleMessage(i, damageDataMapper);
             logicalPayloads.Add(MessagePacket.Create(message, serializer).Data);
             client.Send(controllerId, message);
         }
@@ -229,7 +229,7 @@ public class BattleMessageBatchingTests : MissionTestEnvironment
         });
     }
 
-    private static IMessage CreateBattleMessage(int index, IBattleDamageCodec damageCodec)
+    private static IMessage CreateBattleMessage(int index, IBattleDamageDataMapper damageDataMapper)
     {
         Guid victimId = CreateGuid(index);
         Guid attackerId = CreateGuid(index + 10_000);
@@ -246,7 +246,7 @@ public class BattleMessageBatchingTests : MissionTestEnvironment
                 {
                     InflictedDamage = blow.InflictedDamage,
                 };
-                BattleDamageData damageData = damageCodec.Encode(in blow, in collisionData);
+                BattleDamageData damageData = damageDataMapper.Pack(in blow, in collisionData);
                 return new NetworkApplyBattleDamage(
                     victimId,
                     attackerId,

--- a/source/E2E.Tests/Services/Missions/BattleMessageBatchingTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleMessageBatchingTests.cs
@@ -1,0 +1,291 @@
+﻿using Common.Messaging;
+using Common.Network;
+using Common.Network.Data;
+using Common.Network.Session;
+using Common.PacketHandlers;
+using Common.Serialization;
+using E2E.Tests.Environment.Extensions;
+using E2E.Tests.Environment.MockEngine;
+using GameInterface.Services.Entity;
+using LiteNetLib;
+using Missions.Agents.Handlers;
+using Missions.Agents.Messages;
+using Missions.Battles;
+using Missions.Messages;
+using Missions.Services.Network;
+using Moq;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Missions;
+
+/// <summary>Regression coverage for battle message wire volume and stale hit presentation.</summary>
+public class BattleMessageBatchingTests : MissionTestEnvironment
+{
+    public BattleMessageBatchingTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void HighVolumeSmallBattleMessages_FitWithinOneReliableWindowAndPreserveDeathOrder()
+    {
+        const string instanceId = "battle-batching-test";
+        const string controllerId = "battle-peer";
+        const int logicalMessageCount = 256;
+
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        var config = new Mock<INetworkConfig>();
+        config.SetupGet(value => value.IsTunneled).Returns(true);
+        var relayNetwork = new Mock<IRelayNetwork>();
+        var missionContext = new Mock<IMissionContext>();
+        missionContext.SetupGet(value => value.ControllersInMission)
+            .Returns(new[] { controllerId });
+        var messageBroker = new Mock<IMessageBroker>();
+        var packetManager = new Mock<IPacketManager>();
+        var messagePacketHandler = new Mock<IMessagePacketHandler>();
+        var controllerIdProvider = new Mock<IControllerIdProvider>();
+        var steamBridge = new Mock<ISteamMissionBridge>();
+        var compressor = new MovementPacketCompressor(serializer);
+        var damageCodec = new BattleDamageCodec();
+        var relayedPackets = new List<RelayPacket>();
+        relayNetwork
+            .Setup(network => network.SendAll(It.IsAny<IPacket>()))
+            .Callback<IPacket>(packet => relayedPackets.Add(Assert.IsType<RelayPacket>(packet)));
+
+        using var client = new LiteNetP2PClient(
+            config.Object,
+            relayNetwork.Object,
+            missionContext.Object,
+            serializer,
+            messageBroker.Object,
+            packetManager.Object,
+            messagePacketHandler.Object,
+            controllerIdProvider.Object,
+            steamBridge.Object,
+            compressor,
+            new ReliableMessageBatcher<string>(serializer));
+        client.ConnectToInstance(instanceId);
+
+        var logicalPayloads = new List<byte[]>(logicalMessageCount);
+        for (int i = 0; i < logicalMessageCount; i++)
+        {
+            IMessage message = CreateBattleMessage(i, damageCodec);
+            logicalPayloads.Add(MessagePacket.Create(message, serializer).Data);
+            client.Send(controllerId, message);
+        }
+
+        Assert.True(
+            logicalPayloads.Max(payload => payload.Length) < ReliableMessageBatcher<string>.DefaultBudgetBytes,
+            $"payload sizes: min={logicalPayloads.Min(payload => payload.Length)} " +
+            $"max={logicalPayloads.Max(payload => payload.Length)} " +
+            $"average={logicalPayloads.Average(payload => payload.Length):F1}");
+        Assert.True(relayedPackets.Count < logicalMessageCount);
+
+        client.FlushPendingMessages();
+
+        Assert.InRange(relayedPackets.Count, 1, 63);
+        Assert.All(
+            relayedPackets,
+            packet => Assert.Equal(LiteNetLib.DeliveryMethod.ReliableOrdered, packet.DeliveryMethod));
+
+        var receivedPayloads = new List<byte[]>(logicalMessageCount);
+        foreach (RelayPacket relayPacket in relayedPackets)
+        {
+            object received = serializer.Deserialize(relayPacket.Payload);
+            if (received is AggregateMessagePacket aggregate)
+                receivedPayloads.AddRange(aggregate.Messages);
+            else
+                receivedPayloads.Add(relayPacket.Payload);
+        }
+
+        Assert.Equal(logicalPayloads.Count, receivedPayloads.Count);
+        for (int i = 0; i < logicalPayloads.Count; i++)
+        {
+            Assert.Equal(logicalPayloads[i], receivedPayloads[i]);
+        }
+    }
+
+    [Fact]
+    public void DirectRoute_BatchesMessagesIntoOneReliableQueueSlot()
+    {
+        const string controllerId = "direct-peer";
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        var config = new Mock<INetworkConfig>();
+        var relayNetwork = new Mock<IRelayNetwork>();
+        var missionContext = new Mock<IMissionContext>();
+        NetPeer peer = NetPeerExtensions.CreatePeer(98);
+        missionContext.SetupGet(value => value.ControllersInMission)
+            .Returns(new[] { controllerId });
+        missionContext
+            .Setup(value => value.TryGetPeer(controllerId, out peer))
+            .Returns(true);
+        var messageBroker = new Mock<IMessageBroker>();
+        var packetManager = new Mock<IPacketManager>();
+        var messagePacketHandler = new Mock<IMessagePacketHandler>();
+        var controllerIdProvider = new Mock<IControllerIdProvider>();
+        var steamBridge = new Mock<ISteamMissionBridge>();
+
+        using var client = new LiteNetP2PClient(
+            config.Object,
+            relayNetwork.Object,
+            missionContext.Object,
+            serializer,
+            messageBroker.Object,
+            packetManager.Object,
+            messagePacketHandler.Object,
+            controllerIdProvider.Object,
+            steamBridge.Object,
+            new MovementPacketCompressor(serializer),
+            new ReliableMessageBatcher<string>(serializer));
+
+        client.Send(controllerId, CreateDeath(CreateGuid(10), 10));
+        client.Send(controllerId, CreateDeath(CreateGuid(11), 11));
+        Assert.Equal(0, peer.GetPacketsCountInReliableQueue(0, ordered: true));
+
+        client.FlushPendingMessages();
+
+        Assert.Equal(1, peer.GetPacketsCountInReliableQueue(0, ordered: true));
+        relayNetwork.Verify(network => network.SendAll(It.IsAny<IPacket>()), Times.Never);
+    }
+
+    [Fact]
+    public void MissionReceive_PublishesBareAndAggregateMessagesInOrder()
+    {
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        var config = new Mock<INetworkConfig>();
+        config.SetupGet(value => value.IsTunneled).Returns(true);
+        var relayNetwork = new Mock<IRelayNetwork>();
+        var missionContext = new Mock<IMissionContext>();
+        var messageBroker = new MessageBroker();
+        var packetManager = new PacketManager();
+        using var messagePacketHandler = new MessagePacketHandler(
+            messageBroker,
+            packetManager,
+            serializer);
+        using var aggregateHandler = new AggregateMessagePacketHandler(
+            messagePacketHandler,
+            packetManager,
+            serializer);
+        var controllerIdProvider = new Mock<IControllerIdProvider>();
+        var steamBridge = new Mock<ISteamMissionBridge>();
+        var received = new List<Guid>();
+        Action<MessagePayload<NetworkBattleAgentDied>> subscription =
+            payload => received.Add(payload.What.AgentId);
+        messageBroker.Subscribe(subscription);
+
+        using var client = new LiteNetP2PClient(
+            config.Object,
+            relayNetwork.Object,
+            missionContext.Object,
+            serializer,
+            messageBroker,
+            packetManager,
+            messagePacketHandler,
+            controllerIdProvider.Object,
+            steamBridge.Object,
+            new MovementPacketCompressor(serializer),
+            new ReliableMessageBatcher<string>(serializer));
+        NetPeer peer = NetPeerExtensions.CreatePeer(99);
+        Guid first = CreateGuid(1);
+        Guid second = CreateGuid(2);
+        Guid third = CreateGuid(3);
+        byte[] firstPayload = MessagePacket.Create(CreateDeath(first, 1), serializer).Data;
+        byte[] secondPayload = MessagePacket.Create(CreateDeath(second, 2), serializer).Data;
+        byte[] thirdPayload = MessagePacket.Create(CreateDeath(third, 3), serializer).Data;
+
+        client.HandleReceivedPayload(peer, firstPayload);
+        client.HandleReceivedPayload(
+            peer,
+            serializer.Serialize(new AggregateMessagePacket(
+                new[] { secondPayload, thirdPayload })));
+
+        Assert.Equal(new[] { first, second, third }, received);
+        messageBroker.Unsubscribe(subscription);
+    }
+
+    [Fact]
+    public void PlayBlood_InactiveAgent_DoesNotCallNativePresentation()
+    {
+        using var fixture = new MissionEngineFixture();
+        var client = Clients.First();
+
+        client.Call(() =>
+        {
+            MockMission mission = fixture.CreateMission(client);
+            Agent victim = mission.SpawnMount();
+            Assert.True(AgentMirror.TryGet(victim, out MirrorAgent mirror));
+            mirror.IsActive = false;
+
+            CombatHitPresentationHandler.PlayBlood(victim, 1, 1f);
+
+            Assert.Equal(0, mirror.BloodBurstCalls);
+
+            mirror.IsActive = true;
+            CombatHitPresentationHandler.PlayBlood(victim, 1, 1f);
+
+            Assert.Equal(1, mirror.BloodBurstCalls);
+        });
+    }
+
+    private static IMessage CreateBattleMessage(int index, IBattleDamageCodec damageCodec)
+    {
+        Guid victimId = CreateGuid(index);
+        Guid attackerId = CreateGuid(index + 10_000);
+        switch (index % 3)
+        {
+            case 0:
+                var blow = new Blow(index)
+                {
+                    InflictedDamage = (index % 100) + 1,
+                    DamageType = DamageTypes.Pierce,
+                    GlobalPosition = new Vec3(index, index + 1, index + 2),
+                };
+                var collisionData = new AttackCollisionData
+                {
+                    InflictedDamage = blow.InflictedDamage,
+                };
+                BattleDamageData damageData = damageCodec.Encode(in blow, in collisionData);
+                return new NetworkApplyBattleDamage(
+                    victimId,
+                    attackerId,
+                    damageData,
+                    blow.IsMissile);
+            case 1:
+                return new NetworkMeleeHitPresentation(
+                    victimId,
+                    isMount: false,
+                    MeleeHitPresentationKind.Blood,
+                    collisionBoneIndex: index,
+                    new Vec3(index, 0f, 0f),
+                    WeaponClass.OneHandedSword,
+                    physicsMaterialIndex: -1,
+                    strength: 1f);
+            default:
+                return new NetworkBattleAgentDied(
+                    victimId,
+                    wounded: false,
+                    attackerId,
+                    inflictedDamage: (index % 100) + 1,
+                    BoneBodyPartType.Head,
+                    deathAction: index);
+        }
+    }
+
+    private static NetworkBattleAgentDied CreateDeath(Guid victimId, int deathAction)
+    {
+        return new NetworkBattleAgentDied(
+            victimId,
+            wounded: false,
+            Guid.Empty,
+            inflictedDamage: 1,
+            BoneBodyPartType.Head,
+            deathAction);
+    }
+
+    private static Guid CreateGuid(int value)
+    {
+        return new Guid(value, 0, 0, new byte[8]);
+    }
+}

--- a/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
@@ -127,7 +127,7 @@ public class BattleMountIdentityTests : MissionTestEnvironment
             // The routed hit arrives, addressed to horse A's own id.
             Blow blow = DamagingBlow();
             AttackCollisionData collisionData = default;
-            var damageData = owner.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
+            var damageData = owner.Resolve<IBattleDamageDataMapper>().Pack(in blow, in collisionData);
             owner.Resolve<IMessageBroker>().Publish(this,
                 new NetworkApplyBattleDamage(
                     horseAId,

--- a/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleMountIdentityTests.cs
@@ -125,8 +125,15 @@ public class BattleMountIdentityTests : MissionTestEnvironment
             riderMirror.MountAgent = horseB;
 
             // The routed hit arrives, addressed to horse A's own id.
+            Blow blow = DamagingBlow();
+            AttackCollisionData collisionData = default;
+            var damageData = owner.Resolve<IBattleDamageCodec>().Encode(in blow, in collisionData);
             owner.Resolve<IMessageBroker>().Publish(this,
-                new NetworkApplyBattleDamage(horseAId, Guid.Empty, DamagingBlow(), default));
+                new NetworkApplyBattleDamage(
+                    horseAId,
+                    Guid.Empty,
+                    damageData,
+                    blow.IsMissile));
 
             Assert.True(AgentMirror.TryGet(horseA, out var horseAMirror));
             Assert.Equal(70f, horseAMirror.Health); // the horse that was actually struck

--- a/source/E2E.Tests/Services/Missions/LiteNetP2PClientTests.cs
+++ b/source/E2E.Tests/Services/Missions/LiteNetP2PClientTests.cs
@@ -1,0 +1,183 @@
+﻿using Common.Messaging;
+using Common.Network;
+using Common.Network.Data;
+using Common.Network.Session;
+using Common.PacketHandlers;
+using Common.Serialization;
+using E2E.Tests.Environment.Extensions;
+using GameInterface.Services.Entity;
+using LiteNetLib;
+using Missions.Agents.Handlers;
+using Missions.Messages;
+using Missions.Services.Network;
+using Moq;
+using System.Collections.Concurrent;
+using System.Reflection;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace E2E.Tests.Services.Missions;
+
+public class LiteNetP2PClientTests
+{
+    [Fact]
+    public async Task PeerPromotion_ConcurrentReliableSend_DoesNotInvertLocks()
+    {
+        const string controllerId = "promoting-peer";
+        var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+        var config = new Mock<INetworkConfig>();
+        var relayNetwork = new Mock<IRelayNetwork>();
+        var missionContext = new Mock<IMissionContext>();
+        var routeOrder = new ConcurrentQueue<string>();
+        relayNetwork
+            .Setup(network => network.SendAll(It.IsAny<IPacket>()))
+            .Callback<IPacket>(_ => routeOrder.Enqueue("relay"));
+        missionContext
+            .Setup(context => context.MapPeer(controllerId, It.IsAny<NetPeer>()))
+            .Callback<string, NetPeer>((_, _) => routeOrder.Enqueue("map"));
+        var messageBroker = new Mock<IMessageBroker>();
+        var packetManager = new Mock<IPacketManager>();
+        var messagePacketHandler = new Mock<IMessagePacketHandler>();
+        var controllerIdProvider = new Mock<IControllerIdProvider>();
+        var steamBridge = new Mock<ISteamMissionBridge>();
+        using var batcher = new PromotionRaceBatcher();
+        using var client = new LiteNetP2PClient(
+            config.Object,
+            relayNetwork.Object,
+            missionContext.Object,
+            serializer,
+            messageBroker.Object,
+            packetManager.Object,
+            messagePacketHandler.Object,
+            controllerIdProvider.Object,
+            steamBridge.Object,
+            new MovementPacketCompressor(serializer),
+            batcher);
+        NetPeer peer = NetPeerExtensions.CreatePeer(97);
+        GetPendingPeerControllers(client)[peer] = controllerId;
+
+        Task reliableSend = Task.Run(() => client.Send(
+            controllerId,
+            new NetworkBattleAgentDied(
+                Guid.NewGuid(),
+                wounded: false,
+                Guid.Empty,
+                inflictedDamage: 1,
+                BoneBodyPartType.Head,
+                deathAction: 0)));
+        Assert.True(batcher.SendEntered.Wait(TimeSpan.FromSeconds(5)));
+
+        Task promotion = Task.Run(() => client.OnPeerConnected(peer));
+
+        Task concurrentWork = Task.WhenAll(reliableSend, promotion);
+        Task completed = await Task.WhenAny(
+            concurrentWork,
+            Task.Delay(TimeSpan.FromSeconds(15)));
+
+        Assert.Same(concurrentWork, completed);
+        await concurrentWork;
+        Assert.True(batcher.PromotionFlushAcquiredBuffer);
+        Assert.Equal(new[] { "relay", "map" }, routeOrder);
+        missionContext.Verify(context => context.MapPeer(controllerId, peer), Times.Once);
+    }
+
+    private static Dictionary<NetPeer, string> GetPendingPeerControllers(LiteNetP2PClient client)
+    {
+        FieldInfo field = typeof(LiteNetP2PClient).GetField(
+            "pendingPeerControllers",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return Assert.IsType<Dictionary<NetPeer, string>>(field.GetValue(client));
+    }
+
+    private sealed class PromotionRaceBatcher : IReliableMessageBatcher<string>, IDisposable
+    {
+        private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(5);
+        private readonly object destinationBuffer = new object();
+        private readonly ManualResetEventSlim promotionFlushEntered = new ManualResetEventSlim(false);
+
+        public int BudgetBytes => ReliableMessageBatcher<string>.DefaultBudgetBytes;
+        public ManualResetEventSlim SendEntered { get; } = new ManualResetEventSlim(false);
+        public bool PromotionFlushAcquiredBuffer { get; private set; }
+
+        public event Action<AggregateMessagePacket, int> AggregateSent
+        {
+            add { }
+            remove { }
+        }
+
+        public void Send(
+            string destination,
+            byte[] messagePayload,
+            Action<string, byte[]> sendReliableOrdered)
+        {
+            lock (destinationBuffer)
+            {
+                SendEntered.Set();
+                if (!promotionFlushEntered.Wait(LockTimeout))
+                    throw new TimeoutException("Peer promotion did not start its reliable flush");
+
+                sendReliableOrdered(destination, messagePayload);
+            }
+        }
+
+        public void SendImmediate(
+            string destination,
+            byte[] messagePayload,
+            Action<string, byte[]> sendReliableOrdered)
+        {
+            Send(destination, messagePayload, sendReliableOrdered);
+        }
+
+        public void Flush(
+            string destination,
+            Action<string, byte[]> sendReliableOrdered)
+        {
+            EnterPromotionFlush(null);
+        }
+
+        public void FlushThen(
+            string destination,
+            Action<string, byte[]> sendReliableOrdered,
+            Action sendAfterFlush)
+        {
+            EnterPromotionFlush(sendAfterFlush);
+        }
+
+        private void EnterPromotionFlush(Action? sendAfterFlush)
+        {
+            promotionFlushEntered.Set();
+            bool lockTaken = false;
+            try
+            {
+                Monitor.TryEnter(destinationBuffer, LockTimeout, ref lockTaken);
+                PromotionFlushAcquiredBuffer = lockTaken;
+                if (lockTaken) sendAfterFlush?.Invoke();
+            }
+            finally
+            {
+                if (lockTaken) Monitor.Exit(destinationBuffer);
+            }
+        }
+
+        public void FlushAll(
+            Func<string, bool> isConnected,
+            Action<string, byte[]> sendReliableOrdered)
+        {
+        }
+
+        public void Remove(string destination)
+        {
+        }
+
+        public void Clear()
+        {
+        }
+
+        public void Dispose()
+        {
+            promotionFlushEntered.Dispose();
+            SendEntered.Dispose();
+        }
+    }
+}

--- a/source/E2E.Tests/Services/Missions/MovementNetworkSettingsTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementNetworkSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿using GameInterface.Configuration;
+﻿using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
 using Missions.Agents.Handlers;
 using Moq;
 using Xunit;
@@ -8,22 +8,18 @@ namespace E2E.Tests.Services.Missions;
 public sealed class MovementNetworkSettingsTests
 {
     [Fact]
-    public void MissingValuesUseOneMiBDefaults()
+    public void MissingValuesUseFiveMiBDefaults()
     {
-        MovementNetworkSettings settings = Create(new NetworkConfigData());
+        MovementNetworkSettings settings = Create();
 
-        Assert.Equal(MovementNetworkSettings.BytesPerMiB, settings.OutgoingBytesPerSecond);
-        Assert.Equal(MovementNetworkSettings.BytesPerMiB, settings.IncomingBytesPerSecond);
+        Assert.Equal(MovementNetworkSettings.BytesPerMiB * 5, settings.OutgoingBytesPerSecond);
+        Assert.Equal(MovementNetworkSettings.BytesPerMiB * 5, settings.IncomingBytesPerSecond);
     }
 
     [Fact]
-    public void ConfiguredValuesConvertMiBToBytes()
+    public void CoopOptionsValuesConvertMiBToBytes()
     {
-        MovementNetworkSettings settings = Create(new NetworkConfigData
-        {
-            MovementOutgoingMiBPerSecond = 0.5d,
-            MovementIncomingMiBPerSecond = 2d,
-        });
+        MovementNetworkSettings settings = Create(0.5d, 2d);
 
         Assert.Equal(MovementNetworkSettings.BytesPerMiB / 2, settings.OutgoingBytesPerSecond);
         Assert.Equal(MovementNetworkSettings.BytesPerMiB * 2, settings.IncomingBytesPerSecond);
@@ -32,11 +28,7 @@ public sealed class MovementNetworkSettingsTests
     [Fact]
     public void PositiveSubByteValueClampsToOneBytePerSecond()
     {
-        MovementNetworkSettings settings = Create(new NetworkConfigData
-        {
-            MovementOutgoingMiBPerSecond = 0.0000001d,
-            MovementIncomingMiBPerSecond = 0.0000001d,
-        });
+        MovementNetworkSettings settings = Create(0.0000001d, 0.0000001d);
 
         Assert.Equal(1, settings.OutgoingBytesPerSecond);
         Assert.Equal(1, settings.IncomingBytesPerSecond);
@@ -49,23 +41,19 @@ public sealed class MovementNetworkSettingsTests
     [InlineData(2048d)]
     public void InvalidValuesUseDefaults(double invalid)
     {
-        MovementNetworkSettings settings = Create(new NetworkConfigData
-        {
-            MovementOutgoingMiBPerSecond = invalid,
-            MovementIncomingMiBPerSecond = invalid,
-        });
+        MovementNetworkSettings settings = Create(invalid, invalid);
 
-        Assert.Equal(MovementNetworkSettings.BytesPerMiB, settings.OutgoingBytesPerSecond);
-        Assert.Equal(MovementNetworkSettings.BytesPerMiB, settings.IncomingBytesPerSecond);
+        Assert.Equal(MovementNetworkSettings.BytesPerMiB * 5, settings.OutgoingBytesPerSecond);
+        Assert.Equal(MovementNetworkSettings.BytesPerMiB * 5, settings.IncomingBytesPerSecond);
     }
 
-    private static MovementNetworkSettings Create(NetworkConfigData network)
+    private static MovementNetworkSettings Create(
+        double? uploadMiBPerSecond = null,
+        double? downloadMiBPerSecond = null)
     {
-        var modConfig = new Mock<IModConfig>();
-        modConfig.SetupGet(value => value.Data).Returns(new ModConfigData
-        {
-            Network = network,
-        });
-        return new MovementNetworkSettings(modConfig.Object);
+        var localBandwidth = new Mock<ILocalMovementBandwidth>();
+        localBandwidth.SetupGet(value => value.UploadMiBPerSecond).Returns(uploadMiBPerSecond);
+        localBandwidth.SetupGet(value => value.DownloadMiBPerSecond).Returns(downloadMiBPerSecond);
+        return new MovementNetworkSettings(localBandwidth.Object);
     }
 }

--- a/source/E2E.Tests/Services/Missions/MovementRateControllerTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementRateControllerTests.cs
@@ -52,7 +52,7 @@ public sealed class MovementRateControllerTests
         Assert.Equal(40, state.PriorityHz);
         Assert.Equal("location-fixed", state.Reason);
         Assert.Equal(
-            MovementNetworkSettings.BytesPerMiB,
+            MovementNetworkSettings.DefaultBytesPerSecond,
             Assert.Single(fixture.Advertisements)
                 .MaximumIncomingMovementBytesPerSecondPerSender);
     }

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -1123,6 +1123,7 @@ public class MovementTrafficTests : MissionTestEnvironment
             .Returns(new[] { unusableControllerId });
         var messageBroker = new Mock<IMessageBroker>();
         var packetManager = new Mock<IPacketManager>();
+        var messagePacketHandler = new Mock<IMessagePacketHandler>();
         var controllerIdProvider = new Mock<IControllerIdProvider>();
         var steamBridge = new Mock<ISteamMissionBridge>();
 
@@ -1133,9 +1134,11 @@ public class MovementTrafficTests : MissionTestEnvironment
             serializer,
             messageBroker.Object,
             packetManager.Object,
+            messagePacketHandler.Object,
             controllerIdProvider.Object,
             steamBridge.Object,
-            compressor);
+            compressor,
+            new ReliableMessageBatcher<string>(serializer));
         client.ConnectToInstance(instanceId);
 
         Assert.Equal(0, client.GetMaxUnreliablePayloadBytes());
@@ -1203,6 +1206,7 @@ public class MovementTrafficTests : MissionTestEnvironment
         var missionContext = new Mock<IMissionContext>();
         var messageBroker = new Mock<IMessageBroker>();
         var packetManager = new Mock<IPacketManager>();
+        var messagePacketHandler = new Mock<IMessagePacketHandler>();
         var controllerIdProvider = new Mock<IControllerIdProvider>();
         var steamBridge = new Mock<ISteamMissionBridge>();
 
@@ -1213,9 +1217,11 @@ public class MovementTrafficTests : MissionTestEnvironment
             serializer,
             messageBroker.Object,
             packetManager.Object,
+            messagePacketHandler.Object,
             controllerIdProvider.Object,
             steamBridge.Object,
-            compressor);
+            compressor,
+            new ReliableMessageBatcher<string>(serializer));
         client.ConnectToInstance(instanceId);
 
         client.Send(controllerId, oversizedPacket);

--- a/source/E2E.Tests/Services/Missions/NetworkAgentShootSerializationTests.cs
+++ b/source/E2E.Tests/Services/Missions/NetworkAgentShootSerializationTests.cs
@@ -74,8 +74,8 @@ public class NetworkAgentShootSerializationTests
         blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex = 42;
         var attackerWeapon = new WeaponComponentData(null, WeaponClass.Arrow, default);
         AttackCollisionData collisionData = default;
-        var codec = new BattleDamageCodec();
-        BattleDamageData damageData = codec.Encode(in blow, in collisionData);
+        var mapper = new BattleDamageDataMapper();
+        BattleDamageData damageData = mapper.Pack(in blow, in collisionData);
 
         var original = new NetworkApplyBattleDamage(
             Guid.NewGuid(),
@@ -90,7 +90,7 @@ public class NetworkAgentShootSerializationTests
 
         var result = Assert.IsType<NetworkApplyBattleDamage>(serializer.Deserialize<IMessage>(packet.Data));
 
-        Assert.True(codec.TryDecode(result.DamageData, out Blow decodedBlow, out _));
+        Assert.True(mapper.TryResolve(result.DamageData, out Blow decodedBlow, out _));
         Assert.InRange(packet.Data.Length, 1, 1199);
         Assert.Equal(blow.InflictedDamage, decodedBlow.InflictedDamage);
         Assert.Equal(blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex,

--- a/source/E2E.Tests/Services/Missions/NetworkAgentShootSerializationTests.cs
+++ b/source/E2E.Tests/Services/Missions/NetworkAgentShootSerializationTests.cs
@@ -2,6 +2,7 @@
 using Common.PacketHandlers;
 using Common.Serialization;
 using GameInterface.Surrogates;
+using Missions.Battles;
 using Missions.Messages;
 using Missions.Missiles.Message;
 using System;
@@ -72,12 +73,15 @@ public class NetworkAgentShootSerializationTests
         blow.WeaponRecord._isMissile = true;
         blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex = 42;
         var attackerWeapon = new WeaponComponentData(null, WeaponClass.Arrow, default);
+        AttackCollisionData collisionData = default;
+        var codec = new BattleDamageCodec();
+        BattleDamageData damageData = codec.Encode(in blow, in collisionData);
 
         var original = new NetworkApplyBattleDamage(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            blow,
-            default,
+            damageData,
+            blow.IsMissile,
             missileShotSequence: 4_500_000_123L,
             attackerWeapon: attackerWeapon);
 
@@ -86,6 +90,11 @@ public class NetworkAgentShootSerializationTests
 
         var result = Assert.IsType<NetworkApplyBattleDamage>(serializer.Deserialize<IMessage>(packet.Data));
 
+        Assert.True(codec.TryDecode(result.DamageData, out Blow decodedBlow, out _));
+        Assert.InRange(packet.Data.Length, 1, 1199);
+        Assert.Equal(blow.InflictedDamage, decodedBlow.InflictedDamage);
+        Assert.Equal(blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex,
+            decodedBlow.WeaponRecord.AffectorWeaponSlotOrMissileIndex);
         Assert.Equal(original.VictimAgentId, result.VictimAgentId);
         Assert.Equal(original.AttackerAgentId, result.AttackerAgentId);
         Assert.True(result.IsMissile);

--- a/source/GameInterface.Tests/Configuration/ModConfigTests.cs
+++ b/source/GameInterface.Tests/Configuration/ModConfigTests.cs
@@ -48,8 +48,6 @@ public class ModConfigTests : IDisposable
         Assert.Equal(File.ReadAllText(ShippedTemplatePath), File.ReadAllText(ConfigPath));
         Assert.Equal(DifficultyLevel.VeryEasy, config.Difficulty.PlayerReceivedDamage);
         Assert.False(config.Difficulty.BirthAndDeath);
-        Assert.Equal(1d, config.Network.MovementOutgoingMiBPerSecond);
-        Assert.Equal(1d, config.Network.MovementIncomingMiBPerSecond);
     }
 
     [Fact]
@@ -73,25 +71,24 @@ public class ModConfigTests : IDisposable
         Assert.Equal(1000, config.ModOptions.BattleSize);
         Assert.True(config.UnknownKeys == null || config.UnknownKeys.Count == 0);
         Assert.True(config.Difficulty.UnknownKeys == null || config.Difficulty.UnknownKeys.Count == 0);
-        Assert.True(config.Network.UnknownKeys == null || config.Network.UnknownKeys.Count == 0);
         Assert.True(config.ModOptions.UnknownKeys == null || config.ModOptions.UnknownKeys.Count == 0);
     }
 
     [Fact]
-    public void ConfiguredNetworkValuesBind()
+    public void LegacyNetworkBlock_IsIgnoredWithoutBreakingOtherSettings()
     {
         File.WriteAllText(ConfigPath, @"{
   ""network"": {
-    ""movementOutgoingMiBPerSecond"": 0.5,
-    ""movementIncomingMiBPerSecond"": 2.0,
+    ""movementOutgoingMiBPerSecond"": 1.0,
+    ""movementIncomingMiBPerSecond"": 1.0,
   },
+  ""modOptions"": { ""autoPauseEnabled"": false },
 }");
 
         var config = NewModConfig().Data;
 
-        Assert.Equal(0.5d, config.Network.MovementOutgoingMiBPerSecond);
-        Assert.Equal(2d, config.Network.MovementIncomingMiBPerSecond);
-        Assert.True(config.Network.UnknownKeys == null || config.Network.UnknownKeys.Count == 0);
+        Assert.False(config.ModOptions.AutoPauseEnabled);
+        Assert.True(config.UnknownKeys.ContainsKey("network"));
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Services/UI/CoopOptionsVMTestFactory.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopOptionsVMTestFactory.cs
@@ -5,6 +5,7 @@ using GameInterface.Services.UI.CoopOptions.Providers;
 using GameInterface.Services.UI.CoopOptions.Providers.ChatTab;
 using GameInterface.Services.UI.CoopOptions.Providers.KillFeedTab;
 using GameInterface.Services.UI.CoopOptions.Providers.MapTimeTab;
+using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
 using GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
 using System;
 
@@ -22,7 +23,8 @@ internal static class CoopOptionsVMTestFactory
             new KillFeedOptionsTabProvider(),
             new MapTimeOptionsTabProvider(),
             new ChatOptionsTabProvider(),
-            new PlayerNameplatesOptionsTabProvider()
+            new PlayerNameplatesOptionsTabProvider(),
+            new NetworkOptionsTabProvider(),
         };
         return new CoopOptionsVM(
             optionsStore,

--- a/source/GameInterface.Tests/Services/UI/NetworkOptionsTests.cs
+++ b/source/GameInterface.Tests/Services/UI/NetworkOptionsTests.cs
@@ -1,0 +1,101 @@
+﻿using Common.Messaging;
+using GameInterface.Services.UI.CoopOptions;
+using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
+using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab.Sections;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+public class NetworkOptionsTests
+{
+    [Fact]
+    public void CoopOptionsVM_NetworkBandwidthDefaultsToFiveMiBPerSecond()
+    {
+        string filePath = CreateTempFilePath();
+
+        try
+        {
+            var viewModel = CoopOptionsVMTestFactory.Create(
+                new CoopOptionsStore(filePath),
+                new MessageBroker());
+            var tab = Assert.Single(viewModel.Tabs.Where(value =>
+                value.Id == NetworkOptionsTabProvider.TabId));
+            var section = Assert.IsType<NetworkSection>(Assert.Single(tab.Sections));
+
+            Assert.Equal(NetworkOptionsTabProvider.TabName, tab.Name);
+            Assert.Equal(5f, section.MovementUploadMiBPerSecond);
+            Assert.Equal(5f, section.MovementDownloadMiBPerSecond);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public void CoopOptionsVM_NetworkBandwidthPersistsAfterApply()
+    {
+        string filePath = CreateTempFilePath();
+
+        try
+        {
+            var store = new CoopOptionsStore(filePath);
+            var viewModel = CoopOptionsVMTestFactory.Create(store, new MessageBroker());
+            var tab = Assert.Single(viewModel.Tabs.Where(value =>
+                value.Id == NetworkOptionsTabProvider.TabId));
+            var section = Assert.IsType<NetworkSection>(Assert.Single(tab.Sections));
+
+            tab.ExecuteSelection();
+            section.MovementUploadMiBPerSecond = 7.5f;
+            section.MovementDownloadMiBPerSecond = 9.25f;
+            viewModel.ActionApply();
+
+            var bandwidth = new LocalMovementBandwidth(store);
+            Assert.Equal(7.5d, bandwidth.UploadMiBPerSecond);
+            Assert.Equal(9.25d, bandwidth.DownloadMiBPerSecond);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public void LocalMovementBandwidth_InvalidSavedValuesAreIgnored()
+    {
+        string filePath = CreateTempFilePath();
+
+        try
+        {
+            var store = new CoopOptionsStore(filePath);
+            var options = new CoopOptionsData();
+            options.SetSection(
+                NetworkOptionsTabProvider.TabId,
+                NetworkSection.SectionId,
+                new NetworkSectionOptions
+                {
+                    MovementUploadMiBPerSecond = -1d,
+                    MovementDownloadMiBPerSecond = 2048d,
+                });
+            store.Save(options);
+
+            var bandwidth = new LocalMovementBandwidth(store);
+            Assert.Null(bandwidth.UploadMiBPerSecond);
+            Assert.Null(bandwidth.DownloadMiBPerSecond);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    private static string CreateTempFilePath()
+    {
+        return Path.Combine(
+            Path.GetTempPath(),
+            $"bannerlord-coop-network-options-{Guid.NewGuid():N}.json");
+    }
+}

--- a/source/GameInterface/Configuration/ModConfig.cs
+++ b/source/GameInterface/Configuration/ModConfig.cs
@@ -378,13 +378,19 @@ internal sealed class ModConfig : IModConfig
         if (data.UnknownKeys != null) WarnUnknownKeys(data.UnknownKeys);
         if (data.Difficulty?.UnknownKeys != null) WarnUnknownKeys(data.Difficulty.UnknownKeys, "difficulty ");
         if (data.ModOptions?.UnknownKeys != null) WarnUnknownKeys(data.ModOptions.UnknownKeys, "mod option ");
-        if (data.Network?.UnknownKeys != null) WarnUnknownKeys(data.Network.UnknownKeys, "network ");
     }
 
     private static void WarnUnknownKeys(IDictionary<string, JToken> unknownKeys, string keyType = "")
     {
         foreach (var key in unknownKeys.Keys)
         {
+            // Existing configs may retain the retired local movement settings block.
+            if (string.IsNullOrEmpty(keyType) &&
+                string.Equals(key, "network", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
             Logger.Warning("mod-config.json: unknown {keyType}key '{Key}' ignored", keyType, key);
         }
     }

--- a/source/GameInterface/Configuration/ModConfigData.cs
+++ b/source/GameInterface/Configuration/ModConfigData.cs
@@ -6,9 +6,9 @@ namespace GameInterface.Configuration;
 
 /// <summary>
 /// THE mod-config.json schema: one explicit property per key — the class IS the
-/// schema, adding a property adds the key. Gameplay/mod settings and local mission
-/// network capacity only; process settings (ports, saves, passwords) live in the
-/// dedicated server's server-config.json. Nullable means the owning consumer uses
+/// schema, adding a property adds the key. Gameplay/mod settings only; process
+/// settings (ports, saves, passwords) live in the dedicated server's
+/// server-config.json. Nullable means the owning consumer uses
 /// its documented default or leaves the loaded world's value alone. Keys the file has that the schema
 /// doesn't land in <see cref="UnknownKeys"/> for the load warning.
 /// </summary>
@@ -19,9 +19,6 @@ public sealed class ModConfigData
     public DifficultyConfigData Difficulty { get; set; } = new DifficultyConfigData();
 
     public ModOptionsData ModOptions { get; set; } = new ModOptionsData();
-
-    /// <summary>Local client network capacity. Dedicated servers do not originate mission movement.</summary>
-    public NetworkConfigData Network { get; set; } = new NetworkConfigData();
 
     [JsonExtensionData]
     public IDictionary<string, JToken> UnknownKeys { get; set; }
@@ -65,19 +62,6 @@ public enum DifficultyLevel
     VeryEasy,
     Easy,
     Realistic,
-}
-
-/// <summary>Local mission movement bandwidth limits for this game process.</summary>
-public sealed class NetworkConfigData
-{
-    /// <summary>Total movement payload this client may send per second.</summary>
-    public double? MovementOutgoingMiBPerSecond { get; set; }
-
-    /// <summary>Total movement payload this client asks all mission peers to send per second.</summary>
-    public double? MovementIncomingMiBPerSecond { get; set; }
-
-    [JsonExtensionData]
-    public IDictionary<string, JToken> UnknownKeys { get; set; }
 }
 
 public sealed class ModOptionsData

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -45,6 +45,7 @@ using GameInterface.Services.UI.CoopOptions.Providers;
 using GameInterface.Services.UI.CoopOptions.Providers.ChatTab;
 using GameInterface.Services.UI.CoopOptions.Providers.KillFeedTab;
 using GameInterface.Services.UI.CoopOptions.Providers.MapTimeTab;
+using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
 using GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
 using GameInterface.Services.UI.BugReporting;
 using GameInterface.Services.UI.Patches;
@@ -96,6 +97,8 @@ public class GameInterfaceModule : Module
         builder.RegisterType<MapTimeOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
         builder.RegisterType<ChatOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
         builder.RegisterType<PlayerNameplatesOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
+        builder.RegisterType<NetworkOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
+        builder.RegisterType<LocalMovementBandwidth>().As<ILocalMovementBandwidth>().InstancePerDependency();
         builder.RegisterType<ChatPlayerName>().As<IChatPlayerNameResolver>().InstancePerDependency();
         builder.RegisterType<PlayerPartyRestorer>().As<IPlayerPartyRestorer>().InstancePerDependency();
         builder.RegisterType<PlayerCreationRollback>().As<IPlayerCreationRollback>().InstancePerDependency();

--- a/source/GameInterface/Services/UI/CoopOptions/CoopOptionsUIMovie.template.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/CoopOptionsUIMovie.template.xml
@@ -14,7 +14,7 @@
                        HorizontalAlignment="Center" MarginBottom="24" StackLayout.LayoutMethod="HorizontalLeftToRight">
               <ItemTemplate>
                 <ButtonWidget DoNotPassEventsToChildren="true" WidthSizePolicy="Fixed" HeightSizePolicy="Fixed"
-                              SuggestedWidth="210" SuggestedHeight="58" Brush="Header.Tab.Center"
+                              SuggestedWidth="168" SuggestedHeight="58" Brush="Header.Tab.Center"
                               Command.Click="ExecuteSelection" IsSelected="@IsSelected" UpdateChildrenStates="true">
                   <Children>
                     <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
@@ -29,6 +29,7 @@
 			<!-- COOP_OPTIONS_PROVIDER:Providers/MapTimeTab/MapTimeTab.xml -->
 			<!-- COOP_OPTIONS_PROVIDER:Providers/ChatTab/ChatTab.xml -->
 			<!-- COOP_OPTIONS_PROVIDER:Providers/PlayerNameplatesTab/PlayerNameplatesTab.xml -->
+			<!-- COOP_OPTIONS_PROVIDER:Providers/NetworkTab/NetworkTab.xml -->
 
             <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="CoverChildren"
                        HorizontalAlignment="Center" MarginTop="36"

--- a/source/GameInterface/Services/UI/CoopOptions/CoopOptionsVM.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/CoopOptionsVM.cs
@@ -5,6 +5,7 @@ using GameInterface.Services.UI.CoopOptions.Providers;
 using GameInterface.Services.UI.CoopOptions.Providers.ChatTab;
 using GameInterface.Services.UI.CoopOptions.Providers.KillFeedTab;
 using GameInterface.Services.UI.CoopOptions.Providers.MapTimeTab;
+using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
 using GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
 using GameInterface.Services.UI.Donate;
 using System;
@@ -86,6 +87,9 @@ public class CoopOptionsVM : ViewModel
 
     [DataSourceProperty]
     public CoopOptionsTabVM PlayerNameplatesTab { get; set; }
+
+    [DataSourceProperty]
+    public CoopOptionsTabVM NetworkTab { get; set; }
 
     public void ActionApply()
     {
@@ -200,6 +204,11 @@ public class CoopOptionsVM : ViewModel
         {
             PlayerNameplatesTab = tab;
             OnPropertyChanged(nameof(PlayerNameplatesTab));
+        }
+        else if (tabId == NetworkOptionsTabProvider.TabId)
+        {
+            NetworkTab = tab;
+            OnPropertyChanged(nameof(NetworkTab));
         }
     }
 

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/LocalMovementBandwidth.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/LocalMovementBandwidth.cs
@@ -1,0 +1,40 @@
+﻿using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab.Sections;
+using System;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
+
+/// <summary>Provides this client's saved movement bandwidth overrides.</summary>
+public interface ILocalMovementBandwidth
+{
+    double? UploadMiBPerSecond { get; }
+    double? DownloadMiBPerSecond { get; }
+}
+
+/// <summary>Reads this client's saved movement bandwidth overrides.</summary>
+public class LocalMovementBandwidth : ILocalMovementBandwidth
+{
+    public const double DefaultMiBPerSecond = 5d;
+    public const double MaximumMiBPerSecond = 1024d;
+
+    public double? UploadMiBPerSecond { get; }
+    public double? DownloadMiBPerSecond { get; }
+
+    public LocalMovementBandwidth(ICoopOptionsStore optionsStore)
+    {
+        if (optionsStore == null) throw new ArgumentNullException(nameof(optionsStore));
+
+        CoopOptionsData options = optionsStore.LoadOrDefault();
+        if (!options.TryGetSection(
+                NetworkOptionsTabProvider.TabId,
+                NetworkSection.SectionId,
+                out NetworkSectionOptions sectionOptions))
+        {
+            return;
+        }
+
+        if (sectionOptions.TryGetUpload(out double upload))
+            UploadMiBPerSecond = upload;
+        if (sectionOptions.TryGetDownload(out double download))
+            DownloadMiBPerSecond = download;
+    }
+}

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/NetworkOptionsTabProvider.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/NetworkOptionsTabProvider.cs
@@ -1,0 +1,51 @@
+﻿using Common.Messaging;
+using GameInterface.Configuration;
+using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab.Sections;
+using System;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
+
+/// <summary>Builds the local network options tab.</summary>
+public class NetworkOptionsTabProvider : ICoopOptionsTabProvider
+{
+    public const string TabId = "NetworkTab";
+    public const string TabName = "Network";
+    public const string SectionTitleText = "Movement Bandwidth";
+    public const string SectionDescriptionText =
+        "Limits compressed movement data uploaded and downloaded by this client. Changes apply when the next mission opens.";
+    public const string UploadText = "Upload limit";
+    public const string DownloadText = "Download limit";
+    public const string UnitText = "MiB/s";
+
+    public string Id => TabId;
+
+    public bool IsAvailable(ModOptions modOptions) => true;
+
+    public CoopOptionsTabVM CreateTab(
+        CoopOptionsData options,
+        IMessageBroker messageBroker,
+        Action<CoopOptionsTabVM> onSelect)
+    {
+        NetworkSectionOptions sectionOptions = null;
+        options?.TryGetSection(TabId, NetworkSection.SectionId, out sectionOptions);
+
+        double upload = LocalMovementBandwidth.DefaultMiBPerSecond;
+        double download = LocalMovementBandwidth.DefaultMiBPerSecond;
+        if (sectionOptions != null)
+        {
+            if (sectionOptions.TryGetUpload(out double savedUpload))
+                upload = savedUpload;
+            if (sectionOptions.TryGetDownload(out double savedDownload))
+                download = savedDownload;
+        }
+
+        return new CoopOptionsTabVM(
+            Id,
+            TabName,
+            new CoopOptionsSectionVM[]
+            {
+                new NetworkSection(upload, download),
+            },
+            onSelect);
+    }
+}

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/NetworkTab.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/NetworkTab.xml
@@ -1,0 +1,11 @@
+<ListPanel DataSource="{NetworkTab}" IsVisible="@IsSelected" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+           LayoutImp.LayoutMethod="VerticalTopToBottom">
+  <Children>
+    <ListPanel DataSource="{Sections}" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+               LayoutImp.LayoutMethod="VerticalTopToBottom">
+      <ItemTemplate>
+        <!-- COOP_OPTIONS_SECTION:Sections/NetworkSection.xml -->
+      </ItemTemplate>
+    </ListPanel>
+  </Children>
+</ListPanel>

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/Sections/NetworkSection.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/Sections/NetworkSection.cs
@@ -1,0 +1,77 @@
+﻿using TaleWorlds.Library;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.NetworkTab.Sections;
+
+/// <summary>Edits this client's movement bandwidth limits.</summary>
+public class NetworkSection : CoopOptionsSectionVM
+{
+    public const string SectionId = "NetworkSection";
+    public const float MinimumMiBPerSecond = 0.01f;
+    public const float MaximumMiBPerSecond = (float)LocalMovementBandwidth.MaximumMiBPerSecond;
+
+    private float movementUploadMiBPerSecond;
+    private float movementDownloadMiBPerSecond;
+
+    public NetworkSection(double movementUploadMiBPerSecond, double movementDownloadMiBPerSecond)
+    {
+        this.movementUploadMiBPerSecond = Clamp(movementUploadMiBPerSecond);
+        this.movementDownloadMiBPerSecond = Clamp(movementDownloadMiBPerSecond);
+    }
+
+    public override string Id => SectionId;
+
+    public string TitleText => NetworkOptionsTabProvider.SectionTitleText;
+    public string DescriptionText => NetworkOptionsTabProvider.SectionDescriptionText;
+    public string UploadText => NetworkOptionsTabProvider.UploadText;
+    public string DownloadText => NetworkOptionsTabProvider.DownloadText;
+    public string UnitText => NetworkOptionsTabProvider.UnitText;
+
+    [DataSourceProperty]
+    public float MovementUploadMiBPerSecond
+    {
+        get => movementUploadMiBPerSecond;
+        set
+        {
+            float clamped = Clamp(value);
+            if (movementUploadMiBPerSecond == clamped) return;
+
+            movementUploadMiBPerSecond = clamped;
+            OnPropertyChanged(nameof(MovementUploadMiBPerSecond));
+        }
+    }
+
+    [DataSourceProperty]
+    public float MovementDownloadMiBPerSecond
+    {
+        get => movementDownloadMiBPerSecond;
+        set
+        {
+            float clamped = Clamp(value);
+            if (movementDownloadMiBPerSecond == clamped) return;
+
+            movementDownloadMiBPerSecond = clamped;
+            OnPropertyChanged(nameof(MovementDownloadMiBPerSecond));
+        }
+    }
+
+    public override void Apply(string tabId, CoopOptionsData options)
+    {
+        options.SetSection(tabId, Id, new NetworkSectionOptions
+        {
+            MovementUploadMiBPerSecond = movementUploadMiBPerSecond,
+            MovementDownloadMiBPerSecond = movementDownloadMiBPerSecond,
+        });
+    }
+
+    private static float Clamp(double value)
+    {
+        if (double.IsNaN(value) || double.IsNegativeInfinity(value))
+            return MinimumMiBPerSecond;
+        if (double.IsPositiveInfinity(value))
+            return MaximumMiBPerSecond;
+
+        return (float)System.Math.Max(
+            MinimumMiBPerSecond,
+            System.Math.Min(MaximumMiBPerSecond, value));
+    }
+}

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/Sections/NetworkSection.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/Sections/NetworkSection.xml
@@ -1,0 +1,49 @@
+<ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+           LayoutImp.LayoutMethod="VerticalTopToBottom">
+  <Children>
+    <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="48"
+                Brush="Clan.TabControl.Text" Brush.FontSize="36"
+                Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                Text="@TitleText"/>
+    <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="82"
+                Brush="Clan.TabControl.Text" Brush.FontSize="22" Brush.FontColor="#B8B8B8FF"
+                Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                Text="@DescriptionText"/>
+
+    <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="640" HeightSizePolicy="Fixed" SuggestedHeight="76"
+               HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
+      <Children>
+        <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="320" HeightSizePolicy="StretchToParent"
+                    Brush="Clan.TabControl.Text" Brush.FontSize="28"
+                    Brush.TextHorizontalAlignment="Right" Brush.TextVerticalAlignment="Center"
+                    MarginRight="24" Text="@UploadText"/>
+        <FloatInputTextWidget WidthSizePolicy="Fixed" SuggestedWidth="180" HeightSizePolicy="Fixed" SuggestedHeight="52"
+                              VerticalAlignment="Center" Brush="ScoreboardPanels_2" Brush.AlphaFactor="0.75"
+                              Brush.FontSize="28" Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                              FloatText="@MovementUploadMiBPerSecond" MinFloat="0.01" MaxFloat="1024"
+                              EnableClamp="true" MaxLength="8"/>
+        <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="90" HeightSizePolicy="StretchToParent"
+                    MarginLeft="18" Brush="Clan.TabControl.Text" Brush.FontSize="24"
+                    Brush.TextVerticalAlignment="Center" Text="@UnitText"/>
+      </Children>
+    </ListPanel>
+
+    <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="640" HeightSizePolicy="Fixed" SuggestedHeight="76"
+               HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
+      <Children>
+        <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="320" HeightSizePolicy="StretchToParent"
+                    Brush="Clan.TabControl.Text" Brush.FontSize="28"
+                    Brush.TextHorizontalAlignment="Right" Brush.TextVerticalAlignment="Center"
+                    MarginRight="24" Text="@DownloadText"/>
+        <FloatInputTextWidget WidthSizePolicy="Fixed" SuggestedWidth="180" HeightSizePolicy="Fixed" SuggestedHeight="52"
+                              VerticalAlignment="Center" Brush="ScoreboardPanels_2" Brush.AlphaFactor="0.75"
+                              Brush.FontSize="28" Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                              FloatText="@MovementDownloadMiBPerSecond" MinFloat="0.01" MaxFloat="1024"
+                              EnableClamp="true" MaxLength="8"/>
+        <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="90" HeightSizePolicy="StretchToParent"
+                    MarginLeft="18" Brush="Clan.TabControl.Text" Brush.FontSize="24"
+                    Brush.TextVerticalAlignment="Center" Text="@UnitText"/>
+      </Children>
+    </ListPanel>
+  </Children>
+</ListPanel>

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/Sections/NetworkSectionOptions.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/NetworkTab/Sections/NetworkSectionOptions.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.Json.Serialization;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.NetworkTab.Sections;
+
+/// <summary>Persisted local movement upload and download limits.</summary>
+public class NetworkSectionOptions
+{
+    [JsonPropertyName("movementUploadMiBPerSecond")]
+    public double? MovementUploadMiBPerSecond { get; set; }
+
+    [JsonPropertyName("movementDownloadMiBPerSecond")]
+    public double? MovementDownloadMiBPerSecond { get; set; }
+
+    public bool TryGetUpload(out double value) =>
+        TryGetValue(MovementUploadMiBPerSecond, out value);
+
+    public bool TryGetDownload(out double value) =>
+        TryGetValue(MovementDownloadMiBPerSecond, out value);
+
+    private static bool TryGetValue(double? configured, out double value)
+    {
+        value = configured.GetValueOrDefault();
+        return configured.HasValue &&
+               !double.IsNaN(value) &&
+               !double.IsInfinity(value) &&
+               value > 0d &&
+               value <= LocalMovementBandwidth.MaximumMiBPerSecond;
+    }
+}

--- a/source/Missions/Agents/Handlers/CombatHitPresentationHandler.cs
+++ b/source/Missions/Agents/Handlers/CombatHitPresentationHandler.cs
@@ -197,7 +197,7 @@ public class CombatHitPresentationHandler : ICombatHitPresentationHandler
 
         Agent victim = presentation.IsMount ? info.Agent?.MountAgent : info.Agent;
         Mission mission = Mission.Current;
-        if (mission == null || victim == null || victim.Mission != mission)
+        if (mission == null || victim == null || victim.Mission != mission || !victim.IsActive())
             return;
 
         switch (presentation.Kind)
@@ -206,14 +206,15 @@ public class CombatHitPresentationHandler : ICombatHitPresentationHandler
                 PlayBlood(victim, presentation.CollisionBoneIndex, presentation.Strength);
                 break;
             case MeleeHitPresentationKind.ShieldImpact:
-                if (victim.IsActive())
-                    PlayShieldImpact(mission, victim, presentation);
+                PlayShieldImpact(mission, victim, presentation);
                 break;
         }
     }
 
-    private static void PlayBlood(Agent victim, int collisionBoneIndex, float strength)
+    internal static void PlayBlood(Agent victim, int collisionBoneIndex, float strength)
     {
+        if (!victim.IsActive()) return;
+
         sbyte boneIndex = collisionBoneIndex >= sbyte.MinValue && collisionBoneIndex <= sbyte.MaxValue
             ? (sbyte)collisionBoneIndex
             : (sbyte)-1;

--- a/source/Missions/Agents/Handlers/MovementBatchSender.cs
+++ b/source/Missions/Agents/Handlers/MovementBatchSender.cs
@@ -264,7 +264,9 @@ public sealed class MovementBatchSender : IMovementBatchSender
             packetCompressor,
             new DelegateMovementTrafficBudgetFactory(trafficBudgetFactory),
             new MovementPriorityScheduler(),
-            new MovementNetworkSettings(1d, 1d))
+            new MovementNetworkSettings(
+                MovementNetworkSettings.DefaultMiBPerSecond,
+                MovementNetworkSettings.DefaultMiBPerSecond))
     {
     }
 

--- a/source/Missions/Agents/Handlers/MovementNetworkSettings.cs
+++ b/source/Missions/Agents/Handlers/MovementNetworkSettings.cs
@@ -1,5 +1,5 @@
 ﻿using Common.Logging;
-using GameInterface.Configuration;
+using GameInterface.Services.UI.CoopOptions.Providers.NetworkTab;
 using Serilog;
 using System;
 
@@ -19,23 +19,23 @@ public sealed class MovementNetworkSettings : IMovementNetworkSettings
     private static readonly ILogger Logger = LogManager.GetLogger<MovementNetworkSettings>();
 
     public const int BytesPerMiB = 1024 * 1024;
-    public const double DefaultMiBPerSecond = 1d;
-    private const double MaximumMiBPerSecond = 1024d;
+    public const double DefaultMiBPerSecond = LocalMovementBandwidth.DefaultMiBPerSecond;
+    public const int DefaultBytesPerSecond = (int)(DefaultMiBPerSecond * BytesPerMiB);
+    private const double MaximumMiBPerSecond = LocalMovementBandwidth.MaximumMiBPerSecond;
 
     public int OutgoingBytesPerSecond { get; }
     public int IncomingBytesPerSecond { get; }
     public double OutgoingMiBPerSecond { get; }
     public double IncomingMiBPerSecond { get; }
 
-    public MovementNetworkSettings(IModConfig modConfig)
+    public MovementNetworkSettings(ILocalMovementBandwidth localMovementBandwidth)
     {
-        NetworkConfigData config = modConfig?.Data?.Network;
         OutgoingMiBPerSecond = Validate(
-            config?.MovementOutgoingMiBPerSecond,
-            "movementOutgoingMiBPerSecond");
+            localMovementBandwidth?.UploadMiBPerSecond,
+            "movementUploadMiBPerSecond");
         IncomingMiBPerSecond = Validate(
-            config?.MovementIncomingMiBPerSecond,
-            "movementIncomingMiBPerSecond");
+            localMovementBandwidth?.DownloadMiBPerSecond,
+            "movementDownloadMiBPerSecond");
         OutgoingBytesPerSecond = ToBytes(OutgoingMiBPerSecond);
         IncomingBytesPerSecond = ToBytes(IncomingMiBPerSecond);
     }
@@ -62,7 +62,7 @@ public sealed class MovementNetworkSettings : IMovementNetworkSettings
         if (configured.HasValue)
         {
             Logger.Warning(
-                "mod-config.json: network value for '{Setting}' must be greater than zero and no more than {Maximum}; using {Default}",
+                "Network value for '{Setting}' must be greater than zero and no more than {Maximum}; using {Default}",
                 name,
                 MaximumMiBPerSecond,
                 DefaultMiBPerSecond);

--- a/source/Missions/Agents/Handlers/MovementRateController.cs
+++ b/source/Missions/Agents/Handlers/MovementRateController.cs
@@ -282,7 +282,9 @@ public sealed class MovementRateController : IMovementRateController
             Stopwatch.Frequency,
             ReadFrameLimitHz,
             enableHeartbeat: true,
-            networkSettings: new MovementNetworkSettings(1d, 1d))
+            networkSettings: new MovementNetworkSettings(
+                MovementNetworkSettings.DefaultMiBPerSecond,
+                MovementNetworkSettings.DefaultMiBPerSecond))
     {
     }
 
@@ -308,7 +310,9 @@ public sealed class MovementRateController : IMovementRateController
         this.messageBroker = messageBroker;
         this.controllerIdProvider = controllerIdProvider;
         this.missionContext = missionContext;
-        this.networkSettings = networkSettings ?? new MovementNetworkSettings(1d, 1d);
+        this.networkSettings = networkSettings ?? new MovementNetworkSettings(
+            MovementNetworkSettings.DefaultMiBPerSecond,
+            MovementNetworkSettings.DefaultMiBPerSecond);
         this.timestampProvider = timestampProvider;
         this.timestampFrequency = timestampFrequency;
         this.frameLimitProvider = frameLimitProvider;
@@ -484,16 +488,16 @@ public sealed class MovementRateController : IMovementRateController
     public double GetReceiverIncomingBytesPerSecond(string controllerId)
     {
         if (string.IsNullOrEmpty(controllerId))
-            return MovementNetworkSettings.BytesPerMiB;
+            return MovementNetworkSettings.DefaultBytesPerSecond;
 
         lock (gate)
         {
-            if (disposed) return MovementNetworkSettings.BytesPerMiB;
+            if (disposed) return MovementNetworkSettings.DefaultBytesPerSecond;
 
             PruneExpiredReceiverCaps();
             return receiverCaps.TryGetValue(controllerId, out ReceiverCapEntry receiverCap)
                 ? NormalizeIncomingByteRate(receiverCap.MaximumIncomingBytesPerSecond)
-                : MovementNetworkSettings.BytesPerMiB;
+                : MovementNetworkSettings.DefaultBytesPerSecond;
         }
     }
 

--- a/source/Missions/Battles/BattleDamageCodec.cs
+++ b/source/Missions/Battles/BattleDamageCodec.cs
@@ -1,0 +1,133 @@
+﻿using Missions.Messages;
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Battles;
+
+/// <summary>Converts routed damage between engine structs and the owned network representation.</summary>
+public interface IBattleDamageCodec
+{
+    BattleDamageData Encode(in Blow blow, in AttackCollisionData collisionData);
+    bool TryDecode(
+        BattleDamageData damageData,
+        out Blow blow,
+        out AttackCollisionData collisionData);
+}
+
+/// <summary>Maps routed-damage engine structs to a versioned, field-owned wire representation.</summary>
+public class BattleDamageCodec : IBattleDamageCodec
+{
+    public BattleDamageData Encode(in Blow blow, in AttackCollisionData collisionData)
+    {
+        return new BattleDamageData(
+            new BattleBlowData(blow),
+            new BattleCollisionData(collisionData));
+    }
+
+    public bool TryDecode(
+        BattleDamageData damageData,
+        out Blow blow,
+        out AttackCollisionData collisionData)
+    {
+        blow = default;
+        collisionData = default;
+        if (damageData == null ||
+            damageData.Version != BattleDamageData.CurrentVersion ||
+            damageData.Blow == null ||
+            damageData.Collision == null)
+        {
+            return false;
+        }
+
+        BattleBlowData blowData = damageData.Blow;
+        blow = new Blow(blowData.OwnerId)
+        {
+            WeaponRecord = new BlowWeaponRecord
+            {
+                StartingPosition = blowData.WeaponStartingPosition,
+                CurrentPosition = blowData.WeaponCurrentPosition,
+                Velocity = blowData.WeaponVelocity,
+                ItemFlags = blowData.ItemFlags,
+                WeaponFlags = blowData.WeaponFlags,
+                WeaponClass = blowData.WeaponClass,
+                BoneNoToAttach = blowData.WeaponBoneNoToAttach,
+                AffectorWeaponSlotOrMissileIndex = blowData.AffectorWeaponSlotOrMissileIndex,
+                Weight = blowData.WeaponWeight,
+                _isMissile = blowData.IsMissile,
+                _isMaterialMetal = blowData.IsMaterialMetal,
+            },
+            GlobalPosition = blowData.GlobalPosition,
+            Direction = blowData.Direction,
+            SwingDirection = blowData.SwingDirection,
+            InflictedDamage = blowData.InflictedDamage,
+            SelfInflictedDamage = blowData.SelfInflictedDamage,
+            BaseMagnitude = blowData.BaseMagnitude,
+            DefenderStunPeriod = blowData.DefenderStunPeriod,
+            AttackerStunPeriod = blowData.AttackerStunPeriod,
+            AbsorbedByArmor = blowData.AbsorbedByArmor,
+            MovementSpeedDamageModifier = blowData.MovementSpeedDamageModifier,
+            StrikeType = blowData.StrikeType,
+            AttackType = blowData.AttackType,
+            BlowFlag = blowData.BlowFlag,
+            BoneIndex = blowData.BoneIndex,
+            VictimBodyPart = blowData.VictimBodyPart,
+            DamageType = blowData.DamageType,
+            NoIgnore = blowData.NoIgnore,
+            DamageCalculated = blowData.DamageCalculated,
+            IsFallDamage = blowData.IsFallDamage,
+            DamagedPercentage = blowData.DamagedPercentage,
+        };
+
+        BattleCollisionData collision = damageData.Collision;
+        collisionData = new AttackCollisionData(
+            collision.AttackBlockedWithShield,
+            collision.CorrectSideShieldBlock,
+            collision.IsAlternativeAttack,
+            collision.IsColliderAgent,
+            collision.CollidedWithShieldOnBack,
+            collision.IsMissile,
+            collision.MissileBlockedWithWeapon,
+            collision.MissileHasPhysics,
+            collision.EntityExists,
+            collision.ThrustTipHit,
+            collision.MissileGoneUnderWater,
+            collision.MissileGoneOutOfBorder,
+            collision.CollidedWithLastBoneSegment,
+            collision.CollisionResult,
+            collision.AffectorWeaponSlotOrMissileIndex,
+            collision.StrikeType,
+            collision.DamageType,
+            collision.CollisionBoneIndex,
+            collision.VictimHitBodyPart,
+            collision.AttackBoneIndex,
+            collision.AttackDirection,
+            collision.PhysicsMaterialIndex,
+            collision.CollisionHitResultFlags,
+            collision.AttackProgress,
+            collision.CollisionDistanceOnWeapon,
+            collision.AttackerStunPeriod,
+            collision.DefenderStunPeriod,
+            collision.MissileTotalDamage,
+            collision.MissileStartingBaseSpeed,
+            collision.ChargeVelocity,
+            collision.FallSpeed,
+            collision.WeaponRotUp,
+            collision.WeaponBlowDir,
+            collision.CollisionGlobalPosition,
+            collision.MissileVelocity,
+            collision.MissileStartingPosition,
+            collision.VictimAgentCurVelocity,
+            collision.CollisionGlobalNormal,
+            collision.LastBoneSegmentRotUp,
+            collision.LastBoneSegmentSwingDir)
+        {
+            BaseMagnitude = collision.BaseMagnitude,
+            MovementSpeedDamageModifier = collision.MovementSpeedDamageModifier,
+            AbsorbedByArmor = collision.AbsorbedByArmor,
+            InflictedDamage = collision.InflictedDamage,
+            SelfInflictedDamage = collision.SelfInflictedDamage,
+            IsShieldBroken = collision.IsShieldBroken,
+            IsSneakAttack = collision.IsSneakAttack,
+        };
+        return true;
+    }
+}

--- a/source/Missions/Battles/BattleDamageDataMapper.cs
+++ b/source/Missions/Battles/BattleDamageDataMapper.cs
@@ -4,26 +4,26 @@ using TaleWorlds.MountAndBlade;
 namespace Missions.Battles;
 
 /// <summary>Converts routed damage between engine structs and the owned network representation.</summary>
-public interface IBattleDamageCodec
+public interface IBattleDamageDataMapper
 {
-    BattleDamageData Encode(in Blow blow, in AttackCollisionData collisionData);
-    bool TryDecode(
+    BattleDamageData Pack(in Blow blow, in AttackCollisionData collisionData);
+    bool TryResolve(
         BattleDamageData damageData,
         out Blow blow,
         out AttackCollisionData collisionData);
 }
 
 /// <summary>Maps routed-damage engine structs to a versioned, field-owned wire representation.</summary>
-public class BattleDamageCodec : IBattleDamageCodec
+public class BattleDamageDataMapper : IBattleDamageDataMapper
 {
-    public BattleDamageData Encode(in Blow blow, in AttackCollisionData collisionData)
+    public BattleDamageData Pack(in Blow blow, in AttackCollisionData collisionData)
     {
         return new BattleDamageData(
             new BattleBlowData(blow),
             new BattleCollisionData(collisionData));
     }
 
-    public bool TryDecode(
+    public bool TryResolve(
         BattleDamageData damageData,
         out Blow blow,
         out AttackCollisionData collisionData)

--- a/source/Missions/Battles/BattleDamageRouter.cs
+++ b/source/Missions/Battles/BattleDamageRouter.cs
@@ -40,7 +40,7 @@ public class BattleDamageRouter : IBattleDamageRouter
     private readonly IGuardedHitWindow guardedHitWindow;
     private readonly IAgentNativeMountState agentNativeMountState;
     private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
-    private readonly IBattleDamageCodec battleDamageCodec;
+    private readonly IBattleDamageDataMapper battleDamageDataMapper;
     private readonly Func<Agent, bool?> mountAuthorityProbe;
     private readonly object inboundDamageGate = new();
     private readonly ConcurrentQueue<NetworkApplyBattleDamage> inboundDamage = new();
@@ -136,7 +136,7 @@ public class BattleDamageRouter : IBattleDamageRouter
         IGuardedHitWindow guardedHitWindow,
         IAgentNativeMountState agentNativeMountState,
         IPuppetMountStateRepairer puppetMountStateRepairer,
-        IBattleDamageCodec battleDamageCodec)
+        IBattleDamageDataMapper battleDamageDataMapper)
     {
         this.network = network;
         this.messageBroker = messageBroker;
@@ -145,7 +145,7 @@ public class BattleDamageRouter : IBattleDamageRouter
         this.guardedHitWindow = guardedHitWindow;
         this.agentNativeMountState = agentNativeMountState;
         this.puppetMountStateRepairer = puppetMountStateRepairer;
-        this.battleDamageCodec = battleDamageCodec;
+        this.battleDamageDataMapper = battleDamageDataMapper;
 
         messageBroker.Subscribe<BattlePuppetHit>(Handle_BattlePuppetHit);
         messageBroker.Subscribe<NetworkApplyBattleDamage>(Handle_NetworkApplyBattleDamage);
@@ -412,7 +412,7 @@ public class BattleDamageRouter : IBattleDamageRouter
     {
         Blow blow = pending.Hit.Blow;
         AttackCollisionData collisionData = pending.Hit.CollisionData;
-        BattleDamageData damageData = battleDamageCodec.Encode(in blow, in collisionData);
+        BattleDamageData damageData = battleDamageDataMapper.Pack(in blow, in collisionData);
         return new NetworkApplyBattleDamage(
             victimId,
             pending.AttackerId,
@@ -426,7 +426,7 @@ public class BattleDamageRouter : IBattleDamageRouter
     private void Handle_NetworkApplyBattleDamage(MessagePayload<NetworkApplyBattleDamage> payload)
     {
         NetworkApplyBattleDamage damage = payload.What;
-        if (!battleDamageCodec.TryDecode(
+        if (!battleDamageDataMapper.TryResolve(
                 damage.DamageData,
                 out Blow blow,
                 out AttackCollisionData collisionData))

--- a/source/Missions/Battles/BattleDamageRouter.cs
+++ b/source/Missions/Battles/BattleDamageRouter.cs
@@ -40,6 +40,7 @@ public class BattleDamageRouter : IBattleDamageRouter
     private readonly IGuardedHitWindow guardedHitWindow;
     private readonly IAgentNativeMountState agentNativeMountState;
     private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
+    private readonly IBattleDamageCodec battleDamageCodec;
     private readonly Func<Agent, bool?> mountAuthorityProbe;
     private readonly object inboundDamageGate = new();
     private readonly ConcurrentQueue<NetworkApplyBattleDamage> inboundDamage = new();
@@ -134,7 +135,8 @@ public class BattleDamageRouter : IBattleDamageRouter
         ICoopMissionComponent coopMissionComponent, IBattleSession session,
         IGuardedHitWindow guardedHitWindow,
         IAgentNativeMountState agentNativeMountState,
-        IPuppetMountStateRepairer puppetMountStateRepairer)
+        IPuppetMountStateRepairer puppetMountStateRepairer,
+        IBattleDamageCodec battleDamageCodec)
     {
         this.network = network;
         this.messageBroker = messageBroker;
@@ -143,6 +145,7 @@ public class BattleDamageRouter : IBattleDamageRouter
         this.guardedHitWindow = guardedHitWindow;
         this.agentNativeMountState = agentNativeMountState;
         this.puppetMountStateRepairer = puppetMountStateRepairer;
+        this.battleDamageCodec = battleDamageCodec;
 
         messageBroker.Subscribe<BattlePuppetHit>(Handle_BattlePuppetHit);
         messageBroker.Subscribe<NetworkApplyBattleDamage>(Handle_NetworkApplyBattleDamage);
@@ -353,13 +356,10 @@ public class BattleDamageRouter : IBattleDamageRouter
                     hit.Blow.IsMissile,
                     pending.ShotSequence);
             }
-            network.SendAll(new NetworkApplyBattleDamage(
+            network.SendAll(CreateNetworkDamage(
                 victimInfo.AgentId,
-                pending.AttackerId,
-                hit.Blow,
-                hit.CollisionData,
-                missileShotSequence: pending.ShotSequence,
-                attackerWeapon: pending.AttackerWeapon));
+                pending,
+                isMount: false));
             return;
         }
 
@@ -385,14 +385,10 @@ public class BattleDamageRouter : IBattleDamageRouter
                     hit.Blow.IsMissile,
                     pending.ShotSequence);
             }
-            network.SendAll(new NetworkApplyBattleDamage(
+            network.SendAll(CreateNetworkDamage(
                 riderInfo.AgentId,
-                pending.AttackerId,
-                hit.Blow,
-                hit.CollisionData,
-                isMount: true,
-                missileShotSequence: pending.ShotSequence,
-                attackerWeapon: pending.AttackerWeapon));
+                pending,
+                isMount: true));
             return;
         }
 
@@ -408,9 +404,40 @@ public class BattleDamageRouter : IBattleDamageRouter
             hit.Victim?.IsMount ?? hit.IsMount,
             hit.Blow.IsMissile);
     }
+
+    private NetworkApplyBattleDamage CreateNetworkDamage(
+        Guid victimId,
+        PendingLocalDamage pending,
+        bool isMount)
+    {
+        Blow blow = pending.Hit.Blow;
+        AttackCollisionData collisionData = pending.Hit.CollisionData;
+        BattleDamageData damageData = battleDamageCodec.Encode(in blow, in collisionData);
+        return new NetworkApplyBattleDamage(
+            victimId,
+            pending.AttackerId,
+            damageData,
+            blow.IsMissile,
+            isMount,
+            pending.ShotSequence,
+            pending.AttackerWeapon);
+    }
+
     private void Handle_NetworkApplyBattleDamage(MessagePayload<NetworkApplyBattleDamage> payload)
     {
         NetworkApplyBattleDamage damage = payload.What;
+        if (!battleDamageCodec.TryDecode(
+                damage.DamageData,
+                out Blow blow,
+                out AttackCollisionData collisionData))
+        {
+            Logger.Error(
+                "[BattleDamage] Dropping routed blow with invalid compact data: victimId={VictimId}",
+                damage.VictimAgentId);
+            return;
+        }
+        damage.AttachDecodedData(blow, collisionData);
+
         if (IsMissileDamage(damage) && damage.MissileShotSequence != 0)
         {
             Vec3 impactVelocity = damage.Blow.WeaponRecord.Velocity;

--- a/source/Missions/Battles/CoopBattleController.cs
+++ b/source/Missions/Battles/CoopBattleController.cs
@@ -103,6 +103,7 @@ public class CoopBattleController : CoopMissionController
         IAgentNativeMountState agentNativeMountState,
         IPuppetMountStateRepairer puppetMountStateRepairer,
         IBattleAgentSpawnBatchCodec spawnBatchCodec,
+        IBattleDamageCodec battleDamageCodec,
         IMissionWeaponDataMapper missionWeaponDataMapper)
         : base(
             network,
@@ -152,7 +153,8 @@ public class CoopBattleController : CoopMissionController
             session,
             guardedHitWindow,
             agentNativeMountState,
-            puppetMountStateRepairer);
+            puppetMountStateRepairer,
+            battleDamageCodec);
         reinforcementFielder = new ReinforcementFielder(messageBroker, objectManager, coopMissionComponent, session, deployment, formationAssigner, casualties, agentBudget);
         authorityMigrator = new BattleAuthorityMigrator(relayNetwork, messageBroker, objectManager, playerManager, coopMissionComponent, session, casualties, deployment, formationAssigner, missionContext, reinforcementFielder);
         puppetSpawner = new PuppetSpawner(

--- a/source/Missions/Battles/CoopBattleController.cs
+++ b/source/Missions/Battles/CoopBattleController.cs
@@ -103,7 +103,7 @@ public class CoopBattleController : CoopMissionController
         IAgentNativeMountState agentNativeMountState,
         IPuppetMountStateRepairer puppetMountStateRepairer,
         IBattleAgentSpawnBatchCodec spawnBatchCodec,
-        IBattleDamageCodec battleDamageCodec,
+        IBattleDamageDataMapper battleDamageDataMapper,
         IMissionWeaponDataMapper missionWeaponDataMapper)
         : base(
             network,
@@ -154,7 +154,7 @@ public class CoopBattleController : CoopMissionController
             guardedHitWindow,
             agentNativeMountState,
             puppetMountStateRepairer,
-            battleDamageCodec);
+            battleDamageDataMapper);
         reinforcementFielder = new ReinforcementFielder(messageBroker, objectManager, coopMissionComponent, session, deployment, formationAssigner, casualties, agentBudget);
         authorityMigrator = new BattleAuthorityMigrator(relayNetwork, messageBroker, objectManager, playerManager, coopMissionComponent, session, casualties, deployment, formationAssigner, missionContext, reinforcementFielder);
         puppetSpawner = new PuppetSpawner(

--- a/source/Missions/Messages/BattleDamageData.cs
+++ b/source/Missions/Messages/BattleDamageData.cs
@@ -1,0 +1,205 @@
+﻿using ProtoBuf;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TaleWorlds.MountAndBlade;
+
+namespace Missions.Messages;
+
+/// <summary>Owned, versioned wire representation of the engine structs needed to replay one routed blow.</summary>
+[ProtoContract(SkipConstructor = true)]
+public class BattleDamageData
+{
+    public const int CurrentVersion = 1;
+
+    [ProtoMember(1)]
+    public readonly int Version = CurrentVersion;
+    [ProtoMember(2)]
+    public readonly BattleBlowData Blow;
+    [ProtoMember(3)]
+    public readonly BattleCollisionData Collision;
+
+    public BattleDamageData(BattleBlowData blow, BattleCollisionData collision)
+    {
+        Blow = blow;
+        Collision = collision;
+    }
+}
+
+/// <summary>Field-owned wire representation of <see cref="Blow"/> and its weapon record.</summary>
+[ProtoContract(SkipConstructor = true)]
+public class BattleBlowData
+{
+    [ProtoMember(1)] public readonly Vec3 WeaponStartingPosition;
+    [ProtoMember(2)] public readonly Vec3 WeaponCurrentPosition;
+    [ProtoMember(3)] public readonly Vec3 WeaponVelocity;
+    [ProtoMember(4)] public readonly ItemFlags ItemFlags;
+    [ProtoMember(5)] public readonly WeaponFlags WeaponFlags;
+    [ProtoMember(6)] public readonly WeaponClass WeaponClass;
+    [ProtoMember(7)] public readonly sbyte WeaponBoneNoToAttach;
+    [ProtoMember(8)] public readonly int AffectorWeaponSlotOrMissileIndex;
+    [ProtoMember(9)] public readonly float WeaponWeight;
+    [ProtoMember(10)] public readonly bool IsMissile;
+    [ProtoMember(11)] public readonly bool IsMaterialMetal;
+    [ProtoMember(12)] public readonly Vec3 GlobalPosition;
+    [ProtoMember(13)] public readonly Vec3 Direction;
+    [ProtoMember(14)] public readonly Vec3 SwingDirection;
+    [ProtoMember(15)] public readonly int InflictedDamage;
+    [ProtoMember(16)] public readonly int SelfInflictedDamage;
+    [ProtoMember(17)] public readonly float BaseMagnitude;
+    [ProtoMember(18)] public readonly float DefenderStunPeriod;
+    [ProtoMember(19)] public readonly float AttackerStunPeriod;
+    [ProtoMember(20)] public readonly float AbsorbedByArmor;
+    [ProtoMember(21)] public readonly float MovementSpeedDamageModifier;
+    [ProtoMember(22)] public readonly StrikeType StrikeType;
+    [ProtoMember(23)] public readonly AgentAttackType AttackType;
+    [ProtoMember(24)] public readonly BlowFlags BlowFlag;
+    [ProtoMember(25)] public readonly int OwnerId;
+    [ProtoMember(26)] public readonly sbyte BoneIndex;
+    [ProtoMember(27)] public readonly BoneBodyPartType VictimBodyPart;
+    [ProtoMember(28)] public readonly DamageTypes DamageType;
+    [ProtoMember(29)] public readonly bool NoIgnore;
+    [ProtoMember(30)] public readonly bool DamageCalculated;
+    [ProtoMember(31)] public readonly bool IsFallDamage;
+    [ProtoMember(32)] public readonly float DamagedPercentage;
+
+    public BattleBlowData(Blow blow)
+    {
+        BlowWeaponRecord weapon = blow.WeaponRecord;
+        WeaponStartingPosition = weapon.StartingPosition;
+        WeaponCurrentPosition = weapon.CurrentPosition;
+        WeaponVelocity = weapon.Velocity;
+        ItemFlags = weapon.ItemFlags;
+        WeaponFlags = weapon.WeaponFlags;
+        WeaponClass = weapon.WeaponClass;
+        WeaponBoneNoToAttach = weapon.BoneNoToAttach;
+        AffectorWeaponSlotOrMissileIndex = weapon.AffectorWeaponSlotOrMissileIndex;
+        WeaponWeight = weapon.Weight;
+        IsMissile = weapon.IsMissile;
+        IsMaterialMetal = weapon._isMaterialMetal;
+        GlobalPosition = blow.GlobalPosition;
+        Direction = blow.Direction;
+        SwingDirection = blow.SwingDirection;
+        InflictedDamage = blow.InflictedDamage;
+        SelfInflictedDamage = blow.SelfInflictedDamage;
+        BaseMagnitude = blow.BaseMagnitude;
+        DefenderStunPeriod = blow.DefenderStunPeriod;
+        AttackerStunPeriod = blow.AttackerStunPeriod;
+        AbsorbedByArmor = blow.AbsorbedByArmor;
+        MovementSpeedDamageModifier = blow.MovementSpeedDamageModifier;
+        StrikeType = blow.StrikeType;
+        AttackType = blow.AttackType;
+        BlowFlag = blow.BlowFlag;
+        OwnerId = blow.OwnerId;
+        BoneIndex = blow.BoneIndex;
+        VictimBodyPart = blow.VictimBodyPart;
+        DamageType = blow.DamageType;
+        NoIgnore = blow.NoIgnore;
+        DamageCalculated = blow.DamageCalculated;
+        IsFallDamage = blow.IsFallDamage;
+        DamagedPercentage = blow.DamagedPercentage;
+    }
+}
+
+/// <summary>Field-owned wire representation of <see cref="AttackCollisionData"/>.</summary>
+[ProtoContract(SkipConstructor = true)]
+public class BattleCollisionData
+{
+    [ProtoMember(1)] public readonly bool AttackBlockedWithShield;
+    [ProtoMember(2)] public readonly bool CorrectSideShieldBlock;
+    [ProtoMember(3)] public readonly bool IsAlternativeAttack;
+    [ProtoMember(4)] public readonly bool IsColliderAgent;
+    [ProtoMember(5)] public readonly bool CollidedWithShieldOnBack;
+    [ProtoMember(6)] public readonly bool IsMissile;
+    [ProtoMember(7)] public readonly bool MissileBlockedWithWeapon;
+    [ProtoMember(8)] public readonly bool MissileHasPhysics;
+    [ProtoMember(9)] public readonly bool EntityExists;
+    [ProtoMember(10)] public readonly bool ThrustTipHit;
+    [ProtoMember(11)] public readonly bool MissileGoneUnderWater;
+    [ProtoMember(12)] public readonly bool MissileGoneOutOfBorder;
+    [ProtoMember(13)] public readonly bool CollidedWithLastBoneSegment;
+    [ProtoMember(14)] public readonly CombatCollisionResult CollisionResult;
+    [ProtoMember(15)] public readonly int AffectorWeaponSlotOrMissileIndex;
+    [ProtoMember(16)] public readonly int StrikeType;
+    [ProtoMember(17)] public readonly int DamageType;
+    [ProtoMember(18)] public readonly sbyte CollisionBoneIndex;
+    [ProtoMember(19)] public readonly BoneBodyPartType VictimHitBodyPart;
+    [ProtoMember(20)] public readonly sbyte AttackBoneIndex;
+    [ProtoMember(21)] public readonly Agent.UsageDirection AttackDirection;
+    [ProtoMember(22)] public readonly int PhysicsMaterialIndex;
+    [ProtoMember(23)] public readonly CombatHitResultFlags CollisionHitResultFlags;
+    [ProtoMember(24)] public readonly float AttackProgress;
+    [ProtoMember(25)] public readonly float CollisionDistanceOnWeapon;
+    [ProtoMember(26)] public readonly float AttackerStunPeriod;
+    [ProtoMember(27)] public readonly float DefenderStunPeriod;
+    [ProtoMember(28)] public readonly float MissileTotalDamage;
+    [ProtoMember(29)] public readonly float MissileStartingBaseSpeed;
+    [ProtoMember(30)] public readonly float ChargeVelocity;
+    [ProtoMember(31)] public readonly float FallSpeed;
+    [ProtoMember(32)] public readonly Vec3 WeaponRotUp;
+    [ProtoMember(33)] public readonly Vec3 WeaponBlowDir;
+    [ProtoMember(34)] public readonly Vec3 CollisionGlobalPosition;
+    [ProtoMember(35)] public readonly Vec3 MissileVelocity;
+    [ProtoMember(36)] public readonly Vec3 MissileStartingPosition;
+    [ProtoMember(37)] public readonly Vec3 VictimAgentCurVelocity;
+    [ProtoMember(38)] public readonly Vec3 CollisionGlobalNormal;
+    [ProtoMember(39)] public readonly Vec3 LastBoneSegmentRotUp;
+    [ProtoMember(40)] public readonly Vec3 LastBoneSegmentSwingDir;
+    [ProtoMember(41)] public readonly float BaseMagnitude;
+    [ProtoMember(42)] public readonly float MovementSpeedDamageModifier;
+    [ProtoMember(43)] public readonly int AbsorbedByArmor;
+    [ProtoMember(44)] public readonly int InflictedDamage;
+    [ProtoMember(45)] public readonly int SelfInflictedDamage;
+    [ProtoMember(46)] public readonly bool IsShieldBroken;
+    [ProtoMember(47)] public readonly bool IsSneakAttack;
+
+    public BattleCollisionData(AttackCollisionData collision)
+    {
+        AttackBlockedWithShield = collision.AttackBlockedWithShield;
+        CorrectSideShieldBlock = collision.CorrectSideShieldBlock;
+        IsAlternativeAttack = collision.IsAlternativeAttack;
+        IsColliderAgent = collision.IsColliderAgent;
+        CollidedWithShieldOnBack = collision.CollidedWithShieldOnBack;
+        IsMissile = collision.IsMissile;
+        MissileBlockedWithWeapon = collision.MissileBlockedWithWeapon;
+        MissileHasPhysics = collision.MissileHasPhysics;
+        EntityExists = collision.EntityExists;
+        ThrustTipHit = collision.ThrustTipHit;
+        MissileGoneUnderWater = collision.MissileGoneUnderWater;
+        MissileGoneOutOfBorder = collision.MissileGoneOutOfBorder;
+        CollidedWithLastBoneSegment = collision.CollidedWithLastBoneSegment;
+        CollisionResult = collision.CollisionResult;
+        AffectorWeaponSlotOrMissileIndex = collision.AffectorWeaponSlotOrMissileIndex;
+        StrikeType = collision.StrikeType;
+        DamageType = collision.DamageType;
+        CollisionBoneIndex = collision.CollisionBoneIndex;
+        VictimHitBodyPart = collision.VictimHitBodyPart;
+        AttackBoneIndex = collision.AttackBoneIndex;
+        AttackDirection = collision.AttackDirection;
+        PhysicsMaterialIndex = collision.PhysicsMaterialIndex;
+        CollisionHitResultFlags = collision.CollisionHitResultFlags;
+        AttackProgress = collision.AttackProgress;
+        CollisionDistanceOnWeapon = collision.CollisionDistanceOnWeapon;
+        AttackerStunPeriod = collision.AttackerStunPeriod;
+        DefenderStunPeriod = collision.DefenderStunPeriod;
+        MissileTotalDamage = collision.MissileTotalDamage;
+        MissileStartingBaseSpeed = collision.MissileStartingBaseSpeed;
+        ChargeVelocity = collision.ChargeVelocity;
+        FallSpeed = collision.FallSpeed;
+        WeaponRotUp = collision.WeaponRotUp;
+        WeaponBlowDir = collision.WeaponBlowDir;
+        CollisionGlobalPosition = collision.CollisionGlobalPosition;
+        MissileVelocity = collision.MissileVelocity;
+        MissileStartingPosition = collision.MissileStartingPosition;
+        VictimAgentCurVelocity = collision.VictimAgentCurVelocity;
+        CollisionGlobalNormal = collision.CollisionGlobalNormal;
+        LastBoneSegmentRotUp = collision.LastBoneSegmentRotUp;
+        LastBoneSegmentSwingDir = collision.LastBoneSegmentSwingDir;
+        BaseMagnitude = collision.BaseMagnitude;
+        MovementSpeedDamageModifier = collision.MovementSpeedDamageModifier;
+        AbsorbedByArmor = collision.AbsorbedByArmor;
+        InflictedDamage = collision.InflictedDamage;
+        SelfInflictedDamage = collision.SelfInflictedDamage;
+        IsShieldBroken = collision.IsShieldBroken;
+        IsSneakAttack = collision.IsSneakAttack;
+    }
+}

--- a/source/Missions/Messages/NetworkApplyBattleDamage.cs
+++ b/source/Missions/Messages/NetworkApplyBattleDamage.cs
@@ -7,17 +7,8 @@ using TaleWorlds.MountAndBlade;
 namespace Missions.Messages;
 
 /// <summary>
-/// Attacker's node → peers (over the mesh): a local troop hit a PUPPET, so route the WHOLE blow to that
-/// puppet's owner. Only the owner (the node with authority) acts on it — re-applying the blow through
-/// <c>Agent.RegisterBlow</c> so the engine resolves real damage, hit reaction, ragdoll and death (the death
-/// then flows through <c>Agent.Die</c> → the death/casualty sync). Routing the real blow (instead of a bare
-/// damage number + a synthetic kill) keeps combat faithful and removes the fixed-magnitude "fatal blow".
-/// <para>
-/// Agent indices are per-client, so the blow's attacker index can't be used as-is: <see cref="AttackerAgentId"/>
-/// carries the attacker's network id and the owner re-maps it to its local agent's index. A replicated visual
-/// missile has a receiver-local index, so the owner clears the sender-local index before applying this already
-/// resolved blow.
-/// </para>
+/// Attacker's node to peers over the mesh: a local troop hit a puppet, so route the resolved blow to
+/// that puppet's owner. Only the owner replays it through <c>Agent.RegisterBlow</c>.
 /// </summary>
 [ProtoContract(SkipConstructor = true)]
 public class NetworkApplyBattleDamage : IEvent
@@ -28,38 +19,45 @@ public class NetworkApplyBattleDamage : IEvent
     [ProtoMember(2)]
     public Guid AttackerAgentId { get; }
     [ProtoMember(3)]
-    public Blow Blow { get; }
-    [ProtoMember(4)]
-    public AttackCollisionData CollisionData { get; }
-    /// <summary>True when the blow targets <see cref="VictimAgentId"/>'s mount, not the rider itself. Fallback
-    /// path only: a REGISTERED mount is routed by its own id (IsMount stays false); an unregistered horse is
-    /// keyed off its rider's id and the owner resolves the rider's current MountAgent at apply time.</summary>
+    public BattleDamageData DamageData { get; }
+    /// <summary>True when the blow targets <see cref="VictimAgentId"/>'s mount, not the rider itself.</summary>
     [ProtoMember(5)]
     public bool IsMount { get; }
-    /// <summary>
-    /// Identity of the exact missile launch that produced this blow. Zero means correlation was unavailable.
-    /// </summary>
+    /// <summary>Identity of the exact missile launch that produced this blow.</summary>
     [ProtoMember(6)]
     public long MissileShotSequence { get; }
-    /// <summary>
-    /// Explicit copy of the engine-private missile bit. Keeping this on the envelope makes presentation and
-    /// correlation independent of the binary layout used to serialize <see cref="Blow"/>.
-    /// </summary>
     [ProtoMember(7)]
     public bool IsMissile { get; }
     /// <summary>The original missile weapon used by vanilla to select the combat skill reward.</summary>
     [ProtoMember(8)]
     public WeaponComponentData AttackerWeapon { get; }
-    public NetworkApplyBattleDamage(Guid victimAgentId, Guid attackerAgentId, Blow blow, AttackCollisionData collisionData,
-        bool isMount = false, long missileShotSequence = 0, WeaponComponentData attackerWeapon = null)
+
+    [ProtoIgnore]
+    public Blow Blow { get; private set; }
+    [ProtoIgnore]
+    public AttackCollisionData CollisionData { get; private set; }
+
+    public NetworkApplyBattleDamage(
+        Guid victimAgentId,
+        Guid attackerAgentId,
+        BattleDamageData damageData,
+        bool isMissile,
+        bool isMount = false,
+        long missileShotSequence = 0,
+        WeaponComponentData attackerWeapon = null)
     {
         VictimAgentId = victimAgentId;
         AttackerAgentId = attackerAgentId;
-        Blow = blow;
-        CollisionData = collisionData;
+        DamageData = damageData;
         IsMount = isMount;
         MissileShotSequence = missileShotSequence;
-        IsMissile = blow.IsMissile;
+        IsMissile = isMissile;
         AttackerWeapon = attackerWeapon;
+    }
+
+    internal void AttachDecodedData(Blow blow, AttackCollisionData collisionData)
+    {
+        Blow = blow;
+        CollisionData = collisionData;
     }
 }

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -70,6 +70,9 @@ public class MissionModule : Module
         builder.RegisterType<BattleAgentSpawnBatchCodec>()
             .As<IBattleAgentSpawnBatchCodec>()
             .InstancePerDependency();
+        builder.RegisterType<BattleDamageCodec>()
+            .As<IBattleDamageCodec>()
+            .InstancePerDependency();
         builder.RegisterType<MissionWeaponDataMapper>()
             .As<IMissionWeaponDataMapper>()
             .InstancePerDependency();

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -70,8 +70,8 @@ public class MissionModule : Module
         builder.RegisterType<BattleAgentSpawnBatchCodec>()
             .As<IBattleAgentSpawnBatchCodec>()
             .InstancePerDependency();
-        builder.RegisterType<BattleDamageCodec>()
-            .As<IBattleDamageCodec>()
+        builder.RegisterType<BattleDamageDataMapper>()
+            .As<IBattleDamageDataMapper>()
             .InstancePerDependency();
         builder.RegisterType<MissionWeaponDataMapper>()
             .As<IMissionWeaponDataMapper>()

--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -382,6 +382,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     public void OnPeerConnected(NetPeer peer)
     {
         bool rejectPeer = false;
+        string controllerIdToPromote = null;
         lock (peerGate)
         {
             if (pendingPeerControllers.TryGetValue(peer, out var controllerId))
@@ -400,11 +401,12 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
                 }
                 else
                 {
-                    PromotePeer(peer, controllerId);
+                    controllerIdToPromote = controllerId;
                 }
             }
         }
 
+        if (controllerIdToPromote != null) PromotePeer(peer, controllerIdToPromote);
         if (rejectPeer) netManager.DisconnectPeer(peer);
 
         // Proof-of-P2P diagnostic: the remote endpoint here is the OTHER CLIENT's socket, reached
@@ -421,6 +423,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         if (entered.SteamId == 0) return;
 
         var invalidPeers = new List<NetPeer>();
+        var peersToPromote = new List<NetPeer>();
         bool alreadyTracked;
         int generation;
         lock (peerGate)
@@ -441,7 +444,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
                 }
                 else if (connectedPendingPeers.Contains(pair.Key))
                 {
-                    PromotePeer(pair.Key, entered.ControllerId);
+                    peersToPromote.Add(pair.Key);
                 }
             }
 
@@ -460,6 +463,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             alreadyTracked = HasTrackedPeer(entered.ControllerId);
         }
 
+        foreach (var peerToPromote in peersToPromote) PromotePeer(peerToPromote, entered.ControllerId);
         foreach (var invalidPeer in invalidPeers) netManager.DisconnectPeer(invalidPeer);
         if (alreadyTracked) return;
 
@@ -575,11 +579,25 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     private void PromotePeer(NetPeer peer, string controllerId)
     {
         // Submit earlier relay traffic before switching this controller to the direct route.
-        reliableMessageBatcher.Flush(controllerId, SendReliableMessagePayload);
-        pendingPeerControllers.Remove(peer);
-        connectedPendingPeers.Remove(peer);
-        mappedPeerControllers[peer] = controllerId;
-        missionContext.MapPeer(controllerId, peer);
+        reliableMessageBatcher.FlushThen(
+            controllerId,
+            SendReliableMessagePayload,
+            () =>
+            {
+                lock (peerGate)
+                {
+                    if (!pendingPeerControllers.TryGetValue(peer, out string pendingControllerId) ||
+                        pendingControllerId != controllerId)
+                    {
+                        return;
+                    }
+
+                    pendingPeerControllers.Remove(peer);
+                    connectedPendingPeers.Remove(peer);
+                    mappedPeerControllers[peer] = controllerId;
+                    missionContext.MapPeer(controllerId, peer);
+                }
+            });
     }
 
     private void RemovePeerTracking(NetPeer peer, out string controllerId)

--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -38,6 +38,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     public NetPeer PeerServer { get; private set; }
 
     private readonly IPacketManager packetManager;
+    private readonly IMessagePacketHandler messagePacketHandler;
 
     private readonly NetManager netManager;
     private readonly IRelayNetwork relayNetwork;
@@ -47,6 +48,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     private readonly IControllerIdProvider controllerIdProvider;
     private readonly ISteamMissionBridge steamBridge;
     private readonly IMovementPacketCompressor movementPacketCompressor;
+    private readonly IReliableMessageBatcher<string> reliableMessageBatcher;
     private readonly Poller poller;
 
     private readonly object peerGate = new();
@@ -87,19 +89,26 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         ICommonSerializer serializer,
         IMessageBroker messageBroker,
         IPacketManager packetManager,
+        IMessagePacketHandler messagePacketHandler,
         IControllerIdProvider controllerIdProvider,
         ISteamMissionBridge steamBridge,
-        IMovementPacketCompressor movementPacketCompressor)
+        IMovementPacketCompressor movementPacketCompressor,
+        IReliableMessageBatcher<string> reliableMessageBatcher)
     {
         Config = config;
         this.relayNetwork = relayNetwork;
         this.missionContext = missionContext;
+        if (reliableMessageBatcher == null)
+            throw new ArgumentNullException(nameof(reliableMessageBatcher));
+
         this.packetManager = packetManager;
+        this.messagePacketHandler = messagePacketHandler;
         this.serializer = serializer;
         this.messageBroker = messageBroker;
         this.controllerIdProvider = controllerIdProvider;
         this.steamBridge = steamBridge;
         this.movementPacketCompressor = movementPacketCompressor;
+        this.reliableMessageBatcher = reliableMessageBatcher;
 
         netManager = new NetManager(this)
         {
@@ -158,15 +167,15 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     public void DisconnectPeers()
     {
         Logger.Debug("Disconnecting P2P peers (keeping socket alive)");
+        // Flush queued reliable sends (notably the NetworkLeaveMission broadcast on OnEndMission)
+        // before dropping the connections, so a graceful leave reliably reaches peers instead of being
+        // cut off by DisconnectAll. The disconnect/timeout path stays the fallback for ungraceful exits.
+        FlushReliableSends();
         lock (peerGate)
         {
             instanceId = null;
             instanceGeneration++;
         }
-        // Flush queued reliable sends (notably the NetworkLeaveMission broadcast on OnEndMission)
-        // before dropping the connections, so a graceful leave reliably reaches peers instead of being
-        // cut off by DisconnectAll. The disconnect/timeout path stays the fallback for ungraceful exits.
-        FlushReliableSends();
         netManager.DisconnectAll();
         steamBridge.Stop();
 
@@ -183,6 +192,8 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         {
             relayPayloadBudgets.Clear();
         }
+
+        reliableMessageBatcher.Clear();
     }
 
     // LiteNetLib 1.3.1 has no synchronous flush, so nudge the logic thread and wait (bounded) for each
@@ -191,6 +202,10 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     // the cap keeps an unresponsive peer from hitching it for more than a frame or two.
     private void FlushReliableSends()
     {
+        reliableMessageBatcher.FlushAll(
+            _ => true,
+            SendReliableMessagePayload);
+
         const int maxWaitMs = 100;
         var stopwatch = Stopwatch.StartNew();
         while (stopwatch.ElapsedMilliseconds < maxWaitMs)
@@ -213,6 +228,14 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     {
         netManager.PollEvents();
         netManager.NatPunchModule.PollEvents();
+        FlushPendingMessages();
+    }
+
+    internal void FlushPendingMessages()
+    {
+        reliableMessageBatcher.FlushAll(
+            IsControllerConnected,
+            SendReliableMessagePayload);
     }
 
     public void ConnectToInstance(string instanceId)
@@ -289,6 +312,8 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         }
 
         missionContext.RemovePeer(peer);
+        if (controllerId != null)
+            reliableMessageBatcher.Flush(controllerId, SendReliableMessagePayload);
         if (remoteSteamId != 0) steamBridge.Disconnect(remoteSteamId);
     }
 
@@ -486,6 +511,8 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             trackedPeer = RemoveTrackedPeer(controllerId);
         }
 
+        reliableMessageBatcher.Remove(controllerId);
+
         if (trackedPeer != null)
         {
             missionContext.RemovePeer(trackedPeer);
@@ -516,6 +543,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         if (trackedPeer == null) return;
 
         missionContext.RemovePeer(trackedPeer);
+        reliableMessageBatcher.Flush(controllerId, SendReliableMessagePayload);
         netManager.DisconnectPeer(trackedPeer);
     }
 
@@ -546,6 +574,8 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
 
     private void PromotePeer(NetPeer peer, string controllerId)
     {
+        // Submit earlier relay traffic before switching this controller to the direct route.
+        reliableMessageBatcher.Flush(controllerId, SendReliableMessagePayload);
         pendingPeerControllers.Remove(peer);
         connectedPendingPeers.Remove(peer);
         mappedPeerControllers[peer] = controllerId;
@@ -612,14 +642,36 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
 
     public void Send(string controllerId, IPacket packet, byte[] data)
     {
-        // Send directly to direct peer
-        if (missionContext.TryGetPeer(controllerId, out var peer))
+        if (packet is MessagePacket messagePacket)
+        {
+            reliableMessageBatcher.Send(
+                controllerId,
+                messagePacket.Data,
+                SendReliableMessagePayload);
+            return;
+        }
+
+        if (packet.DeliveryMethod == DeliveryMethod.ReliableOrdered ||
+            packet.DeliveryMethod == DeliveryMethod.ReliableUnordered)
+        {
+            reliableMessageBatcher.FlushThen(
+                controllerId,
+                SendReliableMessagePayload,
+                () => SendPacketToController(controllerId, packet, data));
+            return;
+        }
+
+        SendPacketToController(controllerId, packet, data);
+    }
+
+    private void SendPacketToController(string controllerId, IPacket packet, byte[] data)
+    {
+        if (missionContext.TryGetPeer(controllerId, out NetPeer peer))
         {
             Send(peer, packet, data);
             return;
         }
 
-        // Otherwise send relay packet to the server
         string relayInstanceId;
         lock (peerGate)
         {
@@ -628,8 +680,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
 
         if (IsMovementPacket(packet))
         {
-            int maxRelayPayloadBytes =
-                GetMaxRelayPayloadBytes(relayInstanceId, controllerId);
+            int maxRelayPayloadBytes = GetMaxRelayPayloadBytes(relayInstanceId, controllerId);
             if (data.Length > maxRelayPayloadBytes)
             {
                 if (maxRelayPayloadBytes > 0)
@@ -651,6 +702,32 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             relayInstanceId,
             controllerId,
             data));
+    }
+
+    private void SendReliableMessagePayload(string controllerId, byte[] data)
+    {
+        if (missionContext.TryGetPeer(controllerId, out NetPeer peer))
+        {
+            peer.Send(data, DeliveryMethod.ReliableOrdered);
+            return;
+        }
+
+        string relayInstanceId;
+        lock (peerGate)
+        {
+            relayInstanceId = instanceId;
+        }
+
+        relayNetwork.SendAll(new RelayPacket(
+            DeliveryMethod.ReliableOrdered,
+            relayInstanceId,
+            controllerId,
+            data));
+    }
+
+    private bool IsControllerConnected(string controllerId)
+    {
+        return missionContext.ControllersInMission.Contains(controllerId);
     }
 
     // Peer-reported MTUs can be optimistic, so cap nonfragmentable sends at a conservative ceiling.
@@ -809,18 +886,33 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             if (!mappedPeerControllers.ContainsKey(peer)) return;
         }
 
-#if DEBUG
-        byte[] serializedPacket = reader.GetRemainingBytes();
-        var packet = serializer.Deserialize<IPacket>(serializedPacket);
-        if (packet is AgentActionPacket actionPacket)
+        HandleReceivedPayload(peer, reader.GetRemainingBytes());
+    }
+
+    internal void HandleReceivedPayload(NetPeer peer, byte[] serializedPacket)
+    {
+        object received = serializer.Deserialize(serializedPacket);
+        if (received is IPacket packet)
         {
-            MissionActionDiagnostics.RecordActionPacketReceived(
-                actionPacket,
-                serializedPacket.Length);
-        }
-#else
-        var packet = serializer.Deserialize<IPacket>(reader.GetRemainingBytes());
+#if DEBUG
+            if (packet is AgentActionPacket actionPacket)
+            {
+                MissionActionDiagnostics.RecordActionPacketReceived(
+                    actionPacket,
+                    serializedPacket.Length);
+            }
 #endif
-        packetManager.HandleReceive(peer, packet);
+            packetManager.HandleReceive(peer, packet);
+        }
+        else if (received is IMessage message)
+        {
+            messagePacketHandler.PublishEvent(peer, message);
+        }
+        else
+        {
+            Logger.Error(
+                "Received mission payload deserialized to neither IPacket nor IMessage: {Type}",
+                received?.GetType());
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Large battles put every combat message in its own reliable packet, while routed damage also serializes the full engine structs into payloads over 9 KB. The 64-packet reliable window backs up, delaying deaths and leaving stale presentation messages able to reach removed agents.

## What is the new behavior?

Related to #3363

Small reliable messages are batched through one shared transient component on both campaign and mission networking, including direct and relay mission routes. Routed damage uses a versioned owned wire format that stays below the batching budget, and blood presentation ignores inactive agents.

## How to test

- `dotnet test source/Common.Tests/Common.Tests.csproj -c Debug`
- run the `BattleMessageBatchingTests`, `BattleDamageCodecTests`, and existing routed-damage E2E tests
- join the same large field battle with two clients and confirm deaths do not fall minutes behind ongoing combat

## Bot Changelog Entry

- Reduced delayed deaths and ghost hit effects in large co-op battles.
