### PR TITLE
Fix smithing order completion popup

### DIFF
--- a/source/GameInterface.Tests/Services/Smithing/CraftingResultPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/Smithing/CraftingResultPatchesTests.cs
@@ -1,0 +1,38 @@
+﻿using GameInterface.Services.Smithing.Patches;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem.ViewModelCollection.WeaponCrafting.WeaponDesign;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Smithing;
+
+/// <summary>Verifies crafting finalization follows the mode captured by the result popup.</summary>
+public sealed class CraftingResultPatchesTests
+{
+    [Fact]
+    public void IsFinalizingOrder_WhenScreenModeChangedAfterCompletion_UsesResultPopupMode()
+    {
+        var weaponDesign = (WeaponDesignVM)RuntimeHelpers.GetUninitializedObject(
+            typeof(WeaponDesignVM));
+        var resultPopup = (WeaponDesignResultPopupVM)RuntimeHelpers.GetUninitializedObject(
+            typeof(WeaponDesignResultPopupVM));
+        resultPopup.IsInOrderMode = true;
+        weaponDesign.CraftingResultPopup = resultPopup;
+        weaponDesign.IsInOrderMode = false;
+
+        Assert.True(CraftingResultPatches.IsFinalizingOrder(weaponDesign));
+    }
+
+    [Fact]
+    public void IsFinalizingOrder_WhenResultWasFreeBuild_ReturnsFalse()
+    {
+        var weaponDesign = (WeaponDesignVM)RuntimeHelpers.GetUninitializedObject(
+            typeof(WeaponDesignVM));
+        var resultPopup = (WeaponDesignResultPopupVM)RuntimeHelpers.GetUninitializedObject(
+            typeof(WeaponDesignResultPopupVM));
+        resultPopup.IsInOrderMode = false;
+        weaponDesign.CraftingResultPopup = resultPopup;
+        weaponDesign.IsInOrderMode = true;
+
+        Assert.False(CraftingResultPatches.IsFinalizingOrder(weaponDesign));
+    }
+}

--- a/source/GameInterface/Services/Smithing/Patches/CraftingResultPatches.cs
+++ b/source/GameInterface/Services/Smithing/Patches/CraftingResultPatches.cs
@@ -27,7 +27,7 @@ internal class CraftingResultPatches
             if (GameStateManager.Current.ActiveState is CraftingState)
             {
                 // CompleteOrder and refreshing handled elsewhere
-                if (__instance.IsInOrderMode)
+                if (IsFinalizingOrder(__instance))
                 {
                     __instance.CraftedItemObject = null;
                 }
@@ -52,5 +52,11 @@ internal class CraftingResultPatches
 
         // Replace original
         return false;
+    }
+
+    internal static bool IsFinalizingOrder(WeaponDesignVM weaponDesignVM)
+    {
+        // Completing an order can switch the screen back to free-build mode before the popup is closed.
+        return weaponDesignVM?.CraftingResultPopup?.IsInOrderMode == true;
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Completing a smithing order can remove the order and switch the screen back to free-build mode before the result popup is closed. Finalization then refreshes a stale order index and can leave the popup stuck.

## What is the new behavior?

Finalization uses the result popup's captured order mode, so completed orders clear their result without refreshing a removed order.

## Bot Changelog Entry

- Fixed the smithing order completion popup getting stuck after an order is completed.

## Other information

- Tests: `CraftingResultPatchesTests` (2 passed)