### PR TITLE
Accept settlement center for land entry

### DIFF
--- a/source/Coop.Core/Server/Services/Settlements/SettlementEncounterDistanceValidator.cs
+++ b/source/Coop.Core/Server/Services/Settlements/SettlementEncounterDistanceValidator.cs
@@ -46,12 +46,32 @@ internal class SettlementEncounterDistanceValidator : ISettlementEncounterDistan
             : settlement.IsTown
                 ? encounterModel.NeededMaximumDistanceForEncounteringTown
                 : encounterModel.NeededMaximumDistanceForEncounteringVillage;
-        var targetPosition = usePort ? settlement.PortPosition : settlement.GatePosition;
-
-        if (party.Position.Distance(targetPosition) <= maximumDistance + PositionSyncDriftSlack)
+        if (IsWithinInteractionDistance(
+            party.Position,
+            settlement.Position,
+            settlement.GatePosition,
+            settlement.PortPosition,
+            usePort,
+            maximumDistance + PositionSyncDriftSlack))
             return true;
 
         rejectionReason = "your party is too far from the settlement";
         return false;
+    }
+
+    internal static bool IsWithinInteractionDistance(
+        CampaignVec2 partyPosition,
+        CampaignVec2 settlementPosition,
+        CampaignVec2 gatePosition,
+        CampaignVec2 portPosition,
+        bool usePort,
+        float maximumDistance)
+    {
+        if (usePort)
+            return partyPosition.Distance(portPosition) <= maximumDistance;
+
+        // Land movement may converge on either the settlement's center or its visual gate.
+        return partyPosition.Distance(gatePosition) <= maximumDistance ||
+               partyPosition.Distance(settlementPosition) <= maximumDistance;
     }
 }

--- a/source/Coop.Tests/Server/Services/Settlements/SettlementEncounterDistanceValidatorTests.cs
+++ b/source/Coop.Tests/Server/Services/Settlements/SettlementEncounterDistanceValidatorTests.cs
@@ -1,0 +1,51 @@
+﻿using Coop.Core.Server.Services.Settlements;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.Server.Services.Settlements;
+
+/// <summary>Verifies land and port settlement interaction coordinates remain distinct.</summary>
+public class SettlementEncounterDistanceValidatorTests
+{
+    [Fact]
+    public void LandEntry_AtSettlementCenterFarFromGate_IsAllowed()
+    {
+        Assert.True(SettlementEncounterDistanceValidator.IsWithinInteractionDistance(
+            Position(50f, 60f),
+            Position(50f, 60f),
+            Position(20f, 30f),
+            Position(90f, 100f),
+            usePort: false,
+            maximumDistance: 6f));
+    }
+
+    [Fact]
+    public void PortEntry_AtSettlementCenterFarFromPort_IsRejected()
+    {
+        Assert.False(SettlementEncounterDistanceValidator.IsWithinInteractionDistance(
+            Position(50f, 60f),
+            Position(50f, 60f),
+            Position(20f, 30f),
+            Position(90f, 100f),
+            usePort: true,
+            maximumDistance: 6f));
+    }
+
+    [Fact]
+    public void LandEntry_FarFromCenterAndGate_IsRejected()
+    {
+        Assert.False(SettlementEncounterDistanceValidator.IsWithinInteractionDistance(
+            Position(900f, 900f),
+            Position(50f, 60f),
+            Position(20f, 30f),
+            Position(90f, 100f),
+            usePort: false,
+            maximumDistance: 6f));
+    }
+
+    private static CampaignVec2 Position(float x, float y)
+    {
+        return new CampaignVec2(new Vec2(x, y), true);
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Land settlement entry validates only against the gate coordinate. A server-synced party at the settlement center can be rejected when the center and gate are farther apart than the interaction range.

## What is the new behavior?

Land entry accepts either the settlement center or gate coordinate. Port entry remains restricted to the port coordinate.

## Bot Changelog Entry

- Fixed valid settlement and siege entry being rejected when a party is at the settlement center.

## Other information

- Tests: `SettlementEncounterDistanceValidatorTests` (3 passed)