### PR TITLE
Restore dedicated server save sidecars

### DIFF
--- a/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
+++ b/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
@@ -4,10 +4,8 @@ using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.BugReporting;
 using GameInterface.Services.BugReporting.Messages;
-using GameInterface.Services.Heroes;
 using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Players;
-using GameInterface.Services.Save.Patches;
 using GameInterface.Services.UI.BugReporting;
 using Moq;
 using System;
@@ -19,7 +17,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using TaleWorlds.SaveSystem;
 using Xunit;
 
 namespace GameInterface.Tests.Services.BugReporting;
@@ -182,12 +179,12 @@ public class CoopLogBugReportTests : IDisposable
     }
 
     [Fact]
-    public void ServerSaveProvider_ReturnsTheCampaignSaveFileData()
+    public void ServerSaveProvider_PersistsAndReturnsTheCampaignSave()
     {
         var saveData = Encoding.UTF8.GetBytes("campaign save");
         var saveInterface = new Mock<ISaveInterface>();
         saveInterface
-            .Setup(value => value.SaveCurrentGameAsFileData(BugReportServerSaveProvider.SaveName))
+            .Setup(value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName))
             .Returns(new SaveResults(true, saveData, "campaign-id"));
         var provider = new BugReportServerSaveProvider(saveInterface.Object, Mock.Of<Serilog.ILogger>());
 
@@ -197,35 +194,8 @@ public class CoopLogBugReportTests : IDisposable
         Assert.Equal("coop_bug_report.sav", save.FileName);
         Assert.Equal(saveData, save.Data);
         saveInterface.Verify(
-            value => value.SaveCurrentGameAsFileData(BugReportServerSaveProvider.SaveName),
+            value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName),
             Times.Once);
-    }
-
-    [Fact]
-    public async Task ServerSaveSnapshot_DoesNotOverwriteExistingSavePair()
-    {
-        Directory.CreateDirectory(tempRoot);
-        var campaignPath = Path.Combine(tempRoot, "coop_bug_report.sav");
-        var sessionPath = Path.Combine(tempRoot, "coop_bug_report.json");
-        var existingCampaign = Encoding.UTF8.GetBytes("existing campaign");
-        var existingSession = Encoding.UTF8.GetBytes("existing session");
-        File.WriteAllBytes(campaignPath, existingCampaign);
-        File.WriteAllBytes(sessionPath, existingSession);
-        var driver = new CoopFileInMemSaveDriver();
-        var gameData = new GameData(
-            new byte[] { 1 },
-            new byte[] { 2 },
-            new[] { new byte[] { 3 } },
-            new[] { new byte[] { 4 } });
-
-        await driver.Save(BugReportServerSaveProvider.SaveName, 1, new MetaData(), gameData);
-
-        Assert.Equal(existingCampaign, File.ReadAllBytes(campaignPath));
-        Assert.Equal(existingSession, File.ReadAllBytes(sessionPath));
-        Assert.NotEmpty(driver.Data);
-        Assert.Equal(gameData.Header, driver.Load(BugReportServerSaveProvider.SaveName).GameData.Header);
-        Assert.False(SavePatches.ShouldPublishGameSaved(driver));
-        Assert.True(SavePatches.ShouldPublishGameSaved(new FileDriver()));
     }
 
     [Fact]

--- a/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace GameInterface.Services.BugReporting;
 
-/// <summary>Creates the native-format server campaign save attached to a diagnostic report.</summary>
+/// <summary>Creates the persistent server campaign save attached to a diagnostic report.</summary>
 public interface IBugReportServerSaveProvider
 {
     bool TryCapture(out CollectedBugReportServerSave save);
@@ -31,7 +31,7 @@ public class BugReportServerSaveProvider : IBugReportServerSaveProvider
         save = null;
         try
         {
-            var result = saveInterface.SaveCurrentGameAsFileData(SaveName);
+            var result = saveInterface.SaveCurrentGameToFile(SaveName);
             if (!result.Success || result.Data == null || result.Data.Length == 0)
             {
                 logger.Warning("The server campaign save for the diagnostic bug report could not be created");

--- a/source/GameInterface/Services/Save/CoopInMemSaveDriver.cs
+++ b/source/GameInterface/Services/Save/CoopInMemSaveDriver.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.IO;
-using System.IO.Compression;
-using System.Threading.Tasks;
-using TaleWorlds.Library;
-using TaleWorlds.SaveSystem;
+﻿using TaleWorlds.SaveSystem;
 
 namespace GameInterface.Services.Heroes;
 
@@ -26,56 +21,4 @@ internal class CoopInMemSaveDriver : InMemDriver
             return _data;
         }
     }
-}
-
-/// <summary>Produces a native FileDriver-format campaign save without writing to the user save directory.</summary>
-internal class CoopFileInMemSaveDriver : ISaveDriver
-{
-    private byte[] data = Array.Empty<byte>();
-
-    public byte[] Data => data;
-
-    public Task<SaveResultWithMessage> Save(string saveName, int version, MetaData metaData, GameData gameData)
-    {
-        using var stream = new MemoryStream();
-        metaData.Add("Version", version.ToString());
-        metaData.Serialize(stream);
-        using (var output = new DeflateStream(stream, CompressionLevel.Fastest, leaveOpen: true))
-        using (var writer = new System.IO.BinaryWriter(output))
-        {
-            GameData.Write(writer, gameData);
-        }
-
-        data = stream.ToArray();
-        return Task.FromResult(SaveResultWithMessage.Default);
-    }
-
-    public MetaData LoadMetaData(string saveName)
-    {
-        using var stream = new MemoryStream(data);
-        return MetaData.Deserialize(stream);
-    }
-
-    public LoadData Load(string saveName)
-    {
-        using var stream = new MemoryStream(data);
-        var metaData = MetaData.Deserialize(stream);
-        using var input = new DeflateStream(stream, CompressionMode.Decompress);
-        using var reader = new System.IO.BinaryReader(input);
-        return new LoadData(metaData, GameData.Read(reader));
-    }
-
-    public SaveGameFileInfo[] GetSaveGameFileInfos() => Array.Empty<SaveGameFileInfo>();
-
-    public string[] GetSaveGameFileNames() => Array.Empty<string>();
-
-    public bool Delete(string saveName)
-    {
-        data = Array.Empty<byte>();
-        return true;
-    }
-
-    public bool IsSaveGameFileExists(string saveName) => false;
-
-    public bool IsWorkingAsync() => false;
 }

--- a/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
+++ b/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
@@ -12,7 +12,7 @@ namespace GameInterface.Services.Heroes.Interfaces;
 public interface ISaveInterface : IGameAbstraction
 {
     SaveResults SaveCurrentGame();
-    SaveResults SaveCurrentGameAsFileData(string saveName);
+    SaveResults SaveCurrentGameToFile(string saveName);
 }
 
 internal class SaveInterface : ISaveInterface
@@ -29,16 +29,19 @@ internal class SaveInterface : ISaveInterface
             result.CampaignId);
     }
 
-    public SaveResults SaveCurrentGameAsFileData(string saveName)
+    public SaveResults SaveCurrentGameToFile(string saveName)
     {
         if (string.IsNullOrWhiteSpace(saveName))
             throw new ArgumentException("Save name cannot be empty.", nameof(saveName));
 
-        var saveDriver = new CoopFileInMemSaveDriver();
+        var saveDriver = new FileDriver();
         var result = SaveCurrentGame(saveName, saveDriver);
-        if (!result.Success || saveDriver.Data.Length == 0) return ReportSaveFailure("saved game data");
+        if (!result.Success) return result;
 
-        return new SaveResults(true, saveDriver.Data, result.CampaignId);
+        var data = FileHelper.GetFileContent(FileDriver.GetSaveFilePath(saveName + ".sav"));
+        if (data == null || data.Length == 0) return ReportSaveFailure("saved game file");
+
+        return new SaveResults(true, data, result.CampaignId);
     }
 
     private SaveResults SaveCurrentGame(string saveName, ISaveDriver saveDriver)

--- a/source/GameInterface/Services/Save/Patches/SavePatches.cs
+++ b/source/GameInterface/Services/Save/Patches/SavePatches.cs
@@ -6,27 +6,20 @@ using GameInterface.Services.Save.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
-using TaleWorlds.SaveSystem;
 
 namespace GameInterface.Services.Save.Patches;
 
 [HarmonyPatch(typeof(Game), "Save")]
 class SavePatches
 {
-    static bool Prefix(Game __instance, ref string saveName, ISaveDriver driver)
+    static bool Prefix(Game __instance, ref string saveName)
     {
-        if (ModInformation.IsServer && ShouldPublishGameSaved(driver))
+        if (ModInformation.IsServer)
         {
             MessageBroker.Instance.Publish(__instance, new GameSaved(saveName));
         }
 
         return true;
-    }
-
-    internal static bool ShouldPublishGameSaved(ISaveDriver driver)
-    {
-        // GameSaved writes the co-op session sidecar, so only publish it for a normal campaign save.
-        return driver is FileDriver;
     }
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Dedicated servers save through `AsyncFileSaveDriver`, but the `GameSaved` patch only accepted `FileDriver`. The campaign `.sav` was written without updating its co-op session `.json` sidecar.

Bug report saves were also kept only in memory instead of using the user save directory.

## What is the new behavior?

All server saves publish `GameSaved` again, so dedicated server saves update the paired co-op session JSON. Bug report snapshots use `FileDriver` and persist their `.sav` and `.json` pair in the user save directory.

## Bot Changelog Entry

- Fixed dedicated server saves not updating co-op player data.

## Other information

Tested:
- `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Release -p:NuGetAudit=false --filter "FullyQualifiedName~CoopLogBugReportTests"` (16 passed)
- `dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release -p:NuGetAudit=false --no-build --filter "FullyQualifiedName~SaveGameHandlerTests|FullyQualifiedName~SaveLoadCoopSessionTests"` (12 passed)
