### PR TITLE
Disable automatic unstuck bug reports

### DIFF
--- a/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
+++ b/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
@@ -20,6 +20,16 @@ using Xunit.Abstractions;
 
 namespace E2E.Tests.Services.MobileParties;
 
+/// <summary>Skips unstuck bug-report tests while the feature is disabled.</summary>
+public sealed class UnstuckCommandReportingFactAttribute : FactAttribute
+{
+    public UnstuckCommandReportingFactAttribute()
+    {
+        if (!BugReportConfig.UnstuckCommandReportsEnabled)
+            Skip = "Automatic unstuck bug reports are disabled.";
+    }
+}
+
 /// <summary>
 /// Verifies the dedicated unstuck flow: coop.debug.mobileparty.unstuck forwards a
 /// <see cref="NetworkRequestPlayerUnstuck"/> to the server, the server force-applies each exit
@@ -65,7 +75,7 @@ public class UnstuckCommandTests : MapEventTestBase
         Assert.Equal(player.HeroId, request.HeroId);
     }
 
-    [Fact]
+    [UnstuckCommandReportingFact]
     public void ServerUnstuckRequest_RequestsDiagnosticLogsFromEveryConnectedClient()
     {
         var requester = SetupRegisteredMainHeroAndParty();

--- a/source/GameInterface/Services/BugReporting/BugReportConfig.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace GameInterface.Services.BugReporting;
+
+/// <summary>Controls optional diagnostic bug-report triggers.</summary>
+internal static class BugReportConfig
+{
+    /// <summary>Enables automatic bug reports after the unstuck command runs.</summary>
+    public static bool UnstuckCommandReportsEnabled = false;
+}

--- a/source/GameInterface/Services/MobileParties/Handlers/PlayerUnstuckHandler.cs
+++ b/source/GameInterface/Services/MobileParties/Handlers/PlayerUnstuckHandler.cs
@@ -118,6 +118,8 @@ internal class PlayerUnstuckHandler : IHandler
 
     private void TryRequestBugReport(string partyId, NetPeer requester)
     {
+        if (!BugReportConfig.UnstuckCommandReportsEnabled) return;
+
         if (requester == null ||
             !playerManager.TryGetPlayer(requester, out var player) ||
             player.MobilePartyId != partyId)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Using the unstuck command automatically starts a diagnostic bug report.

## What is the new behavior?

Automatic unstuck reports are behind a disabled `BugReportConfig` flag. Player-submitted bug reports are unchanged.

## Bot Changelog Entry

- The unstuck command no longer automatically submits a bug report.
