### PR TITLE
Handle mount-affector death replays

### DIFF
--- a/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
@@ -511,6 +511,18 @@ public sealed class MissionEngineFixture : IDisposable
             throw new KeyNotFoundException(
                 $"Missile index {blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex} not in the mock mission's missile set (models Mission.OnAgentHit)");
 
+        int affectorWeaponSlot = blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex;
+        if (!blow.IsMissile
+            && affectorWeaponSlot >= 0
+            && TryActiveMock(out mock)
+            && mock.FindAgentWithIndex(blow.OwnerId) is Agent affectorAgent
+            && AgentMirror.TryGet(affectorAgent, out var affector)
+            && affector.IsMount)
+        {
+            throw new NullReferenceException(
+                "Mount has no equipment for Mission.OnAgentHit's affector weapon lookup");
+        }
+
         victim.Health -= blow.InflictedDamage;
         if (TryActiveMock(out var activeMock)
             && activeMock.DismountRiderOnNextBlow)

--- a/source/E2E.Tests/Services/Missions/BattleDeathMirrorTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDeathMirrorTests.cs
@@ -137,6 +137,52 @@ public class BattleDeathMirrorTests : MissionTestEnvironment
     }
 
     [Fact]
+    public void DeathWithMountAffector_AppliesWithoutReplayingAMissingWeaponSlot()
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        var victimId = Guid.NewGuid();
+        var affectorId = Guid.NewGuid();
+        Agent peerVictim = null!;
+        Agent peerMount = null!;
+        CoopBattleController peerController = null!;
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            peerController = peer.Resolve<CoopBattleController>();
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            peerVictim = mock.SpawnAgent(
+                new AgentBuildData(Game.Current.PlayerTroop).Controller(AgentControllerType.None));
+            peerMount = mock.SpawnMount();
+            Assert.True(registry.TryRegisterAgent("owner", victimId, peerVictim));
+            Assert.True(registry.TryRegisterAgent("owner", affectorId, peerMount));
+
+            peer.Resolve<IMessageBroker>().Publish(this,
+                new NetworkBattleAgentDied(
+                    victimId,
+                    wounded: true,
+                    affectorId,
+                    inflictedDamage: 100,
+                    victimBodyPart: BoneBodyPartType.Chest,
+                    deathAction: 3587));
+
+            Assert.False(registry.TryGetAgentInfo(victimId, out _));
+            Assert.True(registry.TryGetAgentInfo(affectorId, out var affectorInfo));
+            Assert.Same(peerMount, affectorInfo.Agent);
+        });
+
+        Assert.True(AgentMirror.TryGet(peerVictim, out var victimMirror));
+        Assert.False(victimMirror.IsActive);
+        Assert.False(victimMirror.WasKilled);
+        Assert.Equal(3587, victimMirror.DeathAction);
+
+        GC.KeepAlive(peerController);
+    }
+
+    [Fact]
     public void DeathBeforeRegistration_AppliesWhenPendingDeathsDrain()
     {
         using var fixture = new MissionEngineFixture();

--- a/source/Missions/Battles/PuppetDeathApplier.cs
+++ b/source/Missions/Battles/PuppetDeathApplier.cs
@@ -279,11 +279,14 @@ public class PuppetDeathApplier : IPuppetDeathApplier
 
     private static Blow CreateReplicatedBlow(NetworkBattleAgentDied message, int ownerId)
     {
-        return new Blow(ownerId)
+        var blow = new Blow(ownerId)
         {
             InflictedDamage = message.InflictedDamage,
             VictimBodyPart = message.VictimBodyPart,
         };
+        // Death broadcasts carry no weapon. Slot zero makes vanilla dereference a mount's missing equipment.
+        blow.WeaponRecord.AffectorWeaponSlotOrMissileIndex = -1;
+        return blow;
     }
 
     private static KillingBlow CreateReplicatedKillingBlow(Blow blow, int deathAction)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Replicated deaths rebuild a `Blow` without weapon data, leaving its default weapon slot at zero. When the affector is a mount, vanilla tries to read slot zero from the mount's missing equipment and throws before the puppet dies or deregisters.

## What is the new behavior?

Related to #3363

Death replays mark the weapon slot as absent. Vanilla keeps the mount as the affector for attribution but uses an invalid weapon instead of reading mount equipment.

## How to test

- run `BattleDeathMirrorTests`
- run `BattleMountIdentityTests` and `BattleDamageMirrorTests`

## Bot Changelog Entry

- Fixed some mount-charge deaths leaving troops alive on other clients.
