### PR TITLE
[2553] Take item modifier into account when reconciling purchase

### DIFF
--- a/source/GameInterface.Tests/Services/Inventory/Handlers/TradeHandlerTests.cs
+++ b/source/GameInterface.Tests/Services/Inventory/Handlers/TradeHandlerTests.cs
@@ -1,0 +1,64 @@
+﻿using GameInterface.Services.Inventory.Handlers;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Inventory.Handlers;
+
+public class TradeHandlerTests
+{
+    [Fact]
+    public void ReconcilePurchases_NoShortfall_WhenExactModifierStockCoversPurchase()
+    {
+        var shield = new ItemObject("old_horsemans_kite_shield");
+        var thick = new ItemModifier();
+
+        var merchantRoster = new ItemRoster();
+        merchantRoster.AddToCounts(new EquipmentElement(shield, thick), 1);
+        merchantRoster.AddToCounts(new EquipmentElement(shield, null), 4);
+
+        var merchantRosterData = merchantRoster.ToArray();
+        var partyRosterData = new[]
+        {
+            new ItemRosterElement(new EquipmentElement(shield, null), 2)
+        };
+
+        var boughtItems = new List<(ItemRosterElement, int)>
+        {
+            (new ItemRosterElement(new EquipmentElement(shield, null), 2), 534)
+        };
+
+        int result = TradeHandler.ReconcilePurchases(merchantRoster, merchantRosterData, partyRosterData, boughtItems, totalAmount: 534);
+
+        Assert.Equal(534, result);
+        Assert.Equal(2, partyRosterData[0].Amount);
+    }
+
+    [Fact]
+    public void ReconcilePurchases_ProratesRefund_OnGenuineShortfall()
+    {
+        var shield = new ItemObject("old_horsemans_kite_shield");
+
+        var merchantRoster = new ItemRoster();
+        merchantRoster.AddToCounts(new EquipmentElement(shield, null), 1);
+
+        var merchantRosterData = merchantRoster.ToArray();
+        var partyRosterData = new[]
+        {
+            new ItemRosterElement(new EquipmentElement(shield, null), 4)
+        };
+
+        var boughtItems = new List<(ItemRosterElement, int)>
+        {
+            (new ItemRosterElement(new EquipmentElement(shield, null), 4), 400)
+        };
+
+        int result = TradeHandler.ReconcilePurchases(merchantRoster, merchantRosterData, partyRosterData, boughtItems, totalAmount: 400);
+
+        // 1 of 4 available: 3 short, refunded at 100 each, so only 100 is paid and 1 is kept.
+        Assert.Equal(100, result);
+        Assert.Equal(1, partyRosterData[0].Amount);
+    }
+}

--- a/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
@@ -148,23 +148,7 @@ internal class TradeHandler : IHandler
             // When looting, taken items are treated as bought items. Don't need to manage changed rosters in these cases
             if (fromRoster != null)
             {
-                foreach (var boughtItem in boughtItems)
-                {
-                    int difference = fromRoster.GetItemNumber(boughtItem.Item1.EquipmentElement.Item) - boughtItem.Item1.Amount;
-
-                    if (difference < 0)
-                    {
-                        int fromRosterDataIndex = fromItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                        if (fromRosterDataIndex >= 0) fromItemRosterData[fromRosterDataIndex].Amount -= difference;
-                        else fromItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, -difference));
-
-                        int toRosterDataIndex = toItemRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
-                        if (toRosterDataIndex >= 0) toItemRosterData[toRosterDataIndex].Amount += difference;
-                        else toItemRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
-
-                        totalAmount -= boughtItem.Item2;
-                    }
-                }
+                totalAmount = ReconcilePurchases(fromRoster, fromItemRosterData, toItemRosterData, boughtItems, totalAmount);
             }
 
             // Update rosters with new data
@@ -209,6 +193,41 @@ internal class TradeHandler : IHandler
                 inventoryLogicInterface.UpdateEquipmentWithData(mobileParty, characterEquipmentsData, initialHero);
             }
         });
+    }
+
+    /// <summary>
+    /// Removes any purchased quantity the merchant can no longer supply from the party roster data and
+    /// refunds the prorated cost.
+    /// </summary>
+    internal static int ReconcilePurchases(
+        ItemRoster merchantRoster,
+        ItemRosterElement[] merchantRosterData,
+        ItemRosterElement[] partyRosterData,
+        List<(ItemRosterElement, int)> boughtItems,
+        int totalAmount)
+    {
+        foreach (var boughtItem in boughtItems)
+        {
+            int amount = boughtItem.Item1.Amount;
+            int elementIndex = merchantRoster.FindIndexOfElement(boughtItem.Item1.EquipmentElement);
+            int available = elementIndex >= 0 ? merchantRoster.GetElementNumber(elementIndex) : 0;
+            int difference = available - amount;
+
+            if (difference < 0)
+            {
+                int fromRosterDataIndex = merchantRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
+                if (fromRosterDataIndex >= 0) merchantRosterData[fromRosterDataIndex].Amount -= difference;
+                else merchantRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, -difference));
+
+                int toRosterDataIndex = partyRosterData.FindIndex(rosterElement => rosterElement.EquipmentElement.Equals(boughtItem.Item1));
+                if (toRosterDataIndex >= 0) partyRosterData[toRosterDataIndex].Amount += difference;
+                else partyRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
+
+                totalAmount -= amount > 0 ? (boughtItem.Item2 / amount) * -difference : boughtItem.Item2;
+            }
+        }
+
+        return totalAmount;
     }
 
     private (ItemRosterElementData, int)[] ResolveTradeItemIds(

--- a/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
+++ b/source/GameInterface/Services/Inventory/Handlers/TradeHandler.cs
@@ -223,7 +223,7 @@ internal class TradeHandler : IHandler
                 if (toRosterDataIndex >= 0) partyRosterData[toRosterDataIndex].Amount += difference;
                 else partyRosterData.AddItem(new ItemRosterElement(boughtItem.Item1.EquipmentElement, difference));
 
-                totalAmount -= amount > 0 ? (boughtItem.Item2 / amount) * -difference : boughtItem.Item2;
+                totalAmount -= amount > 0 ? (boughtItem.Item2 * -difference) / amount : boughtItem.Item2;
             }
         }
 


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When there are multiples of the same item type present in the trade window only the first one will be used to resolve the purchase:

1. Merchant has 1 regular round shield and 3 thick round shields
2. Player buys 2 thick shields 
3. The system will try to resolve based on the first entry in the list without taking into account item modifier
4. After failing to resolve it will refund the transaction and give the player available items of that type for free instead

## What is the new behavior?

Take item modifier into account and also correctly refund the transaction in case if some of the stock is absent.

<!-- Insert issue id after hashtag. -->
Resolves #2553
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->

Fix merchants giving wrong amount of equipment for free

## Other information

Despite the ticket description this does not seem to be related to companions in any way and the issue can be reproduced without them.