### PR TITLE
Enter character creation before intro playback

### DIFF
--- a/source/Coop.Core/Client/States/ValidateModuleState.cs
+++ b/source/Coop.Core/Client/States/ValidateModuleState.cs
@@ -74,7 +74,6 @@ public class ValidateModuleState : ClientStateBase
         this.gameStateInterface = gameStateInterface;
         messageBroker.Subscribe<NetworkModuleVersionsValidated>(Handle_NetworkModuleVersionsValidated);
         messageBroker.Subscribe<NetworkClientValidated>(Handle_NetworkClientValidated);
-        messageBroker.Subscribe<CharacterCreationStarted>(Handle_CharacterCreationStarted);
 
 #if DEBUG
         controllerIdProvider.SetControllerFromProgramArgs();
@@ -101,7 +100,6 @@ public class ValidateModuleState : ClientStateBase
         validationTimeoutTimer?.Dispose();
         messageBroker.Unsubscribe<NetworkModuleVersionsValidated>(Handle_NetworkModuleVersionsValidated);
         messageBroker.Unsubscribe<NetworkClientValidated>(Handle_NetworkClientValidated);
-        messageBroker.Unsubscribe<CharacterCreationStarted>(Handle_CharacterCreationStarted);
     }
 
     internal void TimeoutValidation()
@@ -182,13 +180,26 @@ public class ValidateModuleState : ClientStateBase
         }
         else
         {
-            Logic.StartCharacterCreation();
+            // Leave validation before vanilla activates the intro video, otherwise its forced loading
+            // window stays over the video until the real character-creation state activates.
+            GameThread.RunSafe(BeginCharacterCreation, context: nameof(Handle_NetworkClientValidated));
         }
     }
 
-    internal void Handle_CharacterCreationStarted(MessagePayload<CharacterCreationStarted> obj)
+    private void BeginCharacterCreation()
     {
-        Logic.SetState<CharacterCreationState>();
+        if (disposed || Logic.State != this) return;
+
+        try
+        {
+            Logic.SetState<CharacterCreationState>();
+            gameStateInterface.StartNewGame();
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e, "Failed to start character creation");
+            coopFinalizer.Finalize("Failed to start character creation.");
+        }
     }
 
     public override void EnterMainMenu()

--- a/source/Coop.Core/Client/States/ValidateModuleState.cs
+++ b/source/Coop.Core/Client/States/ValidateModuleState.cs
@@ -167,14 +167,12 @@ public class ValidateModuleState : ClientStateBase
 
     internal void Handle_NetworkClientValidated(MessagePayload<NetworkClientValidated> obj)
     {
-        // The server's terminal validation response. Claim completion before touching Logic so a
-        // timeout firing at the same instant loses the race and no-ops, rather than tearing the
-        // container down in the window between here and the state transition below (which would leave
-        // this handler resolving the next state from a disposed container).
-        if (!TryClaimCompletion()) return;
-
         if (obj.What.HeroExists)
         {
+            // Claim before touching Logic so a concurrent timeout cannot tear down the container
+            // while this handler resolves and enters the next state.
+            if (!TryClaimCompletion()) return;
+
             Logic.Player = obj.What.Player;
             Logic.LoadSavedData();
         }
@@ -189,6 +187,7 @@ public class ValidateModuleState : ClientStateBase
     private void BeginCharacterCreation()
     {
         if (disposed || Logic.State != this) return;
+        if (!TryClaimCompletion()) return;
 
         try
         {

--- a/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
+++ b/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common;
 using Common.Messaging;
 using Coop.Core.Client;
 using Coop.Core.Client.States;
@@ -6,6 +7,7 @@ using Coop.Core.Common.Services.Connection.Messages;
 using Coop.Core.Server.Connections.Messages;
 using GameInterface.Services.CharacterCreation.Messages;
 using GameInterface.Services.GameDebug.Messages;
+using GameInterface.Services.GameState.Interfaces;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.UI.Interfaces;
 using LiteNetLib;
@@ -128,21 +130,61 @@ namespace Coop.Tests.Client.States
         }
 
         [Fact]
-        public void NetworkClientValidated_Publishes_StartCharacterCreation()
+        public void NetworkClientValidated_NewPlayer_EntersCharacterCreationBeforeStartingNewGame()
         {
-            // Arrange
             var validateState = clientLogic.SetState<ValidateModuleState>();
+            var gameStateInterface = clientComponent.Container.Resolve<Mock<IGameStateInterface>>();
+            IClientState? stateWhenGameStarted = null;
+            int startThreadId = 0;
+            int gameThreadId = 0;
 
-            var heroExists = false;
+            gameStateInterface
+                .Setup(x => x.StartNewGame())
+                .Callback(() =>
+                {
+                    stateWhenGameStarted = clientLogic.State;
+                    startThreadId = Environment.CurrentManagedThreadId;
+                });
+            GameThread.Run(() => gameThreadId = Environment.CurrentManagedThreadId, blocking: true);
+
             var payload = new MessagePayload<NetworkClientValidated>(
-                this, new NetworkClientValidated(heroExists, new Player("12345", "111", "12345", "12345", "12345")));
+                this, new NetworkClientValidated(
+                    false,
+                    new Player("12345", "111", "12345", "12345", "12345")));
 
-            // Act
             validateState.Handle_NetworkClientValidated(payload);
+            GameThread.Run(() => { }, blocking: true);
 
-            // Assert
-            var message = Assert.Single(clientComponent.TestMessageBroker.Messages);
-            Assert.IsType<StartCharacterCreation>(message);
+            Assert.IsType<CharacterCreationState>(stateWhenGameStarted);
+            Assert.IsType<CharacterCreationState>(clientLogic.State);
+            Assert.Equal(gameThreadId, startThreadId);
+            gameStateInterface.Verify(x => x.StartNewGame(), Times.Once);
+            clientComponent.Container
+                .Resolve<Mock<ILoadingInterface>>()
+                .Verify(x => x.HideLoadingScreen(), Times.Once);
+        }
+
+        [Fact]
+        public void NetworkClientValidated_StartNewGameFailure_StopsCoop()
+        {
+            var validateState = clientLogic.SetState<ValidateModuleState>();
+            clientComponent.Container
+                .Resolve<Mock<IGameStateInterface>>()
+                .Setup(x => x.StartNewGame())
+                .Throws<InvalidOperationException>();
+
+            var payload = new MessagePayload<NetworkClientValidated>(
+                this, new NetworkClientValidated(
+                    false,
+                    new Player("12345", "111", "12345", "12345", "12345")));
+
+            validateState.Handle_NetworkClientValidated(payload);
+            GameThread.Run(() => { }, blocking: true);
+
+            Assert.Single(clientComponent.TestMessageBroker.GetMessagesFromType<EndCoopMode>());
+            var popup = Assert.Single(
+                clientComponent.TestMessageBroker.GetMessagesFromType<SendPopupMessage>());
+            Assert.Equal("Failed to start character creation.", popup.Text);
         }
 
         [Fact]
@@ -316,19 +358,13 @@ namespace Coop.Tests.Client.States
         }
 
         [Fact]
-        public void CharacterCreationStarted_Transitions_CharacterCreationState()
+        public void CharacterCreationStarted_WithoutServerApproval_DoesNotLeaveValidation()
         {
-            // Arrange
-            var validateState = clientLogic.SetState<ValidateModuleState>();
+            clientLogic.SetState<ValidateModuleState>();
 
-            var payload = new MessagePayload<CharacterCreationStarted>(
-                this, new CharacterCreationStarted());
+            clientComponent.TestMessageBroker.Publish(this, new CharacterCreationStarted());
 
-            // Act
-            validateState.Handle_CharacterCreationStarted(payload);
-
-            // Assert
-            Assert.IsType<CharacterCreationState>(clientLogic.State);
+            Assert.IsType<ValidateModuleState>(clientLogic.State);
         }
 
         [Fact]

--- a/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
+++ b/source/Coop.Tests/Client/States/ValidateModuleStateTests.cs
@@ -3,17 +3,21 @@ using Common;
 using Common.Messaging;
 using Coop.Core.Client;
 using Coop.Core.Client.States;
+using Coop.Core.Common;
 using Coop.Core.Common.Services.Connection.Messages;
 using Coop.Core.Server.Connections.Messages;
 using GameInterface.Services.CharacterCreation.Messages;
+using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Messages;
 using GameInterface.Services.GameState.Interfaces;
+using GameInterface.Services.Modules;
 using GameInterface.Services.Players.Data;
 using GameInterface.Services.UI.Interfaces;
 using LiteNetLib;
 using Moq;
 using System;
 using System.Linq;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -162,6 +166,55 @@ namespace Coop.Tests.Client.States
             clientComponent.Container
                 .Resolve<Mock<ILoadingInterface>>()
                 .Verify(x => x.HideLoadingScreen(), Times.Once);
+        }
+
+        [Fact]
+        public void NetworkClientValidated_NewPlayer_DisconnectBeforeGameThreadApply_CancelsCharacterCreation()
+        {
+            var coopFinalizer = new Mock<ICoopFinalizer>();
+            var gameStateInterface = clientComponent.Container.Resolve<Mock<IGameStateInterface>>();
+            var validateState = new ValidateModuleState(
+                clientLogic,
+                clientComponent.TestMessageBroker,
+                clientComponent.TestNetwork,
+                clientComponent.Container.Resolve<IControllerIdProvider>(),
+                coopFinalizer.Object,
+                gameStateInterface.Object,
+                clientComponent.Container.Resolve<IModuleInfoProvider>());
+            ((ClientLogic)clientLogic).State = validateState;
+
+            using var gameThreadBlocked = new ManualResetEventSlim(false);
+            using var releaseGameThread = new ManualResetEventSlim(false);
+
+            try
+            {
+                GameThread.Run(() =>
+                {
+                    gameThreadBlocked.Set();
+                    releaseGameThread.Wait();
+                });
+                Assert.True(gameThreadBlocked.Wait(TimeSpan.FromSeconds(5)));
+
+                var payload = new MessagePayload<NetworkClientValidated>(
+                    this,
+                    new NetworkClientValidated(
+                        false,
+                        new Player("12345", "111", "12345", "12345", "12345")));
+
+                validateState.Handle_NetworkClientValidated(payload);
+                clientLogic.Disconnect();
+
+                releaseGameThread.Set();
+                GameThread.Run(() => { }, blocking: true);
+
+                coopFinalizer.Verify(x => x.Finalize("Client has been stopped"), Times.Once);
+                Assert.Same(validateState, clientLogic.State);
+                gameStateInterface.Verify(x => x.StartNewGame(), Times.Never);
+            }
+            finally
+            {
+                releaseGameThread.Set();
+            }
         }
 
         [Fact]

--- a/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
+++ b/source/GameInterface/Services/GameDebug/Patches/CharacterCreationIntroPatch.cs
@@ -22,9 +22,8 @@ internal class CharacterCreationIntroPatch
     {
         Logger.Information("Game State is changing to {state}", __instance.GetType().Name);
 
-        // GameLoadingState and MapState also activate while an existing player is validating or
-        // loading the transferred save. Publishing for either one moves the client out of
-        // ValidateModuleState before the server's existing-player response can arrive.
+        // DEBUG automation must only run after the real character-creation state activates.
+        // GameLoadingState and MapState also activate during ordinary joins.
         if (IsCharacterCreationState(__instance.GetType()))
         {
             MessageBroker.Instance.Publish(__instance, new CharacterCreationStarted());


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to stop working as expected)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other

## What is the current behavior?

A new player remains in the client validation state while the character creation intro plays, so the forced `Validating modules...` window covers the video until the real character creation state activates.

## What is the new behavior?

The explicit new-player response now enters the co-op character creation state on the game thread before starting the vanilla new game. This releases the validation window before intro playback without allowing game-state activation events to bypass server approval.

## How to test

- Connect with a controller id that has no saved player and confirm the intro is visible without the validation window over it.
- Finish character creation and confirm the client continues into the host campaign.
- `dotnet test source\Coop.Tests\Coop.Tests.csproj -c Release --filter FullyQualifiedName~Coop.Tests.Client.States.ValidateModuleStateTests`
- `dotnet test source\GameInterface.Tests\GameInterface.Tests.csproj -c Release --filter FullyQualifiedName~GameInterface.Tests.Services.GameDebug.Patches.CharacterCreationIntroPatchTests`

## Bot Changelog Entry

- Fixed the `Validating modules...` screen covering the new-character intro movie.