### PR TITLE
Add injectable command framework

### DIFF
--- a/source/Common.Tests/Commands/CoopCommandArgsFactoryTests.cs
+++ b/source/Common.Tests/Commands/CoopCommandArgsFactoryTests.cs
@@ -1,0 +1,75 @@
+﻿using Common.Commands;
+
+namespace Common.Tests.Commands;
+
+public class CoopCommandArgsFactoryTests
+{
+    private readonly CoopCommandArgsFactory factory = new CoopCommandArgsFactory();
+
+    [Fact]
+    public void FromValues_PreservesStructuredArgumentBoundaries()
+    {
+        ICoopCommandArgs args = factory.FromValues(new[]
+        {
+            "argument with spaces",
+            "quoted \"value\"",
+        });
+
+        Assert.Equal(2, args.Count);
+        Assert.Equal("argument with spaces", args[0]);
+        Assert.Equal("quoted \"value\"", args[1]);
+    }
+
+    [Fact]
+    public void TryFromConsoleTokens_MergesDoubleQuotedTokens()
+    {
+        bool parsed = factory.TryFromConsoleTokens(
+            new[] { "\"argument", "with", "spaces\"", "tail" },
+            out ICoopCommandArgs args,
+            out string error);
+
+        Assert.True(parsed);
+        Assert.Null(error);
+        Assert.Equal(new[] { "argument with spaces", "tail" }, args);
+    }
+
+    [Fact]
+    public void TryFromConsoleTokens_PreservesEscapedQuotesAndBackslashes()
+    {
+        bool parsed = factory.TryFromConsoleTokens(
+            new[] { "\"quoted", "\\\"value\\\"", "at", "c:\\\\temp\"" },
+            out ICoopCommandArgs args,
+            out string error);
+
+        Assert.True(parsed);
+        Assert.Null(error);
+        Assert.Equal(new[] { "quoted \"value\" at c:\\temp" }, args);
+    }
+
+    [Fact]
+    public void TryFromConsoleTokens_PreservesEmptyQuotedArgument()
+    {
+        bool parsed = factory.TryFromConsoleTokens(
+            new[] { "\"\"" },
+            out ICoopCommandArgs args,
+            out string error);
+
+        Assert.True(parsed);
+        Assert.Null(error);
+        Assert.Single(args);
+        Assert.Equal(string.Empty, args[0]);
+    }
+
+    [Fact]
+    public void TryFromConsoleTokens_RejectsUnterminatedQuote()
+    {
+        bool parsed = factory.TryFromConsoleTokens(
+            new[] { "\"argument", "with", "spaces" },
+            out ICoopCommandArgs args,
+            out string error);
+
+        Assert.False(parsed);
+        Assert.Null(args);
+        Assert.Equal("Command arguments contain an unterminated double quote.", error);
+    }
+}

--- a/source/Common.Tests/Commands/CoopCommandRegistryTests.cs
+++ b/source/Common.Tests/Commands/CoopCommandRegistryTests.cs
@@ -1,0 +1,267 @@
+﻿using Common.Commands;
+using Moq;
+using Serilog;
+
+namespace Common.Tests.Commands;
+
+public class CoopCommandRegistryTests
+{
+    [Fact]
+    public void Constructor_ExposesCommandMetadataAndBuildsUsage()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Captures one value.",
+            expectedArgs: new IExpectedArgs[]
+            {
+                new ExpectedArgs("value", "The value to capture."),
+            });
+        var registry = CreateRegistry(command);
+
+        CoopCommandDescriptor descriptor = Assert.Single(registry.Commands);
+        Assert.Equal("coop.debug.test.capture", descriptor.FullName);
+        Assert.Equal(
+            ExpectedUsage(
+                "Usage: coop.debug.test.capture <value>",
+                string.Empty,
+                "Parameters:",
+                "- value (required): The value to capture.",
+                string.Empty,
+                "Note: Wrap parameter values containing spaces in double quotes."),
+            descriptor.Usage);
+        Assert.Equal(command.Description, descriptor.Description);
+
+        IExpectedArgs expectedArg = Assert.Single(descriptor.ExpectedArgs);
+        Assert.Equal("value", expectedArg.Name);
+        Assert.Equal("The value to capture.", expectedArg.Description);
+        Assert.True(expectedArg.IsRequired);
+    }
+
+    [Fact]
+    public void Constructor_WhenDescriptionIsMissing_Throws()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            string.Empty);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CreateRegistry(command));
+
+        Assert.Contains("description", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Constructor_WhenExpectedArgumentNameIsDuplicated_Throws()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Captures values.",
+            expectedArgs: new IExpectedArgs[]
+            {
+                new ExpectedArgs("value", "The first value."),
+                new ExpectedArgs("value", "The second value."),
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CreateRegistry(command));
+
+        Assert.Contains("defined more than once", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WhenRequiredArgumentFollowsOptionalArgument_Throws()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Captures values.",
+            expectedArgs: new IExpectedArgs[]
+            {
+                new ExpectedArgs("optional", "An optional value.", isRequired: false),
+                new ExpectedArgs("required", "A required value."),
+            });
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CreateRegistry(command));
+
+        Assert.Contains("cannot follow optional", exception.Message);
+    }
+
+    [Fact]
+    public void Constructor_WhenFullNameIsDuplicated_Throws()
+    {
+        var first = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "First command.");
+        var second = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Second command.");
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => CreateRegistry(first, second));
+
+        Assert.Contains("coop.debug.test.capture", exception.Message);
+    }
+
+    [Fact]
+    public void ProcessCommand_TrimsArgumentsBeforePassingThemToCommand()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Captures one value.",
+            expectedArgs: new IExpectedArgs[]
+            {
+                new ExpectedArgs("value", "The value to capture."),
+            });
+        var registry = CreateRegistry(command);
+        var args = new CoopCommandArgsFactory().FromValues(new[] { "  argument with spaces  " });
+
+        CoopCommandResult result = registry.ProcessCommand("coop.debug.test.capture", args);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("argument with spaces", result.Output);
+    }
+
+    [Fact]
+    public void ProcessCommand_WhenArgumentsDoNotMatchDefinitions_ReturnsUsageWithoutInvokingCommand()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Captures one value.",
+            expectedArgs: new IExpectedArgs[]
+            {
+                new ExpectedArgs("value", "The value to capture."),
+            });
+        var registry = CreateRegistry(command);
+        var argsFactory = new CoopCommandArgsFactory();
+        ICoopCommandArgs[] invalidArguments =
+        {
+            argsFactory.FromValues(Array.Empty<string>()),
+            argsFactory.FromValues(new[] { string.Empty }),
+            argsFactory.FromValues(new[] { "   " }),
+            argsFactory.FromValues(new[] { "first", "second" }),
+        };
+
+        foreach (ICoopCommandArgs args in invalidArguments)
+        {
+            CoopCommandResult result = registry.ProcessCommand("coop.debug.test.capture", args);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("invalid_arguments", result.ErrorCode);
+            Assert.Equal(
+                ExpectedUsage(
+                    "Usage: coop.debug.test.capture <value>",
+                    string.Empty,
+                    "Parameters:",
+                    "- value (required): The value to capture.",
+                    string.Empty,
+                    "Note: Wrap parameter values containing spaces in double quotes."),
+                result.Output);
+        }
+
+        Assert.Equal(0, command.ProcessCount);
+    }
+
+    [Fact]
+    public void ProcessCommand_WhenOptionalArgumentIsMissing_InvokesCommand()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Captures values.",
+            expectedArgs: new IExpectedArgs[]
+            {
+                new ExpectedArgs("value", "The value to capture."),
+                new ExpectedArgs("format", "The optional output format.", isRequired: false),
+            });
+        var registry = CreateRegistry(command);
+        var args = new CoopCommandArgsFactory().FromValues(new[] { "first" });
+
+        CoopCommandResult result = registry.ProcessCommand("coop.debug.test.capture", args);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(1, command.ProcessCount);
+        Assert.Equal(
+            ExpectedUsage(
+                "Usage: coop.debug.test.capture <value> [<format>]",
+                string.Empty,
+                "Parameters:",
+                "- value (required): The value to capture.",
+                "- format (optional): The optional output format.",
+                string.Empty,
+                "Note: Wrap parameter values containing spaces in double quotes."),
+            Assert.Single(registry.Commands).Usage);
+    }
+
+    [Fact]
+    public void ProcessCommand_WhenCommandThrows_ReturnsFailure()
+    {
+        var command = new TestCommand(
+            "coop.debug.test",
+            "capture",
+            "Captures one value.",
+            throwOnProcess: true);
+        var registry = CreateRegistry(command);
+        var args = new CoopCommandArgsFactory().FromValues(Array.Empty<string>());
+
+        CoopCommandResult result = registry.ProcessCommand("coop.debug.test.capture", args);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("command_failed", result.ErrorCode);
+        Assert.Contains("test failure", result.Output);
+    }
+
+    private static string ExpectedUsage(params string[] lines)
+    {
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static CoopCommandRegistry CreateRegistry(params ICoopCommand[] commands)
+    {
+        return new CoopCommandRegistry(commands, Mock.Of<ILogger>());
+    }
+
+    private sealed class TestCommand : ICoopCommand
+    {
+        private readonly bool throwOnProcess;
+
+        public TestCommand(
+            string prefix,
+            string name,
+            string description,
+            bool throwOnProcess = false,
+            params IExpectedArgs[] expectedArgs)
+        {
+            Prefix = prefix;
+            Name = name;
+            Description = description;
+            ExpectedArgs = expectedArgs;
+            this.throwOnProcess = throwOnProcess;
+        }
+
+        public string Prefix { get; }
+
+        public string Name { get; }
+
+        public string Description { get; }
+
+        public IExpectedArgs[] ExpectedArgs { get; }
+
+        public int ProcessCount { get; private set; }
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            ProcessCount++;
+            if (throwOnProcess) throw new InvalidOperationException("test failure");
+
+            return new CoopCommandResult(true, args.Count == 0 ? string.Empty : args[0]);
+        }
+    }
+}

--- a/source/Common/Commands/CoopCommandArgs.cs
+++ b/source/Common/Commands/CoopCommandArgs.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Common.Commands;
+
+public interface ICoopCommandArgs : IReadOnlyList<string>
+{
+}
+
+internal sealed class CoopCommandArgs : ICoopCommandArgs
+{
+    private readonly IReadOnlyList<string> values;
+
+    public CoopCommandArgs(IReadOnlyList<string> values)
+    {
+        if (values == null) throw new ArgumentNullException(nameof(values));
+
+        this.values = values;
+    }
+
+    public int Count => values.Count;
+
+    public string this[int index] => values[index];
+
+    public IEnumerator<string> GetEnumerator()
+    {
+        return values.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/source/Common/Commands/CoopCommandArgsFactory.cs
+++ b/source/Common/Commands/CoopCommandArgsFactory.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Common.Commands;
+
+public interface ICoopCommandArgsFactory
+{
+    ICoopCommandArgs FromValues(IEnumerable<string> values);
+
+    bool TryFromConsoleTokens(
+        IEnumerable<string> tokens,
+        out ICoopCommandArgs args,
+        out string error);
+}
+
+public sealed class CoopCommandArgsFactory : ICoopCommandArgsFactory
+{
+    public ICoopCommandArgs FromValues(IEnumerable<string> values)
+    {
+        if (values == null) throw new ArgumentNullException(nameof(values));
+
+        var copiedValues = new List<string>();
+        foreach (string value in values)
+        {
+            if (value == null)
+                throw new ArgumentException("Command arguments cannot contain null values.", nameof(values));
+
+            copiedValues.Add(value);
+        }
+
+        return new CoopCommandArgs(copiedValues.AsReadOnly());
+    }
+
+    public bool TryFromConsoleTokens(
+        IEnumerable<string> tokens,
+        out ICoopCommandArgs args,
+        out string error)
+    {
+        args = null;
+        error = null;
+
+        if (tokens == null)
+        {
+            error = "Command arguments cannot be null.";
+            return false;
+        }
+
+        var parsedValues = new List<string>();
+        StringBuilder currentValue = null;
+        bool insideQuotes = false;
+
+        foreach (string token in tokens)
+        {
+            if (token == null)
+            {
+                error = "Command arguments cannot contain null values.";
+                return false;
+            }
+
+            if (!insideQuotes && token.Length == 0) continue;
+
+            if (currentValue == null)
+            {
+                currentValue = new StringBuilder();
+            }
+            else if (insideQuotes)
+            {
+                currentValue.Append(' ');
+            }
+
+            for (int index = 0; index < token.Length; index++)
+            {
+                char current = token[index];
+                if (current == '\\' && index + 1 < token.Length)
+                {
+                    char escaped = token[index + 1];
+                    if (escaped == '\\' || escaped == '"')
+                    {
+                        currentValue.Append(escaped);
+                        index++;
+                        continue;
+                    }
+                }
+
+                if (current == '"')
+                {
+                    insideQuotes = !insideQuotes;
+                    continue;
+                }
+
+                currentValue.Append(current);
+            }
+
+            if (!insideQuotes)
+            {
+                parsedValues.Add(currentValue.ToString());
+                currentValue = null;
+            }
+        }
+
+        if (insideQuotes)
+        {
+            error = "Command arguments contain an unterminated double quote.";
+            return false;
+        }
+
+        args = new CoopCommandArgs(parsedValues.AsReadOnly());
+        return true;
+    }
+}

--- a/source/Common/Commands/CoopCommandDescriptor.cs
+++ b/source/Common/Commands/CoopCommandDescriptor.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Text;
+
+namespace Common.Commands;
+
+public sealed class CoopCommandDescriptor
+{
+    private readonly IExpectedArgs[] expectedArgs;
+
+    internal CoopCommandDescriptor(
+        string prefix,
+        string name,
+        string description,
+        IExpectedArgs[] expectedArgs)
+    {
+        if (expectedArgs == null) throw new ArgumentNullException(nameof(expectedArgs));
+
+        Prefix = prefix;
+        Name = name;
+        FullName = $"{prefix}.{name}";
+        Description = description;
+        this.expectedArgs = (IExpectedArgs[])expectedArgs.Clone();
+        Usage = BuildUsage();
+    }
+
+    public string Prefix { get; }
+
+    public string Name { get; }
+
+    public string FullName { get; }
+
+    public string Usage { get; }
+
+    public string Description { get; }
+
+    public IExpectedArgs[] ExpectedArgs => (IExpectedArgs[])expectedArgs.Clone();
+
+    private string BuildUsage()
+    {
+        var usage = new StringBuilder("Usage: ");
+        usage.Append(FullName);
+        foreach (IExpectedArgs expectedArg in expectedArgs)
+        {
+            usage.Append(expectedArg.IsRequired ? " <" : " [<");
+            usage.Append(expectedArg.Name);
+            usage.Append(expectedArg.IsRequired ? ">" : ">]");
+        }
+
+        if (expectedArgs.Length == 0) return usage.ToString();
+
+        usage.AppendLine();
+        usage.AppendLine();
+        usage.AppendLine("Parameters:");
+        foreach (IExpectedArgs expectedArg in expectedArgs)
+        {
+            usage.Append("- ");
+            usage.Append(expectedArg.Name);
+            usage.Append(expectedArg.IsRequired ? " (required): " : " (optional): ");
+            usage.AppendLine(expectedArg.Description);
+        }
+
+        usage.AppendLine();
+        usage.Append("Note: Wrap parameter values containing spaces in double quotes.");
+        return usage.ToString();
+    }
+}

--- a/source/Common/Commands/CoopCommandRegistry.cs
+++ b/source/Common/Commands/CoopCommandRegistry.cs
@@ -1,0 +1,189 @@
+﻿using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Common.Commands;
+
+public interface ICoopCommandRegistry
+{
+    IReadOnlyList<CoopCommandDescriptor> Commands { get; }
+
+    bool Contains(string fullName);
+
+    CoopCommandResult ProcessCommand(string fullName, ICoopCommandArgs args);
+}
+
+public sealed class CoopCommandRegistry : ICoopCommandRegistry
+{
+    private readonly IReadOnlyDictionary<string, ICoopCommand> commandsByName;
+    private readonly IReadOnlyDictionary<string, CoopCommandDescriptor> descriptorsByName;
+    private readonly ILogger logger;
+
+    public CoopCommandRegistry(IEnumerable<ICoopCommand> commands, ILogger logger)
+    {
+        if (commands == null) throw new ArgumentNullException(nameof(commands));
+        if (logger == null) throw new ArgumentNullException(nameof(logger));
+
+        this.logger = logger;
+
+        var commandMap = new Dictionary<string, ICoopCommand>(StringComparer.Ordinal);
+        var descriptorMap = new Dictionary<string, CoopCommandDescriptor>(StringComparer.Ordinal);
+        var descriptors = new List<CoopCommandDescriptor>();
+        foreach (ICoopCommand command in commands)
+        {
+            if (command == null)
+                throw new ArgumentException("The command collection cannot contain null values.", nameof(commands));
+
+            IExpectedArgs[] expectedArgs = command.ExpectedArgs;
+            ValidateCommand(command, expectedArgs);
+
+            var descriptor = new CoopCommandDescriptor(
+                command.Prefix,
+                command.Name,
+                command.Description,
+                expectedArgs);
+            if (commandMap.ContainsKey(descriptor.FullName))
+                throw new InvalidOperationException($"The command '{descriptor.FullName}' is registered more than once.");
+
+            commandMap.Add(descriptor.FullName, command);
+            descriptorMap.Add(descriptor.FullName, descriptor);
+            descriptors.Add(descriptor);
+        }
+
+        descriptors.Sort((first, second) =>
+            StringComparer.Ordinal.Compare(first.FullName, second.FullName));
+
+        commandsByName = new ReadOnlyDictionary<string, ICoopCommand>(commandMap);
+        descriptorsByName = new ReadOnlyDictionary<string, CoopCommandDescriptor>(descriptorMap);
+        Commands = descriptors.AsReadOnly();
+    }
+
+    public IReadOnlyList<CoopCommandDescriptor> Commands { get; }
+
+    public bool Contains(string fullName)
+    {
+        return fullName != null && commandsByName.ContainsKey(fullName);
+    }
+
+    public CoopCommandResult ProcessCommand(string fullName, ICoopCommandArgs args)
+    {
+        if (args == null) throw new ArgumentNullException(nameof(args));
+
+        if (fullName == null || !commandsByName.TryGetValue(fullName, out ICoopCommand command))
+        {
+            return new CoopCommandResult(
+                false,
+                $"Could not find the command {fullName}",
+                "command_not_found");
+        }
+
+        CoopCommandDescriptor descriptor = descriptorsByName[fullName];
+        if (!ArgumentsAreValid(descriptor.ExpectedArgs, args))
+            return new CoopCommandResult(false, descriptor.Usage, "invalid_arguments");
+
+        ICoopCommandArgs trimmedArgs = TrimArguments(args);
+        try
+        {
+            CoopCommandResult result = command.ProcessCommand(trimmedArgs);
+            if (result == null)
+                throw new InvalidOperationException($"The command '{fullName}' returned no result.");
+
+            return result;
+        }
+        catch (Exception exception)
+        {
+            logger.Error(exception, "Command {CommandName} failed", fullName);
+            return new CoopCommandResult(
+                false,
+                $"Command '{fullName}' failed: {exception.Message}",
+                "command_failed");
+        }
+    }
+
+    private void ValidateCommand(ICoopCommand command, IExpectedArgs[] expectedArgs)
+    {
+        if (string.IsNullOrWhiteSpace(command.Prefix))
+            throw new InvalidOperationException($"{command.GetType().Name} has no command prefix.");
+        if (!string.Equals(command.Prefix, "coop", StringComparison.Ordinal) &&
+            !command.Prefix.StartsWith("coop.", StringComparison.Ordinal))
+            throw new InvalidOperationException($"The command prefix '{command.Prefix}' must begin with 'coop'.");
+        if (command.Prefix.StartsWith(".", StringComparison.Ordinal) ||
+            command.Prefix.EndsWith(".", StringComparison.Ordinal) ||
+            command.Prefix.Contains("..") ||
+            ContainsWhitespace(command.Prefix))
+            throw new InvalidOperationException($"The command prefix '{command.Prefix}' is invalid.");
+        if (string.IsNullOrWhiteSpace(command.Name) ||
+            command.Name.Contains(".") ||
+            ContainsWhitespace(command.Name))
+            throw new InvalidOperationException($"The command name '{command.Name}' is invalid.");
+        if (string.IsNullOrWhiteSpace(command.Description))
+            throw new InvalidOperationException($"The command '{command.Prefix}.{command.Name}' has no description.");
+
+        ValidateExpectedArgs(command, expectedArgs);
+    }
+
+    private void ValidateExpectedArgs(ICoopCommand command, IExpectedArgs[] expectedArgs)
+    {
+        if (expectedArgs == null)
+            throw new InvalidOperationException($"The command '{command.Prefix}.{command.Name}' has no expected argument definitions.");
+
+        var argumentNames = new HashSet<string>(StringComparer.Ordinal);
+        bool optionalArgumentFound = false;
+        foreach (IExpectedArgs expectedArg in expectedArgs)
+        {
+            if (expectedArg == null)
+                throw new InvalidOperationException($"The command '{command.Prefix}.{command.Name}' has a null expected argument definition.");
+            if (string.IsNullOrWhiteSpace(expectedArg.Name) || ContainsWhitespace(expectedArg.Name))
+                throw new InvalidOperationException($"The expected argument name '{expectedArg.Name}' is invalid.");
+            if (string.IsNullOrWhiteSpace(expectedArg.Description))
+                throw new InvalidOperationException($"The expected argument '{expectedArg.Name}' has no description.");
+            if (!argumentNames.Add(expectedArg.Name))
+                throw new InvalidOperationException($"The expected argument '{expectedArg.Name}' is defined more than once.");
+            if (expectedArg.IsRequired && optionalArgumentFound)
+                throw new InvalidOperationException("Required expected arguments cannot follow optional arguments.");
+
+            optionalArgumentFound |= !expectedArg.IsRequired;
+        }
+    }
+
+    private bool ArgumentsAreValid(IExpectedArgs[] expectedArgs, ICoopCommandArgs args)
+    {
+        int requiredArgumentCount = 0;
+        foreach (IExpectedArgs expectedArg in expectedArgs)
+        {
+            if (!expectedArg.IsRequired) break;
+            requiredArgumentCount++;
+        }
+
+        if (args.Count < requiredArgumentCount || args.Count > expectedArgs.Length) return false;
+
+        foreach (string value in args)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return false;
+        }
+
+        return true;
+    }
+
+    private ICoopCommandArgs TrimArguments(ICoopCommandArgs args)
+    {
+        var trimmedValues = new List<string>(args.Count);
+        foreach (string value in args)
+        {
+            trimmedValues.Add(value.Trim());
+        }
+
+        return new CoopCommandArgs(trimmedValues.AsReadOnly());
+    }
+
+    private bool ContainsWhitespace(string value)
+    {
+        foreach (char character in value)
+        {
+            if (char.IsWhiteSpace(character)) return true;
+        }
+
+        return false;
+    }
+}

--- a/source/Common/Commands/CoopCommandResult.cs
+++ b/source/Common/Commands/CoopCommandResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Common.Commands;
+
+public sealed class CoopCommandResult
+{
+    public CoopCommandResult(bool succeeded, string output, string errorCode = null)
+    {
+        if (output == null) throw new ArgumentNullException(nameof(output));
+        if (succeeded && errorCode != null)
+            throw new ArgumentException("A successful command result cannot have an error code.", nameof(errorCode));
+        if (!succeeded && string.IsNullOrWhiteSpace(errorCode))
+            throw new ArgumentException("A failed command result must have an error code.", nameof(errorCode));
+
+        Succeeded = succeeded;
+        Output = output;
+        ErrorCode = errorCode;
+    }
+
+    public bool Succeeded { get; }
+
+    public string Output { get; }
+
+    public string ErrorCode { get; }
+}

--- a/source/Common/Commands/ExpectedArgs.cs
+++ b/source/Common/Commands/ExpectedArgs.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Common.Commands;
+
+public interface IExpectedArgs
+{
+    string Name { get; }
+
+    string Description { get; }
+
+    bool IsRequired { get; }
+}
+
+public sealed class ExpectedArgs : IExpectedArgs
+{
+    public ExpectedArgs(string name, string description, bool isRequired = true)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("An argument name is required.", nameof(name));
+        if (string.IsNullOrWhiteSpace(description)) throw new ArgumentException("An argument description is required.", nameof(description));
+
+        Name = name;
+        Description = description;
+        IsRequired = isRequired;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public bool IsRequired { get; }
+}

--- a/source/Common/Commands/ICoopCommand.cs
+++ b/source/Common/Commands/ICoopCommand.cs
@@ -1,0 +1,14 @@
+﻿namespace Common.Commands;
+
+public interface ICoopCommand
+{
+    string Prefix { get; }
+
+    string Name { get; }
+
+    string Description { get; }
+
+    IExpectedArgs[] ExpectedArgs { get; }
+
+    CoopCommandResult ProcessCommand(ICoopCommandArgs args);
+}

--- a/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
+++ b/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
@@ -1,5 +1,8 @@
 ﻿using Common;
+using Common.Commands;
 using GameInterface.Services.LiveTesting;
+using Moq;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,6 +37,26 @@ public class LiveTestCommandDispatcherTests
 
         Assert.True(result.Found);
         Assert.Equal("argument with spaces|identifier-42", result.Output);
+    }
+
+    [Fact]
+    public void Execute_WhenFrameworkCommandExists_PreservesStructuredArguments()
+    {
+        const string commandName = "coop.debug.live_testing_dispatcher_test.framework_capture";
+        var registry = new CoopCommandRegistry(
+            new[] { new FrameworkCaptureCommand() },
+            Mock.Of<ILogger>());
+        var dispatcher = new LiveTestCommandDispatcher(registry, new CoopCommandArgsFactory());
+        var arguments = new List<string>
+        {
+            "argument with spaces",
+            "quoted \"value\"",
+        };
+
+        LiveTestCommandResult result = dispatcher.Execute(commandName, arguments);
+
+        Assert.True(result.Found);
+        Assert.Equal("argument with spaces|quoted \"value\"", result.Output);
     }
 
     [Fact]
@@ -88,5 +111,25 @@ public class LiveTestCommandDispatcherTests
     {
         nonDebugInvocations++;
         return "invoked";
+    }
+
+    private sealed class FrameworkCaptureCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.live_testing_dispatcher_test";
+
+        public string Name => "framework_capture";
+
+        public string Description => "Captures structured live-test arguments.";
+
+        public IExpectedArgs[] ExpectedArgs => new IExpectedArgs[]
+        {
+            new ExpectedArgs("first", "The first value to capture."),
+            new ExpectedArgs("second", "The second value to capture."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return new CoopCommandResult(true, string.Join("|", args));
+        }
     }
 }

--- a/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
@@ -2,6 +2,8 @@
 using GameInterface.Utils.Commands;
 using Moq;
 using Serilog;
+using System;
+using System.Runtime.CompilerServices;
 using TaleWorlds.Library;
 using Xunit;
 
@@ -63,6 +65,77 @@ public class CoopCommandLineRegistrarTests
         }
 
         Assert.False(CommandLineFunctionality.HasFunctionForCommand(FullName));
+    }
+
+    [Fact]
+    public void Registration_WhenThreeGenerationsOverlap_UnlinksDisposedPredecessors()
+    {
+        var argsFactory = new CoopCommandArgsFactory();
+        var registrations = CreateOverlappingRegistrations(argsFactory);
+
+        try
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            Assert.False(registrations.FirstRegistrar.IsAlive);
+            Assert.False(registrations.FirstRegistry.IsAlive);
+            Assert.False(registrations.SecondRegistrar.IsAlive);
+            Assert.False(registrations.SecondRegistry.IsAlive);
+
+            string output = CommandLineFunctionality.CallFunction(
+                FullName,
+                "current",
+                out bool found);
+
+            Assert.True(found);
+            Assert.Equal("current", output);
+        }
+        finally
+        {
+            registrations.ActiveRegistrar.Dispose();
+        }
+
+        Assert.False(CommandLineFunctionality.HasFunctionForCommand(FullName));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (
+        WeakReference FirstRegistrar,
+        WeakReference FirstRegistry,
+        WeakReference SecondRegistrar,
+        WeakReference SecondRegistry,
+        CoopCommandLineRegistrar ActiveRegistrar) CreateOverlappingRegistrations(
+            CoopCommandArgsFactory argsFactory)
+    {
+        var firstRegistry = new CoopCommandRegistry(
+            new[] { new CaptureCommand() },
+            Mock.Of<ILogger>());
+        var secondRegistry = new CoopCommandRegistry(
+            new[] { new CaptureCommand() },
+            Mock.Of<ILogger>());
+        var thirdRegistry = new CoopCommandRegistry(
+            new[] { new CaptureCommand() },
+            Mock.Of<ILogger>());
+        var firstRegistrar = new CoopCommandLineRegistrar(firstRegistry, argsFactory);
+        var secondRegistrar = new CoopCommandLineRegistrar(secondRegistry, argsFactory);
+        var thirdRegistrar = new CoopCommandLineRegistrar(thirdRegistry, argsFactory);
+
+        var firstRegistrarReference = new WeakReference(firstRegistrar);
+        var firstRegistryReference = new WeakReference(firstRegistry);
+        var secondRegistrarReference = new WeakReference(secondRegistrar);
+        var secondRegistryReference = new WeakReference(secondRegistry);
+
+        firstRegistrar.Dispose();
+        secondRegistrar.Dispose();
+
+        return (
+            firstRegistrarReference,
+            firstRegistryReference,
+            secondRegistrarReference,
+            secondRegistryReference,
+            thirdRegistrar);
     }
 
     private sealed class CaptureCommand : ICoopCommand

--- a/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
@@ -1,0 +1,87 @@
+﻿using Common.Commands;
+using GameInterface.Utils.Commands;
+using Moq;
+using Serilog;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+public class CoopCommandLineRegistrarTests
+{
+    private const string FullName = "coop.debug.command_framework_test.capture";
+
+    [Fact]
+    public void Registration_ExposesCommandToBannerlordAndParsesQuotedArguments()
+    {
+        var registry = new CoopCommandRegistry(
+            new[] { new CaptureCommand() },
+            Mock.Of<ILogger>());
+        var argsFactory = new CoopCommandArgsFactory();
+
+        using (var registrar = new CoopCommandLineRegistrar(registry, argsFactory))
+        {
+            string output = CommandLineFunctionality.CallFunction(
+                FullName,
+                "\"argument with spaces\" tail",
+                out bool found);
+
+            Assert.True(found);
+            Assert.Equal("argument with spaces|tail", output);
+            Assert.True(CommandLineFunctionality.HasFunctionForCommand(FullName));
+        }
+
+        Assert.False(CommandLineFunctionality.HasFunctionForCommand(FullName));
+    }
+
+    [Fact]
+    public void Registration_WhenFrameworkRegistrationAlreadyExists_ReplacesItForNewLifetime()
+    {
+        var registry = new CoopCommandRegistry(
+            new[] { new CaptureCommand() },
+            Mock.Of<ILogger>());
+        var argsFactory = new CoopCommandArgsFactory();
+        var first = new CoopCommandLineRegistrar(registry, argsFactory);
+        var second = new CoopCommandLineRegistrar(registry, argsFactory);
+
+        try
+        {
+            first.Dispose();
+
+            string output = CommandLineFunctionality.CallFunction(
+                FullName,
+                "current",
+                out bool found);
+
+            Assert.True(found);
+            Assert.Equal("current", output);
+        }
+        finally
+        {
+            first.Dispose();
+            second.Dispose();
+        }
+
+        Assert.False(CommandLineFunctionality.HasFunctionForCommand(FullName));
+    }
+
+    private sealed class CaptureCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.command_framework_test";
+
+        public string Name => "capture";
+
+        public string Description => "Captures arguments for the command framework test.";
+
+        public IExpectedArgs[] ExpectedArgs => new IExpectedArgs[]
+        {
+            new ExpectedArgs("first", "The first value."),
+            new ExpectedArgs("second", "The second value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return new CoopCommandResult(true, string.Join("|", args));
+        }
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -2,6 +2,7 @@
 using Autofac.Core;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving.Pipeline;
+using Common.Commands;
 using Common.Logging;
 using Common.PacketHandlers;
 using GameInterface.AutoSync;
@@ -17,6 +18,7 @@ using GameInterface.Services.Chat;
 using GameInterface.Services.Entity;
 using GameInterface.Services.GameDebug.Metrics;
 using GameInterface.Services.Heroes;
+using GameInterface.Services.Heroes.Commands;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Issues.Generic;
 using GameInterface.Services.Issues.Interfaces;
@@ -52,6 +54,7 @@ using GameInterface.Services.UI.BugReporting;
 using GameInterface.Services.UI.Patches;
 using GameInterface.Services.Workshops;
 using GameInterface.Surrogates;
+using GameInterface.Utils.Commands;
 using HarmonyLib;
 using Serilog;
 using System.Linq;
@@ -78,6 +81,17 @@ public class GameInterfaceModule : Module
             .PreserveExistingDefaults();
 
         builder.RegisterType<SurrogateCollection>().As<ISurrogateCollection>().InstancePerLifetimeScope().AutoActivate();
+
+        builder.RegisterType<CoopCommandArgsFactory>().As<ICoopCommandArgsFactory>().InstancePerDependency();
+        builder.RegisterType<CoopCommandRegistry>().As<ICoopCommandRegistry>().InstancePerLifetimeScope();
+        builder.RegisterType<HeroIdCommand>()
+            .As<IHeroIdCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<CoopCommandLineRegistrar>()
+            .As<ICoopCommandLineRegistrar>()
+            .InstancePerLifetimeScope()
+            .AutoActivate();
 
         builder.RegisterType<GameInterface>().As<IGameInterface>().InstancePerLifetimeScope().AutoActivate();
         // mod-config.json: one lazy read per session container (see IModConfig).

--- a/source/GameInterface/Services/Heroes/Commands/HeroDebugCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/HeroDebugCommand.cs
@@ -126,47 +126,6 @@ public class HeroDebugCommand
                $"LIVE_TEST_JSON={structuredState}";
     }
 
-    [CommandLineArgumentFunction("id", "coop.debug.hero")]
-    public static string FindIds(List<string> args)
-    {
-        if (args == null || args.Count == 0)
-        {
-            return "Usage: coop.debug.hero.id <hero name>";
-        }
-
-        var heroName = string.Join(" ", args).Trim();
-        if (string.IsNullOrWhiteSpace(heroName)) return "Usage: coop.debug.hero.id <hero name>";
-
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
-        {
-            return $"Unable to get {nameof(IObjectManager)}";
-        }
-
-        var campaign = Campaign.Current;
-        if (campaign == null) return "Campaign is not loaded.";
-
-        var heroes = campaign.CampaignObjectManager.GetAllHeroes()
-            .Where(hero => string.Equals(hero.Name?.ToString(), heroName, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        if (heroes.Count == 0) return $"No hero named '{heroName}' was found.";
-
-        var result = new StringBuilder();
-        foreach (var hero in heroes)
-        {
-            if (objectManager.TryGetId(hero, out var id))
-            {
-                result.AppendLine($"ID: '{id}', Name: '{hero.Name}', Game StringId: {hero.StringId}");
-            }
-            else
-            {
-                result.AppendLine($"Name: '{hero.Name}' was not registered with object manager");
-            }
-        }
-
-        return result.ToString();
-    }
-
     // coop.debug.hero.info
     [CommandLineArgumentFunction("info", "coop.debug.hero")]
     public static string Info(List<string> args)

--- a/source/GameInterface/Services/Heroes/Commands/HeroIdCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/HeroIdCommand.cs
@@ -1,0 +1,70 @@
+﻿using Common.Commands;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.ObjectManager.Extensions;
+using System;
+using System.Linq;
+using System.Text;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Heroes.Commands;
+
+public interface IHeroIdCommand : ICoopCommand
+{
+}
+
+public sealed class HeroIdCommand : IHeroIdCommand
+{
+    private readonly IObjectManager objectManager;
+
+    public HeroIdCommand(IObjectManager objectManager)
+    {
+        if (objectManager == null) throw new ArgumentNullException(nameof(objectManager));
+
+        this.objectManager = objectManager;
+    }
+
+    public string Prefix => "coop.debug.hero";
+
+    public string Name => "id";
+
+    public string Description => "Finds registered ids for heroes with an exact display name.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs(
+            "heroName",
+            "The exact display name of the hero to find."),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        Campaign campaign = Campaign.Current;
+        if (campaign == null)
+            return new CoopCommandResult(false, "Campaign is not loaded.", "campaign_unavailable");
+
+        string heroName = args[0];
+        var heroes = campaign.CampaignObjectManager.GetAllHeroes()
+            .Where(hero => string.Equals(
+                hero.Name?.ToString(),
+                heroName,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (heroes.Count == 0)
+            return new CoopCommandResult(false, $"No hero named '{heroName}' was found.", "hero_not_found");
+
+        var output = new StringBuilder();
+        foreach (Hero hero in heroes)
+        {
+            if (objectManager.TryGetId(hero, out string id))
+            {
+                output.AppendLine($"ID: '{id}', Name: '{hero.Name}', Game StringId: {hero.StringId}");
+            }
+            else
+            {
+                output.AppendLine($"Name: '{hero.Name}' was not registered with object manager");
+            }
+        }
+
+        return new CoopCommandResult(true, output.ToString());
+    }
+}

--- a/source/GameInterface/Services/LiveTesting/LiveTestCommandDispatcher.cs
+++ b/source/GameInterface/Services/LiveTesting/LiveTestCommandDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Commands;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -23,6 +24,24 @@ public class LiveTestCommandDispatcher : ILiveTestCommandDispatcher
     private const string AllowedCommandPrefix = "coop.debug.";
 
     private static bool functionsCollected;
+
+    private readonly ICoopCommandRegistry commandRegistry;
+    private readonly ICoopCommandArgsFactory argsFactory;
+
+    public LiveTestCommandDispatcher()
+    {
+    }
+
+    public LiveTestCommandDispatcher(
+        ICoopCommandRegistry commandRegistry,
+        ICoopCommandArgsFactory argsFactory)
+    {
+        if (commandRegistry == null) throw new ArgumentNullException(nameof(commandRegistry));
+        if (argsFactory == null) throw new ArgumentNullException(nameof(argsFactory));
+
+        this.commandRegistry = commandRegistry;
+        this.argsFactory = argsFactory;
+    }
 
     public bool EnsureReady()
     {
@@ -63,9 +82,14 @@ public class LiveTestCommandDispatcher : ILiveTestCommandDispatcher
                     throw new InvalidOperationException("Unable to read the Bannerlord command registry");
                 }
 
+                IEnumerable<string> registeredCommands = commandRegistry == null
+                    ? Enumerable.Empty<string>()
+                    : commandRegistry.Commands.Select(command => command.FullName);
                 commandNames = allFunctions.Keys
                     .Cast<string>()
+                    .Concat(registeredCommands)
                     .Where(command => command.StartsWith(AllowedCommandPrefix, StringComparison.Ordinal))
+                    .Distinct(StringComparer.Ordinal)
                     .OrderBy(command => command, StringComparer.Ordinal)
                     .ToArray();
             }
@@ -97,6 +121,14 @@ public class LiveTestCommandDispatcher : ILiveTestCommandDispatcher
             try
             {
                 EnsureFunctionsCollected();
+
+                if (commandRegistry != null && commandRegistry.Contains(command))
+                {
+                    ICoopCommandArgs commandArgs = argsFactory.FromValues(arguments);
+                    CoopCommandResult commandResult = commandRegistry.ProcessCommand(command, commandArgs);
+                    result = new LiveTestCommandResult(true, commandResult.Output);
+                    return;
+                }
 
                 string output = CommandLineFunctionality.CallFunction(command, arguments, out bool found);
                 result = new LiveTestCommandResult(found, output);

--- a/source/GameInterface/Utils/Commands/CoopCommandLineRegistrar.cs
+++ b/source/GameInterface/Utils/Commands/CoopCommandLineRegistrar.cs
@@ -123,9 +123,12 @@ public sealed class CoopCommandLineRegistrar : ICoopCommandLineRegistrar
     {
         foreach (KeyValuePair<string, Registration> registration in registrations)
         {
-            if (!gameCommands.Contains(registration.Key) ||
-                !ReferenceEquals(gameCommands[registration.Key], registration.Value.GameCommand))
+            if (!gameCommands.Contains(registration.Key)) continue;
+
+            object currentRegistration = gameCommands[registration.Key];
+            if (!ReferenceEquals(currentRegistration, registration.Value.GameCommand))
             {
+                PruneDisposedPreviousRegistrations(registration.Key, currentRegistration);
                 continue;
             }
 
@@ -140,6 +143,25 @@ public sealed class CoopCommandLineRegistrar : ICoopCommandLineRegistrar
             {
                 gameCommands[registration.Key] = previousRegistration;
             }
+        }
+    }
+
+    private void PruneDisposedPreviousRegistrations(string fullName, object currentRegistration)
+    {
+        object candidate = currentRegistration;
+        while (candidate != null && TryGetOwningRegistrar(candidate, out CoopCommandLineRegistrar owner))
+        {
+            if (!owner.registrations.TryGetValue(fullName, out Registration registration) ||
+                !ReferenceEquals(registration.GameCommand, candidate))
+            {
+                return;
+            }
+
+            object activePreviousRegistration = FindActivePreviousRegistration(
+                fullName,
+                registration.PreviousRegistration);
+            registration.PreviousRegistration = activePreviousRegistration;
+            candidate = activePreviousRegistration;
         }
     }
 
@@ -206,6 +228,6 @@ public sealed class CoopCommandLineRegistrar : ICoopCommandLineRegistrar
 
         public object GameCommand { get; }
 
-        public object PreviousRegistration { get; }
+        public object PreviousRegistration { get; set; }
     }
 }

--- a/source/GameInterface/Utils/Commands/CoopCommandLineRegistrar.cs
+++ b/source/GameInterface/Utils/Commands/CoopCommandLineRegistrar.cs
@@ -1,0 +1,211 @@
+﻿using Common.Commands;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using TaleWorlds.Library;
+
+namespace GameInterface.Utils.Commands;
+
+public interface ICoopCommandLineRegistrar : IDisposable
+{
+}
+
+public sealed class CoopCommandLineRegistrar : ICoopCommandLineRegistrar
+{
+    private readonly ICoopCommandRegistry commandRegistry;
+    private readonly ICoopCommandArgsFactory argsFactory;
+    private readonly IDictionary gameCommands;
+    private readonly Type gameCommandType;
+    private readonly FieldInfo gameCommandDelegateField;
+    private readonly Dictionary<string, Registration> registrations =
+        new Dictionary<string, Registration>(StringComparer.Ordinal);
+    private bool disposed;
+
+    public CoopCommandLineRegistrar(
+        ICoopCommandRegistry commandRegistry,
+        ICoopCommandArgsFactory argsFactory)
+    {
+        if (commandRegistry == null) throw new ArgumentNullException(nameof(commandRegistry));
+        if (argsFactory == null) throw new ArgumentNullException(nameof(argsFactory));
+
+        this.commandRegistry = commandRegistry;
+        this.argsFactory = argsFactory;
+
+        // Publicizing TaleWorlds.Library here produces duplicate InformationManager members.
+        FieldInfo allFunctionsField = typeof(CommandLineFunctionality).GetField(
+            "AllFunctions",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        gameCommandType = typeof(CommandLineFunctionality).GetNestedType(
+            "CommandLineFunction",
+            BindingFlags.NonPublic);
+        gameCommandDelegateField = gameCommandType?.GetField(
+            "CommandLineFunc",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        if (allFunctionsField == null ||
+            !(allFunctionsField.GetValue(null) is IDictionary registeredGameCommands) ||
+            gameCommandType == null ||
+            gameCommandDelegateField == null)
+        {
+            throw new InvalidOperationException("Unable to access the Bannerlord command registry.");
+        }
+
+        gameCommands = registeredGameCommands;
+
+        try
+        {
+            lock (gameCommands.SyncRoot)
+            {
+                RegisterCommands();
+            }
+        }
+        catch
+        {
+            disposed = true;
+            lock (gameCommands.SyncRoot)
+            {
+                RemoveRegistrations();
+            }
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (disposed) return;
+
+        disposed = true;
+        lock (gameCommands.SyncRoot)
+        {
+            RemoveRegistrations();
+        }
+    }
+
+    private void RegisterCommands()
+    {
+        foreach (CoopCommandDescriptor descriptor in commandRegistry.Commands)
+        {
+            string fullName = descriptor.FullName;
+            object previousRegistration = null;
+            if (gameCommands.Contains(fullName))
+            {
+                previousRegistration = gameCommands[fullName];
+                // Reconnects and tests may temporarily have overlapping session lifetime scopes.
+                if (!TryGetOwningRegistrar(previousRegistration, out _))
+                    throw new InvalidOperationException($"The command '{fullName}' is already registered with the game.");
+            }
+
+            var invoker = new GameCommandInvoker(this, fullName);
+            Func<List<string>, string> commandDelegate = invoker.ProcessCommand;
+            object gameCommand = Activator.CreateInstance(
+                gameCommandType,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null,
+                new object[] { commandDelegate },
+                null);
+            if (gameCommand == null)
+                throw new InvalidOperationException($"Unable to create a game registration for '{fullName}'.");
+
+            gameCommands[fullName] = gameCommand;
+            registrations.Add(fullName, new Registration(gameCommand, previousRegistration));
+        }
+    }
+
+    private string ProcessCommand(string fullName, IEnumerable<string> tokens)
+    {
+        if (!argsFactory.TryFromConsoleTokens(tokens, out ICoopCommandArgs args, out string error))
+            return $"Invalid arguments: {error}";
+
+        return commandRegistry.ProcessCommand(fullName, args).Output;
+    }
+
+    private void RemoveRegistrations()
+    {
+        foreach (KeyValuePair<string, Registration> registration in registrations)
+        {
+            if (!gameCommands.Contains(registration.Key) ||
+                !ReferenceEquals(gameCommands[registration.Key], registration.Value.GameCommand))
+            {
+                continue;
+            }
+
+            object previousRegistration = FindActivePreviousRegistration(
+                registration.Key,
+                registration.Value.PreviousRegistration);
+            if (previousRegistration == null)
+            {
+                gameCommands.Remove(registration.Key);
+            }
+            else
+            {
+                gameCommands[registration.Key] = previousRegistration;
+            }
+        }
+    }
+
+    private object FindActivePreviousRegistration(string fullName, object previousRegistration)
+    {
+        object candidate = previousRegistration;
+        while (candidate != null && TryGetOwningRegistrar(candidate, out CoopCommandLineRegistrar owner))
+        {
+            if (!owner.disposed) return candidate;
+
+            candidate = owner.GetPreviousRegistration(fullName, candidate);
+        }
+
+        return candidate;
+    }
+
+    private object GetPreviousRegistration(string fullName, object gameCommand)
+    {
+        if (registrations.TryGetValue(fullName, out Registration registration) &&
+            ReferenceEquals(registration.GameCommand, gameCommand))
+        {
+            return registration.PreviousRegistration;
+        }
+
+        return null;
+    }
+
+    private bool TryGetOwningRegistrar(object gameCommand, out CoopCommandLineRegistrar registrar)
+    {
+        registrar = null;
+        if (!(gameCommandDelegateField.GetValue(gameCommand) is Delegate commandDelegate)) return false;
+
+        if (!(commandDelegate.Target is GameCommandInvoker invoker)) return false;
+
+        registrar = invoker.Registrar;
+        return true;
+    }
+
+    private sealed class GameCommandInvoker
+    {
+        private readonly string fullName;
+
+        public GameCommandInvoker(CoopCommandLineRegistrar registrar, string fullName)
+        {
+            Registrar = registrar;
+            this.fullName = fullName;
+        }
+
+        public CoopCommandLineRegistrar Registrar { get; }
+
+        public string ProcessCommand(List<string> tokens)
+        {
+            return Registrar.ProcessCommand(fullName, tokens);
+        }
+    }
+
+    private sealed class Registration
+    {
+        public Registration(object gameCommand, object previousRegistration)
+        {
+            GameCommand = gameCommand;
+            PreviousRegistration = previousRegistration;
+        }
+
+        public object GameCommand { get; }
+
+        public object PreviousRegistration { get; }
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Console commands use static attributed methods and handle argument parsing, validation, and usage text individually. The command metadata and execution path cannot be reused cleanly by other transports.

## What is the new behavior?

Adds an Autofac-backed command registry with structured results, generated usage, centralized argument validation, trimming, and quoted argument parsing. Bannerlord console and live testing use adapters over the same registry, while existing attributed commands continue to work during migration.

Migrates `coop.debug.hero.id` as the first injected command.

## Bot Changelog Entry

## Other information

Tests:

- `dotnet test source/Common.Tests/Common.Tests.csproj -c Release --no-restore`
- `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~CoopCommandLineRegistrarTests|FullyQualifiedName~LiveTestCommandDispatcherTests"`
- `dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~ContainerBuildTests"`
