### PR TITLE
Fix lord recruitment failure dialogue

### DIFF
--- a/source/E2E.Tests/Services/Heroes/LordDefectionRetryTests.cs
+++ b/source/E2E.Tests/Services/Heroes/LordDefectionRetryTests.cs
@@ -17,7 +17,8 @@ namespace E2E.Tests.Services.Heroes;
 /// <c>conversation_lord_from_ruling_clan_on_condition</c>, which refuses on
 /// <c>Any(a => a.PersuadedHero == OneToOneConversationHero)</c> - a predicate that checks neither age
 /// nor success - and returns before the gate is consulted. So AlwaysRetry only works if this lord's
-/// records are gone.
+/// records are gone. The active persuasion still needs <c>CanAttemptToPersuade</c> to recognize a fresh
+/// failure and populate its final refusal line.
 /// </remarks>
 public class LordDefectionRetryTests : IDisposable
 {
@@ -92,6 +93,46 @@ public class LordDefectionRetryTests : IDisposable
 
             // Vanilla needs its own week/year rules to decide; NeverExpire needs the refusal to stand.
             Assert.Single(behavior._previousDefectionPersuasionAttempts);
+        });
+    }
+
+    [Fact]
+    public void AlwaysRetry_FreshFailureLetsVanillaSelectItsFailureLine()
+    {
+        var server = TestEnvironment.Server;
+
+        server.Call(() =>
+        {
+            var previousOptions = ModConfigProvider.ModOptions;
+            try
+            {
+                ModConfigProvider.ModOptions = new ModOptions(new ModOptionsData
+                {
+                    LordDefectionRetries = LordDefectionRetryMode.AlwaysRetry,
+                });
+
+                var lord = GameObjectCreator.CreateInitializedObject<Hero>();
+                var behavior = new LordDefectionCampaignBehavior
+                {
+                    _previousDefectionPersuasionAttempts = new List<PersuasionAttempt>
+                    {
+                        Attempt(lord, PersuasionOptionResult.Failure),
+                    },
+                };
+                var result = false;
+
+                // Vanilla reuses this retry check to choose FAILED_PERSUASION_LINE. AlwaysRetry must
+                // run the original for a fresh failure instead of forcing a successful retry result.
+                var runOriginal = LordDefectionRetryPatches.CanAttemptToPersuadePatch.Prefix(
+                    behavior, lord, 0, ref result);
+
+                Assert.True(runOriginal);
+                Assert.False(result);
+            }
+            finally
+            {
+                ModConfigProvider.ModOptions = previousOptions;
+            }
         });
     }
 

--- a/source/GameInterface/Services/MobileParties/Patches/LordDefectionRetryPatches.cs
+++ b/source/GameInterface/Services/MobileParties/Patches/LordDefectionRetryPatches.cs
@@ -20,33 +20,34 @@ namespace GameInterface.Services.MobileParties.Patches;
 ///                                 neither AGE nor SUCCESS, so a single prior attempt blocks forever, and
 ///                                 it returns before CanAttemptToPersuade is ever consulted.
 ///   <c>CanAttemptToPersuade</c> - the GATE. Refuses while a matching unsuccessful attempt is less than
-///                                 ONE WEEK old.
+///                                 ONE WEEK old. The active persuasion also reuses it to choose the failed
+///                                 task whose final refusal line is shown.
 ///   <c>RemoveOldAttempts</c>    - housekeeping on the daily tick, dropping records over a YEAR old. The
 ///                                 only thing that ever removes an attempt, so it is what eventually
 ///                                 releases the pre-gate.
 ///
 /// Patching the gate alone cannot work, because the pre-gate already answered. AlwaysRetry therefore has
-/// to drop this lord's attempt records as well - and it must drop ALL of them, not just the unsuccessful
-/// ones, because the pre-gate's predicate ignores success and every persuasion OPTION records its own
-/// attempt, so a failed persuasion leaves successes behind that would keep refusing on their own.
+/// to drop this lord's attempt records before a new conversation - and it must drop ALL of them, not just
+/// the unsuccessful ones, because the pre-gate's predicate ignores success and every persuasion OPTION
+/// records its own attempt. The gate itself must keep running so a fresh failure can select its refusal line.
 ///
 ///   Vanilla     - unchanged: vanilla's own week/year rules apply (default, matches singleplayer)
 ///   NeverExpire - the gate blocks while ANY unsuccessful attempt survives, and the prune is suppressed
 ///                 so one always does
-///   AlwaysRetry - the pre-gate's record is cleared and the gate never blocks, so the lord can be asked
-///                 again at once
+///   AlwaysRetry - the pre-gate's records are cleared before each conversation, so the lord can be asked
+///                 again at once while fresh failures still complete normally
 /// </remarks>
 internal static class LordDefectionRetryPatches
 {
     /// <summary>
-    /// The gate vanilla consults before offering the persuasion option.
+    /// Keeps unsuccessful attempts blocking indefinitely for <see cref="LordDefectionRetryMode.NeverExpire"/>.
     /// </summary>
     [HarmonyPatch(typeof(LordDefectionCampaignBehavior), "CanAttemptToPersuade",
         new[] { typeof(Hero), typeof(int) })]
     internal class CanAttemptToPersuadePatch
     {
         [HarmonyPrefix]
-        private static bool Prefix(
+        internal static bool Prefix(
             LordDefectionCampaignBehavior __instance, Hero targetHero, int reservationType, ref bool __result)
         {
             switch (ModConfigProvider.ModOptions.LordDefectionRetries)
@@ -56,11 +57,8 @@ internal static class LordDefectionRetryPatches
                     __result = !HasUnsuccessfulAttempt(__instance, targetHero, reservationType);
                     return false;
 
-                case LordDefectionRetryMode.AlwaysRetry:
-                    __result = true;
-                    return false;
-
                 default:
+                    // Vanilla also uses this check to select the current attempt's failure line.
                     return true;
             }
         }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

With `lordDefectionRetries` set to `AlwaysRetry`, the patch forced `CanAttemptToPersuade` to return true. Vanilla also uses that method while ending a failed persuasion to choose `FAILED_PERSUASION_LINE`, so the NPC response was blank and the dialogue could get stuck.

## What is the new behavior?

Resolves #3361

`AlwaysRetry` still clears previous attempts when the next conversation starts, but fresh failures now run vanilla's check so their refusal line is populated and the conversation finishes normally.

## Bot Changelog Entry

Fixed lord recruitment dialogue getting stuck after a failed persuasion.

## Other information

Test: `dotnet test source/E2E.Tests/E2E.Tests.csproj -c Release --filter FullyQualifiedName~LordDefectionRetryTests -p:NuGetAudit=false`
