### PR TITLE
Deploy ModuleData with manual & nightly builds

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -129,6 +129,7 @@ jobs:
             test -s "$binary/$required"
           done
           cp 'deploy/Server Instructions.md' deploy/mod-config.default.json "$module/"
+          cp -R deploy/ModuleData "$module/"
           cp -R UIMovies/. "$module/GUI/Prefabs/"
 
           coop_version=$(sed -n 's/.*<CoopVersion>\([^<]*\)<\/CoopVersion>.*/\1/p' source/Directory.Build.props)

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -172,6 +172,7 @@ jobs:
             test -s "$binary/$required"
           done
           cp 'deploy/Server Instructions.md' deploy/mod-config.default.json "$module/"
+          cp -R deploy/ModuleData "$module/"
           cp -R UIMovies/. "$module/GUI/Prefabs/"
 
           coop_version=$(sed -n 's/.*<CoopVersion>\([^<]*\)<\/CoopVersion>.*/\1/p' source/Directory.Build.props)


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `ModuleData` folder isn't being deployed with the manual and nightly builds. This means custom NPCs, dialogue and tournament fruit throwables aren't loading on deployed versions.