### PR TITLE
Fix troop duplication after donating items

### DIFF
--- a/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
@@ -7,7 +7,6 @@ using GameInterface.Services.Inventory.Data;
 using GameInterface.Services.Inventory.Interfaces;
 using GameInterface.Services.Inventory.Messages;
 using GameInterface.Services.ObjectManager;
-using GameInterface.Services.TroopRosters.Interfaces;
 using GameInterface.Services.Workshops.Messages;
 using HarmonyLib;
 using Helpers;
@@ -31,20 +30,17 @@ internal class TradeHandler : IHandler
     private readonly IMessageBroker messageBroker;
     private readonly IObjectManager objectManager;
     private readonly INetwork network;
-    private readonly ITroopRosterInterface troopRosterInterface;
 
     public TradeHandler(
         IInventoryLogicInterface inventoryLogicInterface,
         IMessageBroker messageBroker,
         IObjectManager objectManager,
-        INetwork network,
-        ITroopRosterInterface troopRosterInterface)
+        INetwork network)
     {
         this.inventoryLogicInterface = inventoryLogicInterface;
         this.messageBroker = messageBroker;
         this.objectManager = objectManager;
         this.network = network;
-        this.troopRosterInterface = troopRosterInterface;
 
         messageBroker.Subscribe<TradeAttempted>(Handle_TradeAttempted);
         messageBroker.Subscribe<CompleteTrade>(Handle_CompleteTrade);
@@ -74,7 +70,6 @@ internal class TradeHandler : IHandler
         if (!objectManager.TryGetIdWithLogging(what.ToRoster, out var toRosterId)) return;
         if (!objectManager.TryGetIdWithLogging(what.Hero, out var heroId)) return;
         if (!objectManager.TryGetIdWithLogging(what.OwnerParty, out var ownerPartyId)) return;
-        if (!objectManager.TryGetIdWithLogging(what.TroopRoster, out var troopRosterId)) return;
         if (!objectManager.TryGetIdWithLogging(what.InitialCharacterEquipment.HeroObject, out var initialHeroId)) return;
 
         // CurrentMobileParty can be already destroyed when this logic runs. Attempt to get an id without logging
@@ -93,8 +88,6 @@ internal class TradeHandler : IHandler
         }
 
         var characterIdEquipmentsData = ResolveCharacterIdEquipmentsData(what.OwnerParty, what.InitialCharacterEquipment);
-
-        var troopRosterData = troopRosterInterface.PackTroopRosterData(what.TroopRoster);
 
         var message = new CompleteTrade(
             fromRosterId,
@@ -115,9 +108,7 @@ internal class TradeHandler : IHandler
             currentSettlementComponentId is null,
             currentSettlementComponentId,
             boughtItems,
-            soldItems,
-            troopRosterId,
-            troopRosterData
+            soldItems
         );
 
         network.SendAll(message);
@@ -136,7 +127,6 @@ internal class TradeHandler : IHandler
             if (!objectManager.TryGetObjectWithLogging<ItemRoster>(message.ToItemRosterId, out var toRoster)) return;
             if (!objectManager.TryGetObjectWithLogging<Hero>(message.HeroId, out var hero)) return;
             if (!objectManager.TryGetObjectWithLogging<MobileParty>(message.OwnerPartyId, out var ownerParty)) return;
-            if (!objectManager.TryGetObjectWithLogging<TroopRoster>(message.TroopRosterId, out var troopRoster)) return;
             if (!objectManager.TryGetObjectWithLogging<Hero>(message.InitialHeroId, out var initialHero)) return;
 
             SettlementComponent currentSettlementComponent = null;
@@ -189,9 +179,6 @@ internal class TradeHandler : IHandler
             // Update hero equipment with new data
             inventoryLogicInterface.UpdateEquipmentWithData(ownerParty, characterEquipmentsData, initialHero);
             network.SendAll(new UpdateEquipmentClients(message.CharacterIdEquipmentsData, message.OwnerPartyId, message.InitialHeroId));
-
-            // Update troop roster for if items were donated
-            troopRosterInterface.UpdateWithData(troopRoster, message.TroopRosterData, hero);
 
             inventoryLogicInterface.ApplyDoneLogic(
                 fromRoster,

--- a/source/GameInterface/Services/Inventory/Messages/CompleteTrade.cs
+++ b/source/GameInterface/Services/Inventory/Messages/CompleteTrade.cs
@@ -1,6 +1,5 @@
 ﻿using Common.Messaging;
 using GameInterface.Services.Inventory.Data;
-using GameInterface.Services.TroopRosters.Data;
 using ProtoBuf;
 using System.Collections.Generic;
 using TaleWorlds.Core;
@@ -50,11 +49,6 @@ internal readonly struct CompleteTrade : ICommand
     [ProtoMember(19)]
     public readonly (ItemRosterElementData, int)[] SoldItems;
 
-    [ProtoMember(20)]
-    public readonly string TroopRosterId;
-    [ProtoMember(21)]
-    public readonly TroopRosterData TroopRosterData;
-
     public CompleteTrade(
         string fromItemRosterId,
         bool isFromItemRosterNull,
@@ -74,9 +68,7 @@ internal readonly struct CompleteTrade : ICommand
         bool isSettlementComponentNull,
         string currentSettlementComponentId,
         (ItemRosterElementData, int)[] boughtItems,
-        (ItemRosterElementData, int)[] soldItems,
-        string troopRosterId,
-        TroopRosterData troopRosterData)
+        (ItemRosterElementData, int)[] soldItems)
     {
         FromItemRosterId = fromItemRosterId;
         IsFromItemRosterNull = isFromItemRosterNull;
@@ -97,7 +89,5 @@ internal readonly struct CompleteTrade : ICommand
         CurrentSettlementComponentId = currentSettlementComponentId;
         BoughtItems = boughtItems;
         SoldItems = soldItems;
-        TroopRosterId = troopRosterId;
-        TroopRosterData = troopRosterData;
     }
 }

--- a/source/GameInterface/Services/Inventory/Messages/TradeAttempted.cs
+++ b/source/GameInterface/Services/Inventory/Messages/TradeAttempted.cs
@@ -25,7 +25,6 @@ public readonly struct TradeAttempted : IEvent
     public readonly SettlementComponent CurrentSettlementComponent;
     public readonly List<(ItemRosterElement, int)> BoughtItems;
     public readonly List<(ItemRosterElement, int)> SoldItems;
-    public readonly TroopRoster TroopRoster;
 
     public TradeAttempted(
         ItemRoster fromRoster,
@@ -41,8 +40,7 @@ public readonly struct TradeAttempted : IEvent
         MobileParty currentMobileParty,
         SettlementComponent currentSettlementComponent,
         List<(ItemRosterElement, int)> boughtItems,
-        List<(ItemRosterElement, int)> soldItems,
-        TroopRoster troopRoster)
+        List<(ItemRosterElement, int)> soldItems)
     {
         FromRoster = fromRoster;
         ToRoster = toRoster;
@@ -58,6 +56,5 @@ public readonly struct TradeAttempted : IEvent
         CurrentSettlementComponent = currentSettlementComponent;
         BoughtItems = boughtItems;
         SoldItems = soldItems;
-        TroopRoster = troopRoster;
     }
 }

--- a/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
+++ b/source/GameInterface/Services/Inventory/Patches/InventoryLogicPatches.cs
@@ -7,7 +7,6 @@ using HarmonyLib;
 using Serilog;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem.Inventory;
-using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 
 namespace GameInterface.Services.Inventory.Patches;
@@ -66,8 +65,7 @@ internal class InventoryLogicPatches
             __instance.CurrentMobileParty,
             __instance.CurrentSettlementComponent,
             __instance.GetBoughtItems(),
-            __instance.GetSoldItems(),
-            PartyBase.MainParty.MemberRoster
+            __instance.GetSoldItems()
         );
 
         MessageBroker.Instance.Publish(__instance, message);


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`TradeHandler` still incorrectly rebuilds the `TroopRoster` after `DoneLogic`. This is leftover from an early implementation when it was assumed that the full state would be applied on the server. Item donation was changed to apply the xp to troops on the server and this rebuild does nothing but cause stale `TroopRosterElement`s to be sent to the server.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3293 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Remove the `troopRosterInterface.UpdateWithData` call from `TradeHandler`. The `TroopRoster` rebuild was only relevant for donation xp which is now distributed on the authoritative roster server-side.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed an issue where troops could be duplicated through upgrades after donating items.
