### PR TITLE
Add bug report button visibility option

### DIFF
--- a/UIMovies/CoopOptionsUIMovie.xml
+++ b/UIMovies/CoopOptionsUIMovie.xml
@@ -6,7 +6,7 @@
 
         <Standard.TopPanel Parameter.Title="@MovieTextHeader"/>
 
-        <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="840" HeightSizePolicy="CoverChildren"
+        <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="1050" HeightSizePolicy="CoverChildren"
                    HorizontalAlignment="Center" VerticalAlignment="Center" MarginTop="-80"
                    LayoutImp.LayoutMethod="VerticalTopToBottom">
           <Children>
@@ -150,6 +150,59 @@
 			                                            Brush.FontSize="28"
 			                                            Brush.TextVerticalAlignment="Center"
 			                                            Text="@ShowMapTimeInMissionsText"/>
+			                            </Children>
+			                        </ListPanel>
+			                    </Children>
+			                </ListPanel>
+			            </ItemTemplate>
+			        </ListPanel>
+			    </Children>
+			</ListPanel>
+			<ListPanel DataSource="{BugReportTab}" IsVisible="@IsSelected" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+			           LayoutImp.LayoutMethod="VerticalTopToBottom">
+			    <Children>
+			        <ListPanel DataSource="{Sections}" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+			                   LayoutImp.LayoutMethod="VerticalTopToBottom">
+			            <ItemTemplate>
+			                <ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+			                           LayoutImp.LayoutMethod="VerticalTopToBottom">
+			                    <Children>
+			                        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="48"
+			                                    Brush="Clan.TabControl.Text" Brush.FontSize="36"
+			                                    Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+			                                    Text="@TitleText"/>
+
+			                        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="58"
+			                                    Brush="Clan.TabControl.Text" Brush.FontSize="22" Brush.FontColor="#B8B8B8FF"
+			                                    Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+			                                    Text="@DescriptionText"/>
+
+			                        <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="64"
+			                                   HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
+			                            <Children>
+			                                <ButtonWidget DoNotPassEventsToChildren="true"
+			                                              WidthSizePolicy="Fixed" HeightSizePolicy="Fixed"
+			                                              SuggestedWidth="40" SuggestedHeight="40"
+			                                              VerticalAlignment="Center"
+			                                              Brush="SPOptions.Checkbox.Empty.Button"
+			                                              ButtonType="Toggle"
+			                                              IsSelected="@ShowBugReportButton"
+			                                              ToggleIndicator="ToggleIndicator"
+			                                              UpdateChildrenStates="true">
+			                                    <Children>
+			                                        <BrushWidget Id="ToggleIndicator"
+			                                                     WidthSizePolicy="StretchToParent"
+			                                                     HeightSizePolicy="StretchToParent"
+			                                                     Brush="SPOptions.Checkbox.Full.Button"/>
+			                                    </Children>
+			                                </ButtonWidget>
+			                                <TextWidget WidthSizePolicy="CoverChildren"
+			                                            HeightSizePolicy="StretchToParent"
+			                                            MarginLeft="16"
+			                                            Brush="Clan.TabControl.Text"
+			                                            Brush.FontSize="28"
+			                                            Brush.TextVerticalAlignment="Center"
+			                                            Text="@ShowBugReportButtonText"/>
 			                            </Children>
 			                        </ListPanel>
 			                    </Children>

--- a/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
+++ b/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
@@ -328,17 +328,13 @@ public class CoopLogBugReportTests : IDisposable
     }
 
     [Fact]
-    public async Task Uploader_UploadsServerSaveThenPostsJsonWithLogs()
+    public async Task Uploader_PutsMetadataLogsAndServerSaveInOneMultipartRequest()
     {
         var handler = new RecordingHttpHandler();
         using var httpClient = new HttpClient(handler);
-        const string publishableKey = "test-publishable-key";
-        const string authorizationToken = "server-bound-token";
         using var uploader = new BugReportUploader(
             httpClient,
-            "https://bug-reports.example.test/api/v1/reports",
-            publishableKey,
-            authorizationToken);
+            "https://bug-reports.example.test/api/v1/reports");
         var serverLog = Compress("server diagnostic\n");
         var clientLog = Compress("client diagnostic\n");
         var serverSave = Encoding.UTF8.GetBytes("server campaign save");
@@ -367,17 +363,15 @@ public class CoopLogBugReportTests : IDisposable
         var result = await uploader.UploadAsync(report, CancellationToken.None);
 
         Assert.True(result.Uploaded);
-        Assert.Equal("application/json; charset=utf-8", handler.ContentType);
-        Assert.Equal(publishableKey, handler.ApiKey);
-        Assert.Equal("Bearer " + authorizationToken, handler.Authorization);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(HttpMethod.Put, handler.Method);
+        Assert.StartsWith("multipart/form-data; boundary=", handler.ContentType);
+        Assert.Null(handler.ApiKey);
+        Assert.Null(handler.Authorization);
         Assert.Equal(report.RequestId, handler.IdempotencyKey);
+        Assert.Equal(serverLog, handler.ServerLogBody);
+        Assert.Equal(clientLog, handler.ClientLogBody);
         Assert.Equal(serverSave, handler.ServerSaveBody);
-        Assert.Equal("server-save", handler.ServerSaveArtifact);
-        Assert.Equal(report.RequestId, handler.ServerSaveReportId);
-        Assert.Equal("coop_bug_report.sav", handler.ServerSaveFileName);
-        Assert.Equal(publishableKey, handler.ServerSaveApiKey);
-        Assert.Equal("Bearer " + authorizationToken, handler.ServerSaveAuthorization);
-        Assert.Equal(report.RequestId + "-server-save", handler.ServerSaveIdempotencyKey);
         using var json = JsonDocument.Parse(handler.Body);
         var root = json.RootElement;
         Assert.Equal("network-client-1", root.GetProperty("reportingClientNetworkId").GetString());
@@ -385,27 +379,25 @@ public class CoopLogBugReportTests : IDisposable
         Assert.Equal(ModInformation.Version.ToString(), root.GetProperty("moduleVersion").GetString());
         Assert.Equal(ModInformation.Commit, root.GetProperty("commit").GetString());
         Assert.Equal(ModInformation.BuildVersion, root.GetProperty("buildVersion").GetString());
-        Assert.Equal(
-            Convert.ToBase64String(serverLog),
-            root.GetProperty("serverLog").GetProperty("data").GetString());
-        Assert.Equal(
-            Convert.ToBase64String(clientLog),
-            root.GetProperty("clientLogs")[0].GetProperty("data").GetString());
-        Assert.Equal(2, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal(3, root.GetProperty("schemaVersion").GetInt32());
+        Assert.Equal("gzip", root.GetProperty("serverLog").GetProperty("contentEncoding").GetString());
+        Assert.Equal(serverLog.Length, root.GetProperty("serverLog").GetProperty("compressedLength").GetInt32());
+        Assert.False(root.GetProperty("serverLog").TryGetProperty("data", out _));
+        Assert.Equal("gzip", root.GetProperty("clientLogs")[0].GetProperty("contentEncoding").GetString());
+        Assert.Equal(clientLog.Length, root.GetProperty("clientLogs")[0].GetProperty("compressedLength").GetInt32());
+        Assert.False(root.GetProperty("clientLogs")[0].TryGetProperty("data", out _));
         Assert.Equal("server-save", root.GetProperty("serverSave").GetProperty("artifact").GetString());
         Assert.Equal(serverSave.Length, root.GetProperty("serverSave").GetProperty("length").GetInt64());
     }
 
     [Fact]
-    public async Task Uploader_DoesNotPostReportWhenServerSaveUploadFails()
+    public async Task Uploader_ReturnsFailureWhenMultipartPutFails()
     {
-        var handler = new RecordingHttpHandler { FailServerSaveUpload = true };
+        var handler = new RecordingHttpHandler { FailUpload = true };
         using var httpClient = new HttpClient(handler);
         using var uploader = new BugReportUploader(
             httpClient,
-            "https://bug-reports.example.test/api/v1/reports",
-            "test-publishable-key",
-            "server-bound-token");
+            "https://bug-reports.example.test/api/v1/reports");
         var report = new BugReportArchiveContents(
             Guid.NewGuid().ToString("N"),
             "network-client-1",
@@ -425,32 +417,32 @@ public class CoopLogBugReportTests : IDisposable
         var result = await uploader.UploadAsync(report, CancellationToken.None);
 
         Assert.False(result.Uploaded);
-        Assert.Null(handler.Body);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.NotNull(handler.Body);
         Assert.NotNull(handler.ServerSaveBody);
     }
 
     [Fact]
-    public void Uploader_DefaultConfigurationIsDisabled()
+    public void Uploader_DefaultConfigurationUsesPublicEdgeFunction()
     {
         using var httpClient = new HttpClient(new RecordingHttpHandler());
         using var uploader = new BugReportUploader(httpClient);
 
-        Assert.False(uploader.IsConfigured);
-        Assert.EndsWith(".invalid/api/v1/reports", BugReportUploader.Endpoint);
+        Assert.True(uploader.IsConfigured);
+        Assert.Equal(
+            "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/create-github-issue-bug-report",
+            BugReportUploader.Endpoint);
     }
 
     [Fact]
-    public void Uploader_DoesNotTreatPublishableKeyAsServerAuthorization()
+    public void Uploader_AnonymousEndpointDoesNotRequireCredentials()
     {
         using var httpClient = new HttpClient(new RecordingHttpHandler());
-        const string publishableKey = "test-publishable-key";
         using var uploader = new BugReportUploader(
             httpClient,
-            "https://bug-reports.example.test/api/v1/reports",
-            publishableKey,
-            publishableKey);
+            "https://bug-reports.example.test/api/v1/reports");
 
-        Assert.False(uploader.IsConfigured);
+        Assert.True(uploader.IsConfigured);
     }
 
     [Fact]
@@ -518,61 +510,45 @@ public class CoopLogBugReportTests : IDisposable
 
     private sealed class RecordingHttpHandler : HttpMessageHandler
     {
+        public int RequestCount { get; private set; }
+        public HttpMethod Method { get; private set; }
         public string Body { get; private set; }
         public string ContentType { get; private set; }
         public string ApiKey { get; private set; }
         public string Authorization { get; private set; }
         public string IdempotencyKey { get; private set; }
+        public byte[] ServerLogBody { get; private set; }
+        public byte[] ClientLogBody { get; private set; }
         public byte[] ServerSaveBody { get; private set; }
-        public string ServerSaveArtifact { get; private set; }
-        public string ServerSaveReportId { get; private set; }
-        public string ServerSaveFileName { get; private set; }
-        public string ServerSaveApiKey { get; private set; }
-        public string ServerSaveAuthorization { get; private set; }
-        public string ServerSaveIdempotencyKey { get; private set; }
-        public bool FailServerSaveUpload { get; set; }
+        public bool FailUpload { get; set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (request.Method == HttpMethod.Put)
+            RequestCount++;
+            Method = request.Method;
+            ContentType = request.Content.Headers.ContentType.ToString();
+            ApiKey = request.Headers.TryGetValues("apikey", out var apiKeys)
+                ? string.Join(string.Empty, apiKeys)
+                : null;
+            Authorization = request.Headers.Authorization?.ToString();
+            IdempotencyKey = string.Join(string.Empty, request.Headers.GetValues("Idempotency-Key"));
+
+            var multipart = Assert.IsType<MultipartFormDataContent>(request.Content);
+            foreach (var part in multipart)
             {
-                ServerSaveBody = await request.Content.ReadAsByteArrayAsync();
-                ServerSaveArtifact = string.Join(
-                    string.Empty,
-                    request.Headers.GetValues("X-Bug-Report-Artifact"));
-                ServerSaveReportId = string.Join(
-                    string.Empty,
-                    request.Headers.GetValues("X-Bug-Report-Id"));
-                ServerSaveFileName = string.Join(
-                    string.Empty,
-                    request.Headers.GetValues("X-Bug-Report-File-Name"));
-                ServerSaveApiKey = string.Join(string.Empty, request.Headers.GetValues("apikey"));
-                ServerSaveAuthorization = request.Headers.Authorization?.ToString();
-                ServerSaveIdempotencyKey = string.Join(
-                    string.Empty,
-                    request.Headers.GetValues("Idempotency-Key"));
-                if (FailServerSaveUpload)
-                {
-                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
-                    {
-                        Content = new StringContent("save rejected"),
-                    };
-                }
-            }
-            else
-            {
-                ContentType = request.Content.Headers.ContentType.ToString();
-                ApiKey = string.Join(string.Empty, request.Headers.GetValues("apikey"));
-                Authorization = request.Headers.Authorization?.ToString();
-                IdempotencyKey = string.Join(string.Empty, request.Headers.GetValues("Idempotency-Key"));
-                Body = await request.Content.ReadAsStringAsync();
+                var name = part.Headers.ContentDisposition.Name.Trim('"');
+                if (name == "report") Body = await part.ReadAsStringAsync();
+                else if (name == "serverLog") ServerLogBody = await part.ReadAsByteArrayAsync();
+                else if (name == "serverSave") ServerSaveBody = await part.ReadAsByteArrayAsync();
+                else if (name == BugReportUploader.GetClientLogPartName(1))
+                    ClientLogBody = await part.ReadAsByteArrayAsync();
             }
 
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            return new HttpResponseMessage(FailUpload ? HttpStatusCode.BadRequest : HttpStatusCode.OK)
             {
-                Content = new StringContent("accepted"),
+                Content = new StringContent(FailUpload ? "report rejected" : "accepted"),
             };
         }
     }

--- a/source/GameInterface.Tests/Services/UI/BugReportOptionsTests.cs
+++ b/source/GameInterface.Tests/Services/UI/BugReportOptionsTests.cs
@@ -1,0 +1,111 @@
+﻿using Common.Messaging;
+using GameInterface.Services.UI.BugReporting;
+using GameInterface.Services.UI.CoopOptions;
+using GameInterface.Services.UI.CoopOptions.Providers.BugReportTab;
+using GameInterface.Services.UI.CoopOptions.Providers.BugReportTab.Sections;
+using GameInterface.Services.UI.Messages;
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Services.UI;
+
+public class BugReportOptionsTests
+{
+    [Fact]
+    public void BugReportOptions_DefaultToShowingTheButton()
+    {
+        using var messageBroker = new MessageBroker();
+        var provider = new BugReportOptionsTabProvider();
+
+        var tab = provider.CreateTab(new CoopOptionsData(), messageBroker, _ => { });
+
+        Assert.Equal(BugReportOptionsTabProvider.TabName, tab.Name);
+        Assert.Equal(BugReportOptionsTabProvider.TabId, tab.Id);
+
+        var section = Assert.IsType<BugReportSection>(Assert.Single(tab.Sections));
+        Assert.Equal(BugReportSection.SectionId, section.Id);
+        Assert.True(section.ShowBugReportButton);
+    }
+
+    [Fact]
+    public void CoopOptionsMovie_BindsBugReportTabAndButtonVisibility()
+    {
+        var document = XDocument.Load(FindMoviePath());
+
+        var tab = Assert.Single(document.Descendants("ListPanel"),
+            element => element.Attribute("DataSource")?.Value == "{BugReportTab}");
+        Assert.Equal("@IsSelected", tab.Attribute("IsVisible")?.Value);
+        Assert.Single(tab.Descendants("ButtonWidget"),
+            element => element.Attribute("IsSelected")?.Value == "@ShowBugReportButton");
+    }
+
+    [Fact]
+    public void BugReportButtonHidden_PersistsAndPublishesAfterApply()
+    {
+        var filePath = CreateTempFilePath();
+
+        try
+        {
+            var store = new CoopOptionsStore(filePath);
+            using var messageBroker = new MessageBroker();
+            BugReportVisibilitySelected? selected = null;
+            Action<MessagePayload<BugReportVisibilitySelected>> handler = payload => selected = payload.What;
+            messageBroker.Subscribe(handler);
+            var existingOptions = store.LoadOrDefault();
+            existingOptions.SetSection(
+                BugReportConsentCoordinator.TabId,
+                BugReportConsentCoordinator.SectionId,
+                new BugReportConsentOptions
+                {
+                    ShareBugReportLogs = true,
+                    DisclosureVersion = BugReportConsentCoordinator.CurrentDisclosureVersion,
+                });
+            store.Save(existingOptions);
+            var provider = new BugReportOptionsTabProvider();
+            var tab = provider.CreateTab(store.LoadOrDefault(), messageBroker, _ => { });
+            var section = Assert.IsType<BugReportSection>(Assert.Single(tab.Sections));
+
+            section.ShowBugReportButton = false;
+            var options = store.LoadOrDefault();
+            tab.Apply(options);
+            store.Save(options);
+            tab.AfterApply();
+
+            var savedOptions = store.LoadOrDefault();
+            Assert.False(BugReportOptionsTabProvider.GetShowBugReportButtonOrDefault(savedOptions));
+            Assert.True(savedOptions.TryGetSection(
+                BugReportConsentCoordinator.TabId,
+                BugReportConsentCoordinator.SectionId,
+                out BugReportConsentOptions consent));
+            Assert.True(consent.ShareBugReportLogs);
+            Assert.Equal(BugReportConsentCoordinator.CurrentDisclosureVersion, consent.DisclosureVersion);
+            Assert.True(selected.HasValue);
+            Assert.False(selected.Value.ShowBugReportButton);
+            GC.KeepAlive(handler);
+        }
+        finally
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+
+    private static string CreateTempFilePath()
+    {
+        return Path.Combine(Path.GetTempPath(),
+            $"bannerlord-coop-bug-report-options-{Guid.NewGuid():N}.json");
+    }
+
+    private static string FindMoviePath([CallerFilePath] string sourceFile = "")
+    {
+        var sourceDirectory = Path.GetDirectoryName(sourceFile);
+        return Path.GetFullPath(Path.Combine(sourceDirectory!,
+            "..", "..", "..", "..", "UIMovies", "CoopOptionsUIMovie.xml"));
+    }
+}

--- a/source/GameInterface.Tests/Services/UI/BugReportOptionsTests.cs
+++ b/source/GameInterface.Tests/Services/UI/BugReportOptionsTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Xml.Linq;
 using Xunit;
 
@@ -74,6 +75,13 @@ public class BugReportOptionsTests
             tab.Apply(options);
             store.Save(options);
             tab.AfterApply();
+
+            using var document = JsonDocument.Parse(File.ReadAllText(filePath));
+            var savedSection = document.RootElement
+                .GetProperty(BugReportOptionsTabProvider.TabId)
+                .GetProperty(BugReportSection.SectionId);
+            Assert.False(savedSection.GetProperty("showBugReportButton").GetBoolean());
+            Assert.False(savedSection.TryGetProperty("ShowBugReportButton", out _));
 
             var savedOptions = store.LoadOrDefault();
             Assert.False(BugReportOptionsTabProvider.GetShowBugReportButtonOrDefault(savedOptions));

--- a/source/GameInterface.Tests/Services/UI/BugReportVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/BugReportVMTests.cs
@@ -7,11 +7,13 @@ namespace GameInterface.Tests.Services.UI;
 public class BugReportVMTests
 {
     [Theory]
-    [InlineData(true, false, false, true)]
-    [InlineData(true, true, false, false)]
-    [InlineData(true, false, true, false)]
-    [InlineData(false, false, false, false)]
-    public void OverlayVisibility_OnlyRequiresUnblockedGameplay(
+    [InlineData(true, true, false, false, true)]
+    [InlineData(false, true, false, false, false)]
+    [InlineData(true, true, true, false, false)]
+    [InlineData(true, true, false, true, false)]
+    [InlineData(true, false, false, false, false)]
+    public void OverlayVisibility_RequiresEnabledUnblockedGameplay(
+        bool showBugReportButton,
         bool isGameplayScreen,
         bool isLoading,
         bool isConversationActive,
@@ -20,6 +22,7 @@ public class BugReportVMTests
         Assert.Equal(
             expected,
             BugReportOverlay.ShouldShowPresentation(
+                showBugReportButton,
                 isGameplayScreen,
                 isLoading,
                 isConversationActive));

--- a/source/GameInterface.Tests/Services/UI/CoopOptionsVMTestFactory.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopOptionsVMTestFactory.cs
@@ -2,6 +2,7 @@
 using GameInterface.Configuration;
 using GameInterface.Services.UI.CoopOptions;
 using GameInterface.Services.UI.CoopOptions.Providers;
+using GameInterface.Services.UI.CoopOptions.Providers.BugReportTab;
 using GameInterface.Services.UI.CoopOptions.Providers.ChatTab;
 using GameInterface.Services.UI.CoopOptions.Providers.KillFeedTab;
 using GameInterface.Services.UI.CoopOptions.Providers.MapTimeTab;
@@ -22,6 +23,7 @@ internal static class CoopOptionsVMTestFactory
         {
             new KillFeedOptionsTabProvider(),
             new MapTimeOptionsTabProvider(),
+            new BugReportOptionsTabProvider(),
             new ChatOptionsTabProvider(),
             new PlayerNameplatesOptionsTabProvider(),
             new NetworkOptionsTabProvider(),

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -42,6 +42,7 @@ using GameInterface.Services.Time;
 using GameInterface.Services.TroopRosters;
 using GameInterface.Services.TroopRosters.Logging;
 using GameInterface.Services.UI.CoopOptions.Providers;
+using GameInterface.Services.UI.CoopOptions.Providers.BugReportTab;
 using GameInterface.Services.UI.CoopOptions.Providers.ChatTab;
 using GameInterface.Services.UI.CoopOptions.Providers.KillFeedTab;
 using GameInterface.Services.UI.CoopOptions.Providers.MapTimeTab;
@@ -96,6 +97,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<BugReportSubmissionConsent>().As<IBugReportSubmissionConsent>().InstancePerDependency();
         builder.RegisterType<KillFeedOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
         builder.RegisterType<MapTimeOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
+        builder.RegisterType<BugReportOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
         builder.RegisterType<ChatOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
         builder.RegisterType<PlayerNameplatesOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();
         builder.RegisterType<NetworkOptionsTabProvider>().As<ICoopOptionsTabProvider>().InstancePerDependency();

--- a/source/GameInterface/Services/BugReporting/BugReportService.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportService.cs
@@ -706,9 +706,9 @@ internal class BugReportService : IBugReportService, IDisposable
         if (!upload.EndpointConfigured)
         {
             Logger.Information(
-                "Diagnostic bug report {RequestId} was not uploaded because authorization is not configured",
+                "Diagnostic bug report {RequestId} was not uploaded because the endpoint is not configured",
                 contents.RequestId);
-            SendResult(finalized, "The bug report was saved on the server; upload authorization is not configured.");
+            SendResult(finalized, "The bug report was saved on the server; the upload endpoint is not configured.");
         }
         else
         {

--- a/source/GameInterface/Services/BugReporting/BugReportUploader.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportUploader.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace GameInterface.Services.BugReporting;
 
-/// <summary>Uploads the server save as a raw artifact, then posts diagnostic report metadata as JSON.</summary>
+/// <summary>Uploads diagnostic metadata, logs, and the server save in one multipart request.</summary>
 public interface IBugReportUploader
 {
     bool IsConfigured { get; }
@@ -24,10 +24,8 @@ public interface IBugReportUploader
 /// <inheritdoc />
 public class BugReportUploader : IBugReportUploader, IDisposable
 {
-    public const string Endpoint = "https://bug-reports.bannerlordcoop.invalid/api/v1/reports";
-    public const string EndpointEnvironmentVariable = "BANNERLORDCOOP_BUG_REPORT_ENDPOINT";
-    public const string PublishableKeyEnvironmentVariable = "BANNERLORDCOOP_BUG_REPORT_PUBLISHABLE_KEY";
-    public const string AuthorizationTokenEnvironmentVariable = "BANNERLORDCOOP_BUG_REPORT_TOKEN";
+    public const string Endpoint =
+        "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/create-github-issue-bug-report";
     internal const int MaximumCompressedReportBytes = 10 * 1024 * 1024;
     internal const int MaximumServerSaveBytes = 48 * 1024 * 1024;
 
@@ -38,21 +36,14 @@ public class BugReportUploader : IBugReportUploader, IDisposable
 
     private readonly HttpClient httpClient;
     private readonly string endpoint;
-    private readonly string supabasePublishableKey;
-    private readonly string authorizationToken;
     private readonly bool ownsClient;
 
     public bool IsConfigured =>
-        !new Uri(endpoint).Host.EndsWith(".invalid", StringComparison.OrdinalIgnoreCase) &&
-        !string.IsNullOrWhiteSpace(supabasePublishableKey) &&
-        !string.IsNullOrWhiteSpace(authorizationToken) &&
-        !string.Equals(authorizationToken, supabasePublishableKey, StringComparison.Ordinal);
+        !new Uri(endpoint).Host.EndsWith(".invalid", StringComparison.OrdinalIgnoreCase);
 
     public BugReportUploader() : this(
         new HttpClient { Timeout = TimeSpan.FromMinutes(2) },
-        Environment.GetEnvironmentVariable(EndpointEnvironmentVariable) ?? Endpoint,
-        Environment.GetEnvironmentVariable(PublishableKeyEnvironmentVariable),
-        Environment.GetEnvironmentVariable(AuthorizationTokenEnvironmentVariable),
+        Endpoint,
         true)
     {
     }
@@ -60,8 +51,6 @@ public class BugReportUploader : IBugReportUploader, IDisposable
     internal BugReportUploader(
         HttpClient httpClient,
         string endpoint = Endpoint,
-        string supabasePublishableKey = null,
-        string authorizationToken = null,
         bool ownsClient = false)
     {
         if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
@@ -69,8 +58,6 @@ public class BugReportUploader : IBugReportUploader, IDisposable
             throw new ArgumentException("Endpoint cannot be empty.", nameof(endpoint));
         this.httpClient = httpClient;
         this.endpoint = endpoint;
-        this.supabasePublishableKey = supabasePublishableKey;
-        this.authorizationToken = authorizationToken;
         this.ownsClient = ownsClient;
     }
 
@@ -84,7 +71,7 @@ public class BugReportUploader : IBugReportUploader, IDisposable
             return new BugReportUploadResult(
                 false,
                 false,
-                "Bug-report upload authorization is not configured.");
+                "The bug-report upload endpoint is not configured.");
         }
 
         if (!IsWithinCompressedLogLimit(GetCompressedLogBytes(report)))
@@ -113,15 +100,13 @@ public class BugReportUploader : IBugReportUploader, IDisposable
                     true,
                     "The server campaign save exceeds the upload size limit.");
             }
-
-            var saveUpload = await UploadServerSaveAsync(report, cancellationToken).ConfigureAwait(false);
-            if (!saveUpload.Uploaded) return saveUpload;
         }
 
         var json = JsonSerializer.Serialize(CreateRequest(report), JsonOptions);
-        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        using var content = CreateMultipartContent(report, json);
+        using var request = new HttpRequestMessage(HttpMethod.Put, endpoint)
         {
-            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            Content = content,
         };
         AddRequestHeaders(request, report.RequestId);
         using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -154,38 +139,54 @@ public class BugReportUploader : IBugReportUploader, IDisposable
         return saveBytes > 0 && saveBytes <= MaximumServerSaveBytes;
     }
 
-    private async Task<BugReportUploadResult> UploadServerSaveAsync(
+    private static MultipartFormDataContent CreateMultipartContent(
         BugReportArchiveContents report,
-        CancellationToken cancellationToken)
+        string json)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Put, endpoint)
+        var content = new MultipartFormDataContent();
+        content.Add(new StringContent(json, Encoding.UTF8, "application/json"), "report");
+
+        if (report.ServerLog != null)
         {
-            Content = new ByteArrayContent(report.ServerSave.Data),
-        };
-        request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
-            "application/octet-stream");
-        request.Headers.TryAddWithoutValidation("X-Bug-Report-Artifact", "server-save");
-        request.Headers.TryAddWithoutValidation("X-Bug-Report-Id", report.RequestId);
-        request.Headers.TryAddWithoutValidation("X-Bug-Report-File-Name", report.ServerSave.FileName);
-        AddRequestHeaders(request, report.RequestId + "-server-save");
+            content.Add(
+                CreateBinaryContent(report.ServerLog.CompressedData, "application/gzip"),
+                "serverLog",
+                "Coop_server.log.gz");
+        }
 
-        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        var details = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        if (response.IsSuccessStatusCode)
-            return new BugReportUploadResult(true, true, details);
+        foreach (var log in report.Logs.OrderBy(item => item.ClientNumber))
+        {
+            content.Add(
+                CreateBinaryContent(log.CompressedData, "application/gzip"),
+                GetClientLogPartName(log.ClientNumber),
+                "client-" + log.ClientNumber.ToString("D2", CultureInfo.InvariantCulture) + ".log.gz");
+        }
 
-        return new BugReportUploadResult(
-            false,
-            true,
-            string.IsNullOrWhiteSpace(details)
-                ? "The server-save endpoint returned " + ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + "."
-                : details);
+        if (report.ServerSave != null)
+        {
+            content.Add(
+                CreateBinaryContent(report.ServerSave.Data, "application/octet-stream"),
+                "serverSave",
+                report.ServerSave.FileName);
+        }
+
+        return content;
     }
 
-    private void AddRequestHeaders(HttpRequestMessage request, string idempotencyKey)
+    private static ByteArrayContent CreateBinaryContent(byte[] data, string mediaType)
     {
-        request.Headers.TryAddWithoutValidation("apikey", supabasePublishableKey);
-        request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + authorizationToken);
+        var content = new ByteArrayContent(data);
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mediaType);
+        return content;
+    }
+
+    internal static string GetClientLogPartName(int clientNumber)
+    {
+        return "clientLog-" + clientNumber.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static void AddRequestHeaders(HttpRequestMessage request, string idempotencyKey)
+    {
         request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
     }
 
@@ -267,7 +268,7 @@ public sealed class BugReportUploadResult
 /// <summary>Defines the versioned JSON payload posted to the bug-report endpoint.</summary>
 internal sealed class BugReportJsonRequest
 {
-    public int SchemaVersion => 2;
+    public int SchemaVersion => 3;
     public string ReportId { get; }
     public string ReportingClientNetworkId { get; }
     public string Summary { get; }
@@ -328,19 +329,19 @@ internal sealed class BugReportJsonRequest
     }
 }
 
-/// <summary>Contains one gzip-compressed log encoded as JSON base64.</summary>
+/// <summary>Describes one gzip-compressed log included as a multipart field.</summary>
 internal sealed class BugReportJsonLog
 {
     public string FileName { get; }
-    public string ContentEncoding => "gzip+base64";
+    public string ContentEncoding => "gzip";
+    public int CompressedLength { get; }
     public int UncompressedLength { get; }
-    public byte[] Data { get; }
 
     public BugReportJsonLog(string fileName, int uncompressedLength, byte[] data)
     {
         FileName = fileName;
+        CompressedLength = data?.Length ?? 0;
         UncompressedLength = uncompressedLength;
-        Data = data;
     }
 }
 
@@ -358,20 +359,20 @@ internal sealed class BugReportJsonServerSave
     }
 }
 
-/// <summary>Contains one pseudonymous client log in the JSON payload.</summary>
+/// <summary>Describes one pseudonymous client log included as a multipart field.</summary>
 internal sealed class BugReportJsonClientLog
 {
     public int ClientNumber { get; }
     public string FileName => "client-" + ClientNumber.ToString("D2", CultureInfo.InvariantCulture) + ".log";
-    public string ContentEncoding => "gzip+base64";
+    public string ContentEncoding => "gzip";
+    public int CompressedLength { get; }
     public int UncompressedLength { get; }
-    public byte[] Data { get; }
 
     public BugReportJsonClientLog(int clientNumber, int uncompressedLength, byte[] data)
     {
         ClientNumber = clientNumber;
+        CompressedLength = data?.Length ?? 0;
         UncompressedLength = uncompressedLength;
-        Data = data;
     }
 }
 

--- a/source/GameInterface/Services/UI/BugReporting/BugReportOverlay.cs
+++ b/source/GameInterface/Services/UI/BugReporting/BugReportOverlay.cs
@@ -1,5 +1,9 @@
 ﻿using Common;
+using Common.Messaging;
 using GameInterface.Services.BugReporting;
+using GameInterface.Services.UI.CoopOptions;
+using GameInterface.Services.UI.CoopOptions.Providers.BugReportTab;
+using GameInterface.Services.UI.Messages;
 using SandBox.View.Map;
 using System;
 using TaleWorlds.CampaignSystem;
@@ -30,26 +34,37 @@ internal sealed class BugReportOverlay : GlobalLayer, IBugReportOverlay
 
     private readonly IBugReportService bugReportService;
     private readonly IBugReportSubmissionConsent submissionConsent;
+    private readonly ICoopOptionsStore optionsStore;
+    private readonly IMessageBroker messageBroker;
     private BugReportVM dataSource;
     private GauntletLayer gauntletLayer;
     private GauntletMovieIdentifier movie;
     private EditableTextWidget summaryInput;
     private bool initialized;
+    private bool showBugReportButton;
 
     public BugReportOverlay(
         IBugReportService bugReportService,
-        IBugReportSubmissionConsent submissionConsent)
+        IBugReportSubmissionConsent submissionConsent,
+        ICoopOptionsStore optionsStore,
+        IMessageBroker messageBroker)
     {
         if (bugReportService == null) throw new ArgumentNullException(nameof(bugReportService));
         if (submissionConsent == null) throw new ArgumentNullException(nameof(submissionConsent));
+        if (optionsStore == null) throw new ArgumentNullException(nameof(optionsStore));
+        if (messageBroker == null) throw new ArgumentNullException(nameof(messageBroker));
         this.bugReportService = bugReportService;
         this.submissionConsent = submissionConsent;
+        this.optionsStore = optionsStore;
+        this.messageBroker = messageBroker;
     }
 
     public void Initialize()
     {
         if (initialized || ModInformation.IsServer || Game.Current == null) return;
 
+        showBugReportButton = BugReportOptionsTabProvider.GetShowBugReportButtonOrDefault(
+            optionsStore.LoadOrDefault());
         dataSource = new BugReportVM(Submit);
         dataSource.OpenRequested += FocusForm;
         dataSource.CloseRequested += ReleaseInputFocus;
@@ -60,6 +75,7 @@ internal sealed class BugReportOverlay : GlobalLayer, IBugReportOverlay
         SetPassiveInputRestrictions();
         Layer = gauntletLayer;
         ScreenManager.AddGlobalLayer(this, false);
+        messageBroker.Subscribe<BugReportVisibilitySelected>(HandleVisibilitySelected);
         initialized = true;
     }
 
@@ -77,6 +93,7 @@ internal sealed class BugReportOverlay : GlobalLayer, IBugReportOverlay
     {
         if (!initialized) return;
 
+        messageBroker.Unsubscribe<BugReportVisibilitySelected>(HandleVisibilitySelected);
         dataSource.OpenRequested -= FocusForm;
         dataSource.CloseRequested -= ReleaseInputFocus;
         dataSource.Submitted -= HandleSubmitted;
@@ -179,17 +196,25 @@ internal sealed class BugReportOverlay : GlobalLayer, IBugReportOverlay
             isConversationActive |= missionScreen.IsConversationActive;
 
         var shouldShow = ShouldShowPresentation(
+            showBugReportButton,
             isGameplayScreen,
             LoadingWindow.IsLoadingWindowActive,
             isConversationActive);
         dataSource.SetPresentationVisible(shouldShow);
     }
 
+    private void HandleVisibilitySelected(MessagePayload<BugReportVisibilitySelected> payload)
+    {
+        showBugReportButton = payload.What.ShowBugReportButton;
+        if (!showBugReportButton) dataSource.SetPresentationVisible(false);
+    }
+
     internal static bool ShouldShowPresentation(
+        bool showBugReportButton,
         bool isGameplayScreen,
         bool isLoading,
         bool isConversationActive)
     {
-        return isGameplayScreen && !isLoading && !isConversationActive;
+        return showBugReportButton && isGameplayScreen && !isLoading && !isConversationActive;
     }
 }

--- a/source/GameInterface/Services/UI/CoopOptions/CoopOptionsUIMovie.template.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/CoopOptionsUIMovie.template.xml
@@ -6,7 +6,7 @@
 
         <Standard.TopPanel Parameter.Title="@MovieTextHeader"/>
 
-        <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="840" HeightSizePolicy="CoverChildren"
+        <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="1050" HeightSizePolicy="CoverChildren"
                    HorizontalAlignment="Center" VerticalAlignment="Center" MarginTop="-80"
                    LayoutImp.LayoutMethod="VerticalTopToBottom">
           <Children>
@@ -27,6 +27,7 @@
 
             <!-- COOP_OPTIONS_PROVIDER:Providers/KillFeedTab/KillFeedTab.xml -->
 			<!-- COOP_OPTIONS_PROVIDER:Providers/MapTimeTab/MapTimeTab.xml -->
+			<!-- COOP_OPTIONS_PROVIDER:Providers/BugReportTab/BugReportTab.xml -->
 			<!-- COOP_OPTIONS_PROVIDER:Providers/ChatTab/ChatTab.xml -->
 			<!-- COOP_OPTIONS_PROVIDER:Providers/PlayerNameplatesTab/PlayerNameplatesTab.xml -->
 			<!-- COOP_OPTIONS_PROVIDER:Providers/NetworkTab/NetworkTab.xml -->

--- a/source/GameInterface/Services/UI/CoopOptions/CoopOptionsVM.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/CoopOptionsVM.cs
@@ -2,6 +2,7 @@
 using GameInterface.Configuration;
 using GameInterface.Services.CampaignService.Messages;
 using GameInterface.Services.UI.CoopOptions.Providers;
+using GameInterface.Services.UI.CoopOptions.Providers.BugReportTab;
 using GameInterface.Services.UI.CoopOptions.Providers.ChatTab;
 using GameInterface.Services.UI.CoopOptions.Providers.KillFeedTab;
 using GameInterface.Services.UI.CoopOptions.Providers.MapTimeTab;
@@ -81,6 +82,9 @@ public class CoopOptionsVM : ViewModel
 
     [DataSourceProperty]
     public CoopOptionsTabVM MapTimeTab { get; set; }
+
+    [DataSourceProperty]
+    public CoopOptionsTabVM BugReportTab { get; set; }
 
     [DataSourceProperty]
     public CoopOptionsTabVM ChatTab { get; set; }
@@ -194,6 +198,11 @@ public class CoopOptionsVM : ViewModel
         {
             MapTimeTab = tab;
             OnPropertyChanged(nameof(MapTimeTab));
+        }
+        else if (tabId == BugReportOptionsTabProvider.TabId)
+        {
+            BugReportTab = tab;
+            OnPropertyChanged(nameof(BugReportTab));
         }
         else if (tabId == ChatOptionsTabProvider.TabId)
         {

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/BugReportOptionsTabProvider.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/BugReportOptionsTabProvider.cs
@@ -1,0 +1,41 @@
+﻿using Common.Messaging;
+using GameInterface.Configuration;
+using GameInterface.Services.UI.CoopOptions.Providers.BugReportTab.Sections;
+using System;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.BugReportTab;
+
+/// <summary>Provides the client bug-report presentation options tab.</summary>
+public class BugReportOptionsTabProvider : ICoopOptionsTabProvider
+{
+    public const string TabId = "BugReporting";
+    public const string TabName = "Bug Report";
+
+    public string Id => TabId;
+    public bool IsAvailable(ModOptions modOptions) => true;
+
+    public CoopOptionsTabVM CreateTab(
+        CoopOptionsData options,
+        IMessageBroker messageBroker,
+        Action<CoopOptionsTabVM> onSelect)
+    {
+        return new CoopOptionsTabVM(
+            Id,
+            TabName,
+            new CoopOptionsSectionVM[]
+            {
+                new BugReportSection(GetShowBugReportButtonOrDefault(options), messageBroker)
+            },
+            onSelect);
+    }
+
+    public static bool GetShowBugReportButtonOrDefault(CoopOptionsData options)
+    {
+        var sectionOptions =
+            (options ?? new CoopOptionsData()).GetSectionOrDefault(
+                TabId,
+                BugReportSection.SectionId,
+                new BugReportSectionOptions());
+        return sectionOptions.GetShowBugReportButtonOrDefault();
+    }
+}

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/BugReportTab.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/BugReportTab.xml
@@ -1,0 +1,11 @@
+<ListPanel DataSource="{BugReportTab}" IsVisible="@IsSelected" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+           LayoutImp.LayoutMethod="VerticalTopToBottom">
+    <Children>
+        <ListPanel DataSource="{Sections}" WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+                   LayoutImp.LayoutMethod="VerticalTopToBottom">
+            <ItemTemplate>
+                <!-- COOP_OPTIONS_SECTION:Sections/BugReportSection.xml -->
+            </ItemTemplate>
+        </ListPanel>
+    </Children>
+</ListPanel>

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSection.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSection.cs
@@ -1,0 +1,51 @@
+﻿using Common.Messaging;
+using GameInterface.Services.UI.Messages;
+using TaleWorlds.Library;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.BugReportTab.Sections;
+
+/// <summary>Configures visibility of the in-game bug-report button.</summary>
+public class BugReportSection : CoopOptionsSectionVM
+{
+    public const string SectionId = "BugReportButton";
+
+    private readonly IMessageBroker messageBroker;
+    private bool showBugReportButton;
+
+    public BugReportSection(bool showBugReportButton, IMessageBroker messageBroker)
+    {
+        this.showBugReportButton = showBugReportButton;
+        this.messageBroker = messageBroker;
+    }
+
+    public override string Id => SectionId;
+    public string TitleText => "Bug Report";
+    public string DescriptionText => "Configure the in-game co-op bug-report button.";
+    public string ShowBugReportButtonText => "Show Coop Bug Report Button";
+
+    [DataSourceProperty]
+    public bool ShowBugReportButton
+    {
+        get => showBugReportButton;
+        set
+        {
+            if (showBugReportButton == value) return;
+
+            showBugReportButton = value;
+            OnPropertyChanged(nameof(ShowBugReportButton));
+        }
+    }
+
+    public override void Apply(string tabId, CoopOptionsData options)
+    {
+        options.SetSection(
+            tabId,
+            Id,
+            new BugReportSectionOptions { ShowBugReportButton = showBugReportButton });
+    }
+
+    public override void AfterApply()
+    {
+        messageBroker.Publish(this, new BugReportVisibilitySelected(showBugReportButton));
+    }
+}

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSection.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSection.xml
@@ -1,0 +1,43 @@
+<ListPanel WidthSizePolicy="StretchToParent" HeightSizePolicy="CoverChildren"
+           LayoutImp.LayoutMethod="VerticalTopToBottom">
+    <Children>
+        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="48"
+                    Brush="Clan.TabControl.Text" Brush.FontSize="36"
+                    Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                    Text="@TitleText"/>
+
+        <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="Fixed" SuggestedHeight="58"
+                    Brush="Clan.TabControl.Text" Brush.FontSize="22" Brush.FontColor="#B8B8B8FF"
+                    Brush.TextHorizontalAlignment="Center" Brush.TextVerticalAlignment="Center"
+                    Text="@DescriptionText"/>
+
+        <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="64"
+                   HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
+            <Children>
+                <ButtonWidget DoNotPassEventsToChildren="true"
+                              WidthSizePolicy="Fixed" HeightSizePolicy="Fixed"
+                              SuggestedWidth="40" SuggestedHeight="40"
+                              VerticalAlignment="Center"
+                              Brush="SPOptions.Checkbox.Empty.Button"
+                              ButtonType="Toggle"
+                              IsSelected="@ShowBugReportButton"
+                              ToggleIndicator="ToggleIndicator"
+                              UpdateChildrenStates="true">
+                    <Children>
+                        <BrushWidget Id="ToggleIndicator"
+                                     WidthSizePolicy="StretchToParent"
+                                     HeightSizePolicy="StretchToParent"
+                                     Brush="SPOptions.Checkbox.Full.Button"/>
+                    </Children>
+                </ButtonWidget>
+                <TextWidget WidthSizePolicy="CoverChildren"
+                            HeightSizePolicy="StretchToParent"
+                            MarginLeft="16"
+                            Brush="Clan.TabControl.Text"
+                            Brush.FontSize="28"
+                            Brush.TextVerticalAlignment="Center"
+                            Text="@ShowBugReportButtonText"/>
+            </Children>
+        </ListPanel>
+    </Children>
+</ListPanel>

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSectionOptions.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSectionOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace GameInterface.Services.UI.CoopOptions.Providers.BugReportTab.Sections;
+
+/// <summary>Persists the client's bug-report button visibility choice.</summary>
+public class BugReportSectionOptions
+{
+    public const bool DefaultShowBugReportButton = true;
+
+    public bool? ShowBugReportButton { get; set; }
+
+    public bool GetShowBugReportButtonOrDefault()
+    {
+        return ShowBugReportButton ?? DefaultShowBugReportButton;
+    }
+}

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSectionOptions.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/BugReportTab/Sections/BugReportSectionOptions.cs
@@ -1,10 +1,13 @@
-﻿namespace GameInterface.Services.UI.CoopOptions.Providers.BugReportTab.Sections;
+﻿using System.Text.Json.Serialization;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.BugReportTab.Sections;
 
 /// <summary>Persists the client's bug-report button visibility choice.</summary>
 public class BugReportSectionOptions
 {
     public const bool DefaultShowBugReportButton = true;
 
+    [JsonPropertyName("showBugReportButton")]
     public bool? ShowBugReportButton { get; set; }
 
     public bool GetShowBugReportButtonOrDefault()

--- a/source/GameInterface/Services/UI/Messages/BugReportVisibilitySelected.cs
+++ b/source/GameInterface/Services/UI/Messages/BugReportVisibilitySelected.cs
@@ -1,0 +1,14 @@
+﻿using Common.Messaging;
+
+namespace GameInterface.Services.UI.Messages;
+
+/// <summary>Notifies the active client overlay of its saved button visibility choice.</summary>
+public readonly struct BugReportVisibilitySelected : IEvent
+{
+    public readonly bool ShowBugReportButton;
+
+    public BugReportVisibilitySelected(bool showBugReportButton)
+    {
+        ShowBugReportButton = showBugReportButton;
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

The `Report Coop Bug` button is always shown during gameplay.

## What is the new behavior?

Coop Options has a Bug Report tab with a `Show Coop Bug Report Button` checkbox. The choice is saved per client and applies immediately. Hiding the button does not change diagnostic log-sharing consent or automatic reports triggered by recovery actions.

Tested with:

`dotnet test source/CoopUnitTests.slnf -c Release --no-restore`

## Bot Changelog Entry

- The in-game bug-report button can now be hidden from Coop Options.
