### PR TITLE
Report server statistics and battles fought

### DIFF
--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -18,6 +18,7 @@ using Coop.Core.Server.Services.MobileParties;
 using Coop.Core.Server.Services.Save;
 using Coop.Core.Server.Services.Session;
 using Coop.Core.Server.Services.Settlements;
+using Coop.Core.Server.Services.Telemetry;
 using Coop.Core.Server.Services.Time;
 using Coop.Core.Server.States;
 using Coop.Steam;
@@ -82,6 +83,19 @@ public class ServerModule : CommonModule
         // Pauses time while a peer's packet queue is overloaded (slow client catching up). Constructed
         // as a CoopServer dependency, so it registers its unpause policy when the server is built.
         builder.RegisterType<OverloadedPeerManager>().As<IOverloadedPeerManager>().InstancePerLifetimeScope().AutoActivate();
+
+        builder.RegisterType<ServerTelemetryUploader>()
+            .As<IServerTelemetryUploader>()
+            .As<IBattlesFoughtUploader>()
+            .InstancePerLifetimeScope();
+        builder.RegisterType<ServerTelemetryReporter>()
+            .As<IServerTelemetryReporter>()
+            .InstancePerLifetimeScope()
+            .AutoActivate();
+        builder.RegisterType<BattlesFoughtReporter>()
+            .As<IBattlesFoughtReporter>()
+            .InstancePerLifetimeScope()
+            .AutoActivate();
 
         // Policies
         builder.RegisterType<ServerSyncPolicy>().As<ISyncPolicy>().InstancePerLifetimeScope();

--- a/source/Coop.Core/Server/Services/Telemetry/BattlesFoughtReporter.cs
+++ b/source/Coop.Core/Server/Services/Telemetry/BattlesFoughtReporter.cs
@@ -1,0 +1,101 @@
+﻿using Common.Logging;
+using Common.Messaging;
+using GameInterface.Services.MapEvents.Messages.Start;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using TaleWorlds.CampaignSystem.MapEvents;
+
+namespace Coop.Core.Server.Services.Telemetry;
+
+public interface IBattlesFoughtReporter : IDisposable
+{
+}
+
+/// <summary>Reports each player battle once during the server session.</summary>
+public class BattlesFoughtReporter : IBattlesFoughtReporter
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<BattlesFoughtReporter>();
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly IBattlesFoughtUploader uploader;
+    private readonly CancellationTokenSource cancellation;
+    private readonly object reportGate = new object();
+    private readonly HashSet<string> reportedMapEvents = new HashSet<string>();
+
+    private bool disposed;
+
+    public BattlesFoughtReporter(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        IBattlesFoughtUploader uploader,
+        CancellationTokenSource sessionCancellation)
+    {
+        if (messageBroker == null) throw new ArgumentNullException(nameof(messageBroker));
+        if (objectManager == null) throw new ArgumentNullException(nameof(objectManager));
+        if (uploader == null) throw new ArgumentNullException(nameof(uploader));
+        if (sessionCancellation == null) throw new ArgumentNullException(nameof(sessionCancellation));
+
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.uploader = uploader;
+        cancellation = CancellationTokenSource.CreateLinkedTokenSource(sessionCancellation.Token);
+
+        messageBroker.Subscribe<PlayerJoinedBattle>(Handle_PlayerJoinedBattle);
+    }
+
+    private void Handle_PlayerJoinedBattle(MessagePayload<PlayerJoinedBattle> payload)
+    {
+        if (!(payload.Who is MapEvent mapEvent) ||
+            !objectManager.TryGetIdWithLogging(mapEvent, out var mapEventId))
+            return;
+
+        lock (reportGate)
+        {
+            if (disposed || !reportedMapEvents.Add(mapEventId)) return;
+        }
+
+        _ = RecordBattleStartedAsync(mapEventId);
+    }
+
+    private async Task RecordBattleStartedAsync(string mapEventId)
+    {
+        try
+        {
+            var result = await uploader.RecordBattleStartedAsync(cancellation.Token).ConfigureAwait(false);
+            if (!result.Uploaded && result.EndpointConfigured)
+            {
+                Logger.Warning(
+                    "Reporting player battle {MapEventId} failed: {Details}",
+                    mapEventId,
+                    result.Details);
+            }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Reporting player battle {MapEventId} failed", mapEventId);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (reportGate)
+        {
+            if (disposed) return;
+
+            disposed = true;
+            cancellation.Cancel();
+            reportedMapEvents.Clear();
+        }
+
+        messageBroker.Unsubscribe<PlayerJoinedBattle>(Handle_PlayerJoinedBattle);
+        cancellation.Dispose();
+    }
+}

--- a/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryReporter.cs
+++ b/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryReporter.cs
@@ -1,0 +1,161 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Coop.Core.Server.Connections.Messages;
+using Coop.Core.Server.Services.Session.Messages;
+using Serilog;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Timers;
+using Timer = System.Timers.Timer;
+
+namespace Coop.Core.Server.Services.Telemetry;
+
+public interface IServerTelemetryReporter : IDisposable
+{
+}
+
+/// <summary>Reports the server status at a fixed interval while it is listening.</summary>
+public class ServerTelemetryReporter : IServerTelemetryReporter
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<ServerTelemetryReporter>();
+    internal static readonly TimeSpan ReportInterval = TimeSpan.FromSeconds(60);
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IServerTelemetryUploader uploader;
+    private readonly CancellationTokenSource cancellation;
+    private readonly Func<DateTime> getUtcNow;
+    private readonly Func<string> createSessionId;
+    private readonly object reportGate = new object();
+    private readonly Timer reportTimer;
+
+    private string sessionId;
+    private DateTime startedAt;
+    private int playerCount;
+    private bool started;
+    private bool disposed;
+
+    public ServerTelemetryReporter(
+        IMessageBroker messageBroker,
+        IServerTelemetryUploader uploader,
+        CancellationTokenSource sessionCancellation)
+        : this(
+            messageBroker,
+            uploader,
+            sessionCancellation,
+            ReportInterval,
+            () => DateTime.UtcNow,
+            () => Guid.NewGuid().ToString("N"))
+    {
+    }
+
+    internal ServerTelemetryReporter(
+        IMessageBroker messageBroker,
+        IServerTelemetryUploader uploader,
+        CancellationTokenSource sessionCancellation,
+        TimeSpan reportInterval,
+        Func<DateTime> getUtcNow,
+        Func<string> createSessionId)
+    {
+        if (messageBroker == null) throw new ArgumentNullException(nameof(messageBroker));
+        if (uploader == null) throw new ArgumentNullException(nameof(uploader));
+        if (sessionCancellation == null) throw new ArgumentNullException(nameof(sessionCancellation));
+        if (reportInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(reportInterval));
+        if (getUtcNow == null) throw new ArgumentNullException(nameof(getUtcNow));
+        if (createSessionId == null) throw new ArgumentNullException(nameof(createSessionId));
+
+        this.messageBroker = messageBroker;
+        this.uploader = uploader;
+        this.getUtcNow = getUtcNow;
+        this.createSessionId = createSessionId;
+        cancellation = CancellationTokenSource.CreateLinkedTokenSource(sessionCancellation.Token);
+
+        reportTimer = new Timer(reportInterval.TotalMilliseconds) { AutoReset = false };
+        reportTimer.Elapsed += Handle_ReportTimerElapsed;
+
+        messageBroker.Subscribe<ServerListening>(Handle_ServerListening);
+        messageBroker.Subscribe<ConnectedPlayersChanged>(Handle_ConnectedPlayersChanged);
+    }
+
+    private void Handle_ServerListening(MessagePayload<ServerListening> _)
+    {
+        lock (reportGate)
+        {
+            if (disposed || started) return;
+
+            sessionId = createSessionId();
+            startedAt = getUtcNow().ToUniversalTime();
+            started = true;
+            reportTimer.Start();
+        }
+    }
+
+    private void Handle_ConnectedPlayersChanged(MessagePayload<ConnectedPlayersChanged> payload)
+    {
+        Volatile.Write(ref playerCount, Math.Max(0, payload.What.ConnectedPlayers));
+    }
+
+    private void Handle_ReportTimerElapsed(object sender, ElapsedEventArgs e)
+    {
+        ServerTelemetryStatus status;
+        lock (reportGate)
+        {
+            if (disposed || !started) return;
+
+            status = new ServerTelemetryStatus(
+                sessionId,
+                ModInformation.Version.ToString(),
+                ModInformation.Commit,
+                startedAt,
+                Volatile.Read(ref playerCount));
+        }
+
+        _ = UploadAndScheduleNextAsync(status);
+    }
+
+    private async Task UploadAndScheduleNextAsync(ServerTelemetryStatus status)
+    {
+        try
+        {
+            var result = await uploader.UploadAsync(status, cancellation.Token).ConfigureAwait(false);
+            if (!result.Uploaded && result.EndpointConfigured)
+            {
+                Logger.Warning("Reporting server telemetry failed: {Details}", result.Details);
+            }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Reporting server telemetry failed");
+        }
+        finally
+        {
+            lock (reportGate)
+            {
+                if (!disposed) reportTimer.Start();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (reportGate)
+        {
+            if (disposed) return;
+
+            disposed = true;
+            cancellation.Cancel();
+            reportTimer.Elapsed -= Handle_ReportTimerElapsed;
+            reportTimer.Stop();
+            reportTimer.Dispose();
+        }
+
+        messageBroker.Unsubscribe<ServerListening>(Handle_ServerListening);
+        messageBroker.Unsubscribe<ConnectedPlayersChanged>(Handle_ConnectedPlayersChanged);
+        cancellation.Dispose();
+    }
+}

--- a/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryStatus.cs
+++ b/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryStatus.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Coop.Core.Server.Services.Telemetry;
+
+/// <summary>Describes one campaign server heartbeat.</summary>
+public sealed class ServerTelemetryStatus
+{
+    public string SessionId { get; }
+    public string ModVersion { get; }
+    public string Commit { get; }
+    public DateTime StartedAt { get; }
+    public int PlayerCount { get; }
+
+    public ServerTelemetryStatus(
+        string sessionId,
+        string modVersion,
+        string commit,
+        DateTime startedAt,
+        int playerCount)
+    {
+        SessionId = sessionId;
+        ModVersion = modVersion;
+        Commit = commit;
+        StartedAt = startedAt;
+        PlayerCount = playerCount;
+    }
+}

--- a/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryUploader.cs
+++ b/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryUploader.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Coop.Core.Server.Services.Telemetry;
+
+public interface IServerTelemetryUploader
+{
+    bool IsConfigured { get; }
+    Task<ServerTelemetryUploadResult> UploadAsync(
+        ServerTelemetryStatus status,
+        CancellationToken cancellationToken);
+}
+
+public interface IBattlesFoughtUploader
+{
+    Task<ServerTelemetryUploadResult> RecordBattleStartedAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>Posts authenticated server statistics to the configured edge functions.</summary>
+public class ServerTelemetryUploader : IServerTelemetryUploader, IBattlesFoughtUploader, IDisposable
+{
+    public const string Endpoint =
+        "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/upsert-platform-statistics";
+    public const string BattlesFoughtEndpoint =
+        "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/battles-fought-upsert";
+    internal const string PublishableKey = "sb_publishable_tseZMeJ-RYeSHI0KwU2p0g_PE4GVtN6";
+
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private readonly HttpClient httpClient;
+    private readonly string endpoint;
+    private readonly bool ownsClient;
+
+    public bool IsConfigured => IsEndpointConfigured(endpoint);
+
+    public ServerTelemetryUploader() : this(
+        new HttpClient { Timeout = TimeSpan.FromSeconds(15) },
+        Endpoint,
+        true)
+    {
+    }
+
+    internal ServerTelemetryUploader(
+        HttpClient httpClient,
+        string endpoint = Endpoint,
+        bool ownsClient = false)
+    {
+        if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
+        if (string.IsNullOrWhiteSpace(endpoint))
+            throw new ArgumentException("Endpoint cannot be empty.", nameof(endpoint));
+
+        this.httpClient = httpClient;
+        this.endpoint = endpoint;
+        this.ownsClient = ownsClient;
+    }
+
+    public async Task<ServerTelemetryUploadResult> UploadAsync(
+        ServerTelemetryStatus status,
+        CancellationToken cancellationToken)
+    {
+        if (status == null) throw new ArgumentNullException(nameof(status));
+        if (!IsConfigured)
+        {
+            return new ServerTelemetryUploadResult(
+                false,
+                false,
+                "The server telemetry endpoint is not configured.");
+        }
+
+        var json = JsonSerializer.Serialize(status, JsonOptions);
+        return await PostAsync(endpoint, json, "server telemetry", cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<ServerTelemetryUploadResult> RecordBattleStartedAsync(
+        CancellationToken cancellationToken)
+    {
+        if (!IsEndpointConfigured(BattlesFoughtEndpoint))
+        {
+            return new ServerTelemetryUploadResult(
+                false,
+                false,
+                "The battles-fought endpoint is not configured.");
+        }
+
+        return await PostAsync(BattlesFoughtEndpoint, "{}", "battles-fought", cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<ServerTelemetryUploadResult> PostAsync(
+        string requestEndpoint,
+        string json,
+        string endpointName,
+        CancellationToken cancellationToken)
+    {
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestEndpoint)
+        {
+            Content = content,
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", PublishableKey);
+        request.Headers.TryAddWithoutValidation("apikey", PublishableKey);
+
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var details = response.Content == null
+            ? string.Empty
+            : await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return new ServerTelemetryUploadResult(
+                false,
+                true,
+                string.IsNullOrWhiteSpace(details)
+                    ? "The " + endpointName + " endpoint returned " +
+                      ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture) + "."
+                    : details);
+        }
+
+        return new ServerTelemetryUploadResult(true, true, details);
+    }
+
+    private static bool IsEndpointConfigured(string requestEndpoint) =>
+        !new Uri(requestEndpoint).Host.EndsWith(".invalid", StringComparison.OrdinalIgnoreCase);
+
+    public void Dispose()
+    {
+        if (ownsClient) httpClient.Dispose();
+    }
+}
+
+/// <summary>Describes the outcome of one server statistics request.</summary>
+public sealed class ServerTelemetryUploadResult
+{
+    public bool Uploaded { get; }
+    public bool EndpointConfigured { get; }
+    public string Details { get; }
+
+    public ServerTelemetryUploadResult(bool uploaded, bool endpointConfigured, string details)
+    {
+        Uploaded = uploaded;
+        EndpointConfigured = endpointConfigured;
+        Details = details;
+    }
+}

--- a/source/Coop.Tests/Server/Services/Telemetry/BattlesFoughtReporterTests.cs
+++ b/source/Coop.Tests/Server/Services/Telemetry/BattlesFoughtReporterTests.cs
@@ -1,0 +1,57 @@
+﻿using Common.Tests.Utils;
+using Common.Util;
+using Coop.Core.Server.Services.Telemetry;
+using GameInterface.Services.MapEvents.Messages.Start;
+using GameInterface.Services.ObjectManager;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using TaleWorlds.CampaignSystem.MapEvents;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.Telemetry;
+
+public class BattlesFoughtReporterTests
+{
+    [Fact]
+    public void PlayerJoinedBattle_ReportsEachMapEventOnce()
+    {
+        var messageBroker = new TestMessageBroker();
+        var objectManager = new Mock<IObjectManager>();
+        var uploader = new RecordingBattlesFoughtUploader();
+        using var sessionCancellation = new CancellationTokenSource();
+        var firstBattle = ObjectHelper.SkipConstructor<MapEvent>();
+        var secondBattle = ObjectHelper.SkipConstructor<MapEvent>();
+        string firstBattleId = "map-event-1";
+        string secondBattleId = "map-event-2";
+        objectManager
+            .Setup(manager => manager.TryGetIdWithLogging(firstBattle, out firstBattleId))
+            .Returns(true);
+        objectManager
+            .Setup(manager => manager.TryGetIdWithLogging(secondBattle, out secondBattleId))
+            .Returns(true);
+        using var reporter = new BattlesFoughtReporter(
+            messageBroker,
+            objectManager.Object,
+            uploader,
+            sessionCancellation);
+
+        messageBroker.Publish(firstBattle, new PlayerJoinedBattle());
+        messageBroker.Publish(firstBattle, new PlayerJoinedBattle());
+        messageBroker.Publish(secondBattle, new PlayerJoinedBattle());
+
+        Assert.Equal(2, uploader.ReportCount);
+    }
+
+    private sealed class RecordingBattlesFoughtUploader : IBattlesFoughtUploader
+    {
+        public int ReportCount { get; private set; }
+
+        public Task<ServerTelemetryUploadResult> RecordBattleStartedAsync(
+            CancellationToken cancellationToken)
+        {
+            ReportCount++;
+            return Task.FromResult(new ServerTelemetryUploadResult(true, true, "accepted"));
+        }
+    }
+}

--- a/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryReporterTests.cs
+++ b/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryReporterTests.cs
@@ -1,0 +1,78 @@
+﻿using Common;
+using Common.Tests.Utils;
+using Coop.Core.Server.Connections.Messages;
+using Coop.Core.Server.Services.Session.Messages;
+using Coop.Core.Server.Services.Telemetry;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.Telemetry;
+
+public class ServerTelemetryReporterTests
+{
+    [Fact]
+    public async Task ServerListening_StartsSixtySecondStatusReportsWithStableSessionData()
+    {
+        var messageBroker = new TestMessageBroker();
+        var uploader = new RecordingTelemetryUploader(expectedReports: 2);
+        using var sessionCancellation = new CancellationTokenSource();
+        var startedAt = new DateTime(2026, 8, 29, 22, 15, 0, DateTimeKind.Utc);
+        using var reporter = new ServerTelemetryReporter(
+            messageBroker,
+            uploader,
+            sessionCancellation,
+            TimeSpan.FromMilliseconds(20),
+            () => startedAt,
+            () => "41fa0000000000000000000000000000");
+
+        messageBroker.Publish(this, new ConnectedPlayersChanged(5));
+        await Task.Delay(60);
+        Assert.Empty(uploader.Statuses);
+
+        messageBroker.Publish(this, new ServerListening());
+        await uploader.ExpectedReportsReceived.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var statuses = uploader.Statuses.Take(2).ToArray();
+        Assert.Equal(TimeSpan.FromSeconds(60), ServerTelemetryReporter.ReportInterval);
+        Assert.Equal(2, statuses.Length);
+        Assert.All(statuses, status =>
+        {
+            Assert.Equal("41fa0000000000000000000000000000", status.SessionId);
+            Assert.Equal(ModInformation.Version.ToString(), status.ModVersion);
+            Assert.Equal(ModInformation.Commit, status.Commit);
+            Assert.Equal(startedAt, status.StartedAt);
+            Assert.Equal(5, status.PlayerCount);
+        });
+    }
+
+    private sealed class RecordingTelemetryUploader : IServerTelemetryUploader
+    {
+        private readonly int expectedReports;
+        private int reportCount;
+
+        public bool IsConfigured => true;
+        public ConcurrentQueue<ServerTelemetryStatus> Statuses { get; } = new();
+        public TaskCompletionSource<bool> ExpectedReportsReceived { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public RecordingTelemetryUploader(int expectedReports)
+        {
+            this.expectedReports = expectedReports;
+        }
+
+        public Task<ServerTelemetryUploadResult> UploadAsync(
+            ServerTelemetryStatus status,
+            CancellationToken cancellationToken)
+        {
+            Statuses.Enqueue(status);
+            if (Interlocked.Increment(ref reportCount) >= expectedReports)
+                ExpectedReportsReceived.TrySetResult(true);
+
+            return Task.FromResult(new ServerTelemetryUploadResult(true, true, "accepted"));
+        }
+    }
+}

--- a/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryUploaderTests.cs
+++ b/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryUploaderTests.cs
@@ -1,0 +1,136 @@
+﻿using Coop.Core.Server.Services.Telemetry;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.Telemetry;
+
+public class ServerTelemetryUploaderTests
+{
+    [Fact]
+    public async Task UploadAsync_PostsExpectedServerStatusJson()
+    {
+        var handler = new RecordingHttpHandler();
+        using var httpClient = new HttpClient(handler);
+        using var uploader = new ServerTelemetryUploader(
+            httpClient,
+            "https://telemetry.example.test/api/v1/status");
+        var startedAt = new DateTime(2026, 8, 29, 22, 15, 0, DateTimeKind.Utc);
+        var status = new ServerTelemetryStatus(
+            "41fa0000000000000000000000000000",
+            "0.1.4",
+            "abc123",
+            startedAt,
+            5);
+
+        var result = await uploader.UploadAsync(status, CancellationToken.None);
+
+        Assert.True(result.Uploaded);
+        Assert.True(result.EndpointConfigured);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(HttpMethod.Post, handler.Method);
+        Assert.Equal("https://telemetry.example.test/api/v1/status", handler.RequestUri?.ToString());
+        Assert.Equal("application/json; charset=utf-8", handler.ContentType);
+        Assert.Equal("Bearer " + ServerTelemetryUploader.PublishableKey, handler.Authorization);
+        Assert.Equal(ServerTelemetryUploader.PublishableKey, handler.ApiKey);
+
+        using var json = JsonDocument.Parse(handler.Body ?? string.Empty);
+        var root = json.RootElement;
+        Assert.Equal(
+            new[] { "sessionId", "modVersion", "commit", "startedAt", "playerCount" },
+            root.EnumerateObject().Select(property => property.Name).ToArray());
+        Assert.Equal("41fa0000000000000000000000000000", root.GetProperty("sessionId").GetString());
+        Assert.Equal("0.1.4", root.GetProperty("modVersion").GetString());
+        Assert.Equal("abc123", root.GetProperty("commit").GetString());
+        Assert.Equal("2026-08-29T22:15:00Z", root.GetProperty("startedAt").GetString());
+        Assert.Equal(5, root.GetProperty("playerCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task RecordBattleStartedAsync_PostsToBattlesFoughtEdgeFunction()
+    {
+        var handler = new RecordingHttpHandler();
+        using var httpClient = new HttpClient(handler);
+        using var uploader = new ServerTelemetryUploader(httpClient);
+
+        var result = await uploader.RecordBattleStartedAsync(CancellationToken.None);
+
+        Assert.True(result.Uploaded);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(HttpMethod.Post, handler.Method);
+        Assert.Equal(ServerTelemetryUploader.BattlesFoughtEndpoint, handler.RequestUri?.ToString());
+        Assert.Equal("application/json; charset=utf-8", handler.ContentType);
+        Assert.Equal("Bearer " + ServerTelemetryUploader.PublishableKey, handler.Authorization);
+        Assert.Equal(ServerTelemetryUploader.PublishableKey, handler.ApiKey);
+        Assert.Equal("{}", handler.Body);
+    }
+
+    [Fact]
+    public async Task DefaultConfigurationUsesPublicEdgeFunction()
+    {
+        var handler = new RecordingHttpHandler();
+        using var httpClient = new HttpClient(handler);
+        using var uploader = new ServerTelemetryUploader(httpClient);
+        var status = new ServerTelemetryStatus(
+            "session",
+            "0.1.4",
+            "abc123",
+            DateTime.UtcNow,
+            0);
+
+        var result = await uploader.UploadAsync(status, CancellationToken.None);
+
+        Assert.True(uploader.IsConfigured);
+        Assert.True(result.Uploaded);
+        Assert.True(result.EndpointConfigured);
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(
+            "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/upsert-platform-statistics",
+            ServerTelemetryUploader.Endpoint);
+        Assert.Equal(ServerTelemetryUploader.Endpoint, handler.RequestUri?.ToString());
+        Assert.Equal(
+            "sb_publishable_tseZMeJ-RYeSHI0KwU2p0g_PE4GVtN6",
+            ServerTelemetryUploader.PublishableKey);
+        Assert.Equal(
+            "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/battles-fought-upsert",
+            ServerTelemetryUploader.BattlesFoughtEndpoint);
+    }
+
+    private sealed class RecordingHttpHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+        public HttpMethod? Method { get; private set; }
+        public Uri? RequestUri { get; private set; }
+        public string? ContentType { get; private set; }
+        public string? Authorization { get; private set; }
+        public string? ApiKey { get; private set; }
+        public string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            Method = request.Method;
+            RequestUri = request.RequestUri;
+            ContentType = request.Content?.Headers.ContentType?.ToString();
+            Authorization = request.Headers.Authorization?.ToString();
+            ApiKey = request.Headers.TryGetValues("apikey", out var apiKeys)
+                ? string.Join(string.Empty, apiKeys)
+                : null;
+            Body = request.Content == null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync();
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("accepted"),
+            };
+        }
+    }
+}

--- a/source/GameInterface/Services/MapEvents/Messages/Start/PlayerJoinedBattle.cs
+++ b/source/GameInterface/Services/MapEvents/Messages/Start/PlayerJoinedBattle.cs
@@ -2,6 +2,6 @@
 
 namespace GameInterface.Services.MapEvents.Messages.Start;
 
-internal readonly struct PlayerJoinedBattle : IEvent
+public readonly struct PlayerJoinedBattle : IEvent
 {
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Dedicated servers do not report session status or player battles to the platform statistics edge functions.

## What is the new behavior?

The server reports its session id, version, commit, start time, and connected player count every 60 seconds while listening. A newly started player battle reports to `battles-fought-upsert` once per map event, so joins and repeated battle-start messages do not increment it again.

Both requests use the Supabase publishable key for `Authorization` and `apikey` authentication.

Tests:
- `dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release -p:NuGetAudit=false --filter "FullyQualifiedName~Telemetry|FullyQualifiedName~BattlesFought"`

## Bot Changelog Entry

