### PR TITLE
[3078] Keep party AI batches running after tick failures

### DIFF
--- a/source/GameInterface.Tests/Services/MobilePartyAIs/PartyAiBatchRunnerTests.cs
+++ b/source/GameInterface.Tests/Services/MobilePartyAIs/PartyAiBatchRunnerTests.cs
@@ -1,0 +1,74 @@
+﻿using Common.Util;
+using GameInterface.Services.MobilePartyAIs;
+using GameInterface.Services.MobilePartyAIs.Patches;
+using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem.Party;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobilePartyAIs;
+
+public sealed class PartyAiBatchRunnerTests
+{
+    [Fact]
+    public void TickParties_ThrowingParty_ContinuesWithRemainingParties()
+    {
+        MobileParty first = CreateParty();
+        MobileParty poisoned = CreateParty();
+        MobileParty last = CreateParty();
+        var attempts = new List<MobilePartyAi>();
+        using var runner = new PartyAiBatchRunner((ai, _) =>
+        {
+            attempts.Add(ai);
+            if (ai == poisoned.Ai)
+                throw new InvalidOperationException("poisoned party");
+        });
+
+        runner.TickParties(new[] { first, poisoned, last }, 3, 0f);
+
+        Assert.Equal(new[] { first.Ai, poisoned.Ai, last.Ai }, attempts);
+    }
+
+    [Fact]
+    public void TickParties_MissingAi_ContinuesWithRemainingParties()
+    {
+        MobileParty missingAi = ObjectHelper.SkipConstructor<MobileParty>();
+        MobileParty healthy = CreateParty();
+        var attempts = new List<MobilePartyAi>();
+        using var runner = new PartyAiBatchRunner((ai, _) => attempts.Add(ai));
+
+        runner.TickParties(new[] { missingAi, healthy }, 2, 0f);
+
+        Assert.Equal(new[] { healthy.Ai }, attempts);
+    }
+
+    [Fact]
+    public void Dispose_OlderRunner_DoesNotUnbindReplacement()
+    {
+        var first = new PartyAiBatchRunner();
+        var replacement = new PartyAiBatchRunner();
+
+        try
+        {
+            Assert.Same(replacement, PartiesThinkPatch.BoundRunner);
+
+            first.Dispose();
+
+            Assert.Same(replacement, PartiesThinkPatch.BoundRunner);
+        }
+        finally
+        {
+            replacement.Dispose();
+            first.Dispose();
+        }
+
+        Assert.Null(PartiesThinkPatch.BoundRunner);
+    }
+
+    private static MobileParty CreateParty()
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        party.Ai = new MobilePartyAi(party);
+        return party;
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -32,6 +32,7 @@ using GameInterface.Services.MapEvents.Initialization;
 using GameInterface.Services.MapEvents.Logging;
 using GameInterface.Services.MobileParties;
 using GameInterface.Services.MobileParties.Data;
+using GameInterface.Services.MobilePartyAIs;
 using GameInterface.Services.Modules;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Party;
@@ -106,6 +107,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<PlayerPartyRestorer>().As<IPlayerPartyRestorer>().InstancePerDependency();
         builder.RegisterType<PlayerCreationRollback>().As<IPlayerCreationRollback>().InstancePerDependency();
         builder.RegisterType<MobilePartyBehaviorSnapshot>().As<IMobilePartyBehaviorSnapshot>().InstancePerDependency();
+        builder.RegisterType<PartyAiBatchRunner>().As<IPartyAiBatchRunner>().InstancePerLifetimeScope().AutoActivate();
         builder.RegisterType<BarterClientPresentation>().As<IBarterClientPresentation>().InstancePerDependency();
         builder.RegisterType<SafePassagePartyResolver>().AsSelf().As<ISafePassagePartyResolver>().InstancePerDependency();
         builder.RegisterType<PeacePursuitCleaner>().As<IPeacePursuitCleaner>().InstancePerDependency();

--- a/source/GameInterface/Services/MobilePartyAIs/PartyAiBatchRunner.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/PartyAiBatchRunner.cs
@@ -1,0 +1,135 @@
+﻿using Common.Logging;
+using GameInterface.Services.MobilePartyAIs.Patches;
+using Serilog;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobilePartyAIs;
+
+internal interface IPartyAiBatchRunner
+{
+    void TickBatch(Campaign campaign, float dt);
+}
+
+/// <summary>
+/// Ticks server party AI in bounded batches without letting one invalid party stop later parties.
+/// </summary>
+internal sealed class PartyAiBatchRunner : IPartyAiBatchRunner, IDisposable
+{
+    private const int UpdatesPerTick = 100;
+    private const int TickDelayMilliseconds = 100;
+
+    private static readonly ILogger Logger = LogManager.GetLogger<PartyAiBatchRunner>();
+
+    private readonly MobileParty[] batch = new MobileParty[UpdatesPerTick];
+    private readonly ConditionalWeakTable<MobileParty, object> loggedFailures =
+        new ConditionalWeakTable<MobileParty, object>();
+    private readonly Action<MobilePartyAi, float> tickOverride;
+    private Task delay = Task.CompletedTask;
+    private int currentStartIndex;
+    private bool loggedNullParty;
+
+    public PartyAiBatchRunner()
+    {
+        PartiesThinkPatch.Bind(this);
+    }
+
+    internal PartyAiBatchRunner(Action<MobilePartyAi, float> tickOverride)
+    {
+        if (tickOverride == null) throw new ArgumentNullException(nameof(tickOverride));
+        this.tickOverride = tickOverride;
+    }
+
+    public void TickBatch(Campaign campaign, float dt)
+    {
+        if (campaign == null || !delay.IsCompleted) return;
+        delay = Task.Delay(TickDelayMilliseconds);
+
+        var parties = campaign.MobileParties;
+        int partyCount = parties.Count;
+        if (partyCount == 0)
+        {
+            currentStartIndex = 0;
+            return;
+        }
+
+        int count = Math.Min(UpdatesPerTick, partyCount);
+        int startIndex = currentStartIndex % partyCount;
+        currentStartIndex = (startIndex + count) % partyCount;
+
+        for (int i = 0; i < count; i++)
+            batch[i] = parties[(startIndex + i) % partyCount];
+
+        try
+        {
+            TickParties(batch, count, dt);
+        }
+        finally
+        {
+            Array.Clear(batch, 0, count);
+        }
+    }
+
+    internal void TickParties(MobileParty[] parties, int count, float dt)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            MobileParty party = parties[i];
+            if (party == null)
+            {
+                if (!loggedNullParty)
+                {
+                    loggedNullParty = true;
+                    Logger.Error("Skipping null party in mobile-party AI batch");
+                }
+                continue;
+            }
+
+            MobilePartyAi ai = party.Ai;
+            if (ai == null)
+            {
+                LogFailureOnce(party, null, "Party AI is unavailable");
+                continue;
+            }
+
+            try
+            {
+                if (tickOverride == null)
+                    ai.Tick(dt);
+                else
+                    tickOverride(ai, dt);
+            }
+            catch (Exception ex)
+            {
+                LogFailureOnce(party, ex, "Party AI tick threw");
+            }
+        }
+    }
+
+    private void LogFailureOnce(MobileParty party, Exception exception, string reason)
+    {
+        if (loggedFailures.TryGetValue(party, out _)) return;
+        loggedFailures.Add(party, new object());
+
+        if (exception == null)
+        {
+            Logger.Error(
+                "Skipping mobile-party AI tick for {PartyId}: {Reason}",
+                party.StringId,
+                reason);
+        }
+        else
+        {
+            Logger.Error(
+                exception,
+                "Skipping mobile-party AI tick for {PartyId}: {Reason}",
+                party.StringId,
+                reason);
+        }
+    }
+
+    public void Dispose() => PartiesThinkPatch.Unbind(this);
+}

--- a/source/GameInterface/Services/MobilePartyAIs/Patches/PartiesThinkPatch.cs
+++ b/source/GameInterface/Services/MobilePartyAIs/Patches/PartiesThinkPatch.cs
@@ -1,25 +1,28 @@
 ﻿using Common;
 using Common.Logging;
+using GameInterface.Services.MobilePartyAIs;
 using HarmonyLib;
 using Serilog;
-using System.Threading.Tasks;
+using System;
+using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.MobilePartyAIs.Patches;
 
 [HarmonyPatch(typeof(Campaign))]
-internal class PartiesThinkPatch
+internal static class PartiesThinkPatch
 {
-    // TODO move to config
-    private const int UPDATES_PER_TICK = 100;
-    private const int TICK_DELAY_MS = 100;
+    private static readonly ILogger Logger = LogManager.GetLogger(typeof(PartiesThinkPatch));
+    private static IPartyAiBatchRunner runner;
 
-    private static Task delay = Task.CompletedTask;
+    internal static IPartyAiBatchRunner BoundRunner => Volatile.Read(ref runner);
 
-    private static int CurrentStartIdx = 0;
+    internal static void Bind(IPartyAiBatchRunner value) =>
+        Interlocked.Exchange(ref runner, value);
 
-    private static readonly ILogger Logger = LogManager.GetLogger<PartiesThinkPatch>();
+    internal static void Unbind(IPartyAiBatchRunner value) =>
+        Interlocked.CompareExchange(ref runner, null, value);
 
     [HarmonyPatch("PartiesThink")]
     [HarmonyPrefix]
@@ -33,20 +36,18 @@ internal class PartiesThinkPatch
             return false;
         }
 
-        if (delay.IsCompleted == false) return false;
+        IPartyAiBatchRunner current = BoundRunner;
+        if (current == null)
+            return true;
 
-        delay = Task.Delay(TICK_DELAY_MS);
-
-        for (int i = 0; i < UPDATES_PER_TICK; i++)
+        try
         {
-            var currentIdx = (CurrentStartIdx + i) % __instance.MobileParties.Count;
-
-            var ai = __instance.MobileParties[currentIdx]?.Ai;
-
-            ai.Tick(dt);
+            current.TickBatch(__instance, dt);
         }
-
-        CurrentStartIdx = (CurrentStartIdx + UPDATES_PER_TICK) % __instance.MobileParties.Count;
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to tick mobile-party AI batch");
+        }
 
         return false;
     }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

A null or throwing party AI aborts the throttled AI batch before its cursor advances. The same batch can then be retried while later campaign parties stop receiving AI ticks.

## What is the new behavior?

Related to #3078

Each party AI tick has its own failure boundary, so a broken party is logged and the remaining parties continue. The lifetime-scoped batch runner binds to the Harmony patch once, avoiding Autofac resolution in the tick path.

Tests:
- `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Debug --filter "FullyQualifiedName~PartyAiBatchRunnerTests"`
- `dotnet build source/GameInterface/GameInterface.csproj -c Release`

## Bot Changelog Entry

- Fixed one broken AI party preventing other campaign parties from moving.
