### PR TITLE
StanceLink duplicate id register overflow

### DIFF
--- a/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
+++ b/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
@@ -54,7 +54,6 @@ public class StanceLinkRegistrationGuardTests : IDisposable
 
         FirstClient.Call(() =>
         {
-
             Assert.True(FirstClient.ObjectManager.TryGetObject<IFaction>(faction1Id, out var clientFaction1));
             Assert.True(FirstClient.ObjectManager.TryGetObject<IFaction>(faction2Id, out var clientFaction2));
 
@@ -66,7 +65,6 @@ public class StanceLinkRegistrationGuardTests : IDisposable
         Assert.Empty(FirstClient.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
         Assert.Empty(Server.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
     }
-
 
     [Fact]
     public void BanditMismatchedFaction_Server_NeverPublishesRequestStanceLinkConstructed()

--- a/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
+++ b/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
@@ -1,4 +1,5 @@
-﻿using E2E.Tests.Environment;
+﻿using Common.Util;
+using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
 using GameInterface.Services.StanceLinks.Messages;
 using TaleWorlds.CampaignSystem;
@@ -64,6 +65,37 @@ public class StanceLinkRegistrationGuardTests : IDisposable
         });
         Assert.Empty(FirstClient.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
         Assert.Empty(Server.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
+    }
+
+    [Fact]
+    public void DelayedEliminatedFaction_Server_NeverCreatesStanceLink()
+    {
+        string faction1Id = null;
+        string faction2Id = null;
+        Server.Call(() =>
+        {
+            var faction1 = Kingdom.CreateKingdom("guard_elim_kingdom_5");
+            var faction2 = Kingdom.CreateKingdom("guard_elim_kingdom_6");
+
+            Assert.True(Server.ObjectManager.TryGetId(faction1, out faction1Id));
+            Assert.True(Server.ObjectManager.TryGetId(faction2, out faction2Id));
+            using (new AllowedThread())
+            {
+                faction2.DeactivateKingdom();
+            }
+        });
+
+        FirstClient.Call(() =>
+        {
+            Assert.True(FirstClient.ObjectManager.TryGetObject<IFaction>(faction1Id, out var clientFaction1));
+            Assert.True(FirstClient.ObjectManager.TryGetObject<IFaction>(faction2Id, out var clientFaction2));
+            Assert.False(clientFaction2.IsEliminated);
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.NotNull(FactionManager.Instance.GetStanceLinkInternal(clientFaction1, clientFaction2));
+            }
+        });
+        Assert.Empty(FactionManager.Instance._stances.GetStanceLinks());
     }
 
     [Fact]

--- a/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
+++ b/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
@@ -1,0 +1,149 @@
+﻿using E2E.Tests.Environment;
+using E2E.Tests.Environment.Instance;
+using GameInterface.Services.StanceLinks.Messages;
+using TaleWorlds.CampaignSystem;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.StanceLinks;
+
+public class StanceLinkRegistrationGuardTests : IDisposable
+{
+    private E2ETestEnvironment TestEnvironment { get; }
+    private EnvironmentInstance Server => TestEnvironment.Server;
+    private EnvironmentInstance FirstClient => TestEnvironment.Clients.First();
+
+    public StanceLinkRegistrationGuardTests(ITestOutputHelper output)
+    {
+        TestEnvironment = new E2ETestEnvironment(output);
+    }
+
+    public void Dispose() => TestEnvironment.Dispose();
+
+    [Fact]
+    public void EliminatedFaction_RepeatedServerLookups_NeverPublishAcrossMultipleCalls()
+    {
+        Server.Call(() =>
+        {
+            var faction1 = Kingdom.CreateKingdom("guard_elim_kingdom_3");
+            var faction2 = Kingdom.CreateKingdom("guard_elim_kingdom_4");
+            faction2.DeactivateKingdom();
+
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.NotNull(FactionManager.Instance.GetStanceLinkInternal(faction1, faction2));
+            }
+        });
+
+        Assert.Empty(Server.InternalMessages.GetMessages<RequestStanceLinkConstructed>());
+    }
+
+    [Fact]
+    public void EliminatedFaction_RepeatedClientLookups_NeverPublishAcrossMultipleCalls()
+    {
+        string faction1Id = null;
+        string faction2Id = null;
+        Server.Call(() =>
+        {
+            var faction1 = Kingdom.CreateKingdom("guard_elim_kingdom_3");
+            var faction2 = Kingdom.CreateKingdom("guard_elim_kingdom_4");
+            faction2.DeactivateKingdom();
+
+            Assert.True(Server.ObjectManager.TryGetId(faction1, out faction1Id));
+            Assert.True(Server.ObjectManager.TryGetId(faction2, out faction2Id));
+        });
+
+        FirstClient.Call(() =>
+        {
+
+            Assert.True(FirstClient.ObjectManager.TryGetObject<IFaction>(faction1Id, out var clientFaction1));
+            Assert.True(FirstClient.ObjectManager.TryGetObject<IFaction>(faction2Id, out var clientFaction2));
+
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.NotNull(FactionManager.Instance.GetStanceLinkInternal(clientFaction1, clientFaction2));
+            }
+        });
+        Assert.Empty(FirstClient.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
+    }
+
+
+    [Fact]
+    public void BanditMismatchedFaction_Server_NeverPublishesRequestStanceLinkConstructed()
+    {
+        Server.Call(() =>
+        {
+            var kingdom = Kingdom.CreateKingdom("guard_bandit_kingdom_1");
+            var banditClan = Clan.CreateClan("guard_bandit_clan_1");
+            banditClan.IsBanditFaction = true;
+
+            Assert.True(banditClan.IsBanditFaction);
+            Assert.False(kingdom.IsBanditFaction);
+
+            Assert.NotNull(FactionManager.Instance.GetStanceLinkInternal(kingdom, banditClan));
+        });
+
+        Assert.Empty(Server.InternalMessages.GetMessages<RequestStanceLinkConstructed>());
+    }
+
+    [Fact]
+    public void BanditMisMatchedFaction_Client_NeverPublishesRequestStanceLinkConstructed()
+    {
+        string kingdomId = null;
+        string banditClanId = null;
+        Server.Call(() =>
+        {
+            var kingdom = Kingdom.CreateKingdom("guard_bandit_kingdom_1");
+            var banditClan = Clan.CreateClan("guard_bandit_clan_1");
+            banditClan.IsBanditFaction = true;
+
+            Assert.True(banditClan.IsBanditFaction);
+            Assert.False(kingdom.IsBanditFaction);
+            Server.ObjectManager.TryGetId(kingdom, out kingdomId);
+            Server.ObjectManager.TryGetId(banditClan, out banditClanId);
+        });
+
+        FirstClient.Call(() =>
+        {
+            FirstClient.ObjectManager.TryGetObject<Kingdom>(kingdomId, out var kingdom);
+            FirstClient.ObjectManager.TryGetObject<Clan>(banditClanId, out var banditClan);
+            banditClan.IsBanditFaction = true;
+            Assert.NotNull(FactionManager.Instance.GetStanceLinkInternal(kingdom, banditClan));
+            Assert.True(banditClan.IsBanditFaction);
+            Assert.False(kingdom.IsBanditFaction);
+        });
+        Assert.Empty(FirstClient.InternalMessages.GetMessages<RequestStanceLinkConstructed>());
+    }
+
+    [Fact]
+    public void NormalPair_Client_SendsRequestExactlyOnceAcrossRepeatedLookups()
+    {
+        var server = Server;
+        var client = FirstClient;
+        string faction1Id = null;
+        string faction2Id = null;
+
+        server.Call(() =>
+        {
+            var faction1 = Kingdom.CreateKingdom("guard_client_normal_kingdom_1");
+            var faction2 = Kingdom.CreateKingdom("guard_client_normal_kingdom_2");
+
+            Assert.True(server.ObjectManager.TryGetId(faction1, out faction1Id));
+            Assert.True(server.ObjectManager.TryGetId(faction2, out faction2Id));
+        });
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<IFaction>(faction1Id, out var clientFaction1));
+            Assert.True(client.ObjectManager.TryGetObject<IFaction>(faction2Id, out var clientFaction2));
+
+            var firstLookup = FactionManager.Instance.GetStanceLinkInternal(clientFaction1, clientFaction2);
+
+            var secondLookup = FactionManager.Instance.GetStanceLinkInternal(clientFaction1, clientFaction2);
+
+            Assert.Same(firstLookup, secondLookup);
+        });
+
+        Assert.Single(client.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
+    }
+}

--- a/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
+++ b/source/E2E.Tests/Services/StanceLinks/StanceLinkRegistrationGuardTests.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
+using GameInterface.Services.StanceLinks;
 using GameInterface.Services.StanceLinks.Messages;
 using TaleWorlds.CampaignSystem;
 using Xunit.Abstractions;
@@ -72,16 +73,18 @@ public class StanceLinkRegistrationGuardTests : IDisposable
     {
         string faction1Id = null;
         string faction2Id = null;
+        IFaction faction1 = null;
+        IFaction faction2 = null;
         Server.Call(() =>
         {
-            var faction1 = Kingdom.CreateKingdom("guard_elim_kingdom_5");
-            var faction2 = Kingdom.CreateKingdom("guard_elim_kingdom_6");
+            faction1 = Kingdom.CreateKingdom("guard_elim_kingdom_5");
+            faction2 = Kingdom.CreateKingdom("guard_elim_kingdom_6");
 
             Assert.True(Server.ObjectManager.TryGetId(faction1, out faction1Id));
             Assert.True(Server.ObjectManager.TryGetId(faction2, out faction2Id));
             using (new AllowedThread())
             {
-                faction2.DeactivateKingdom();
+                ((Kingdom)faction2).DeactivateKingdom();
             }
         });
 
@@ -95,7 +98,10 @@ public class StanceLinkRegistrationGuardTests : IDisposable
                 Assert.NotNull(FactionManager.Instance.GetStanceLinkInternal(clientFaction1, clientFaction2));
             }
         });
-        Assert.Empty(FactionManager.Instance._stances.GetStanceLinks());
+        var id = StanceLinkHandler.GetStanceLinkKey(faction1, faction2);
+        var stanceLinkKey = $"{typeof(StanceLink).Name}_{id}";
+        Assert.False(Server.ObjectManager.TryGetObject<StanceLink>(stanceLinkKey, out _));
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<StanceLinkConstructed>());
     }
 
     [Fact]

--- a/source/GameInterface/Services/StanceLinks/StanceLinkHandler.cs
+++ b/source/GameInterface/Services/StanceLinks/StanceLinkHandler.cs
@@ -74,6 +74,7 @@ internal class StanceLinkHandler : IHandler
 
             if (stanceLink == null)
             {
+                if (faction1.IsEliminated || faction2.IsEliminated) return;
                 if (ModInformation.IsServer)
                 {
                     stanceLink = new StanceLink(obj.StanceType, faction1, faction2);

--- a/source/GameInterface/Services/StanceLinks/StanceLinkHandler.cs
+++ b/source/GameInterface/Services/StanceLinks/StanceLinkHandler.cs
@@ -95,7 +95,6 @@ internal class StanceLinkHandler : IHandler
 
             if (!objectManager.AddExisting($"{typeof(StanceLink).Name}_{id}", stanceLink))
             {
-                Logger.Error("Unable to register StanceLink with id {Id}", id);
                 return;
             }
             if (ModInformation.IsServer)

--- a/source/GameInterface/Services/StanceLinks/StanceLinkPatches.cs
+++ b/source/GameInterface/Services/StanceLinks/StanceLinkPatches.cs
@@ -23,6 +23,7 @@ internal class StanceLinkPatches
     {
         if (CallOriginalPolicy.IsOriginalAllowed()) return true;
         if (faction1.IsBanditFaction != faction2.IsBanditFaction) return true;
+        if (faction1.IsEliminated || faction2.IsEliminated) return true;
 
         StanceLink stanceLink = __instance._stances.GetStance(faction1, faction2);
         if (stanceLink == null)


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ x ] All new classes have class-level documentation comments, if there are any at all
- [ x ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, `StanceLinks` that contain one or more eliminated factions, still send a message to the server,  where the server creates the new `StanceLink`, because `_stances` is empty.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
`StanceLinks` do not get sent to the server or to other clients when one of the factions are eliminated.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information
