### PR TITLE
[3345] Reduce Vec3 wire size without allocations

### DIFF
--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -1347,6 +1347,11 @@ public class MovementTrafficTests : MissionTestEnvironment
             Assert.Equal(movement.IdentityScopeId, roundTripped.IdentityScopeId);
             Assert.Equal(movement.AgentIds, roundTripped.AgentIds);
             Assert.Equal(movement.Agents.Length, roundTripped.Agents.Length);
+            for (int i = 0; i < agents.Length; i++)
+            {
+                Assert.Equal(agents[i].Position, roundTripped.Agents[i].Position);
+                Assert.Equal(agents[i].LookDirection, roundTripped.Agents[i].LookDirection);
+            }
             Assert.All(
                 roundTripped.Agents,
                 agent => Assert.Equal(
@@ -1398,10 +1403,20 @@ public class MovementTrafficTests : MissionTestEnvironment
 
             var serializer = new ProtoBufSerializer(new SerializableTypeMapper());
             var compressor = new MovementPacketCompressor(serializer);
-            AssertFitsAndDispatchesThroughRelay(serializer, compressor, packetManager, peer.NetPeer,
-                new MovementPacket("76561198000000042", ids, riders));
-            AssertFitsAndDispatchesThroughRelay(serializer, compressor, packetManager, peer.NetPeer,
-                new MountMovementPacket("76561198000000042", ids, mounts));
+            var restoredRiders = Assert.IsType<MovementPacket>(
+                AssertFitsAndDispatchesThroughRelay(serializer, compressor, packetManager, peer.NetPeer,
+                    new MovementPacket("76561198000000042", ids, riders)));
+            var restoredMounts = Assert.IsType<MountMovementPacket>(
+                AssertFitsAndDispatchesThroughRelay(serializer, compressor, packetManager, peer.NetPeer,
+                    new MountMovementPacket("76561198000000042", ids, mounts)));
+
+            for (int i = 0; i < ids.Length; i++)
+            {
+                Assert.Equal(riders[i].Position, restoredRiders.Agents[i].Position);
+                Assert.Equal(riders[i].LookDirection, restoredRiders.Agents[i].LookDirection);
+                Assert.Equal(mounts[i].MountPosition, restoredMounts.Mounts[i].MountPosition);
+                Assert.Equal(mounts[i].MountLookDirection, restoredMounts.Mounts[i].MountLookDirection);
+            }
         });
     }
 
@@ -1428,7 +1443,7 @@ public class MovementTrafficTests : MissionTestEnvironment
             LiteNetP2PClient.SelectDeliveryMethod(ordinaryUnreliable, datagramCeiling - 1, 0));
     }
 
-    private static void AssertFitsAndDispatchesThroughRelay(
+    private static IPacket AssertFitsAndDispatchesThroughRelay(
         ProtoBufSerializer serializer,
         MovementPacketCompressor compressor,
         IPacketManager packetManager,
@@ -1463,6 +1478,7 @@ public class MovementTrafficTests : MissionTestEnvironment
             Assert.Equal(1, restoredHandler.HandleCount);
             Assert.Same(sourcePeer, restoredHandler.SourcePeer);
             Assert.Equal(packet.GetType(), restoredHandler.Received.GetType());
+            return restoredHandler.Received;
         }
         finally
         {

--- a/source/GameInterface.Tests/Serialization/Vec3SurrogateTests.cs
+++ b/source/GameInterface.Tests/Serialization/Vec3SurrogateTests.cs
@@ -55,6 +55,17 @@ public class Vec3SurrogateTests
     }
 
     [Fact]
+    public void Serialize_UsesFieldTwoForZ()
+    {
+        Vec3Surrogate surrogate = new Vec3(1f, 2f, 3f);
+
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, surrogate);
+
+        Assert.Equal((byte)0x15, stream.ToArray()[9]);
+    }
+
+    [Fact]
     public void ImplicitConversions_AllocateNoMemoryAfterWarmup()
     {
         var value = new Vec3(1024.25f, -2048.5f, 512.75f);

--- a/source/GameInterface.Tests/Serialization/Vec3SurrogateTests.cs
+++ b/source/GameInterface.Tests/Serialization/Vec3SurrogateTests.cs
@@ -1,0 +1,112 @@
+﻿using GameInterface.Surrogates;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization;
+
+public class Vec3SurrogateTests
+{
+    public static IEnumerable<object[]> ExactBitCases()
+    {
+        yield return new object[] { 1f, 2f, 3f };
+        yield return new object[] { -123.5f, 0.125f, -7.25f };
+        yield return new object[] { float.MaxValue, float.MinValue, float.Epsilon };
+        yield return new object[] { BitConverter.Int32BitsToSingle(unchecked((int)0x80000000)), 0f, 1f };
+        yield return new object[]
+        {
+            BitConverter.Int32BitsToSingle(unchecked((int)0x7FC12345)),
+            float.PositiveInfinity,
+            float.NegativeInfinity,
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(ExactBitCases))]
+    public void Serialize_RoundTripPreservesExactComponents(float x, float y, float z)
+    {
+        Vec3Surrogate surrogate = new Vec3(x, y, z);
+
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, surrogate);
+        stream.Position = 0;
+        Vec3 roundTripped = Serializer.Deserialize<Vec3Surrogate>(stream);
+
+        Assert.Equal(BitConverter.SingleToInt32Bits(x), BitConverter.SingleToInt32Bits(roundTripped.x));
+        Assert.Equal(BitConverter.SingleToInt32Bits(y), BitConverter.SingleToInt32Bits(roundTripped.y));
+        Assert.Equal(BitConverter.SingleToInt32Bits(z), BitConverter.SingleToInt32Bits(roundTripped.z));
+    }
+
+    [Theory]
+    [InlineData(1f, 2f, 3f, 14)]
+    [InlineData(1f, 2f, 0f, 9)]
+    [InlineData(0f, 0f, 0f, 0)]
+    public void Serialize_UsesCompactWireSize(float x, float y, float z, int expectedBytes)
+    {
+        Vec3Surrogate surrogate = new Vec3(x, y, z);
+
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, surrogate);
+
+        Assert.Equal((long)expectedBytes, stream.Length);
+    }
+
+    [Fact]
+    public void ImplicitConversions_AllocateNoMemoryAfterWarmup()
+    {
+        var value = new Vec3(1024.25f, -2048.5f, 512.75f);
+        float sum = ConvertRepeatedly(value, 1_000);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        sum += ConvertRepeatedly(value, 1_000);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        GC.KeepAlive(sum);
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void ContainingTypes_RoundTripPackedVec3Values()
+    {
+        _ = new SurrogateCollection();
+        var matrix = new Mat3(
+            new Vec3(-123.5f, 0.125f, float.MaxValue),
+            new Vec3(float.PositiveInfinity, -0f, 3.25f),
+            new Vec3(float.NegativeInfinity, float.Epsilon, -7.5f));
+        var frame = new MatrixFrame(matrix, new Vec3(1024.25f, -2048.5f, 512.75f));
+
+        Mat3 roundTrippedMatrix = Serializer.DeepClone(matrix);
+        MatrixFrame roundTrippedFrame = Serializer.DeepClone(frame);
+
+        AssertVec3BitsEqual(matrix.f, roundTrippedMatrix.f);
+        AssertVec3BitsEqual(matrix.s, roundTrippedMatrix.s);
+        AssertVec3BitsEqual(matrix.u, roundTrippedMatrix.u);
+        AssertVec3BitsEqual(frame.rotation.f, roundTrippedFrame.rotation.f);
+        AssertVec3BitsEqual(frame.rotation.s, roundTrippedFrame.rotation.s);
+        AssertVec3BitsEqual(frame.rotation.u, roundTrippedFrame.rotation.u);
+        AssertVec3BitsEqual(frame.origin, roundTrippedFrame.origin);
+    }
+
+    private static float ConvertRepeatedly(Vec3 value, int count)
+    {
+        float sum = 0f;
+        for (int i = 0; i < count; i++)
+        {
+            Vec3Surrogate surrogate = value;
+            Vec3 roundTripped = surrogate;
+            sum += roundTripped.x;
+        }
+
+        return sum;
+    }
+
+    private static void AssertVec3BitsEqual(Vec3 expected, Vec3 actual)
+    {
+        Assert.Equal(BitConverter.SingleToInt32Bits(expected.x), BitConverter.SingleToInt32Bits(actual.x));
+        Assert.Equal(BitConverter.SingleToInt32Bits(expected.y), BitConverter.SingleToInt32Bits(actual.y));
+        Assert.Equal(BitConverter.SingleToInt32Bits(expected.z), BitConverter.SingleToInt32Bits(actual.z));
+    }
+}

--- a/source/GameInterface/Surrogates/Vec3Surrogate.cs
+++ b/source/GameInterface/Surrogates/Vec3Surrogate.cs
@@ -10,7 +10,7 @@ internal struct Vec3Surrogate
     [ProtoMember(1, DataFormat = DataFormat.FixedSize)]
     public ulong XY { get; set; }
 
-    [ProtoMember(3)]
+    [ProtoMember(2)]
     public float Z { get; set; }
 
     public Vec3Surrogate(Vec3 v)

--- a/source/GameInterface/Surrogates/Vec3Surrogate.cs
+++ b/source/GameInterface/Surrogates/Vec3Surrogate.cs
@@ -1,4 +1,5 @@
-using ProtoBuf;
+﻿using ProtoBuf;
+using System.Runtime.InteropServices;
 using TaleWorlds.Library;
 
 namespace GameInterface.Surrogates;
@@ -6,23 +7,36 @@ namespace GameInterface.Surrogates;
 [ProtoContract]
 internal struct Vec3Surrogate
 {
-    [ProtoMember(1)]
-    public float X { get; set; }
-
-    [ProtoMember(2)]
-    public float Y { get; set; }
+    [ProtoMember(1, DataFormat = DataFormat.FixedSize)]
+    public ulong XY { get; set; }
 
     [ProtoMember(3)]
     public float Z { get; set; }
 
     public Vec3Surrogate(Vec3 v)
     {
-        X = v.x;
-        Y = v.y;
+        XY = GetBits(v.x) | ((ulong)GetBits(v.y) << 32);
         Z = v.z;
     }
 
     public static implicit operator Vec3Surrogate(Vec3 v) => new Vec3Surrogate(v);
 
-    public static implicit operator Vec3(Vec3Surrogate s) => new Vec3(s.X, s.Y, s.Z);
+    public static implicit operator Vec3(Vec3Surrogate s) => new Vec3(
+        GetFloat((uint)s.XY),
+        GetFloat((uint)(s.XY >> 32)),
+        s.Z);
+
+    private static uint GetBits(float value) => new FloatBits { Float = value }.Bits;
+
+    private static float GetFloat(uint bits) => new FloatBits { Bits = bits }.Float;
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct FloatBits
+    {
+        [FieldOffset(0)]
+        public float Float;
+
+        [FieldOffset(0)]
+        public uint Bits;
+    }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Movement and other network messages encode ordinary three-dimensional vectors as three separate values, producing a 15-byte body for vectors whose components are all nonzero.

## What is the new behavior?

Resolves #3345

Movement and other network messages now use a smaller allocation-free vector representation while preserving the exact component values, including signed zero and non-finite values.

| Measurement | Current | New |
| --- | ---: | ---: |
| Ordinary nonzero vector body | 15 bytes | 14 bytes |
| Vector body with zero Z | 10 bytes | 9 bytes |
| Managed conversion allocation after warmup | 0 bytes | 0 bytes |
| Final 32-agent on-foot movement payload | 688 bytes | 662 bytes |
| Final 32-agent mounted-rider movement payload | 6,409 bytes | 6,276 bytes |
| Final 32-agent standalone-mount movement payload | 4,233 bytes | 4,164 bytes |
| Representative MatrixFrame body | 72 bytes | 68 bytes |
| Paired serialization median | 217.092 ns/op | 204.617 ns/op |

## Bot Changelog Entry

- Reduced network payload size for movement and other three-dimensional position updates without adding runtime allocations.
