### PR TITLE
Keep battles fought tests off production endpoint

### DIFF
--- a/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryUploader.cs
+++ b/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryUploader.cs
@@ -38,6 +38,7 @@ public class ServerTelemetryUploader : IServerTelemetryUploader, IBattlesFoughtU
 
     private readonly HttpClient httpClient;
     private readonly string endpoint;
+    private readonly string battlesFoughtEndpoint;
     private readonly bool ownsClient;
 
     public bool IsConfigured => IsEndpointConfigured(endpoint);
@@ -52,14 +53,20 @@ public class ServerTelemetryUploader : IServerTelemetryUploader, IBattlesFoughtU
     internal ServerTelemetryUploader(
         HttpClient httpClient,
         string endpoint = Endpoint,
-        bool ownsClient = false)
+        bool ownsClient = false,
+        string battlesFoughtEndpoint = BattlesFoughtEndpoint)
     {
         if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
         if (string.IsNullOrWhiteSpace(endpoint))
             throw new ArgumentException("Endpoint cannot be empty.", nameof(endpoint));
+        if (string.IsNullOrWhiteSpace(battlesFoughtEndpoint))
+            throw new ArgumentException(
+                "Battles-fought endpoint cannot be empty.",
+                nameof(battlesFoughtEndpoint));
 
         this.httpClient = httpClient;
         this.endpoint = endpoint;
+        this.battlesFoughtEndpoint = battlesFoughtEndpoint;
         this.ownsClient = ownsClient;
     }
 
@@ -83,7 +90,7 @@ public class ServerTelemetryUploader : IServerTelemetryUploader, IBattlesFoughtU
     public async Task<ServerTelemetryUploadResult> RecordBattleStartedAsync(
         CancellationToken cancellationToken)
     {
-        if (!IsEndpointConfigured(BattlesFoughtEndpoint))
+        if (!IsEndpointConfigured(battlesFoughtEndpoint))
         {
             return new ServerTelemetryUploadResult(
                 false,
@@ -91,7 +98,7 @@ public class ServerTelemetryUploader : IServerTelemetryUploader, IBattlesFoughtU
                 "The battles-fought endpoint is not configured.");
         }
 
-        return await PostAsync(BattlesFoughtEndpoint, "{}", "battles-fought", cancellationToken)
+        return await PostAsync(battlesFoughtEndpoint, "{}", "battles-fought", cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/source/Coop.IntegrationTests/Environment/Mock/MockServerTelemetryUploader.cs
+++ b/source/Coop.IntegrationTests/Environment/Mock/MockServerTelemetryUploader.cs
@@ -1,0 +1,23 @@
+﻿using Coop.Core.Server.Services.Telemetry;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Coop.IntegrationTests.Environment.Mock;
+
+/// <summary>Prevents integration test containers from sending external telemetry.</summary>
+public sealed class MockServerTelemetryUploader :
+    IServerTelemetryUploader,
+    IBattlesFoughtUploader
+{
+    private static readonly Task<ServerTelemetryUploadResult> DisabledResult = Task.FromResult(
+        new ServerTelemetryUploadResult(false, false, "Disabled in tests."));
+
+    public bool IsConfigured => false;
+
+    public Task<ServerTelemetryUploadResult> UploadAsync(
+        ServerTelemetryStatus status,
+        CancellationToken cancellationToken) => DisabledResult;
+
+    public Task<ServerTelemetryUploadResult> RecordBattleStartedAsync(
+        CancellationToken cancellationToken) => DisabledResult;
+}

--- a/source/Coop.IntegrationTests/Environment/TestEnvironment.cs
+++ b/source/Coop.IntegrationTests/Environment/TestEnvironment.cs
@@ -7,6 +7,7 @@ using Common.Tests.Utils;
 using Coop.Core.Client;
 using Coop.Core.Server;
 using Coop.Core.Server.Services.Settlements;
+using Coop.Core.Server.Services.Telemetry;
 using Coop.IntegrationTests.Environment.Instance;
 using Coop.IntegrationTests.Environment.Mock;
 using GameInterface;
@@ -86,6 +87,10 @@ public class TestEnvironment
         builder.RegisterType<ServerInstance>().AsSelf();
 
         AddSharedDependencies(builder);
+        builder.RegisterType<MockServerTelemetryUploader>()
+            .As<IServerTelemetryUploader>()
+            .As<IBattlesFoughtUploader>()
+            .SingleInstance();
 
         var container = BuildContainer(builder);
 

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -5,6 +5,8 @@ using Common.Network.Session;
 using Coop.Core.Common.Configuration;
 using Coop.Core.Client;
 using Coop.Core.Server;
+using Coop.Core.Server.Services.Telemetry;
+using Coop.Tests.Mocks;
 using GameInterface;
 using Xunit;
 
@@ -35,6 +37,7 @@ namespace Coop.Tests.Autofac
             ContainerBuilder builder = new ContainerBuilder();
             builder.RegisterModule<ServerModule>();
             builder.RegisterModule<GameInterfaceModule>();
+            RegisterMockServerTelemetry(builder);
             using var container = builder.Build();
 
             Assert.NotNull(container);
@@ -56,11 +59,20 @@ namespace Coop.Tests.Autofac
             builder.RegisterModule<ServerModule>();
             builder.RegisterModule<GameInterfaceModule>();
             builder.RegisterInstance(selectedConfig).AsSelf().SingleInstance();
+            RegisterMockServerTelemetry(builder);
 
             using var container = builder.Build();
 
             Assert.Same(selectedConfig, container.Resolve<SessionAdvertisementConfig>());
             Assert.Equal(visibility, container.Resolve<SessionAdvertisementConfig>().Visibility);
+        }
+
+        private static void RegisterMockServerTelemetry(ContainerBuilder builder)
+        {
+            builder.RegisterType<MockServerTelemetryUploader>()
+                .As<IServerTelemetryUploader>()
+                .As<IBattlesFoughtUploader>()
+                .SingleInstance();
         }
     }
 }

--- a/source/Coop.Tests/Mocks/MockServerTelemetryUploader.cs
+++ b/source/Coop.Tests/Mocks/MockServerTelemetryUploader.cs
@@ -1,0 +1,23 @@
+﻿using Coop.Core.Server.Services.Telemetry;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Coop.Tests.Mocks;
+
+/// <summary>Prevents server test containers from sending external telemetry.</summary>
+public sealed class MockServerTelemetryUploader :
+    IServerTelemetryUploader,
+    IBattlesFoughtUploader
+{
+    private static readonly Task<ServerTelemetryUploadResult> DisabledResult = Task.FromResult(
+        new ServerTelemetryUploadResult(false, false, "Disabled in tests."));
+
+    public bool IsConfigured => false;
+
+    public Task<ServerTelemetryUploadResult> UploadAsync(
+        ServerTelemetryStatus status,
+        CancellationToken cancellationToken) => DisabledResult;
+
+    public Task<ServerTelemetryUploadResult> RecordBattleStartedAsync(
+        CancellationToken cancellationToken) => DisabledResult;
+}

--- a/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryUploaderTests.cs
+++ b/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryUploaderTests.cs
@@ -54,16 +54,19 @@ public class ServerTelemetryUploaderTests
     [Fact]
     public async Task RecordBattleStartedAsync_PostsToBattlesFoughtEdgeFunction()
     {
+        const string testEndpoint = "https://telemetry.example.test/api/v1/battles-fought";
         var handler = new RecordingHttpHandler();
         using var httpClient = new HttpClient(handler);
-        using var uploader = new ServerTelemetryUploader(httpClient);
+        using var uploader = new ServerTelemetryUploader(
+            httpClient,
+            battlesFoughtEndpoint: testEndpoint);
 
         var result = await uploader.RecordBattleStartedAsync(CancellationToken.None);
 
         Assert.True(result.Uploaded);
         Assert.Equal(1, handler.RequestCount);
         Assert.Equal(HttpMethod.Post, handler.Method);
-        Assert.Equal(ServerTelemetryUploader.BattlesFoughtEndpoint, handler.RequestUri?.ToString());
+        Assert.Equal(testEndpoint, handler.RequestUri?.ToString());
         Assert.Equal("application/json; charset=utf-8", handler.ContentType);
         Assert.Equal("Bearer " + ServerTelemetryUploader.PublishableKey, handler.Authorization);
         Assert.Equal(ServerTelemetryUploader.PublishableKey, handler.ApiKey);

--- a/source/Coop.Tests/ServerTestComponent.cs
+++ b/source/Coop.Tests/ServerTestComponent.cs
@@ -1,5 +1,7 @@
 ﻿using Autofac;
 using Coop.Core.Server;
+using Coop.Core.Server.Services.Telemetry;
+using Coop.Tests.Mocks;
 using GameInterface.Registry;
 using Xunit.Abstractions;
 
@@ -12,6 +14,10 @@ internal class ServerTestComponent : TestComponentBase
         var builder = new ContainerBuilder();
         builder.RegisterModule<ServerModule>();
         builder.RegisterModule<RegistryModule>();
+        builder.RegisterType<MockServerTelemetryUploader>()
+            .As<IServerTelemetryUploader>()
+            .As<IBattlesFoughtUploader>()
+            .SingleInstance();
 
         RegisterMock<ICoopServer>(builder);
 

--- a/source/E2E.Tests/Environment/TestEnvironment.cs
+++ b/source/E2E.Tests/Environment/TestEnvironment.cs
@@ -5,6 +5,7 @@ using Common.Serialization;
 using Common.Tests.Utils;
 using Coop.Core.Client;
 using Coop.Core.Server;
+using Coop.Core.Server.Services.Telemetry;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Environment.Mock;
 using E2E.Tests.Environment.MockEngine;
@@ -14,6 +15,7 @@ using Missions;
 using Missions.Agents.Handlers;
 using Missions.Battles;
 using Xunit.Abstractions;
+using MockServerTelemetryUploader = Coop.IntegrationTests.Environment.Mock.MockServerTelemetryUploader;
 
 namespace E2E.Tests.Environment;
 
@@ -93,6 +95,10 @@ public class TestEnvironment
         builder.RegisterType<ServerInstance>().AsSelf();
 
         AddSharedDependencies(builder);
+        builder.RegisterType<MockServerTelemetryUploader>()
+            .As<IServerTelemetryUploader>()
+            .As<IBattlesFoughtUploader>()
+            .SingleInstance();
 
         container = builder.Build();
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Server, integration, and E2E test containers resolve the production telemetry uploader from `ServerModule`. Tests that create player battles can post to the live battles-fought endpoint.

The uploader unit test uses a mocked HTTP handler, but still builds its request with the production URI.

## What is the new behavior?

Every server test container overrides both telemetry uploader interfaces with `MockServerTelemetryUploader`, which returns without making a request. The uploader unit test also uses `telemetry.example.test` instead of the production URI.

Tests:
- `dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release --no-restore` (727 passed, 1 skipped)
- `dotnet build source/Coop.IntegrationTests/Coop.IntegrationTests.csproj -c Release -p:NuGetAudit=false`
- `dotnet build source/E2E.Tests/E2E.Tests.csproj -c Release --no-restore`

## Bot Changelog Entry

