### PR TITLE
Fix loading overlay during character creation intro

### DIFF
--- a/source/GameInterface.Tests/Services/GameDebug/Patches/CharacterCreationIntroPatchTests.cs
+++ b/source/GameInterface.Tests/Services/GameDebug/Patches/CharacterCreationIntroPatchTests.cs
@@ -2,6 +2,7 @@
 using System;
 using TaleWorlds.CampaignSystem.GameState;
 using TaleWorlds.CampaignSystem.CharacterCreationContent;
+using TaleWorlds.MountAndBlade;
 using Xunit;
 using TaleworldGameState = TaleWorlds.Core.GameState;
 
@@ -21,5 +22,64 @@ public class CharacterCreationIntroPatchTests
     public void IsCharacterCreationState_ReturnsFalseForOtherGameStates(Type stateType)
     {
         Assert.False(CharacterCreationIntroPatch.IsCharacterCreationState(stateType));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Bannerlord\Modules\SandBox\Videos\CampaignIntro\campaign_intro.ivf")]
+    [InlineData("/bannerlord/Modules/SandBox/Videos/CampaignIntro/CAMPAIGN_INTRO.IVF")]
+    [InlineData("campaign_intro.ivf")]
+    public void IsCharacterCreationIntro_ReturnsTrueForCampaignIntroVideo(string videoPath)
+    {
+        var state = new VideoPlaybackState();
+        state.SetStartingParameters(
+            videoPath,
+            @"C:\Bannerlord\Modules\SandBox\Videos\CampaignIntro\campaign_intro.ogg",
+            "campaign_intro");
+
+        Assert.True(CharacterCreationIntroPatch.IsCharacterCreationIntro(state));
+    }
+
+    [Theory]
+    [InlineData("launcher_logo.ivf")]
+    [InlineData("campaign_intro_teaser.ivf")]
+    [InlineData("intro_campaign_intro_backup.ivf")]
+    public void IsCharacterCreationIntro_ReturnsFalseForUnrelatedVideo(string videoPath)
+    {
+        var state = new VideoPlaybackState();
+        state.SetStartingParameters(videoPath, "audio.ogg", "subtitles");
+
+        Assert.False(CharacterCreationIntroPatch.IsCharacterCreationIntro(state));
+    }
+
+    [Fact]
+    public void IsCharacterCreationIntro_ReturnsFalseWithoutVideoPath()
+    {
+        Assert.False(CharacterCreationIntroPatch.IsCharacterCreationIntro(new VideoPlaybackState()));
+    }
+
+    [Fact]
+    public void IsCharacterCreationIntro_ReturnsFalseForNonVideoState()
+    {
+        Assert.False(CharacterCreationIntroPatch.IsCharacterCreationIntro(new MapState()));
+    }
+
+    [Theory]
+    [InlineData(true, true, true, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, true, false, false)]
+    [InlineData(false, false, false, false)]
+    public void ShouldHideCoopLoadingWindow_RequiresForcedClientIntro(
+        bool isCharacterCreationIntro,
+        bool forceLoadingWindow,
+        bool isClient,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            CharacterCreationIntroPatch.ShouldHideCoopLoadingWindow(
+                isCharacterCreationIntro,
+                forceLoadingWindow,
+                isClient));
     }
 }

--- a/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
@@ -2,11 +2,15 @@
 using Common.Messaging;
 using GameInterface.Services.GameDebug.Interfaces;
 using GameInterface.Services.GameDebug.Messages;
+using GameInterface.Services.UI.Interfaces;
+using GameInterface.Services.UI.Patches;
 using HarmonyLib;
 using Serilog;
 using System;
+using System.IO;
 using TaleworldGameState = TaleWorlds.Core.GameState;
 using TaleworldCharacterCreationState = TaleWorlds.CampaignSystem.CharacterCreationContent.CharacterCreationState;
+using TaleworldVideoPlaybackState = TaleWorlds.MountAndBlade.VideoPlaybackState;
 
 namespace GameInterface.Services.GameDebug.Patches;
 
@@ -22,6 +26,16 @@ internal class CharacterCreationIntroPatch
     {
         Logger.Information("Game State is changing to {state}", __instance.GetType().Name);
 
+        var isCharacterCreationIntro = IsCharacterCreationIntro(__instance);
+        if (ShouldHideCoopLoadingWindow(
+                isCharacterCreationIntro,
+                LoadingWindowPatches.ForceLoadingWindow,
+                Common.ModInformation.IsClient) &&
+            ContainerProvider.TryResolve<ILoadingInterface>(out var loadingInterface))
+        {
+            loadingInterface.HideLoadingScreen();
+        }
+
         // GameLoadingState and MapState also activate while an existing player is validating or
         // loading the transferred save. Publishing for either one moves the client out of
         // ValidateModuleState before the server's existing-player response can arrive.
@@ -31,7 +45,7 @@ internal class CharacterCreationIntroPatch
         }
 
 #if DEBUG
-        if (DebugCharacterCreationInterface.InCharacterCreationIntro())
+        if (isCharacterCreationIntro)
         {
             // The DEBUG fast path previously depended on the lifecycle event above. Keep the
             // automation behavior without misreporting unrelated game-state transitions as
@@ -52,4 +66,23 @@ internal class CharacterCreationIntroPatch
 
     internal static bool IsCharacterCreationState(Type stateType) =>
         typeof(TaleworldCharacterCreationState).IsAssignableFrom(stateType);
+
+    internal static bool IsCharacterCreationIntro(TaleworldGameState state)
+    {
+        if (state is not TaleworldVideoPlaybackState videoState ||
+            string.IsNullOrEmpty(videoState.VideoPath))
+        {
+            return false;
+        }
+
+        var normalizedPath = videoState.VideoPath.Replace('\\', '/');
+        var videoName = Path.GetFileNameWithoutExtension(normalizedPath);
+        return string.Equals(videoName, "campaign_intro", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool ShouldHideCoopLoadingWindow(
+        bool isCharacterCreationIntro,
+        bool forceLoadingWindow,
+        bool isClient) =>
+        isClient && forceLoadingWindow && isCharacterCreationIntro;
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A first-time client can reach Bannerlord's native `campaign_intro` video while Coop's forced loading layer is still active. That layer blocks the intro from being visible even though the video state is active.

## What is the new behavior?

When the active state is exactly the native `campaign_intro` video, the forced Coop loading layer is dismissed on clients. Other videos, non-video states, servers, and non-forced loading windows are untouched. The `CharacterCreationStarted` lifecycle event still waits for the actual `CharacterCreationState`, so existing-player save synchronization does not transition early.

## Bot Changelog Entry

- First-time players can now see the character creation intro instead of a stuck loading screen.

## Other information

Validation:
- `dotnet build source\CoopTests.slnf -c Release` (0 errors)
- 16 focused character-creation intro tests passed
- full `CoopUnitTests.slnf` passed: 2,214 passed, 14 expected skips

This is the isolated upstream port of gamingmenacers-svg/The-Realm#148.