### PR TITLE
Hold castle capture aftermath menu

### DIFF
--- a/source/GameInterface.Tests/Services/SiegeEvents/SiegeCaptureMenuHoldPatchTests.cs
+++ b/source/GameInterface.Tests/Services/SiegeEvents/SiegeCaptureMenuHoldPatchTests.cs
@@ -1,0 +1,26 @@
+﻿using GameInterface.Services.SiegeEvents.Patches;
+using HarmonyLib;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using Xunit;
+
+namespace GameInterface.Tests.Services.SiegeEvents;
+
+/// <summary>Verifies capture aftermath holds cover every fortification entry menu.</summary>
+public class SiegeCaptureMenuHoldPatchTests
+{
+    [Theory]
+    [InlineData(nameof(EncounterGameMenuBehavior.game_menu_town_outside_on_init))]
+    [InlineData(nameof(EncounterGameMenuBehavior.game_menu_castle_outside_on_init))]
+    public void CaptureHold_PatchesEveryFortificationOutsideMenu(string methodName)
+    {
+        var patchedMethods = typeof(SiegeCaptureMenuHoldPatch)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .SelectMany(method => method.GetCustomAttributes<HarmonyPatch>())
+            .Where(patch => patch.info.declaringType == typeof(EncounterGameMenuBehavior))
+            .Select(patch => patch.info.methodName);
+
+        Assert.Contains(methodName, patchedMethods);
+    }
+}

--- a/source/GameInterface/Services/SiegeEvents/Patches/SiegeCaptureMenuHoldPatch.cs
+++ b/source/GameInterface/Services/SiegeEvents/Patches/SiegeCaptureMenuHoldPatch.cs
@@ -9,8 +9,8 @@ namespace GameInterface.Services.SiegeEvents.Patches;
 /// <summary>
 /// Vanilla holds menu_settlement_taken (the Devastate/Pillage/Mercy choice) open by pausing the campaign
 /// until the player picks. A co-op client can't pause — time is server-driven — so its settlement
-/// encounter keeps advancing and rolls the menu out to the town menu before the player chooses. While a
-/// capture choice is pending for a settlement, redirect the settlement-entry menu back to
+/// encounter keeps advancing and rolls the menu out to the fortification menu before the player chooses. While
+/// a capture choice is pending for a settlement, redirect the settlement-entry menu back to
 /// menu_settlement_taken, enforcing the same hold in a co-op-compatible way. Released when the player picks.
 /// </summary>
 [HarmonyPatch]
@@ -28,9 +28,13 @@ internal static class SiegeCaptureMenuHoldPatch
         if (settlement != null) pendingChoice.Remove(settlement);
     }
 
-    [HarmonyPatch(typeof(EncounterGameMenuBehavior), "game_menu_town_outside_on_init")]
+    [HarmonyPatch(typeof(EncounterGameMenuBehavior), nameof(EncounterGameMenuBehavior.game_menu_town_outside_on_init))]
     [HarmonyPrefix]
     private static bool TownOutsideInitPrefix() => RedirectIfHeld();
+
+    [HarmonyPatch(typeof(EncounterGameMenuBehavior), nameof(EncounterGameMenuBehavior.game_menu_castle_outside_on_init))]
+    [HarmonyPrefix]
+    private static bool CastleOutsideInitPrefix() => RedirectIfHeld();
 
     private static bool RedirectIfHeld()
     {


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

The co-op capture aftermath hold patches the town outside menu only. Castle captures can advance past the Devastate, Pillage, or Mercy decision while server time continues.

## What is the new behavior?

The same pending-choice redirect now patches both town and castle outside menu initializers.

## Bot Changelog Entry

- Fixed castle captures skipping the post-capture decision menu.

## Other information

- Tests: `SiegeCaptureMenuHoldPatchTests` (2 passed)