### PR TITLE
Skip relation changes with unresolved heroes

### DIFF
--- a/source/GameInterface.Tests/Services/Actions/ChangeRelationActionPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Actions/ChangeRelationActionPatchesTests.cs
@@ -1,0 +1,136 @@
+﻿using Common;
+using GameInterface.Services.Actions.Patches;
+using GameInterface.Tests.Bootstrap;
+using HarmonyLib;
+using System;
+using System.Reflection;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using Xunit;
+using FormatterServices = System.Runtime.Serialization.FormatterServices;
+
+namespace GameInterface.Tests.Services.Actions;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class ChangeRelationActionPatchesTests
+{
+    public ChangeRelationActionPatchesTests()
+    {
+        GameBootStrap.Initialize();
+    }
+
+    [Fact]
+    public void ClientAlwaysSkipsNativeApplyInternal()
+    {
+        Hero source = Raw<Hero>();
+        Hero target = Raw<Hero>();
+
+        Assert.False(RunPrefix(source, target, relationChange: 1, isServer: false));
+    }
+
+    [Fact]
+    public void ServerRunsNativeApplyInternalForValidEffectiveHeroes()
+    {
+        Hero source = HeroWithSelfLedClan();
+        Hero target = HeroWithSelfLedClan();
+
+        Assert.True(RunPrefix(source, target, relationChange: 1, isServer: true));
+    }
+
+    [Fact]
+    public void ServerSkipsRelationChangeWithNullOriginalHero()
+    {
+        Hero target = Raw<Hero>();
+
+        Assert.False(RunPrefix(null, target, relationChange: 1, isServer: true));
+    }
+
+    [Fact]
+    public void ServerSkipsRelationChangeWhenClanLeaderMakesEffectiveHeroNull()
+    {
+        Hero source = Raw<Hero>();
+        source._clan = Raw<Clan>();
+        source._companionOf = source._clan;
+        source._clan._leader = null;
+        Hero target = HeroWithSelfLedClan();
+
+        Assert.False(RunPrefix(source, target, relationChange: 1, isServer: true));
+    }
+
+    [Fact]
+    public void ServerSkipsRelationChangeWhenTargetClanLeaderMakesEffectiveHeroNull()
+    {
+        Hero source = HeroWithSelfLedClan();
+        Hero target = Raw<Hero>();
+        target._clan = Raw<Clan>();
+        target._companionOf = target._clan;
+        target._clan._leader = null;
+
+        Assert.False(RunPrefix(source, target, relationChange: 1, isServer: true));
+    }
+
+    [Fact]
+    public void ServerPreservesDiplomacyModelFallbackWhenBothClanLeadersAreNull()
+    {
+        Hero source = Raw<Hero>();
+        source._clan = Raw<Clan>();
+        source._companionOf = source._clan;
+        source._clan._leader = null;
+        Hero target = Raw<Hero>();
+        target._clan = Raw<Clan>();
+        target._companionOf = target._clan;
+        target._clan._leader = null;
+
+        Assert.True(RunPrefix(source, target, relationChange: 1, isServer: true));
+    }
+
+    [Fact]
+    public void ServerPreservesNativeNoOpWithoutResolvingHeroes()
+    {
+        Assert.True(RunPrefix(null, null, relationChange: 0, isServer: true));
+    }
+
+    [Fact]
+    public void ApplyInternalTargetHasExpectedSignature()
+    {
+        MethodInfo target = AccessTools.Method(
+            typeof(ChangeRelationAction),
+            nameof(ChangeRelationAction.ApplyInternal),
+            new[]
+            {
+                typeof(Hero),
+                typeof(Hero),
+                typeof(int),
+                typeof(bool),
+                typeof(ChangeRelationAction.ChangeRelationDetail),
+            });
+
+        Assert.NotNull(target);
+    }
+
+    private static bool RunPrefix(Hero? source, Hero? target, int relationChange, bool isServer)
+    {
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = isServer;
+            return ChangeRelationActionPatches.ApplyInternalPrefix(source, target, relationChange);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
+    }
+
+    private static T Raw<T>() where T : class =>
+        (T)FormatterServices.GetUninitializedObject(typeof(T));
+
+    private static Hero HeroWithSelfLedClan()
+    {
+        Hero hero = Raw<Hero>();
+        hero._clan = Raw<Clan>();
+        hero._companionOf = hero._clan;
+        hero._clan._leader = hero;
+        return hero;
+    }
+}

--- a/source/GameInterface/Services/Actions/Patches/ChangeRelationActionPatches.cs
+++ b/source/GameInterface/Services/Actions/Patches/ChangeRelationActionPatches.cs
@@ -3,18 +3,118 @@ using Common.Logging;
 using GameInterface.Services.Heroes.Patches;
 using HarmonyLib;
 using Serilog;
+using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.ComponentInterfaces;
 
 namespace GameInterface.Services.Actions.Patches;
 
 [HarmonyPatch(typeof(ChangeRelationAction))]
 internal class ChangeRelationActionPatches
 {
-    private static readonly ILogger Logger = LogManager.GetLogger<ChangeRelationActionPatches>();
+    private const int InvalidEffectiveHeroPairLogLimit = 256;
 
-    [HarmonyPatch(nameof(ChangeRelationAction.ApplyInternal))]
-    static bool Prefix() => ModInformation.IsServer;
+    private static readonly ILogger Logger = LogManager.GetLogger<ChangeRelationActionPatches>();
+    private static readonly HashSet<string> LoggedInvalidEffectiveHeroPairs = new HashSet<string>();
+    private static readonly object LoggedInvalidEffectiveHeroPairsLock = new object();
+
+    [HarmonyPatch(nameof(ChangeRelationAction.ApplyInternal), new[]
+    {
+        typeof(Hero),
+        typeof(Hero),
+        typeof(int),
+        typeof(bool),
+        typeof(ChangeRelationAction.ChangeRelationDetail),
+    })]
+    [HarmonyPrefix]
+    internal static bool ApplyInternalPrefix(
+        Hero originalHero,
+        Hero originalGainedRelationWith,
+        int relationChange)
+    {
+        if (ModInformation.IsClient)
+        {
+            return false;
+        }
+
+        // Native ApplyInternal does not inspect either hero for a no-op relation
+        // change, so preserve that behavior even if campaign state is incomplete.
+        if (relationChange == 0)
+        {
+            return true;
+        }
+
+        DiplomacyModel diplomacyModel = Campaign.Current?.Models?.DiplomacyModel;
+        if (TryResolveEffectiveHeroes(
+            diplomacyModel,
+            originalHero,
+            originalGainedRelationWith,
+            out Hero effectiveHero,
+            out Hero effectiveGainedRelationWith))
+        {
+            return true;
+        }
+
+        string sourceHeroId = originalHero?.StringId ?? "<null>";
+        string sourceClanId = originalHero?.Clan?.StringId ?? "<none>";
+        string targetHeroId = originalGainedRelationWith?.StringId ?? "<null>";
+        string targetClanId = originalGainedRelationWith?.Clan?.StringId ?? "<none>";
+        string pairKey = $"{sourceHeroId}|{sourceClanId}|{targetHeroId}|{targetClanId}";
+
+        if (ShouldLogInvalidEffectiveHeroPair(pairKey))
+        {
+            Logger.Warning(
+                "Skipped relation change because its effective hero pair could not be resolved: " +
+                "sourceHero={SourceHeroId}, sourceClan={SourceClanId}, targetHero={TargetHeroId}, targetClan={TargetClanId}, " +
+                "effectiveSource={EffectiveSourceHeroId}, effectiveTarget={EffectiveTargetHeroId}",
+                sourceHeroId,
+                sourceClanId,
+                targetHeroId,
+                targetClanId,
+                effectiveHero?.StringId ?? "<null>",
+                effectiveGainedRelationWith?.StringId ?? "<null>");
+        }
+
+        return false;
+    }
+
+    private static bool ShouldLogInvalidEffectiveHeroPair(string pairKey)
+    {
+        lock (LoggedInvalidEffectiveHeroPairsLock)
+        {
+            if (LoggedInvalidEffectiveHeroPairs.Count >= InvalidEffectiveHeroPairLogLimit)
+            {
+                return false;
+            }
+
+            return LoggedInvalidEffectiveHeroPairs.Add(pairKey);
+        }
+    }
+
+    internal static bool TryResolveEffectiveHeroes(
+        DiplomacyModel diplomacyModel,
+        Hero originalHero,
+        Hero originalGainedRelationWith,
+        out Hero effectiveHero,
+        out Hero effectiveGainedRelationWith)
+    {
+        effectiveHero = null;
+        effectiveGainedRelationWith = null;
+
+        if (diplomacyModel == null || originalHero == null || originalGainedRelationWith == null)
+        {
+            return false;
+        }
+
+        diplomacyModel.GetHeroesForEffectiveRelation(
+            originalHero,
+            originalGainedRelationWith,
+            out effectiveHero,
+            out effectiveGainedRelationWith);
+
+        return effectiveHero != null && effectiveGainedRelationWith != null;
+    }
 
     // Patch for server to use passed down ClientHero instead of server's MainHero
     // which is a different hero


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

The relation-action patch only decides whether native `ApplyInternal` runs on this process. On the server, Bannerlord's diplomacy model can resolve one effective hero to null when a clan has no leader, after which the native relation action throws during callbacks such as the daily party tick.

## What is the new behavior?

The exact native overload is patched and the server validates the effective hero pair before allowing a non-zero relation change through. Valid pairs and Bannerlord's both-leaders-missing fallback still run natively, zero changes remain no-ops without resolution, and clients still skip the native action. Invalid pairs are logged once per identity tuple with a bounded 256-entry diagnostic set.

## Bot Changelog Entry

- Leaderless clans no longer make relation updates throw during campaign ticks.

## Other information

Validation:
- `dotnet build source\CoopTests.slnf -c Release` (0 errors)
- 8 focused relation-action tests passed
- full `CoopUnitTests.slnf` passed: 2,209 passed, 14 expected skips
