### PR TITLE
Load heroes in settlement when connecting

### DIFF
--- a/source/GameInterface/Services/Locations/Handlers/LocationHandler.cs
+++ b/source/GameInterface/Services/Locations/Handlers/LocationHandler.cs
@@ -220,11 +220,21 @@ public class LocationHandler : IHandler
                 ReconcileSettlementRosters(locationComplex, obj.Entries ?? Array.Empty<LocationCharacterData>());
             }
 
+            if (Settlement.CurrentSettlement != settlement) return;
+
             // Update settlement overlay if relevant to this client
             var overlay = MapScreen.Instance?._menuViewContext?.GetMenuView<GauntletMenuOverlayBaseView>()?._overlayDataSource as SettlementMenuOverlayVM;
-            if (settlement == null || overlay?._settlement != settlement) return;
+            if (overlay?._settlement == settlement)
+            {
+                overlay.Refresh();
+            }
 
-            overlay.Refresh();
+            // Update menu options. Certain options can remain unavailable like entering a keep
+            var menuContext = Campaign.Current?.CurrentMenuContext;
+            if (menuContext?.GameMenu != null)
+            {
+                Campaign.Current.GameMenuManager.RefreshMenuOptionConditions(menuContext);
+            }
         });
     }
 

--- a/source/GameInterface/Services/Locations/Handlers/LocationHandler.cs
+++ b/source/GameInterface/Services/Locations/Handlers/LocationHandler.cs
@@ -4,9 +4,12 @@ using Common.Messaging;
 using Common.Network;
 using Common.Util;
 using GameInterface.Services.Heroes.Extensions;
+using GameInterface.Services.Heroes.Messages;
 using GameInterface.Services.Locations.Messages;
 using GameInterface.Services.Locations.Patches;
 using GameInterface.Services.ObjectManager;
+using SandBox.GauntletUI.Menu;
+using SandBox.View.Map;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -15,6 +18,7 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Settlements.Locations;
+using TaleWorlds.CampaignSystem.ViewModelCollection.GameMenu.Overlay;
 using TaleWorlds.Core;
 
 namespace GameInterface.Services.Locations.Handlers;
@@ -30,7 +34,10 @@ public class LocationHandler : IHandler
     private readonly INetwork network;
     private readonly IObjectManager objectManager;
 
-    public LocationHandler(IMessageBroker messageBroker, INetwork network, IObjectManager objectManager)
+    public LocationHandler(
+        IMessageBroker messageBroker,
+        INetwork network,
+        IObjectManager objectManager)
     {
         this.messageBroker = messageBroker;
         this.network = network;
@@ -48,6 +55,8 @@ public class LocationHandler : IHandler
         messageBroker.Subscribe<NetworkAddLocationSpecialItem>(Handle_NetworkAddLocationSpecialItem);
         messageBroker.Subscribe<NetworkRemoveLocationSpecialItem>(Handle_NetworkRemoveLocationSpecialItem);
         messageBroker.Subscribe<NetworkLocationRosterSnapshot>(Handle_NetworkLocationRosterSnapshot);
+
+        messageBroker.Subscribe<PlayerHeroChanged>(Handle_PlayerHeroChanged);
     }
 
     public void Dispose()
@@ -64,6 +73,8 @@ public class LocationHandler : IHandler
         messageBroker.Unsubscribe<NetworkAddLocationSpecialItem>(Handle_NetworkAddLocationSpecialItem);
         messageBroker.Unsubscribe<NetworkRemoveLocationSpecialItem>(Handle_NetworkRemoveLocationSpecialItem);
         messageBroker.Unsubscribe<NetworkLocationRosterSnapshot>(Handle_NetworkLocationRosterSnapshot);
+
+        messageBroker.Unsubscribe<PlayerHeroChanged>(Handle_PlayerHeroChanged);
     }
 
     private void Handle_LocationCharacterAdded(MessagePayload<LocationCharacterAdded> payload)
@@ -197,19 +208,38 @@ public class LocationHandler : IHandler
 
         var obj = payload.What;
 
-        if (objectManager.TryGetObjectWithLogging(obj.SettlementId, out Settlement settlement) == false) return;
-
-        var locationComplex = settlement.LocationComplex;
-        if (locationComplex == null) return;
-
-        var entries = obj.Entries ?? Array.Empty<LocationCharacterData>();
-
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
+            if (!objectManager.TryGetObjectWithLogging<Settlement>(obj.SettlementId, out var settlement)) return;
+
+            var locationComplex = settlement.LocationComplex;
+            if (locationComplex == null) return;
+
             using (new AllowedThread())
             {
-                ReconcileSettlementRosters(locationComplex, entries);
+                ReconcileSettlementRosters(locationComplex, obj.Entries ?? Array.Empty<LocationCharacterData>());
             }
+
+            // Update settlement overlay if relevant to this client
+            var overlay = MapScreen.Instance?._menuViewContext?.GetMenuView<GauntletMenuOverlayBaseView>()?._overlayDataSource as SettlementMenuOverlayVM;
+            if (settlement == null || overlay?._settlement != settlement) return;
+
+            overlay.Refresh();
+        });
+    }
+
+    private void Handle_PlayerHeroChanged(MessagePayload<PlayerHeroChanged> obj)
+    {
+        if (ModInformation.IsServer) return;
+
+        GameThread.RunSafe(() =>
+        {
+            var settlement = Settlement.CurrentSettlement;
+            if (Hero.MainHero.IsPrisoner || settlement == null || settlement.IsUnderSiege) return;
+
+            if (!objectManager.TryGetIdWithLogging(settlement, out var currentSettlementId)) return;
+
+            network.SendAll(new NetworkRequestLocationRosterSnapshot(currentSettlementId));
         });
     }
 

--- a/source/GameInterface/Services/Locations/Messages/NetworkRequestLocationRosterSnapshot.cs
+++ b/source/GameInterface/Services/Locations/Messages/NetworkRequestLocationRosterSnapshot.cs
@@ -1,0 +1,16 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Locations.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkRequestLocationRosterSnapshot : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string SettlementId;
+
+    public NetworkRequestLocationRosterSnapshot(string settlementId)
+    {
+        SettlementId = settlementId;
+    }
+}

--- a/source/GameInterface/Services/Locations/SettlementPopulationTracker.cs
+++ b/source/GameInterface/Services/Locations/SettlementPopulationTracker.cs
@@ -6,6 +6,8 @@ using GameInterface.Services.Heroes.Extensions;
 using GameInterface.Services.Locations.Messages;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using LiteNetLib;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -35,6 +37,7 @@ internal class SettlementPopulationTracker : IHandler
     private readonly IObjectManager objectManager;
     private readonly FixedTownNpcService fixedTownNpcService;
     private readonly ISettlementHeroSpawnPool heroSpawnPool;
+    private readonly IPlayerManager playerManager;
 
     // Keyed by Settlement.StringId; holds the settlement so cleanup never rescans the campaign.
     private readonly Dictionary<string, Settlement> populatedSettlements = new Dictionary<string, Settlement>();
@@ -45,20 +48,24 @@ internal class SettlementPopulationTracker : IHandler
         INetwork network,
         IObjectManager objectManager,
         FixedTownNpcService fixedTownNpcService,
-        ISettlementHeroSpawnPool heroSpawnPool)
+        ISettlementHeroSpawnPool heroSpawnPool,
+        IPlayerManager playerManager)
     {
         this.messageBroker = messageBroker;
         this.network = network;
         this.objectManager = objectManager;
         this.fixedTownNpcService = fixedTownNpcService;
         this.heroSpawnPool = heroSpawnPool;
+        this.playerManager = playerManager;
 
         messageBroker.Subscribe<SettlementRosterHeroesChanged>(Handle_SettlementRosterHeroesChanged);
+        messageBroker.Subscribe<NetworkRequestLocationRosterSnapshot>(Handle_NetworkRequestLocationRosterSnapshot);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<SettlementRosterHeroesChanged>(Handle_SettlementRosterHeroesChanged);
+        messageBroker.Unsubscribe<NetworkRequestLocationRosterSnapshot>(Handle_NetworkRequestLocationRosterSnapshot);
     }
 
     /// <summary>
@@ -179,10 +186,11 @@ internal class SettlementPopulationTracker : IHandler
     {
         if (ModInformation.IsServer == false) return;
         if (settlement?.LocationComplex == null) return;
-        if (objectManager.TryGetIdWithLogging(settlement, out var settlementId) == false) return;
 
-        GameThread.Run(() =>
+        GameThread.RunSafe(() =>
         {
+            if (objectManager.TryGetIdWithLogging(settlement, out var settlementId) == false) return;
+
             if (populatedSettlements.ContainsKey(settlement.StringId) == false)
             {
                 populatedSettlements.Add(settlement.StringId, settlement);
@@ -203,23 +211,17 @@ internal class SettlementPopulationTracker : IHandler
 
     private void PopulateSettlement(Settlement settlement)
     {
-        var behavior = Campaign.Current?.GetCampaignBehavior<HeroAgentSpawnCampaignBehavior>();
-        if (behavior == null)
+        if (!TryGetHeroAgentSpawnCampaignBehavior(out var behavior)) return;
+
+        foreach (var hero in heroSpawnPool.GetAmbientCandidates(settlement))
         {
-            Logger.Warning("HeroAgentSpawnCampaignBehavior not found; cannot populate {Settlement}", settlement.StringId);
-        }
-        else
-        {
-            foreach (var hero in heroSpawnPool.GetAmbientCandidates(settlement))
+            try
             {
-                try
-                {
-                    behavior.RefreshLocationOfHeroForSettlement(hero, settlement);
-                }
-                catch (Exception e)
-                {
-                    Logger.Warning(e, "Failed to place {Hero} in {Settlement}", hero.StringId, settlement.StringId);
-                }
+                behavior.RefreshLocationOfHeroForSettlement(hero, settlement);
+            }
+            catch (Exception e)
+            {
+                Logger.Warning(e, "Failed to place {Hero} in {Settlement}", hero.StringId, settlement.StringId);
             }
         }
 
@@ -228,8 +230,7 @@ internal class SettlementPopulationTracker : IHandler
 
     private void RefreshHeroPlacement(Hero hero, Settlement settlement)
     {
-        var behavior = Campaign.Current?.GetCampaignBehavior<HeroAgentSpawnCampaignBehavior>();
-        if (behavior == null) return;
+        if (!TryGetHeroAgentSpawnCampaignBehavior(out var behavior)) return;
 
         try
         {
@@ -291,5 +292,34 @@ internal class SettlementPopulationTracker : IHandler
         }
 
         network.SendAll(new NetworkLocationRosterSnapshot(settlementId, entries.ToArray()));
+    }
+
+    private void Handle_NetworkRequestLocationRosterSnapshot(MessagePayload<NetworkRequestLocationRosterSnapshot> obj)
+    {
+        if (ModInformation.IsClient || obj.Who is not NetPeer peer) return;
+
+        var data = obj.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!playerManager.TryGetPlayer(peer, out var player)) return;
+
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var party)) return;
+            if (!objectManager.TryGetObjectWithLogging<Settlement>(data.SettlementId, out var settlement)) return;
+
+            if (party.CurrentSettlement != settlement) return;
+
+            // A loaded player party is already inside, run the settlement-entry event to restore the roster
+            OnPartyEnteredSettlement(settlement, party);
+        });
+    }
+
+    private bool TryGetHeroAgentSpawnCampaignBehavior(out HeroAgentSpawnCampaignBehavior heroAgentSpawnBehavior)
+    {
+        heroAgentSpawnBehavior = Campaign.Current?.GetCampaignBehavior<HeroAgentSpawnCampaignBehavior>();
+        if (heroAgentSpawnBehavior != null) return true;
+
+        Logger.Debug("Skipping hero agent spawn update because the campaign behavior is unavailable");
+        return false;
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Location complex data doesn't persist across save games so a joining player that is already in a settlement can't see any heroes in that settlement until they leave and re-enter it.

<img width="2206" height="662" alt="image" src="https://github.com/user-attachments/assets/530fc788-93e0-4c6e-9b3e-78ad10b29490" />


## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3370
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Load location complex data when a client with a hero in a settlement joins. Also includes a screen refresh on clients when receiving updated location roster snapshots.

<img width="1841" height="503" alt="image" src="https://github.com/user-attachments/assets/d1ecdf83-c44e-481b-ac4e-419ef73b6d9e" />


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed an issue where joining a game when in a settlement wouldn't show the heroes in that settlement.