### PR TITLE
Bind manual nightly dispatch to the due cutoff date

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       release_date:
-        description: Release date to rebuild (YYYY-MM-DD); defaults to today in Central time
+        description: Due nightly date (YYYY-MM-DD). Leave empty to use the current 11:57 PM Central cutoff.
         required: false
         type: string
 
@@ -115,6 +115,13 @@ jobs:
           REQUESTED_RELEASE_DATE: ${{ inputs.release_date }}
         run: |
           set -eu
+          due_epoch=$(date +%s)
+          due_hour=$(TZ=America/Chicago date +%H)
+          due_minute=$(TZ=America/Chicago date +%M)
+          if [ "$due_hour" -lt 23 ] || { [ "$due_hour" -eq 23 ] && [ "$due_minute" -lt 57 ]; }; then
+            due_epoch=$((due_epoch - 86400))
+          fi
+          due_date=$(TZ=America/Chicago date -d "@$due_epoch" +%F)
           if [ -n "$REQUESTED_RELEASE_DATE" ]; then
             if ! printf '%s\n' "$REQUESTED_RELEASE_DATE" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
               echo 'release_date must use YYYY-MM-DD' >&2
@@ -125,15 +132,12 @@ jobs:
               echo 'release_date is not a valid calendar date' >&2
               exit 1
             fi
-          else
-            release_epoch=$(date +%s)
-            if [ "$GITHUB_EVENT_NAME" = schedule ]; then
-              release_hour=$(TZ=America/Chicago date +%H)
-              release_minute=$(TZ=America/Chicago date +%M)
-              if [ "$release_hour" -lt 23 ] || { [ "$release_hour" -eq 23 ] && [ "$release_minute" -lt 57 ]; }; then
-                release_epoch=$((release_epoch - 86400))
-              fi
+            if [ "$REQUESTED_RELEASE_DATE" != "$due_date" ]; then
+              echo 'release_date must be the currently due nightly' >&2
+              exit 1
             fi
+          else
+            release_epoch=$due_epoch
           fi
           release_date=$(TZ=America/Chicago date -d "@$release_epoch" +%F)
           display_date=$(TZ=America/Chicago date -d "@$release_epoch" +%m-%d-%Y)


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI related changes

## What is the current behavior?

`workflow_dispatch` with an empty date uses today's Central calendar date. A morning recovery of a missed 11:57 PM cron therefore labels the build as the next day. A typed historical `release_date` is also accepted.

## What is the new behavior?

Blank and typed dates must be the currently due nightly: after 11:57 PM Central that calendar day, otherwise yesterday. A historical date fails the metadata step.

## Test plan

- [ ] Run workflow with an empty date this morning and confirm `release_date` is `2026-08-26`
- [ ] Run workflow with `2026-08-26` and confirm it builds
- [ ] Run workflow with `2026-08-01` and confirm it fails

## Bot Changelog Entry
