### PR TITLE
Update and Normalize Battle, Party, and Mission Commands

### DIFF
--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -10,6 +11,7 @@ using Coop.Core.Client.Services.MobileParties;
 using Coop.Core.Client.Services.Session;
 using Coop.Core.Client.States;
 using Coop.Core.Common;
+using Coop.Core.Common.Commands;
 using Coop.Core.Common.Configuration;
 using Coop.Core.Common.Session;
 using Coop.Steam;
@@ -30,6 +32,21 @@ public class ClientModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<MissionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinStateCommand>()
+            .As<IJoinStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<ArmInactivePartyDeficitCommand>()
+            .As<IArmInactivePartyDeficitCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<DisconnectCommand>()
+            .As<IDisconnectCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
 
         builder.RegisterType<ClientContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ClientLogic>().As<ILogic>().As<IClientLogic>().InstancePerLifetimeScope();

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -27,7 +27,6 @@ internal static class JoinDebugCommands
     private static MobileParty stagedInactiveParty;
     private static bool stagedInactivePartyWasActive;
 
-    [CommandLineArgumentFunction("join_state", "coop.debug.connection")]
     public static string JoinState(List<string> args)
     {
         if (args.Count != 0)
@@ -65,7 +64,6 @@ internal static class JoinDebugCommands
               $"forcedInactiveParty={lastForcedPartyId}";
     }
 
-    [CommandLineArgumentFunction("arm_inactive_party_deficit", "coop.debug.connection")]
     public static string ArmInactivePartyDeficit(List<string> args)
     {
         if (args.Count != 1)
@@ -84,7 +82,6 @@ internal static class JoinDebugCommands
                "from the client campaign collection before validation.";
     }
 
-    [CommandLineArgumentFunction("stage_inactive_party", "coop.debug.connection")]
     public static string StageInactiveParty(List<string> args)
     {
         if (args.Count != 0)
@@ -125,7 +122,6 @@ internal static class JoinDebugCommands
         return GetStagedPartyResult(stagedInactiveParty);
     }
 
-    [CommandLineArgumentFunction("restore_inactive_party", "coop.debug.connection")]
     public static string RestoreInactiveParty(List<string> args)
     {
         if (args.Count != 0)
@@ -149,7 +145,6 @@ internal static class JoinDebugCommands
         return $"restoredParty={partyId} active={restoredActive}";
     }
 
-    [CommandLineArgumentFunction("disconnect", "coop.debug.connection")]
     public static string Disconnect(List<string> args)
     {
         if (args.Count != 0)
@@ -169,7 +164,10 @@ internal static class JoinDebugCommands
         return "Client session is returning to the main menu.";
     }
 
-    [CommandLineArgumentFunction("reconnect", "coop.debug.connection")]
+    // This command must be available before the session registrar exists so reconnect can create a session.
+    [CommandLineArgumentFunction(
+        LegacyConnectionCommandExceptions.ReconnectName,
+        LegacyConnectionCommandExceptions.Prefix)]
     public static string Reconnect(List<string> args)
     {
         if (args.Count != 0)

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
-using static TaleWorlds.Library.CommandLineFunctionality;
 using ServerLoadingState = Coop.Core.Server.Connections.States.LoadingState;
 
 namespace Coop.Core.Common.Commands;
@@ -162,29 +161,6 @@ internal static class JoinDebugCommands
 
         clientLogic.Disconnect();
         return "Client session is returning to the main menu.";
-    }
-
-    // This command must be available before the session registrar exists so reconnect can create a session.
-    [CommandLineArgumentFunction(
-        LegacyConnectionCommandExceptions.ReconnectName,
-        LegacyConnectionCommandExceptions.Prefix)]
-    public static string Reconnect(List<string> args)
-    {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.reconnect";
-        }
-        if (ModInformation.IsServer)
-        {
-            return "reconnect must be run on a client.";
-        }
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
-        {
-            return "No client session was found.";
-        }
-
-        clientLogic.Connect();
-        return "Client session is reconnecting to the configured server.";
     }
 
     internal static void ForceArmedInactivePartyDeficit()

--- a/source/Coop.Core/Common/Commands/JoinDebugCoopCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCoopCommands.cs
@@ -1,0 +1,132 @@
+﻿#if DEBUG
+using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace Coop.Core.Common.Commands;
+
+internal static class JoinDebugLegacyCommandResult
+{
+    public static CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool failed = output.StartsWith("Usage:", StringComparison.OrdinalIgnoreCase) ||
+                      output.StartsWith("Failed", StringComparison.OrdinalIgnoreCase) ||
+                      output.StartsWith("No ", StringComparison.OrdinalIgnoreCase) ||
+                      output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                      output.IndexOf("client-only", StringComparison.OrdinalIgnoreCase) >= 0;
+        return failed
+            ? new CoopCommandResult(false, output, "command_rejected")
+            : new CoopCommandResult(true, output);
+    }
+}
+
+public interface IJoinStateCommand : ICoopCommand
+{
+}
+
+public sealed class JoinStateCommand : IJoinStateCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "join_state";
+
+    public string Description => "Reports the current campaign join state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.JoinState(new List<string>(args)));
+    }
+}
+
+public interface IArmInactivePartyDeficitCommand : ICoopCommand
+{
+}
+
+public sealed class ArmInactivePartyDeficitCommand : IArmInactivePartyDeficitCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "arm_inactive_party_deficit";
+
+    public string Description => "Arms the next client join baseline to omit an inactive party.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_string_id", "The inactive party StringId."),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.ArmInactivePartyDeficit(new List<string>(args)));
+    }
+}
+
+public interface IStageInactivePartyCommand : ICoopCommand
+{
+}
+
+public sealed class StageInactivePartyCommand : IStageInactivePartyCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "stage_inactive_party";
+
+    public string Description => "Stages an isolated server party as inactive for join testing.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.StageInactiveParty(new List<string>(args)));
+    }
+}
+
+public interface IRestoreInactivePartyCommand : ICoopCommand
+{
+}
+
+public sealed class RestoreInactivePartyCommand : IRestoreInactivePartyCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "restore_inactive_party";
+
+    public string Description => "Restores the staged inactive server party.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.RestoreInactiveParty(new List<string>(args)));
+    }
+}
+
+public interface IDisconnectCommand : ICoopCommand
+{
+}
+
+public sealed class DisconnectCommand : IDisconnectCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "disconnect";
+
+    public string Description => "Disconnects the active client session.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.Disconnect(new List<string>(args)));
+    }
+}
+#endif

--- a/source/Coop.Core/Common/Commands/LegacyConnectionCommandExceptions.cs
+++ b/source/Coop.Core/Common/Commands/LegacyConnectionCommandExceptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Coop.Core.Common.Commands;
+
+/// <summary>
+/// Identifies commands that must remain available outside the session command registrar lifecycle.
+/// </summary>
+public static class LegacyConnectionCommandExceptions
+{
+    public const string Prefix = "coop.debug.connection";
+
+    public const string StartName = "start";
+
+    public const string ReconnectName = "reconnect";
+}

--- a/source/Coop.Core/Common/Commands/LegacyConnectionCommands.cs
+++ b/source/Coop.Core/Common/Commands/LegacyConnectionCommands.cs
@@ -1,0 +1,69 @@
+﻿#if DEBUG
+using Common;
+using Coop.Core.Client;
+using GameInterface;
+using System;
+using System.Collections.Generic;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace Coop.Core.Common.Commands;
+
+/// <summary>
+/// Connection commands that must remain available while no session container exists.
+/// </summary>
+public static class LegacyConnectionCommands
+{
+    [CommandLineArgumentFunction(
+        LegacyConnectionCommandExceptions.StartName,
+        LegacyConnectionCommandExceptions.Prefix)]
+    public static string Start(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.start";
+        }
+        if (ModInformation.IsServer)
+        {
+            return "start must be run on a client.";
+        }
+        if (ContainerProvider.TryResolve<global::Common.LogicStates.ILogic>(out _))
+        {
+            return "Client co-op connection is already starting or running.";
+        }
+
+        StartClientSession();
+        return "Client co-op connection started.";
+    }
+
+    [CommandLineArgumentFunction(
+        LegacyConnectionCommandExceptions.ReconnectName,
+        LegacyConnectionCommandExceptions.Prefix)]
+    public static string Reconnect(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.reconnect";
+        }
+        if (ModInformation.IsServer)
+        {
+            return "reconnect must be run on a client.";
+        }
+        if (ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+        {
+            clientLogic.Connect();
+            return "Client session is reconnecting to the configured server.";
+        }
+
+        StartClientSession();
+        return "Client co-op session restarted after teardown.";
+    }
+
+    private static void StartClientSession()
+    {
+        if (!ProcessLifetimeClientSessionStarter.Start())
+        {
+            throw new InvalidOperationException("Client co-op connection start was refused.");
+        }
+    }
+}
+#endif

--- a/source/Coop.Core/Common/Commands/ProcessLifetimeClientSessionStarter.cs
+++ b/source/Coop.Core/Common/Commands/ProcessLifetimeClientSessionStarter.cs
@@ -1,0 +1,37 @@
+﻿#if DEBUG
+using System;
+using System.Threading;
+
+namespace Coop.Core.Common.Commands;
+
+/// <summary>
+/// Bridges pre-session commands to the process-owned co-op session lifecycle.
+/// </summary>
+public static class ProcessLifetimeClientSessionStarter
+{
+    private static Func<bool> startClientSession;
+
+    public static void Configure(Func<bool> starter)
+    {
+        if (starter == null) throw new ArgumentNullException(nameof(starter));
+
+        Volatile.Write(ref startClientSession, starter);
+    }
+
+    public static bool Start()
+    {
+        Func<bool> starter = Volatile.Read(ref startClientSession);
+        if (starter == null)
+        {
+            throw new InvalidOperationException("The process client-session starter is unavailable.");
+        }
+
+        return starter();
+    }
+
+    internal static void Reset()
+    {
+        Volatile.Write(ref startClientSession, null);
+    }
+}
+#endif

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -8,6 +9,7 @@ using Common.PacketHandlers;
 using Coop.Core.Client.Services.Kingdoms;
 using Coop.Core.Client.Services.MobileParties;
 using Coop.Core.Common;
+using Coop.Core.Common.Commands;
 using Coop.Core.Common.Configuration;
 using Coop.Core.Common.Session;
 using Coop.Core.Server.Connections;
@@ -39,6 +41,21 @@ public class ServerModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<ConnectionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinStateCommand>()
+            .As<IJoinStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<StageInactivePartyCommand>()
+            .As<IStageInactivePartyCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<RestoreInactivePartyCommand>()
+            .As<IRestoreInactivePartyCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
 
         // The mission/P2P stack is composed into the server container too (it is also in ClientModule) so the
         // server-authoritative battle classes — notably BattleHostHandler, which elects the battle host — run

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -32,6 +32,15 @@ namespace Coop.Tests.Autofac
             var commandRegistry = container.Resolve<ICoopCommandRegistry>();
             Assert.True(commandRegistry.Contains("coop.debug.map_event.click_deployment_ready"));
             Assert.True(commandRegistry.Contains("coop.debug.battle.state"));
+            Assert.True(commandRegistry.Contains("coop.debug.hero.id"));
+            Assert.True(commandRegistry.Contains("coop.debug.campaign_options.list"));
+            Assert.True(commandRegistry.Contains("coop.debug.player_captivity.capture_player"));
+#if DEBUG
+            Assert.True(commandRegistry.Contains("coop.debug.connection.join_state"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.arm_inactive_party_deficit"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.disconnect"));
+            Assert.False(commandRegistry.Contains("coop.debug.connection.stage_inactive_party"));
+#endif
         }
 
         [Fact]
@@ -53,6 +62,15 @@ namespace Coop.Tests.Autofac
             var commandRegistry = container.Resolve<ICoopCommandRegistry>();
             Assert.True(commandRegistry.Contains("coop.debug.map_event.click_deployment_ready"));
             Assert.True(commandRegistry.Contains("coop.debug.battle.state"));
+            Assert.True(commandRegistry.Contains("coop.debug.hero.id"));
+            Assert.True(commandRegistry.Contains("coop.debug.campaign_options.list"));
+            Assert.True(commandRegistry.Contains("coop.debug.player_captivity.capture_player"));
+#if DEBUG
+            Assert.True(commandRegistry.Contains("coop.debug.connection.join_state"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.stage_inactive_party"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.restore_inactive_party"));
+            Assert.False(commandRegistry.Contains("coop.debug.connection.disconnect"));
+#endif
         }
 
         [Theory]

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Network;
 using Common.Network.Session;
@@ -27,6 +28,10 @@ namespace Coop.Tests.Autofac
 
             var logic = container.Resolve<ILogic>();
             Assert.NotNull(logic);
+
+            var commandRegistry = container.Resolve<ICoopCommandRegistry>();
+            Assert.True(commandRegistry.Contains("coop.debug.map_event.click_deployment_ready"));
+            Assert.True(commandRegistry.Contains("coop.debug.battle.state"));
         }
 
         [Fact]
@@ -44,6 +49,10 @@ namespace Coop.Tests.Autofac
 
             var logic = container.Resolve<ILogic>();
             Assert.NotNull(logic);
+
+            var commandRegistry = container.Resolve<ICoopCommandRegistry>();
+            Assert.True(commandRegistry.Contains("coop.debug.map_event.click_deployment_ready"));
+            Assert.True(commandRegistry.Contains("coop.debug.battle.state"));
         }
 
         [Theory]

--- a/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
+++ b/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
@@ -1,0 +1,37 @@
+﻿#if DEBUG
+using Coop.Core.Common.Commands;
+using System.Reflection;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.CommandTests;
+
+public class LegacyConnectionCommandExceptionTests
+{
+    [Fact]
+    public void LifecycleCommands_DocumentOnlyStartAndReconnectAsLegacyExceptions()
+    {
+        Assert.Equal("coop.debug.connection.start",
+            $"{LegacyConnectionCommandExceptions.Prefix}.{LegacyConnectionCommandExceptions.StartName}");
+        Assert.Equal("coop.debug.connection.reconnect",
+            $"{LegacyConnectionCommandExceptions.Prefix}.{LegacyConnectionCommandExceptions.ReconnectName}");
+
+        MethodInfo reconnect = typeof(JoinDebugCommands).GetMethod(nameof(JoinDebugCommands.Reconnect))!;
+        Assert.NotNull(reconnect.GetCustomAttribute<CommandLineFunctionality.CommandLineArgumentFunction>());
+
+        string[] migratedMethods =
+        {
+            nameof(JoinDebugCommands.JoinState),
+            nameof(JoinDebugCommands.ArmInactivePartyDeficit),
+            nameof(JoinDebugCommands.StageInactiveParty),
+            nameof(JoinDebugCommands.RestoreInactiveParty),
+            nameof(JoinDebugCommands.Disconnect),
+        };
+        Assert.All(migratedMethods, methodName =>
+        {
+            MethodInfo method = typeof(JoinDebugCommands).GetMethod(methodName)!;
+            Assert.Empty(method.GetCustomAttributes<CommandLineFunctionality.CommandLineArgumentFunction>());
+        });
+    }
+}
+#endif

--- a/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
+++ b/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
@@ -1,13 +1,32 @@
 ﻿#if DEBUG
+using Autofac;
+using Common;
+using Coop.Core.Client;
 using Coop.Core.Common.Commands;
+using GameInterface;
+using Moq;
+using System;
+using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.Library;
 using Xunit;
 
 namespace Coop.Tests.CommandTests;
 
-public class LegacyConnectionCommandExceptionTests
+[Collection(ModInformationRoleCollection.Name)]
+public class LegacyConnectionCommandExceptionTests : IDisposable
 {
+    private readonly bool wasServer = ModInformation.IsServer;
+    private IContainer sessionContainer;
+
+    public void Dispose()
+    {
+        ContainerProvider.Clear();
+        sessionContainer?.Dispose();
+        ProcessLifetimeClientSessionStarter.Reset();
+        ModInformation.IsServer = wasServer;
+    }
+
     [Fact]
     public void LifecycleCommands_DocumentOnlyStartAndReconnectAsLegacyExceptions()
     {
@@ -16,8 +35,8 @@ public class LegacyConnectionCommandExceptionTests
         Assert.Equal("coop.debug.connection.reconnect",
             $"{LegacyConnectionCommandExceptions.Prefix}.{LegacyConnectionCommandExceptions.ReconnectName}");
 
-        MethodInfo reconnect = typeof(JoinDebugCommands).GetMethod(nameof(JoinDebugCommands.Reconnect))!;
-        Assert.NotNull(reconnect.GetCustomAttribute<CommandLineFunctionality.CommandLineArgumentFunction>());
+        AssertLegacyAttribute(nameof(LegacyConnectionCommands.Start));
+        AssertLegacyAttribute(nameof(LegacyConnectionCommands.Reconnect));
 
         string[] migratedMethods =
         {
@@ -32,6 +51,71 @@ public class LegacyConnectionCommandExceptionTests
             MethodInfo method = typeof(JoinDebugCommands).GetMethod(methodName)!;
             Assert.Empty(method.GetCustomAttributes<CommandLineFunctionality.CommandLineArgumentFunction>());
         });
+    }
+
+    [Fact]
+    public void Reconnect_WhileSessionExists_ReconnectsExistingClientLogic()
+    {
+        ModInformation.IsServer = false;
+        var clientLogic = new Mock<IClientLogic>();
+        int processStarts = 0;
+        ProcessLifetimeClientSessionStarter.Configure(() =>
+        {
+            processStarts++;
+            return true;
+        });
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(clientLogic.Object).As<IClientLogic>();
+        sessionContainer = builder.Build();
+        ContainerProvider.SetContainer(sessionContainer);
+
+        string result = LegacyConnectionCommands.Reconnect(new List<string>());
+
+        Assert.Equal("Client session is reconnecting to the configured server.", result);
+        clientLogic.Verify(logic => logic.Connect(), Times.Once);
+        Assert.Equal(0, processStarts);
+    }
+
+    [Fact]
+    public void Reconnect_AfterSessionTeardown_StartsNewClientSession()
+    {
+        ModInformation.IsServer = false;
+        int processStarts = 0;
+        ProcessLifetimeClientSessionStarter.Configure(() =>
+        {
+            processStarts++;
+            return true;
+        });
+        ContainerProvider.Clear();
+
+        string result = LegacyConnectionCommands.Reconnect(new List<string>());
+
+        Assert.Equal("Client co-op session restarted after teardown.", result);
+        Assert.Equal(1, processStarts);
+    }
+
+    [Fact]
+    public void Start_WithoutSession_StartsNewClientSession()
+    {
+        ModInformation.IsServer = false;
+        int processStarts = 0;
+        ProcessLifetimeClientSessionStarter.Configure(() =>
+        {
+            processStarts++;
+            return true;
+        });
+        ContainerProvider.Clear();
+
+        string result = LegacyConnectionCommands.Start(new List<string>());
+
+        Assert.Equal("Client co-op connection started.", result);
+        Assert.Equal(1, processStarts);
+    }
+
+    private static void AssertLegacyAttribute(string methodName)
+    {
+        MethodInfo method = typeof(LegacyConnectionCommands).GetMethod(methodName)!;
+        Assert.NotNull(method.GetCustomAttribute<CommandLineFunctionality.CommandLineArgumentFunction>());
     }
 }
 #endif

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -25,9 +25,6 @@ using GameInterface.Utils;
 using HarmonyLib;
 using Serilog;
 using System;
-#if DEBUG
-using System.Collections.Generic;
-#endif
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -42,9 +39,6 @@ using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.View;
 using TaleWorlds.ScreenSystem;
-#if DEBUG
-using static TaleWorlds.Library.CommandLineFunctionality;
-#endif
 using Module = TaleWorlds.MountAndBlade.Module;
 
 namespace Coop
@@ -483,6 +477,11 @@ namespace Coop
                 CrashDiagnostics.SetPhase,
                 activeLogFilePath);
 
+#if DEBUG
+            global::Coop.Core.Common.Commands.ProcessLifetimeClientSessionStarter.Configure(
+                () => Coop.StartAsClient());
+#endif
+
             Updateables.Add(GameThread.Instance);
 
 #if DEBUG
@@ -801,39 +800,4 @@ namespace Coop
         }
     }
 
-#if DEBUG
-    /// <summary>
-    /// Starts a deferred live-test client through the normal connection path.
-    /// </summary>
-    internal static class JoinFixtureCommands
-    {
-        // This command must be available before the session registrar exists so start can create a session.
-        [CommandLineArgumentFunction(
-            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.StartName,
-            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.Prefix)]
-        public static string Start(List<string> args)
-        {
-            if (args.Count != 0)
-            {
-                return "Usage: coop.debug.connection.start";
-            }
-
-            if (ModInformation.IsServer)
-            {
-                return "start must be run on a client.";
-            }
-
-            if (ContainerProvider.TryResolve<Common.LogicStates.ILogic>(out _))
-            {
-                return "Client co-op connection is already starting or running.";
-            }
-
-            if (!CoopMod.Coop.StartAsClient())
-            {
-                throw new InvalidOperationException("Client co-op connection start was refused.");
-            }
-            return "Client co-op connection started.";
-        }
-    }
-#endif
 }

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -807,7 +807,10 @@ namespace Coop
     /// </summary>
     internal static class JoinFixtureCommands
     {
-        [CommandLineArgumentFunction("start", "coop.debug.connection")]
+        // This command must be available before the session registrar exists so start can create a session.
+        [CommandLineArgumentFunction(
+            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.StartName,
+            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.Prefix)]
         public static string Start(List<string> args)
         {
             if (args.Count != 0)

--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -4,6 +4,7 @@ using Common.LiveTesting;
 using Common.Logging;
 using Common.LogicStates;
 using Coop.Core.Client;
+using Coop.Core.Common.Commands;
 using Coop.Core.Server;
 using GameInterface;
 using GameInterface.Services.LiveTesting;
@@ -192,7 +193,7 @@ namespace Coop.LiveTesting
                 {
                     if (string.Equals(command, "coop.debug.connection.start", StringComparison.Ordinal))
                     {
-                        string output = Coop.JoinFixtureCommands.Start(arguments);
+                        string output = LegacyConnectionCommands.Start(arguments);
                         bool hasFallbackStructuredResult = TryParseStructuredResult(
                             output,
                             out var fallbackStructuredResult);

--- a/source/E2E.Tests/Services/Missions/MigratedMissionCommandTests.cs
+++ b/source/E2E.Tests/Services/Missions/MigratedMissionCommandTests.cs
@@ -88,6 +88,38 @@ public class MigratedMissionCommandTests
         Assert.Equal(output, result.Output);
     }
 
+    [Theory]
+    [InlineData("BATTLE_REPLICATION_FIXTURE coop spawn capture is not active")]
+    [InlineData("BATTLE_REPLICATION_FIXTURE finish local deployment first")]
+    [InlineData("BATTLE_REPLICATION_FIXTURE_INITIAL network agent registry is unavailable")]
+    [InlineData("BATTLE_REPLICATION_FIXTURE_INITIAL native spawn returned no agent")]
+    [InlineData("COLUMN_REINFORCEMENT_FIXTURE already active")]
+    [InlineData("COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to an eligible locally controlled formation")]
+    [InlineData("COLUMN_REINFORCEMENT_FIXTURE mission ended")]
+    [InlineData("WIELD_TEST main agent has no weapon")]
+    [InlineData("Siege ladder 42 was not found")]
+    public void BattleResult_Rejection_IsFailure(string output)
+    {
+        CoopCommandResult result = new BattleLegacyCommandResult().FromOutput(output);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("command_failed", result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    [Theory]
+    [InlineData("BATTLE_REPLICATION_FIXTURE_CATCHUP queued peer=player-1")]
+    [InlineData("COLUMN_REINFORCEMENT_FIXTURE_STARTED side=Defender formation=0")]
+    [InlineData("Focused the mission camera on siege ladder 42")]
+    public void BattleResult_Success_IsSuccessful(string output)
+    {
+        CoopCommandResult result = new BattleLegacyCommandResult().FromOutput(output);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
     private static ICoopCommand[] CreateCommands()
     {
         return typeof(MissionModule).Assembly.GetTypes()

--- a/source/E2E.Tests/Services/Missions/MigratedMissionCommandTests.cs
+++ b/source/E2E.Tests/Services/Missions/MigratedMissionCommandTests.cs
@@ -120,6 +120,33 @@ public class MigratedMissionCommandTests
         Assert.Equal(output, result.Output);
     }
 
+    [Fact]
+    public void TypedBattleCommandBoundaries_ReachableRejections_AreFailures()
+    {
+        var resultFactory = new BattleLegacyCommandResult();
+        var argsFactory = new CoopCommandArgsFactory();
+
+#if DEBUG
+        CoopCommandResult replicationResult = new ReplicationFixtureCommand(resultFactory)
+            .ProcessCommand(argsFactory.FromValues(new[] { "initial" }));
+        CoopCommandResult columnResult = new ColumnReinforcementFixtureCommand(resultFactory)
+            .ProcessCommand(argsFactory.FromValues(new[] { "state" }));
+
+        Assert.False(replicationResult.Succeeded);
+        Assert.Equal("command_failed", replicationResult.ErrorCode);
+        Assert.Equal("BATTLE_REPLICATION_FIXTURE no active coop battle", replicationResult.Output);
+        Assert.False(columnResult.Succeeded);
+        Assert.Equal("command_failed", columnResult.ErrorCode);
+        Assert.Equal("COLUMN_REINFORCEMENT_FIXTURE inactive", columnResult.Output);
+#endif
+        CoopCommandResult ladderResult = new FocusLadderCommand(resultFactory)
+            .ProcessCommand(argsFactory.FromValues(new[] { int.MaxValue.ToString() }));
+
+        Assert.False(ladderResult.Succeeded);
+        Assert.Equal("command_failed", ladderResult.ErrorCode);
+        Assert.Equal($"Siege ladder {int.MaxValue} was not found", ladderResult.Output);
+    }
+
     private static ICoopCommand[] CreateCommands()
     {
         return typeof(MissionModule).Assembly.GetTypes()

--- a/source/E2E.Tests/Services/Missions/MigratedMissionCommandTests.cs
+++ b/source/E2E.Tests/Services/Missions/MigratedMissionCommandTests.cs
@@ -1,0 +1,130 @@
+﻿using Common.Commands;
+using Missions;
+using Missions.Agents.Handlers;
+using Missions.Battles;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+public class MigratedMissionCommandTests
+{
+    private static readonly string[] CommandNamespaces =
+    {
+        "Missions.Agents.Handlers",
+        "Missions.Battles",
+    };
+
+    [Fact]
+    public void Commands_HaveValidUniqueMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var logger = new LoggerConfiguration().CreateLogger();
+
+        var registry = new CoopCommandRegistry(commands, logger);
+
+#if DEBUG
+        Assert.Equal(26, commands.Length);
+#else
+        Assert.Equal(15, commands.Length);
+#endif
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.All(commands, AssertNormalizedMetadata);
+    }
+
+    [Fact]
+    public void ConditionalArgumentMetadata_MatchesLegacyBehavior()
+    {
+#if DEBUG
+        var replication = new ReplicationFixtureCommand(new BattleLegacyCommandResult());
+        Assert.Equal(new[] { "mode", "connected_controller_id" },
+            replication.ExpectedArgs.Select(argument => argument.Name));
+        Assert.True(replication.ExpectedArgs[0].IsRequired);
+        Assert.False(replication.ExpectedArgs[1].IsRequired);
+
+        var movementResultFactory = new MovementLegacyCommandResult();
+        Assert.Single(new ForceRateCommand(movementResultFactory).ExpectedArgs);
+        Assert.Single(new ForceReceiverCapCommand(movementResultFactory).ExpectedArgs);
+#endif
+        var resultFactory = new BattleLegacyCommandResult();
+        var mountState = new MountStateCommand(resultFactory);
+        Assert.Single(mountState.ExpectedArgs);
+        Assert.False(mountState.ExpectedArgs[0].IsRequired);
+
+        var ladderState = new LadderStateCommand(resultFactory);
+        Assert.Single(ladderState.ExpectedArgs);
+        Assert.False(ladderState.ExpectedArgs[0].IsRequired);
+    }
+
+    [Fact]
+    public void Registry_RejectsInvalidCountBeforeCallingMissionLogic()
+    {
+        var logger = new LoggerConfiguration().CreateLogger();
+        var command = new CaptureMountPoseCommand(new BattleLegacyCommandResult());
+        var registry = new CoopCommandRegistry(new[] { command }, logger);
+        var argsFactory = new CoopCommandArgsFactory();
+
+        CoopCommandResult result = registry.ProcessCommand(
+            "coop.debug.battle.capture_mount_pose",
+            argsFactory.FromValues(Array.Empty<string>()));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+        Assert.Contains("<mount_agent_id>", result.Output);
+    }
+
+    [Theory]
+    [InlineData("No active coop battle mission", false)]
+    [InlineData("Charged 2 locally owned formation(s) with 12 active agent(s)", true)]
+    public void LegacyResult_MapsSuccessAndFailure(string output, bool succeeded)
+    {
+        CoopCommandResult result = new BattleLegacyCommandResult().FromOutput(output);
+
+        Assert.Equal(succeeded, result.Succeeded);
+        Assert.Equal(succeeded ? null : "command_failed", result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return typeof(MissionModule).Assembly.GetTypes()
+            .Where(type => type.IsClass && !type.IsAbstract && typeof(ICoopCommand).IsAssignableFrom(type))
+            .Where(type => CommandNamespaces.Contains(type.Namespace))
+            .Select(CreateCommand)
+            .ToArray();
+    }
+
+    private static ICoopCommand CreateCommand(Type type)
+    {
+        object resultFactory = type.Namespace switch
+        {
+            "Missions.Agents.Handlers" => new MovementLegacyCommandResult(),
+            "Missions.Battles" => new BattleLegacyCommandResult(),
+            _ => throw new InvalidOperationException(type.FullName),
+        };
+        return (ICoopCommand)Activator.CreateInstance(type, resultFactory);
+    }
+
+    private static void AssertNormalizedMetadata(ICoopCommand command)
+    {
+        Assert.StartsWith("coop.", command.Prefix);
+        Assert.Matches("^[a-z0-9_]+(?:\\.[a-z0-9_]+)*$", command.Prefix);
+        Assert.Matches("^[a-z0-9_]+$", command.Name);
+        Assert.False(string.IsNullOrWhiteSpace(command.Description));
+        Assert.NotNull(command.ExpectedArgs);
+
+        bool optionalFound = false;
+        var argumentNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (IExpectedArgs expectedArg in command.ExpectedArgs)
+        {
+            Assert.Matches("^[a-z0-9_]+$", expectedArg.Name);
+            Assert.True(argumentNames.Add(expectedArg.Name));
+            Assert.False(string.IsNullOrWhiteSpace(expectedArg.Description));
+            Assert.False(expectedArg.IsRequired && optionalFound);
+            optionalFound |= !expectedArg.IsRequired;
+        }
+    }
+}

--- a/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
@@ -1,0 +1,132 @@
+﻿using Common.Commands;
+using GameInterface.Services.MapEvents.Commands;
+using GameInterface.Services.Party.Commands;
+using GameInterface.Services.PartyVisuals.Commands;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+public class MigratedAttributedCommandTests
+{
+    private static readonly string[] CommandNamespaces =
+    {
+        "GameInterface.Services.MapEvents.Commands",
+        "GameInterface.Services.Party.Commands",
+        "GameInterface.Services.PartyVisuals.Commands",
+    };
+
+    [Fact]
+    public void Commands_HaveValidUniqueMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var logger = new LoggerConfiguration().CreateLogger();
+
+        var registry = new CoopCommandRegistry(commands, logger);
+
+#if DEBUG
+        Assert.Equal(120, commands.Length);
+#else
+        Assert.Equal(101, commands.Length);
+#endif
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.All(commands, AssertNormalizedMetadata);
+    }
+
+    [Fact]
+    public void QuotedLegacyArguments_AreRepresentedAsSingleRegistryArguments()
+    {
+        var resultFactory = new PartyLegacyCommandResult();
+        AssertArgumentNames(new CharacterIdsCommand(resultFactory), "hero_name_or_id");
+        AssertArgumentNames(new AddTroopXpCommand(resultFactory), "hero_name", "xp_amount");
+        AssertArgumentNames(new ImprisonCompanionCommand(resultFactory), "captor_hero", "prisoner_hero");
+
+        var optionalCommand = new StartNearestBanditAttackCommand(new MapEventLegacyCommandResult());
+        AssertArgumentNames(optionalCommand, "controller_id", "excluded_party_id");
+        Assert.False(optionalCommand.ExpectedArgs[1].IsRequired);
+    }
+
+    [Fact]
+    public void Registry_RejectsInvalidCountBeforeCallingLegacyLogic()
+    {
+        var logger = new LoggerConfiguration().CreateLogger();
+        var command = new CharacterIdsCommand(new PartyLegacyCommandResult());
+        var registry = new CoopCommandRegistry(new[] { command }, logger);
+        var argsFactory = new CoopCommandArgsFactory();
+
+        CoopCommandResult missing = registry.ProcessCommand(
+            "coop.debug.mobile_party.character_ids",
+            argsFactory.FromValues(Array.Empty<string>()));
+        CoopCommandResult extra = registry.ProcessCommand(
+            "coop.debug.mobile_party.character_ids",
+            argsFactory.FromValues(new[] { "Hero One", "extra" }));
+
+        Assert.False(missing.Succeeded);
+        Assert.Equal("invalid_arguments", missing.ErrorCode);
+        Assert.Contains("<hero_name_or_id>", missing.Output);
+        Assert.False(extra.Succeeded);
+        Assert.Equal("invalid_arguments", extra.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("Failed: no active mission.", false)]
+    [InlineData("Run this command on the server.", false)]
+    [InlineData("Killed 3 enemy agent(s).", true)]
+    public void LegacyResult_MapsSuccessAndFailure(string output, bool succeeded)
+    {
+        CoopCommandResult result = new MapEventLegacyCommandResult().FromOutput(output);
+
+        Assert.Equal(succeeded, result.Succeeded);
+        Assert.Equal(succeeded ? null : "command_failed", result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return typeof(BufferStateCommand).Assembly.GetTypes()
+            .Where(type => type.IsClass && !type.IsAbstract && typeof(ICoopCommand).IsAssignableFrom(type))
+            .Where(type => CommandNamespaces.Contains(type.Namespace))
+            .Select(CreateCommand)
+            .ToArray();
+    }
+
+    private static ICoopCommand CreateCommand(Type type)
+    {
+        object resultFactory = type.Namespace switch
+        {
+            "GameInterface.Services.MapEvents.Commands" => new MapEventLegacyCommandResult(),
+            "GameInterface.Services.Party.Commands" => new PartyLegacyCommandResult(),
+            "GameInterface.Services.PartyVisuals.Commands" => new PartyVisualLegacyCommandResult(),
+            _ => throw new InvalidOperationException(type.FullName),
+        };
+        return (ICoopCommand)Activator.CreateInstance(type, resultFactory);
+    }
+
+    private static void AssertNormalizedMetadata(ICoopCommand command)
+    {
+        Assert.StartsWith("coop.", command.Prefix);
+        Assert.Matches("^[a-z0-9_]+(?:\\.[a-z0-9_]+)*$", command.Prefix);
+        Assert.Matches("^[a-z0-9_]+$", command.Name);
+        Assert.False(string.IsNullOrWhiteSpace(command.Description));
+        Assert.NotNull(command.ExpectedArgs);
+
+        bool optionalFound = false;
+        var argumentNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (IExpectedArgs expectedArg in command.ExpectedArgs)
+        {
+            Assert.Matches("^[a-z0-9_]+$", expectedArg.Name);
+            Assert.True(argumentNames.Add(expectedArg.Name));
+            Assert.False(string.IsNullOrWhiteSpace(expectedArg.Description));
+            Assert.False(expectedArg.IsRequired && optionalFound);
+            optionalFound |= !expectedArg.IsRequired;
+        }
+    }
+
+    private static void AssertArgumentNames(ICoopCommand command, params string[] expected)
+    {
+        Assert.Equal(expected, command.ExpectedArgs.Select(argument => argument.Name));
+    }
+}

--- a/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
@@ -76,6 +76,9 @@ public class MigratedAttributedCommandTests
     [Theory]
     [InlineData("Failed: no active mission.", false)]
     [InlineData("Run this command on the server.", false)]
+    [InlineData("Battle start coordinator is unavailable", false)]
+    [InlineData("Saved map event map_event_42 did not finalize cleanly.", false)]
+    [InlineData("Fixture already active for player-1.", false)]
     [InlineData("Killed 3 enemy agent(s).", true)]
     public void LegacyResult_MapsSuccessAndFailure(string output, bool succeeded)
     {
@@ -91,7 +94,58 @@ public class MigratedAttributedCommandTests
     {
         const string output = "Map event id: map_event_42\r\n\r\nSummary:";
 
-        CoopCommandResult result = new MapEventLegacyCommandResult().FromOutput(output, "Map event id:");
+        CoopCommandResult result = new MapEventLegacyCommandResult().FromOutput(output);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    [Theory]
+    [InlineData("CLAN_PARTY_TRANSFER_REJECTED")]
+    [InlineData("CLAN_PARTY_TRANSFER_NOT_COMMITTED")]
+    [InlineData("PARTY_SCREEN_UPGRADE_REJECTED character=aserai_recruit")]
+    [InlineData("Garrison party 'town_comp_ES1' was not found.")]
+    [InlineData("Danustica does not belong to the local player's clan.")]
+    public void ClanPartyTransferResult_Rejection_IsFailure(string output)
+    {
+        CoopCommandResult result = new PartyLegacyCommandResult().FromOutput(output);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("command_failed", result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    [Theory]
+    [InlineData("CLAN_PARTY_TRANSFER_STAGED")]
+    [InlineData("CLAN_PARTY_TRANSFER_COMMITTED")]
+    public void ClanPartyTransferResult_Success_IsSuccessful(string output)
+    {
+        CoopCommandResult result = new PartyLegacyCommandResult().FromOutput(output);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    [Theory]
+    [InlineData("Mobile party visual manager is unavailable.")]
+    [InlineData("stage_over_limit_fixture must be run on the server.")]
+    public void PartyVisualResult_Rejection_IsFailure(string output)
+    {
+        CoopCommandResult result = new PartyVisualLegacyCommandResult().FromOutput(output);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("command_failed", result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    [Fact]
+    public void PartyVisualResult_BufferState_IsSuccessful()
+    {
+        const string output = "visualCount=3 bufferCapacity=128 dirtyCount=1";
+
+        CoopCommandResult result = new PartyVisualLegacyCommandResult().FromOutput(output);
 
         Assert.True(result.Succeeded);
         Assert.Null(result.ErrorCode);

--- a/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using Common.Commands;
+﻿using Common;
+using Common.Commands;
 using GameInterface.Services.MapEvents.Commands;
 using GameInterface.Services.Party.Commands;
 using GameInterface.Services.PartyVisuals.Commands;
@@ -10,6 +11,7 @@ using Xunit;
 
 namespace GameInterface.Tests.Utils.Commands;
 
+[Collection(global::GameInterface.Tests.ModInformationRoleCollection.Name)]
 public class MigratedAttributedCommandTests
 {
     private static readonly string[] CommandNamespaces =
@@ -82,6 +84,41 @@ public class MigratedAttributedCommandTests
         Assert.Equal(succeeded, result.Succeeded);
         Assert.Equal(succeeded ? null : "command_failed", result.ErrorCode);
         Assert.Equal(output, result.Output);
+    }
+
+    [Fact]
+    public void GetEventResult_MapEventSummary_IsSuccessful()
+    {
+        const string output = "Map event id: map_event_42\r\n\r\nSummary:";
+
+        CoopCommandResult result = new MapEventLegacyCommandResult().FromOutput(output, "Map event id:");
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    [Fact]
+    public void AddTroopXpResult_InvalidXp_IsFailure()
+    {
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            var command = new AddTroopXpCommand(new PartyLegacyCommandResult());
+            var argsFactory = new CoopCommandArgsFactory();
+
+            CoopCommandResult result = command.ProcessCommand(
+                argsFactory.FromValues(new[] { "Hero One", "not-an-integer" }));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+            Assert.Equal("Please enter an integer for xp amount", result.Output);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
     }
 
     private static ICoopCommand[] CreateCommands()

--- a/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/MigratedAttributedCommandTests.cs
@@ -77,6 +77,8 @@ public class MigratedAttributedCommandTests
     [InlineData("Failed: no active mission.", false)]
     [InlineData("Run this command on the server.", false)]
     [InlineData("Battle start coordinator is unavailable", false)]
+    [InlineData("Server rejected attack mission for map_event_42", false)]
+    [InlineData("Local deployment finished, but the local player agent was not assigned.", false)]
     [InlineData("Saved map event map_event_42 did not finalize cleanly.", false)]
     [InlineData("Fixture already active for player-1.", false)]
     [InlineData("Killed 3 enemy agent(s).", true)]
@@ -101,13 +103,27 @@ public class MigratedAttributedCommandTests
         Assert.Equal(output, result.Output);
     }
 
+    [Fact]
+    public void BattleRewardCleanPreflightResult_IsSuccessful()
+    {
+        const string output = "Battle reward fixture preflight is already clean.";
+
+        CoopCommandResult result = new MapEventLegacyCommandResult().FromOutput(output, output);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
     [Theory]
     [InlineData("CLAN_PARTY_TRANSFER_REJECTED")]
     [InlineData("CLAN_PARTY_TRANSFER_NOT_COMMITTED")]
     [InlineData("PARTY_SCREEN_UPGRADE_REJECTED character=aserai_recruit")]
     [InlineData("Garrison party 'town_comp_ES1' was not found.")]
     [InlineData("Danustica does not belong to the local player's clan.")]
-    public void ClanPartyTransferResult_Rejection_IsFailure(string output)
+    [InlineData("Please enter an integer for wounded count.")]
+    [InlineData("Applied prison snapshot to Raganvad; 1 hero prisoner(s) still present (companion-preserve wrongly kept them).")]
+    public void PartyResult_Rejection_IsFailure(string output)
     {
         CoopCommandResult result = new PartyLegacyCommandResult().FromOutput(output);
 
@@ -150,6 +166,43 @@ public class MigratedAttributedCommandTests
         Assert.True(result.Succeeded);
         Assert.Null(result.ErrorCode);
         Assert.Equal(output, result.Output);
+    }
+
+    [Fact]
+    public void TypedCommandBoundaries_RoleRejections_AreFailures()
+    {
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            var argsFactory = new CoopCommandArgsFactory();
+
+            CoopCommandResult stageResult = new StageClanPartyTransferCommand(new PartyLegacyCommandResult())
+                .ProcessCommand(argsFactory.FromValues(new[] { "clan-party", "character" }));
+            CoopCommandResult commitResult = new CommitClanPartyTransferCommand(new PartyLegacyCommandResult())
+                .ProcessCommand(argsFactory.FromValues(Array.Empty<string>()));
+            CoopCommandResult bufferResult = new BufferStateCommand(new PartyVisualLegacyCommandResult())
+                .ProcessCommand(argsFactory.FromValues(Array.Empty<string>()));
+            CoopCommandResult woundedResult = new SetTroopWoundedCommand(new PartyLegacyCommandResult())
+                .ProcessCommand(argsFactory.FromValues(new[] { "party", "character", "not-an-integer" }));
+
+            Assert.False(stageResult.Succeeded);
+            Assert.Equal("command_failed", stageResult.ErrorCode);
+            Assert.Equal("Command can only be run on a client.", stageResult.Output);
+            Assert.False(commitResult.Succeeded);
+            Assert.Equal("command_failed", commitResult.ErrorCode);
+            Assert.Equal("Command can only be run on a client.", commitResult.Output);
+            Assert.False(bufferResult.Succeeded);
+            Assert.Equal("command_failed", bufferResult.ErrorCode);
+            Assert.Equal("Run this command on a client.", bufferResult.Output);
+            Assert.False(woundedResult.Succeeded);
+            Assert.Equal("command_failed", woundedResult.ErrorCode);
+            Assert.Equal("Please enter an integer for wounded count.", woundedResult.Output);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
     }
 
     [Fact]

--- a/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
@@ -1,0 +1,104 @@
+﻿using Common.Commands;
+using GameInterface.Services.SystemDeveloper.Commands;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+public class SystemDeveloperCommandTests
+{
+    [Fact]
+    public void Commands_HaveValidUniqueNormalizedMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var registry = new CoopCommandRegistry(commands, new LoggerConfiguration().CreateLogger());
+
+#if DEBUG
+        Assert.Equal(106, commands.Length);
+#else
+        Assert.Equal(95, commands.Length);
+#endif
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.All(commands, AssertNormalizedMetadata);
+    }
+
+    [Fact]
+    public void MultiWordArguments_UseFixedLogicalSlots()
+    {
+        AssertArgumentNames(new HeroDeveloperAddSkillXpCommand(),
+            "hero_name_or_id", "skill_name", "xp_amount");
+        AssertArgumentNames(new PlayerCaptivityCapturePlayerCommand(),
+            "hero_id", "captor_party_id");
+        AssertArgumentNames(new GameThreadStallCommand(), "milliseconds");
+
+        IExpectedArgs mode = new CampaignOptionsPlayerTroopsReceivedDamageCommand().ExpectedArgs.Single();
+        Assert.False(mode.IsRequired);
+    }
+
+    [Fact]
+    public void Registry_RejectsExtraUnquotedHeroNameTokens()
+    {
+        var command = new HeroDeveloperAddAttributePointsCommand();
+        var registry = new CoopCommandRegistry(
+            new[] { command },
+            new LoggerConfiguration().CreateLogger());
+        var argsFactory = new CoopCommandArgsFactory();
+
+        CoopCommandResult result = registry.ProcessCommand(
+            "coop.debug.hero_developer.add_attribute_points",
+            argsFactory.FromValues(new[] { "Hero", "With", "Spaces", "2" }));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("Failed: no active campaign.", false)]
+    [InlineData("Command can only be run on the server.", false)]
+    [InlineData("Advanced campaign time forward by 2 days.", true)]
+    public void LegacyResult_MapsSuccessAndFailure(string output, bool succeeded)
+    {
+        CoopCommandResult result = SystemDeveloperLegacyCommandResult.FromOutput(output);
+
+        Assert.Equal(succeeded, result.Succeeded);
+        Assert.Equal(succeeded ? null : "command_rejected", result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return typeof(CampaignOptionsListCommand).Assembly.GetTypes()
+            .Where(type => type.IsClass && !type.IsAbstract)
+            .Where(type => type.Namespace == "GameInterface.Services.SystemDeveloper.Commands")
+            .Where(type => typeof(ICoopCommand).IsAssignableFrom(type))
+            .Select(type => (ICoopCommand)Activator.CreateInstance(type))
+            .ToArray();
+    }
+
+    private static void AssertNormalizedMetadata(ICoopCommand command)
+    {
+        Assert.Matches("^[a-z0-9_]+(?:\\.[a-z0-9_]+)*$", command.Prefix);
+        Assert.Matches("^[a-z0-9_]+$", command.Name);
+        Assert.False(string.IsNullOrWhiteSpace(command.Description));
+        Assert.NotNull(command.ExpectedArgs);
+
+        bool optionalFound = false;
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (IExpectedArgs expectedArg in command.ExpectedArgs)
+        {
+            Assert.Matches("^[a-z0-9_]+$", expectedArg.Name);
+            Assert.True(names.Add(expectedArg.Name));
+            Assert.False(string.IsNullOrWhiteSpace(expectedArg.Description));
+            Assert.False(expectedArg.IsRequired && optionalFound);
+            optionalFound |= !expectedArg.IsRequired;
+        }
+    }
+
+    private static void AssertArgumentNames(ICoopCommand command, params string[] expected)
+    {
+        Assert.Equal(expected, command.ExpectedArgs.Select(argument => argument.Name));
+    }
+}

--- a/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using Common.Commands;
+﻿using Common;
+using Common.Commands;
 using GameInterface.Services.SystemDeveloper.Commands;
 using Serilog;
 using System;
@@ -8,6 +9,7 @@ using Xunit;
 
 namespace GameInterface.Tests.Utils.Commands;
 
+[Collection(ModInformationRoleCollection.Name)]
 public class SystemDeveloperCommandTests
 {
     [Fact]
@@ -55,9 +57,43 @@ public class SystemDeveloperCommandTests
         Assert.Equal("invalid_arguments", result.ErrorCode);
     }
 
+    [Fact]
+    public void CampaignOptionRoleFailure_ReturnsFailedResultThroughRegistry()
+    {
+        bool wasServer = ModInformation.IsServer;
+        ModInformation.IsServer = false;
+        try
+        {
+            var command = new CampaignOptionsAutoAllocateClanMemberPerksCommand();
+            var registry = new CoopCommandRegistry(
+                new[] { command },
+                new LoggerConfiguration().CreateLogger());
+            var argsFactory = new CoopCommandArgsFactory();
+
+            CoopCommandResult result = registry.ProcessCommand(
+                "coop.debug.campaign_options.auto_allocate_clan_member_perks",
+                argsFactory.FromValues(new[] { "true" }));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_rejected", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+    }
+
     [Theory]
     [InlineData("Failed: no active campaign.", false)]
     [InlineData("Command can only be run on the server.", false)]
+    [InlineData("Managing campaign options is disabled on clients; the host does this.", false)]
+    [InlineData("An integer amount of xp is required.", false)]
+    [InlineData("Hero not found.", false)]
+    [InlineData("A save is already queued.", false)]
+    [InlineData("Unknown quest type key 'missing'.", false)]
+    [InlineData("Tactical unit symbols configuration is unavailable.", false)]
+    [InlineData("Close screen failed.\nException: InvalidOperationException", false)]
+    [InlineData("Diagnostic bug-report log sharing is disabled.", true)]
     [InlineData("Advanced campaign time forward by 2 days.", true)]
     public void LegacyResult_MapsSuccessAndFailure(string output, bool succeeded)
     {
@@ -66,6 +102,20 @@ public class SystemDeveloperCommandTests
         Assert.Equal(succeeded, result.Succeeded);
         Assert.Equal(succeeded ? null : "command_rejected", result.ErrorCode);
         Assert.Equal(output, result.Output);
+    }
+
+    [Fact]
+    public void LegacyResult_CommandSpecificFailure_DoesNotChangeStatusResult()
+    {
+        const string output = "Steam integration inactive";
+
+        CoopCommandResult hostResult = SystemDeveloperLegacyCommandResult.FromOutput(
+            output,
+            "Steam integration inactive");
+        CoopCommandResult statusResult = SystemDeveloperLegacyCommandResult.FromOutput(output);
+
+        Assert.False(hostResult.Succeeded);
+        Assert.True(statusResult.Succeeded);
     }
 
     private static ICoopCommand[] CreateCommands()

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -87,6 +87,15 @@ public class GameInterfaceModule : Module
         builder.RegisterType<LegacyCoopCommandExecutor>()
             .As<ILegacyCoopCommandExecutor>()
             .InstancePerDependency();
+        builder.RegisterType<Services.MapEvents.Commands.MapEventLegacyCommandResult>()
+            .As<Services.MapEvents.Commands.IMapEventLegacyCommandResult>()
+            .InstancePerDependency();
+        builder.RegisterType<Services.Party.Commands.PartyLegacyCommandResult>()
+            .As<Services.Party.Commands.IPartyLegacyCommandResult>()
+            .InstancePerDependency();
+        builder.RegisterType<Services.PartyVisuals.Commands.PartyVisualLegacyCommandResult>()
+            .As<Services.PartyVisuals.Commands.IPartyVisualLegacyCommandResult>()
+            .InstancePerDependency();
         builder.RegisterAssemblyTypes(typeof(GameInterfaceModule).Assembly)
             .Where(type => type.IsClass &&
                            !type.IsAbstract &&

--- a/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using static TaleWorlds.CampaignSystem.CampaignOptions;
-using static TaleWorlds.Library.CommandLineFunctionality;
 using static TaleWorlds.MountAndBlade.BannerlordConfig;
 
 namespace GameInterface.Services.CampaignService.Commands;
@@ -17,7 +16,6 @@ namespace GameInterface.Services.CampaignService.Commands;
 /// </summary>
 internal class CampaignOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.campaignoptions")]
     public static string ListOptionsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new();
@@ -39,7 +37,6 @@ internal class CampaignOptionsCommands
         return stringBuilder.ToString();
     }
 
-    [CommandLineArgumentFunction("AutoAllocateClanMemberPerks", "coop.debug.campaignoptions")]
     public static string AutoAllocateClanMemberPerksCommand(List<string> strings)
     {
         return HandleBooleanOptionCommand(
@@ -49,7 +46,6 @@ internal class CampaignOptionsCommands
             value => AutoAllocateClanMemberPerks = value);
     }
 
-    [CommandLineArgumentFunction("PlayerTroopsReceivedDamage", "coop.debug.campaignoptions")]
     public static string PlayerTroopsReceivedDamageCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -59,7 +55,6 @@ internal class CampaignOptionsCommands
             value => PlayerTroopsReceivedDamage = value);
     }
 
-    [CommandLineArgumentFunction("RecruitmentDifficulty", "coop.debug.campaignoptions")]
     public static string RecruitmentDifficultyCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -69,7 +64,6 @@ internal class CampaignOptionsCommands
             value => RecruitmentDifficulty = value);
     }
 
-    [CommandLineArgumentFunction("PlayerMapMovementSpeed", "coop.debug.campaignoptions")]
     public static string PlayerMapMovementSpeedCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -79,7 +73,6 @@ internal class CampaignOptionsCommands
             value => PlayerMapMovementSpeed = value);
     }
 
-    [CommandLineArgumentFunction("StealthAndDisguiseDifficulty", "coop.debug.campaignoptions")]
     public static string StealthAndDisguiseDifficultyCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -89,7 +82,6 @@ internal class CampaignOptionsCommands
             value => StealthAndDisguiseDifficulty = value);
     }
 
-    [CommandLineArgumentFunction("CombatAIDifficulty", "coop.debug.campaignoptions")]
     public static string CombatAIDifficultyCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -99,7 +91,6 @@ internal class CampaignOptionsCommands
             value => CombatAIDifficulty = value);
     }
 
-    [CommandLineArgumentFunction("IsLifeDeathCycleDisabled", "coop.debug.campaignoptions")]
     public static string IsLifeDeathCycleDisabledCommand(List<string> strings)
     {
         return HandleBooleanOptionCommand(
@@ -109,7 +100,6 @@ internal class CampaignOptionsCommands
             value => IsLifeDeathCycleDisabled = value);
     }
 
-    [CommandLineArgumentFunction("PersuasionSuccessChance", "coop.debug.campaignoptions")]
     public static string PersuasionSuccessChanceCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -119,7 +109,6 @@ internal class CampaignOptionsCommands
             value => PersuasionSuccessChance = value);
     }
 
-    [CommandLineArgumentFunction("ClanMemberDeathChance", "coop.debug.campaignoptions")]
     public static string ClanMemberDeathChanceCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -129,7 +118,6 @@ internal class CampaignOptionsCommands
             value => ClanMemberDeathChance = value);
     }
 
-    [CommandLineArgumentFunction("IsIronmanMode", "coop.debug.campaignoptions")]
     public static string IsIronmanModeCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -141,7 +129,6 @@ internal class CampaignOptionsCommands
         return "This option can only be set at game start.";
     }
 
-    [CommandLineArgumentFunction("BattleDeath", "coop.debug.campaignoptions")]
     public static string BattleDeathCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -151,7 +138,6 @@ internal class CampaignOptionsCommands
             value => BattleDeath = value);
     }
 
-    [CommandLineArgumentFunction("PlayerReceivedDamageDifficulty", "coop.debug.campaignoptions")]
     public static string SetPlayerReceivedDamageDifficulty(List<string> strings)
     {
         Difficulty oldValue = (Difficulty)PlayerReceivedDamageDifficulty;

--- a/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
@@ -2,13 +2,11 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.CampaignService.Commands;
 
 internal class ModOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.modconfig")]
     public static string ListOptionsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new();

--- a/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
+++ b/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
@@ -9,7 +9,6 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Caravans.Commands;
 
@@ -31,7 +30,6 @@ internal class CaravansCommands
     /// <summary>
     /// View prohibited kingdoms for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_prohibited_kingdoms", "coop.debug.caravans")]
     public static string ViewProhibitedKingdomsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -70,7 +68,6 @@ internal class CaravansCommands
     /// <summary>
     /// View interacted caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_interacted_caravans", "coop.debug.caravans")]
     public static string ViewInteractedCaravansCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -109,7 +106,6 @@ internal class CaravansCommands
     /// <summary>
     /// View player trade rumor taken caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_taken_trade_rumors", "coop.debug.caravans")]
     public static string ViewTakenTradeRumorsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -145,7 +141,6 @@ internal class CaravansCommands
         return "Failed to retrieve trade rumor taken caravans";
     }
 
-    [CommandLineArgumentFunction("view_trade_action_logs", "coop.debug.caravans")]
     public static string ViewTradeActionLogs(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -175,7 +170,6 @@ internal class CaravansCommands
         return "Failed to retrieve trade action logs";
     }
 
-    [CommandLineArgumentFunction("view_looted_caravans", "coop.debug.caravans")]
     public static string ViewLootedCaravans(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();

--- a/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
@@ -6,7 +6,6 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.CharacterDevelopers.Commands;
 
@@ -17,7 +16,6 @@ internal class CharacterDeveloperCommands
     /// <summary>
     /// Output attributes, focuses, skills and perks of a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("stats", "coop.debug.herodeveloper")]
     public static string HeroStatsCommand(List<string> strings)
     {
         if (strings.Count == 0)

--- a/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
+++ b/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.ObjectSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.CharacterObjects.Commands;
 internal class CharacterObjectCommands
@@ -16,7 +15,6 @@ internal class CharacterObjectCommands
     /// the synced _characterTraits / _occupation / _persona fields live) so a server screenshot and a client
     /// screenshot can be compared field-for-field to confirm CharacterObject syncs still replicate.
     /// </summary>
-    [CommandLineArgumentFunction("info", "coop.debug.characterObjects")]
     public static string Info(List<string> args)
     {
         if (args.Count != 1) return "Usage: coop.debug.characterObjects.info <charId>";
@@ -35,7 +33,6 @@ internal class CharacterObjectCommands
     }
 
     // coop.debug.characterObjects.list
-    [CommandLineArgumentFunction("list", "coop.debug.characterObjects")]
     public static string ListCharacterObjects(List<string> args)
     {
         var characters = MBObjectManager.Instance.GetObjectTypeList<CharacterObject>();

--- a/source/GameInterface/Services/GameDebug/Commands/BugReportLogSharingCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/BugReportLogSharingCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -13,7 +12,6 @@ namespace GameInterface.Services.GameDebug.Commands;
 public class BugReportLogSharingCommand
 {
     // coop.bug_report_log_sharing status|enable|disable
-    [CommandLineArgumentFunction("bug_report_log_sharing", "coop")]
     public static string Configure(List<string> args)
     {
         if (!ModInformation.IsClient) return "Command can only be run on a client.";

--- a/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
@@ -1,20 +1,17 @@
 ﻿using SandBox.View.Map;
 using System.Collections.Generic;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
 internal class CameraReset
 {
-    [CommandLineArgumentFunction("fix_camera", "coop.debug")]
     public static string ChangeClanLeader(List<string> strings)
     {
         Game.Current.GameStateManager.UnregisterActiveStateDisableRequest(MapScreen.Instance);
         return "Camera reset";
     }
 
-    [CommandLineArgumentFunction("focus_main_party", "coop.debug.map_camera")]
     public static string FocusMainParty(List<string> strings)
     {
         if (strings.Count != 0)
@@ -32,7 +29,6 @@ internal class CameraReset
         return GetCameraState(cameraView);
     }
 
-    [CommandLineArgumentFunction("state", "coop.debug.map_camera")]
     public static string GetState(List<string> strings)
     {
         if (strings.Count != 0)

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Common;
 using System.Collections.Generic;
 using System.Threading;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -17,7 +16,6 @@ public class GameThreadDebugCommand
     /// Turns the game-thread drain instrumentation on or off, or reports its current state. With no
     /// argument it flips the current setting.
     /// </summary>
-    [CommandLineArgumentFunction("instrument", "coop.debug.gamethread")]
     public static string Instrument(List<string> args)
     {
         var arg = args.Count > 0 ? args[0].ToLowerInvariant() : "toggle";
@@ -47,7 +45,6 @@ public class GameThreadDebugCommand
                "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.";
     }
 
-    [CommandLineArgumentFunction("stall", "coop.debug.gamethread")]
     public static string Stall(List<string> args)
     {
         if (ModInformation.IsClient)

--- a/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
@@ -1,9 +1,8 @@
-using Common;
+﻿using Common;
 using GameInterface.Services.GameDebug.Metrics;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -11,7 +10,6 @@ public class PartySyncPerformanceLogsCommand
 {
     private const string Usage = "Usage: coop.debug.metrics.party_sync_performance_logs on <seconds> <filename> | off | status";
 
-    [CommandLineArgumentFunction("party_sync_performance_logs", "coop.debug.metrics")]
     public static string PartySyncPerformanceLogs(List<string> args)
     {
         if (ModInformation.IsServer)

--- a/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
@@ -17,7 +17,6 @@ using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -35,7 +34,6 @@ internal class UiDebugCommands
 
 Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle encounter screen left open.";
 
-    [CommandLineArgumentFunction("close_screen", "coop.debug.ui")]
     public static string CloseScreen(List<string> args)
     {
         var ctx = new CommandContext("close_screen", CloseScreenUsage, args);
@@ -57,7 +55,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return "Called GameMenu.ExitToLast().";
     }
 
-    [CommandLineArgumentFunction("prepare_evidence_map", "coop.debug.ui")]
     public static string PrepareEvidenceMap(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -88,7 +85,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return GetEvidenceMapState(mapScreen);
     }
 
-    [CommandLineArgumentFunction("evidence_map_state", "coop.debug.ui")]
     public static string EvidenceMapState(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -128,7 +124,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
                $"loading={LoadingWindow.IsLoadingWindowActive}";
     }
 
-    [CommandLineArgumentFunction("leave_settlement_encounter", "coop.debug.ui")]
     public static string LeaveSettlementEncounter(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -167,7 +162,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("map_click_offset", "coop.debug.ui")]
     public static string MapClickOffset(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -223,7 +217,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
             $"behavior={mainParty.DefaultBehavior}; target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}.";
     }
 
-    [CommandLineArgumentFunction("map_movement_state", "coop.debug.ui")]
     public static string MapMovementState(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -245,7 +238,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
     }
 #endif
 
-    [CommandLineArgumentFunction("switch_menu", "coop.debug.ui")]
     public static string SwitchMenu(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -269,7 +261,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return $"Switched to game menu {args[0]}.";
     }
 
-    [CommandLineArgumentFunction("pop_state", "coop.debug.ui")]
     public static string PopState(List<string> args)
     {
         if (args.Count != 0)
@@ -286,7 +277,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return $"Queued pop for {activeState.GetType().Name}.";
     }
 
-    [CommandLineArgumentFunction("active_state", "coop.debug.ui")]
     public static string ActiveState(List<string> args)
     {
         if (args.Count != 0)
@@ -295,7 +285,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return Game.Current?.GameStateManager?.ActiveState?.GetType().Name ?? "none";
     }
 
-    [CommandLineArgumentFunction("loading_window_state", "coop.debug.ui")]
     public static string LoadingWindowState(List<string> args)
     {
         if (args.Count != 0)
@@ -304,7 +293,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return $"Loading window: {(LoadingWindow.IsLoadingWindowActive ? "ACTIVE" : "INACTIVE")}.";
     }
 
-    [CommandLineArgumentFunction("saving_overlay_state", "coop.debug.ui")]
     public static string SavingOverlayState(List<string> args)
     {
         if (args.Count != 0)

--- a/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
@@ -4,7 +4,6 @@ using GameInterface.Services.MobileParties.Messages.Unstuck;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -14,7 +13,6 @@ public class UnstuckCommand
     /// <summary>
     /// Requests a server-authoritative unstuck of the local player party. Client only.
     /// </summary>
-    [CommandLineArgumentFunction("unstuck", "coop")]
     public static string Unstuck(List<string> args)
     {
         if (!ModInformation.IsClient) return "Command can only be run on a client.";

--- a/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
@@ -7,7 +7,6 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.HeroDevelopers.Commands;
 
@@ -20,7 +19,6 @@ internal class HeroDeveloperCommands
     /// Examples: 
     /// coop.debug.herodeveloper.addskillxp RandomPlayer OneHanded 3000
     /// </summary>
-    [CommandLineArgumentFunction("addskillxp", "coop.debug.herodeveloper")]
     public static string AddSkillXpCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -52,7 +50,6 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addattributepoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addattributepoints", "coop.debug.herodeveloper")]
     public static string AddAttributePointsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -82,7 +79,6 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addfocuspoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addfocuspoints", "coop.debug.herodeveloper")]
     public static string AddFocusPointsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -112,7 +108,6 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.resetskills
     /// </summary>
-    [CommandLineArgumentFunction("resetskills", "coop.debug.herodeveloper")]
     public static string ResetSkillsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";

--- a/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
+++ b/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Inventory.Commands;
 
@@ -29,7 +28,6 @@ internal class InventoryCommands
     /// <summary>
     /// View item ids in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemids", "coop.debug.inventory")]
     public static string ViewItemIdsCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -61,7 +59,6 @@ internal class InventoryCommands
     /// <summary>
     /// View item values in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemvalues", "coop.debug.inventory")]
     public static string ViewItemValuesCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -93,7 +90,6 @@ internal class InventoryCommands
     /// <summary>
     /// Output equipment ids of battle, civilian and stealth equipment for a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("heroequipment", "coop.debug.inventory")]
     public static string HeroEquipmentCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -130,7 +126,6 @@ internal class InventoryCommands
     /// <summary>
     /// Give debug animals to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("giveanimals", "coop.debug.inventory")]
     public static string GiveAnimalsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -186,7 +181,6 @@ internal class InventoryCommands
     /// <summary>
     /// Give war horses to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givewarhorses", "coop.debug.inventory")]
     public static string GiveWarhorsesCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";

--- a/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
+++ b/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Inventory.TradeSkills.Commands;
 
@@ -13,7 +12,6 @@ internal class TradeSkillCommands
     /// <summary>
     /// View trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_data", "coop.debug.inventory")]
     public static string ViewPlayerTradeDataCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -52,7 +50,6 @@ internal class TradeSkillCommands
     /// <summary>
     /// View trade rumors for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_rumors", "coop.debug.inventory")]
     public static string ViewPlayerTradeRumorsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -95,7 +92,6 @@ internal class TradeSkillCommands
     /// <summary>
     /// View entered settlements trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_entered_settlements", "coop.debug.inventory")]
     public static string ViewPlayerEnteredSettlementsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();

--- a/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
+++ b/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.Issues.Generic;
+﻿using GameInterface.Services.Issues.Generic;
 using GameInterface.Utils.Commands;
 using System;
 using System.Collections.Generic;
@@ -6,13 +6,11 @@ using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Issues;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Issues.Commands;
 
 public static class IssuesDebugCommand
 {
-    [CommandLineArgumentFunction("give", "coop.debug.issues")]
     public static string Give(List<string> args)
     {
         if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.give")) return error;
@@ -103,7 +101,6 @@ public static class IssuesDebugCommand
             $"Issue StringId: '{hero.Issue?.StringId}'. Quest StringId: '{hero.Issue?.IssueQuest?.StringId ?? "none"}'.";
     }
 
-    [CommandLineArgumentFunction("complete", "coop.debug.issues")]
     public static string Complete(List<string> args)
     {
         if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.complete")) return error;
@@ -166,7 +163,6 @@ public static class IssuesDebugCommand
         return $"Completed quest for hero '{hero.Name}' (StringId '{hero.StringId}') with outcome '{outcome}'.";
     }
 
-    [CommandLineArgumentFunction("list_types", "coop.debug.issues")]
     public static string ListTypes(List<string> args)
     {
         var sb = new StringBuilder();

--- a/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
+++ b/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
@@ -3,7 +3,6 @@ using GameInterface.Services.ObjectManager;
 using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.ItemObjects.Commands
 {
@@ -20,7 +19,6 @@ namespace GameInterface.Services.ItemObjects.Commands
         /// <summary>
         /// View select properties of an item object retrieved by string id
         /// </summary>
-        [CommandLineArgumentFunction("data", "coop.debug.itemobject")]
         public static string ViewCraftedItemData(List<string> strings)
         {
             if (strings.Count == 0)

--- a/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
+++ b/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
@@ -11,13 +11,11 @@ using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.ObjectSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.ItemRosters.Commands
 {
     internal class ItemRosterDebugCommands
     {
-        [CommandLineArgumentFunction("add_random_item", "coop.debug.itemrosters")]
         public static string AddRandomItem(List<string> args)
         {
             if (args.Count < 1)
@@ -41,7 +39,6 @@ namespace GameInterface.Services.ItemRosters.Commands
             return $"Added {randomItem.Name} to {settlement.Name}'s ItemRoster";
         }
 
-        [CommandLineArgumentFunction("add_item_burst", "coop.debug.itemrosters")]
         public static string AddItemBurst(List<string> args)
         {
             if (ModInformation.IsClient)
@@ -82,7 +79,6 @@ namespace GameInterface.Services.ItemRosters.Commands
             return $"Added {count}x {randomItem.Name} to {settlement.Name}'s ItemRoster in one tick";
         }
 
-        [CommandLineArgumentFunction("info", "coop.debug.itemrosters")]
         public static string Info(List<string> args)
         {
             if (args.Count < 1)
@@ -101,7 +97,6 @@ namespace GameInterface.Services.ItemRosters.Commands
                 owner, roster.Count, roster.Sum((i) => { return i.Amount; }), ItemRosterHash(roster));
         }
 
-        [CommandLineArgumentFunction("export", "coop.debug.itemrosters")]
         public static string Export(List<string> args)
         {
             if (args.Count < 1)

--- a/source/GameInterface/Services/LoadingScreen/Handlers/CoopLoadingScreenHandler.cs
+++ b/source/GameInterface/Services/LoadingScreen/Handlers/CoopLoadingScreenHandler.cs
@@ -45,21 +45,4 @@
 //        messageBroker.Unsubscribe<HideLoadingScreen>(Handle);
 //    }
 
-//    /*The part below is to test the show and hide mechanics in console, can be used as follows in console:
-//     * tutorial.testShow
-//     * tutorial.testHide                                                                       */
-
-//    [CommandLineFunctionality.CommandLineArgumentFunction("ShowLoadingScreen", "Coop.Debug")]
-//    public static string testShow(List<string> strings)
-//    {
-//        MessageBroker.Instance.Publish(null, new ShowLoadingScreen());
-//        return "Command Executed!";
-//    }
-
-//    [CommandLineFunctionality.CommandLineArgumentFunction("HideLoadingScreen", "Coop.Debug")]
-//    public static string testHide(List<string> strings)
-//    {
-//        MessageBroker.Instance.Publish(null, new HideLoadingScreen());
-//        return "Command Executed!";
-//    }
 //}

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -15,7 +15,6 @@ using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.GauntletUI.Mission.Singleplayer;
 using TaleWorlds.MountAndBlade.GauntletUI.Widgets.Scoreboard;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.MapEvents.Commands;
 
@@ -23,7 +22,7 @@ namespace GameInterface.Services.MapEvents.Commands;
 /// Battle fixture commands for deployment, scoreboard inspection, mission exit, and combat outcomes. Run the
 /// direct kill commands on the battle-authority client because it owns the AI/enemy
 /// agents, so each kill goes through the coop death path: <c>Agent.Die</c>, the mission death callback,
-/// the death broadcast, and the server-roster casualty, exactly like <c>coop.debug.mapevent.kms</c>.
+/// the death broadcast, and the server-roster casualty, exactly like <c>coop.debug.map_event.kms</c>.
 /// </summary>
 internal class BattleTeamKillCommands
 {
@@ -35,11 +34,10 @@ internal class BattleTeamKillCommands
 
     private const string ClickDeploymentReadyUsage =
 @"Usage:
-  coop.debug.mapevent.click_deployment_ready
+  coop.debug.map_event.click_deployment_ready
 
 Activates the deployment Ready button's native UI callback.";
 
-    [CommandLineArgumentFunction("click_deployment_ready", "coop.debug.mapevent")]
     public static string ClickDeploymentReady(List<string> args)
     {
         var ctx = new CommandContext("click_deployment_ready", ClickDeploymentReadyUsage, args);
@@ -66,14 +64,13 @@ Activates the deployment Ready button's native UI callback.";
 
     private const string FinishDeploymentUsage =
 @"Usage:
-  coop.debug.mapevent.finish_deployment
+  coop.debug.map_event.finish_deployment
 
 Finishes the current battle deployment through the native deployment handler.";
 
-    [CommandLineArgumentFunction("deployment_state", "coop.debug.mapevent")]
     public static string DeploymentState(List<string> args)
     {
-        var ctx = new CommandContext("deployment_state", "Usage: coop.debug.mapevent.deployment_state", args);
+        var ctx = new CommandContext("deployment_state", "Usage: coop.debug.map_event.deployment_state", args);
         if (!ctx.RequireArgCount(0, out var error))
             return error;
 
@@ -87,7 +84,6 @@ Finishes the current battle deployment through the native deployment handler.";
                $"teamSetupOver={controller?.TeamSetupOver ?? false}, handler={handler != null}.";
     }
 
-    [CommandLineArgumentFunction("finish_deployment", "coop.debug.mapevent")]
     public static string FinishDeployment(List<string> args)
     {
         var ctx = new CommandContext("finish_deployment", FinishDeploymentUsage, args);
@@ -114,11 +110,10 @@ Finishes the current battle deployment through the native deployment handler.";
 
     private const string ToggleScoreboardUsage =
 @"Usage:
-  coop.debug.mapevent.toggle_scoreboard
+  coop.debug.map_event.toggle_scoreboard
 
 Holds or releases the native scoreboard input without requiring window focus.";
 
-    [CommandLineArgumentFunction("toggle_scoreboard", "coop.debug.mapevent")]
     public static string ToggleScoreboard(List<string> args)
     {
         var ctx = new CommandContext("toggle_scoreboard", ToggleScoreboardUsage, args);
@@ -147,11 +142,10 @@ Holds or releases the native scoreboard input without requiring window focus.";
 
     private const string CollapseScoreboardPartiesUsage =
 @"Usage:
-  coop.debug.mapevent.collapse_scoreboard_parties
+  coop.debug.map_event.collapse_scoreboard_parties
 
 Collapses every native scoreboard party roster and returns the scroll position to the top.";
 
-    [CommandLineArgumentFunction("collapse_scoreboard_parties", "coop.debug.mapevent")]
     public static string CollapseScoreboardParties(List<string> args)
     {
         var ctx = new CommandContext("collapse_scoreboard_parties", CollapseScoreboardPartiesUsage, args);
@@ -184,11 +178,10 @@ Collapses every native scoreboard party roster and returns the scroll position t
 
     private const string ScoreboardStateUsage =
 @"Usage:
-  coop.debug.mapevent.scoreboard_state
+  coop.debug.map_event.scoreboard_state
 
 Lists the map-event parties and party rows currently loaded by the battle scoreboard.";
 
-    [CommandLineArgumentFunction("scoreboard_state", "coop.debug.mapevent")]
     public static string ScoreboardState(List<string> args)
     {
         var ctx = new CommandContext("scoreboard_state", ScoreboardStateUsage, args);
@@ -331,11 +324,10 @@ Lists the map-event parties and party rows currently loaded by the battle scoreb
 
     private const string LeaveBattleUsage =
 @"Usage:
-  coop.debug.mapevent.leave_battle
+  coop.debug.map_event.leave_battle
 
 Leaves the current battle through the native mission lifecycle.";
 
-    [CommandLineArgumentFunction("leave_battle", "coop.debug.mapevent")]
     public static string LeaveBattle(List<string> args)
     {
         if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
@@ -355,11 +347,10 @@ Leaves the current battle through the native mission lifecycle.";
 
     private const string KillEnemyUsage =
 @"Usage:
-  coop.debug.mapevent.kill_enemy
+  coop.debug.map_event.kill_enemy
 
 Kills one live enemy-team agent in the current battle (battle-authority side).";
 
-    [CommandLineArgumentFunction("kill_enemy", "coop.debug.mapevent")]
     public static string KillOneEnemy(List<string> args)
     {
         if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
@@ -390,11 +381,10 @@ Kills one live enemy-team agent in the current battle (battle-authority side).";
 
     private const string KillEnemyTeamUsage =
 @"Usage:
-  coop.debug.mapevent.kill_enemy_team
+  coop.debug.map_event.kill_enemy_team
 
 Kills every live enemy-team agent in the current battle (battle-authority side). Useful for testing a coop battle WIN.";
 
-    [CommandLineArgumentFunction("kill_enemy_team", "coop.debug.mapevent")]
     public static string KillEnemyTeam(List<string> args)
     {
         if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
@@ -416,12 +406,11 @@ Kills every live enemy-team agent in the current battle (battle-authority side).
 
     private const string KillOwnTeamUsage =
 @"Usage:
-  coop.debug.mapevent.kill_own_team
+  coop.debug.map_event.kill_own_team
 
 Kills every live agent on the local player team in the current battle (battle-authority side). Useful for testing a
 coop battle LOSS.";
 
-    [CommandLineArgumentFunction("kill_own_team", "coop.debug.mapevent")]
     public static string KillOwnTeam(List<string> args)
     {
         if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)

--- a/source/GameInterface/Services/MapEvents/Commands/KillPlayerAgentCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/KillPlayerAgentCommands.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.MapEvents.Commands;
 
@@ -15,12 +14,11 @@ internal class KillPlayerAgentCommands
 
     private const string KillPlayerAgentUsage =
 @"Usage:
-  coop.debug.mapevent.kms
+  coop.debug.map_event.kms
 
 Kills the main agent (the player) in the current battle mission.
 Useful for testing player captivity without waiting to die.";
 
-    [CommandLineArgumentFunction("kms", "coop.debug.mapevent")]
     public static string KillPlayerAgent(List<string> args)
     {
         var ctx = new CommandContext(

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
@@ -22,7 +22,8 @@ public sealed class MapEventLegacyCommandResult : IMapEventLegacyCommandResult
     {
         if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
 
-        bool isKnownSuccess = successfulPrefix != null && output.StartsWith(successfulPrefix, StringComparison.Ordinal);
+        bool isKnownSuccess = output.StartsWith("Map event id:", StringComparison.Ordinal) ||
+                              successfulPrefix != null && output.StartsWith(successfulPrefix, StringComparison.Ordinal);
         bool succeeded = isKnownSuccess || !LooksLikeFailure(output);
         return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
     }
@@ -70,7 +71,26 @@ public sealed class MapEventLegacyCommandResult : IMapEventLegacyCommandResult
             if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
         }
 
-        return false;
+        return HasFailurePhrase(output);
+    }
+
+    private static bool HasFailurePhrase(string output)
+    {
+        return output.IndexOf(" not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" is not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" are not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" did not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" does not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" has no ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" has not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" is unavailable", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" is already ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" cannot ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" must ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" failed", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" already active", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.StartsWith("Add the ", StringComparison.OrdinalIgnoreCase) ||
+               output.StartsWith("Begin the ", StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -2026,13 +2046,9 @@ public interface IGetEventsCommand : ICoopCommand
 
 public sealed class GetEventsCommand : IGetEventsCommand
 {
-    private readonly IMapEventLegacyCommandResult resultFactory;
-
     public GetEventsCommand(IMapEventLegacyCommandResult resultFactory)
     {
         if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
-
-        this.resultFactory = resultFactory;
     }
     public string Prefix => "coop.debug.map_event";
 
@@ -2044,8 +2060,7 @@ public sealed class GetEventsCommand : IGetEventsCommand
 
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
-        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetEvents(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetEvents(new List<string>(args));
     }
 }
 

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
@@ -89,8 +89,10 @@ public sealed class MapEventLegacyCommandResult : IMapEventLegacyCommandResult
                output.IndexOf(" must ", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" failed", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" already active", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" was not assigned", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.StartsWith("Add the ", StringComparison.OrdinalIgnoreCase) ||
-               output.StartsWith("Begin the ", StringComparison.OrdinalIgnoreCase);
+               output.StartsWith("Begin the ", StringComparison.OrdinalIgnoreCase) ||
+               output.StartsWith("Server rejected ", StringComparison.OrdinalIgnoreCase);
     }
 }
 
@@ -971,7 +973,7 @@ public sealed class BattleRewardFixturePrepareCommand : IBattleRewardFixturePrep
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
         string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.PrepareBattleRewardFixture(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return resultFactory.FromOutput(output, "Battle reward fixture preflight is already clean.");
     }
 }
 

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
@@ -1,0 +1,2233 @@
+﻿using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.MapEvents.Commands;
+
+public interface IMapEventLegacyCommandResult
+{
+    CoopCommandResult FromOutput(string output);
+}
+
+public sealed class MapEventLegacyCommandResult : IMapEventLegacyCommandResult
+{
+    public CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool succeeded = !LooksLikeFailure(output);
+        return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
+    }
+
+    private static bool LooksLikeFailure(string output)
+    {
+        string[] failurePrefixes =
+        {
+            "Usage:",
+            "Failed",
+            "Unable",
+            "No ",
+            "Run this",
+            "Command can",
+            "The host has disabled",
+            "Cannot ",
+            "Could not",
+            "Refusing",
+            "Prepare ",
+            "Both ",
+            "Player parties must",
+            "Attacker and defender",
+            "Exists must",
+            "State requires",
+            "A ",
+            "The ",
+            "Party ",
+            "Character ",
+            "Settlement ",
+            "Object manager",
+            "Network ",
+            "Battle agent",
+            "Active mount",
+            "Upgrade ",
+            "Clan-party",
+            "Map event",
+            "Invalid ",
+            "Player parties",
+            "Player party",
+            "Player '",
+        };
+
+        foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return false;
+    }
+}
+
+public interface IClickDeploymentReadyCommand : ICoopCommand
+{
+}
+
+public sealed class ClickDeploymentReadyCommand : IClickDeploymentReadyCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public ClickDeploymentReadyCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "click_deployment_ready";
+
+    public string Description => "Runs the click deployment ready debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.ClickDeploymentReady(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IDeploymentStateCommand : ICoopCommand
+{
+}
+
+public sealed class DeploymentStateCommand : IDeploymentStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public DeploymentStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "deployment_state";
+
+    public string Description => "Reports deployment state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.DeploymentState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IFinishDeploymentCommand : ICoopCommand
+{
+}
+
+public sealed class FinishDeploymentCommand : IFinishDeploymentCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public FinishDeploymentCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "finish_deployment";
+
+    public string Description => "Runs the finish deployment debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.FinishDeployment(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IToggleScoreboardCommand : ICoopCommand
+{
+}
+
+public sealed class ToggleScoreboardCommand : IToggleScoreboardCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public ToggleScoreboardCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "toggle_scoreboard";
+
+    public string Description => "Runs the toggle scoreboard debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.ToggleScoreboard(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ICollapseScoreboardPartiesCommand : ICoopCommand
+{
+}
+
+public sealed class CollapseScoreboardPartiesCommand : ICollapseScoreboardPartiesCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public CollapseScoreboardPartiesCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "collapse_scoreboard_parties";
+
+    public string Description => "Runs the collapse scoreboard parties debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.CollapseScoreboardParties(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IScoreboardStateCommand : ICoopCommand
+{
+}
+
+public sealed class ScoreboardStateCommand : IScoreboardStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public ScoreboardStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "scoreboard_state";
+
+    public string Description => "Reports scoreboard state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.ScoreboardState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILeaveBattleCommand : ICoopCommand
+{
+}
+
+public sealed class LeaveBattleCommand : ILeaveBattleCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LeaveBattleCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "leave_battle";
+
+    public string Description => "Runs the leave battle debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.LeaveBattle(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IKillEnemyCommand : ICoopCommand
+{
+}
+
+public sealed class KillEnemyCommand : IKillEnemyCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public KillEnemyCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "kill_enemy";
+
+    public string Description => "Runs the kill enemy debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.KillOneEnemy(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IKillEnemyTeamCommand : ICoopCommand
+{
+}
+
+public sealed class KillEnemyTeamCommand : IKillEnemyTeamCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public KillEnemyTeamCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "kill_enemy_team";
+
+    public string Description => "Runs the kill enemy team debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.KillEnemyTeam(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IKillOwnTeamCommand : ICoopCommand
+{
+}
+
+public sealed class KillOwnTeamCommand : IKillOwnTeamCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public KillOwnTeamCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "kill_own_team";
+
+    public string Description => "Runs the kill own team debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.BattleTeamKillCommands.KillOwnTeam(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IKmsCommand : ICoopCommand
+{
+}
+
+public sealed class KmsCommand : IKmsCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public KmsCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "kms";
+
+    public string Description => "Runs the kms debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.KillPlayerAgentCommands.KillPlayerAgent(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IPrisonerPromptStateCommand : ICoopCommand
+{
+}
+
+public sealed class PrisonerPromptStateCommand : IPrisonerPromptStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PrisonerPromptStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "prisoner_prompt_state";
+
+    public string Description => "Reports prisoner prompt state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.PrisonerPromptState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IPrisonerPromptCommand : ICoopCommand
+{
+}
+
+public sealed class PrisonerPromptCommand : IPrisonerPromptCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PrisonerPromptCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "prisoner_prompt";
+
+    public string Description => "Runs the prisoner prompt debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("action", "The action.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.PrisonerPrompt(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStartPlayerFieldBattleCommand : ICoopCommand
+{
+}
+
+public sealed class StartPlayerFieldBattleCommand : IStartPlayerFieldBattleCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public StartPlayerFieldBattleCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "start_player_field_battle";
+
+    public string Description => "Runs the start player field battle debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("attacker_mobile_party_id", "The attacker mobile party id.", true),
+        new ExpectedArgs("defender_mobile_party_id", "The defender mobile party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartPlayerFieldBattle(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IRestorePlayerFieldBattleCommand : ICoopCommand
+{
+}
+
+public sealed class RestorePlayerFieldBattleCommand : IRestorePlayerFieldBattleCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public RestorePlayerFieldBattleCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "restore_player_field_battle";
+
+    public string Description => "Restores or clears restore player field battle.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RestorePlayerFieldBattle(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IRequestPlayerFieldBattleCommand : ICoopCommand
+{
+}
+
+public sealed class RequestPlayerFieldBattleCommand : IRequestPlayerFieldBattleCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public RequestPlayerFieldBattleCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "request_player_field_battle";
+
+    public string Description => "Runs the request player field battle debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("defender_mobile_party_id", "The defender mobile party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RequestPlayerFieldBattle(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IPlayerInteractionStateCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerInteractionStateCommand : IPlayerInteractionStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PlayerInteractionStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "player_interaction_state";
+
+    public string Description => "Reports player interaction state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.PlayerInteractionState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ISubmitPlayerInteractionCommand : ICoopCommand
+{
+}
+
+public sealed class SubmitPlayerInteractionCommand : ISubmitPlayerInteractionCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public SubmitPlayerInteractionCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "submit_player_interaction";
+
+    public string Description => "Runs the submit player interaction debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("option", "The option.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.SubmitPlayerInteraction(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStartAttackMissionCommand : ICoopCommand
+{
+}
+
+public sealed class StartAttackMissionCommand : IStartAttackMissionCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public StartAttackMissionCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "start_attack_mission";
+
+    public string Description => "Runs the start attack mission debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartAttackMission(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStartLooterCommand : ICoopCommand
+{
+}
+
+public sealed class StartLooterCommand : IStartLooterCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public StartLooterCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "start_looter";
+
+    public string Description => "Runs the start looter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartRandomLooterMapEvent(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStartNearestLooterCommand : ICoopCommand
+{
+}
+
+public sealed class StartNearestLooterCommand : IStartNearestLooterCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public StartNearestLooterCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "start_nearest_looter";
+
+    public string Description => "Runs the start nearest looter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartNearestLooterMapEvent(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStartNearestBanditAttackCommand : ICoopCommand
+{
+}
+
+public sealed class StartNearestBanditAttackCommand : IStartNearestBanditAttackCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public StartNearestBanditAttackCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "start_nearest_bandit_attack";
+
+    public string Description => "Runs the start nearest bandit attack debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("excluded_party_id", "The excluded party id.", false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartNearestBanditAttack(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBanditAttackFixturePrepareCommand : ICoopCommand
+{
+}
+
+public sealed class BanditAttackFixturePrepareCommand : IBanditAttackFixturePrepareCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BanditAttackFixturePrepareCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "bandit_attack_fixture_prepare";
+
+    public string Description => "Runs the bandit attack fixture prepare debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("bandit_party_id", "The bandit party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.PrepareBanditAttackFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBanditAttackFixtureStartCommand : ICoopCommand
+{
+}
+
+public sealed class BanditAttackFixtureStartCommand : IBanditAttackFixtureStartCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BanditAttackFixtureStartCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "bandit_attack_fixture_start";
+
+    public string Description => "Runs the bandit attack fixture start debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("bandit_party_id", "The bandit party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartBanditAttackFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBanditAttackFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class BanditAttackFixtureStateCommand : IBanditAttackFixtureStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BanditAttackFixtureStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "bandit_attack_fixture_state";
+
+    public string Description => "Reports bandit attack fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("bandit_party_id", "The bandit party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetBanditAttackFixtureState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBanditAttackFixtureRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class BanditAttackFixtureRestoreCommand : IBanditAttackFixtureRestoreCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BanditAttackFixtureRestoreCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "bandit_attack_fixture_restore";
+
+    public string Description => "Restores or clears bandit attack fixture restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RestoreBanditAttackFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IFinishNonBattleEncounterCommand : ICoopCommand
+{
+}
+
+public sealed class FinishNonBattleEncounterCommand : IFinishNonBattleEncounterCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public FinishNonBattleEncounterCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "finish_non_battle_encounter";
+
+    public string Description => "Runs the finish non battle encounter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.FinishNonBattleEncounter(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IJoinExistingCommand : ICoopCommand
+{
+}
+
+public sealed class JoinExistingCommand : IJoinExistingCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public JoinExistingCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "join_existing";
+
+    public string Description => "Runs the join existing debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("map_event_id", "The map event id.", true),
+        new ExpectedArgs("side", "The battle side.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.JoinExistingBattle(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixturePrepareCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixturePrepareCommand : IBattleRewardFixturePrepareCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixturePrepareCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_prepare";
+
+    public string Description => "Runs the battle reward fixture prepare debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("initiator_controller_id", "The initiator controller id.", true),
+        new ExpectedArgs("late_joiner_controller_id", "The late joiner controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.PrepareBattleRewardFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixtureStartCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixtureStartCommand : IBattleRewardFixtureStartCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixtureStartCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_start";
+
+    public string Description => "Runs the battle reward fixture start debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("initiator_controller_id", "The initiator controller id.", true),
+        new ExpectedArgs("late_joiner_controller_id", "The late joiner controller id.", true),
+        new ExpectedArgs("army", "The army.", false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartBattleRewardFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixtureReinforceCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixtureReinforceCommand : IBattleRewardFixtureReinforceCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixtureReinforceCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_reinforce";
+
+    public string Description => "Runs the battle reward fixture reinforce debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.ReinforceBattleRewardFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixtureJoinCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixtureJoinCommand : IBattleRewardFixtureJoinCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixtureJoinCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_join";
+
+    public string Description => "Runs the battle reward fixture join debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.JoinBattleRewardFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixtureBeginRoutCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixtureBeginRoutCommand : IBattleRewardFixtureBeginRoutCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixtureBeginRoutCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_begin_rout";
+
+    public string Description => "Runs the battle reward fixture begin rout debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.BeginBattleRewardFixtureRout(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixtureRouteEnemiesCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixtureRouteEnemiesCommand : IBattleRewardFixtureRouteEnemiesCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixtureRouteEnemiesCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_route_enemies";
+
+    public string Description => "Runs the battle reward fixture route enemies debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RouteBattleRewardFixtureEnemies(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixtureStateCommand : IBattleRewardFixtureStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixtureStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_state";
+
+    public string Description => "Reports battle reward fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetBattleRewardFixtureState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardClientStateCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardClientStateCommand : IBattleRewardClientStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardClientStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_client_state";
+
+    public string Description => "Reports battle reward client state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetBattleRewardClientState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IBattleRewardFixtureRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class BattleRewardFixtureRestoreCommand : IBattleRewardFixtureRestoreCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public BattleRewardFixtureRestoreCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "battle_reward_fixture_restore";
+
+    public string Description => "Restores or clears battle reward fixture restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RestoreBattleRewardFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IWoundedAlliedFixtureStartCommand : ICoopCommand
+{
+}
+
+public sealed class WoundedAlliedFixtureStartCommand : IWoundedAlliedFixtureStartCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public WoundedAlliedFixtureStartCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "wounded_allied_fixture_start";
+
+    public string Description => "Runs the wounded allied fixture start debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartWoundedAlliedFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IWoundedAlliedFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class WoundedAlliedFixtureStateCommand : IWoundedAlliedFixtureStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public WoundedAlliedFixtureStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "wounded_allied_fixture_state";
+
+    public string Description => "Reports wounded allied fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetWoundedAlliedFixtureState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IWoundedAlliedFixtureRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class WoundedAlliedFixtureRestoreCommand : IWoundedAlliedFixtureRestoreCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public WoundedAlliedFixtureRestoreCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "wounded_allied_fixture_restore";
+
+    public string Description => "Restores or clears wounded allied fixture restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RestoreWoundedAlliedFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILeaveSettlementCommand : ICoopCommand
+{
+}
+
+public sealed class LeaveSettlementCommand : ILeaveSettlementCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LeaveSettlementCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "leave_settlement";
+
+    public string Description => "Runs the leave settlement debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.LeaveSettlement(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IFinishCurrentEncounterCommand : ICoopCommand
+{
+}
+
+public sealed class FinishCurrentEncounterCommand : IFinishCurrentEncounterCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public FinishCurrentEncounterCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "finish_current_encounter";
+
+    public string Description => "Runs the finish current encounter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.FinishCurrentEncounter(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IEnterCurrentBattleCommand : ICoopCommand
+{
+}
+
+public sealed class EnterCurrentBattleCommand : IEnterCurrentBattleCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public EnterCurrentBattleCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "enter_current_battle";
+
+    public string Description => "Runs the enter current battle debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.EnterCurrentBattle(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IFinishPlayerEncounterCommand : ICoopCommand
+{
+}
+
+public sealed class FinishPlayerEncounterCommand : IFinishPlayerEncounterCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public FinishPlayerEncounterCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "finish_player_encounter";
+
+    public string Description => "Runs the finish player encounter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.FinishPlayerEncounter(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IConversationHoldStateCommand : ICoopCommand
+{
+}
+
+public sealed class ConversationHoldStateCommand : IConversationHoldStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public ConversationHoldStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "conversation_hold_state";
+
+    public string Description => "Reports conversation hold state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_base_id", "The party base id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.ConversationHoldState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILateJoinModeFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeFixtureCommand : ILateJoinModeFixtureCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeFixtureCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_fixture";
+
+    public string Description => "Runs the late join mode fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("first_controller_id", "The first controller id.", true),
+        new ExpectedArgs("joining_controller_id", "The joining controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.StartLateJoinModeFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILateJoinModeJoinCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeJoinCommand : ILateJoinModeJoinCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeJoinCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_join";
+
+    public string Description => "Runs the late join mode join debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.JoinLateJoinModeFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILateJoinModeEnterCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeEnterCommand : ILateJoinModeEnterCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeEnterCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_enter";
+
+    public string Description => "Runs the late join mode enter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.EnterLateJoinModeFixtureMission(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface ILateJoinModeBeginFieldBattleCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeBeginFieldBattleCommand : ILateJoinModeBeginFieldBattleCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeBeginFieldBattleCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_begin_field_battle";
+
+    public string Description => "Runs the late join mode begin field battle debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.BeginLateJoinModeFixtureFieldBattle(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILateJoinModeDisableDyingCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeDisableDyingCommand : ILateJoinModeDisableDyingCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeDisableDyingCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_disable_dying";
+
+    public string Description => "Runs the late join mode disable dying debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.DisableLateJoinModeFixtureDying(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILateJoinModeExitMissionsCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeExitMissionsCommand : ILateJoinModeExitMissionsCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeExitMissionsCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_exit_missions";
+
+    public string Description => "Runs the late join mode exit missions debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.ExitLateJoinModeFixtureMissions(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILateJoinModeRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeRestoreCommand : ILateJoinModeRestoreCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeRestoreCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_restore";
+
+    public string Description => "Restores or clears late join mode restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RestoreLateJoinModeFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+#endif
+
+public interface ILateJoinModeStateCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeStateCommand : ILateJoinModeStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_state";
+
+    public string Description => "Reports late join mode state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetLateJoinModeState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILateJoinModeCleanupCommand : ICoopCommand
+{
+}
+
+public sealed class LateJoinModeCleanupCommand : ILateJoinModeCleanupCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public LateJoinModeCleanupCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "late_join_mode_cleanup";
+
+    public string Description => "Runs the late join mode cleanup debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.CleanupLateJoinModeFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IPeacePursuitFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PeacePursuitFixtureCommand : IPeacePursuitFixtureCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PeacePursuitFixtureCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "peace_pursuit_fixture";
+
+    public string Description => "Runs the peace pursuit fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetPeacePursuitFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IPeacePursuitStateCommand : ICoopCommand
+{
+}
+
+public sealed class PeacePursuitStateCommand : IPeacePursuitStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PeacePursuitStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "peace_pursuit_state";
+
+    public string Description => "Reports peace pursuit state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("party_string_id", "The party string id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetPeacePursuitState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ITestPeaceStopsPursuitCommand : ICoopCommand
+{
+}
+
+public sealed class TestPeaceStopsPursuitCommand : ITestPeaceStopsPursuitCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public TestPeaceStopsPursuitCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "test_peace_stops_pursuit";
+
+    public string Description => "Runs the test peace stops pursuit debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("party_string_id", "The party string id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.TestPeaceStopsPursuit(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IKillRandomTroopCommand : ICoopCommand
+{
+}
+
+public sealed class KillRandomTroopCommand : IKillRandomTroopCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public KillRandomTroopCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "kill_random_troop";
+
+    public string Description => "Runs the kill random troop debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.KillRandomTroop(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IKillAllButOneCommand : ICoopCommand
+{
+}
+
+public sealed class KillAllButOneCommand : IKillAllButOneCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public KillAllButOneCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "kill_all_but_one";
+
+    public string Description => "Runs the kill all but one debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.KillAllButOneTroop(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IListPlayerEncounterCommand : ICoopCommand
+{
+}
+
+public sealed class ListPlayerEncounterCommand : IListPlayerEncounterCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public ListPlayerEncounterCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "list_player_encounter";
+
+    public string Description => "Reports player encounter.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.ListPlayerEncounter(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IEncounterStateCommand : ICoopCommand
+{
+}
+
+public sealed class EncounterStateCommand : IEncounterStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public EncounterStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "encounter_state";
+
+    public string Description => "Reports encounter state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.EncounterState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IRetreatConfirmationCommand : ICoopCommand
+{
+}
+
+public sealed class RetreatConfirmationCommand : IRetreatConfirmationCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public RetreatConfirmationCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "retreat_confirmation";
+
+    public string Description => "Runs the retreat confirmation debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("action", "The action.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.RetreatConfirmation(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ICompleteEncounterMeetingCommand : ICoopCommand
+{
+}
+
+public sealed class CompleteEncounterMeetingCommand : ICompleteEncounterMeetingCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public CompleteEncounterMeetingCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "complete_encounter_meeting";
+
+    public string Description => "Runs the complete encounter meeting debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.CompleteEncounterMeeting(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IChooseBattleModeCommand : ICoopCommand
+{
+}
+
+public sealed class ChooseBattleModeCommand : IChooseBattleModeCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public ChooseBattleModeCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "choose_battle_mode";
+
+    public string Description => "Runs the choose battle mode debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "The battle mode.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.ChooseBattleMode(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IGetEventsCommand : ICoopCommand
+{
+}
+
+public sealed class GetEventsCommand : IGetEventsCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public GetEventsCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "get_events";
+
+    public string Description => "Reports events.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetEvents(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IGetEventCommand : ICoopCommand
+{
+}
+
+public sealed class GetEventCommand : IGetEventCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public GetEventCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "get_event";
+
+    public string Description => "Reports event.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("map_event_id", "The map event id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetEvent(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IPostBattleFreezeFixtureStartCommand : ICoopCommand
+{
+}
+
+public sealed class PostBattleFreezeFixtureStartCommand : IPostBattleFreezeFixtureStartCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PostBattleFreezeFixtureStartCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "post_battle_freeze_fixture_start";
+
+    public string Description => "Runs the post battle freeze fixture start debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("first_controller_id", "The first controller id.", true),
+        new ExpectedArgs("second_controller_id", "The second controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.PostBattleFreezeFixtureCommands.StartFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPostBattleFreezeFixtureOpenCommand : ICoopCommand
+{
+}
+
+public sealed class PostBattleFreezeFixtureOpenCommand : IPostBattleFreezeFixtureOpenCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PostBattleFreezeFixtureOpenCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "post_battle_freeze_fixture_open";
+
+    public string Description => "Runs the post battle freeze fixture open debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.PostBattleFreezeFixtureCommands.OpenFixtureEncounters(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPostBattleFreezeFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class PostBattleFreezeFixtureStateCommand : IPostBattleFreezeFixtureStateCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PostBattleFreezeFixtureStateCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "post_battle_freeze_fixture_state";
+
+    public string Description => "Reports post battle freeze fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.PostBattleFreezeFixtureCommands.GetFixtureState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPostBattleFreezeFixtureUnpauseCommand : ICoopCommand
+{
+}
+
+public sealed class PostBattleFreezeFixtureUnpauseCommand : IPostBattleFreezeFixtureUnpauseCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PostBattleFreezeFixtureUnpauseCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "post_battle_freeze_fixture_unpause";
+
+    public string Description => "Runs the post battle freeze fixture unpause debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.PostBattleFreezeFixtureCommands.UnpauseFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPostBattleFreezeFixtureRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class PostBattleFreezeFixtureRestoreCommand : IPostBattleFreezeFixtureRestoreCommand
+{
+    private readonly IMapEventLegacyCommandResult resultFactory;
+
+    public PostBattleFreezeFixtureRestoreCommand(IMapEventLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.map_event";
+
+    public string Name => "post_battle_freeze_fixture_restore";
+
+    public string Description => "Restores or clears post battle freeze fixture restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.MapEvents.Commands.PostBattleFreezeFixtureCommands.RestoreFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventCoopCommands.cs
@@ -7,15 +7,23 @@ namespace GameInterface.Services.MapEvents.Commands;
 public interface IMapEventLegacyCommandResult
 {
     CoopCommandResult FromOutput(string output);
+
+    CoopCommandResult FromOutput(string output, string successfulPrefix);
 }
 
 public sealed class MapEventLegacyCommandResult : IMapEventLegacyCommandResult
 {
     public CoopCommandResult FromOutput(string output)
     {
+        return FromOutput(output, null);
+    }
+
+    public CoopCommandResult FromOutput(string output, string successfulPrefix)
+    {
         if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
 
-        bool succeeded = !LooksLikeFailure(output);
+        bool isKnownSuccess = successfulPrefix != null && output.StartsWith(successfulPrefix, StringComparison.Ordinal);
+        bool succeeded = isKnownSuccess || !LooksLikeFailure(output);
         return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
     }
 
@@ -2069,7 +2077,7 @@ public sealed class GetEventCommand : IGetEventCommand
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
         string output = global::GameInterface.Services.Villages.Commands.MapEventDebugCommands.GetEvent(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return resultFactory.FromOutput(output, "Map event id:");
     }
 }
 

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common;
+using Common.Commands;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -3140,13 +3141,13 @@ public class MapEventDebugCommands
         return $"id={id} finalized={mapEvent.IsFinalized} state={mapEvent.BattleState} winner={mapEvent.WinningSide}";
     }
 
-    public static string GetEvents(List<string> args)
+    public static CoopCommandResult GetEvents(List<string> args)
     {
         var sb = new StringBuilder();
 
         if(!TryGetObjectManager(out var objectManager))
         {
-            return "Failed to get object manager";
+            return new CoopCommandResult(false, "Failed to get object manager", "command_failed");
         }
 
         foreach(var mapEvent in Campaign.Current.MapEventManager.MapEvents)
@@ -3163,7 +3164,7 @@ public class MapEventDebugCommands
             sb.AppendLine($"\tDefender: {string.Join(",", FormatSideNames(mapEvent.DefenderSide))}");
         }
 
-        return sb.ToString();
+        return new CoopCommandResult(true, sb.ToString());
     }
 
     private static string[] FormatSideNames(MapEventSide side)

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -50,7 +50,6 @@ using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Source.Missions.Handlers;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Villages.Commands;
 
@@ -60,20 +59,18 @@ public class MapEventDebugCommands
     private static LateJoinModeFixture lateJoinModeFixture;
     private static InquiryData pendingPrisonerPromptInquiry;
 
-    [CommandLineArgumentFunction("prisoner_prompt_state", "coop.debug.mapevent")]
     public static string PrisonerPromptState(List<string> args)
     {
         if (!ModInformation.IsClient) return "Run this command on a client.";
-        if (args.Count != 0) return "Usage: coop.debug.mapevent.prisoner_prompt_state";
+        if (args.Count != 0) return "Usage: coop.debug.map_event.prisoner_prompt_state";
         return CreatePrisonerPromptStateResult();
     }
 
-    [CommandLineArgumentFunction("prisoner_prompt", "coop.debug.mapevent")]
     public static string PrisonerPrompt(List<string> args)
     {
         if (!ModInformation.IsClient) return "Run this command on a client.";
         if (args.Count != 1 || (args[0] != "commit" && args[0] != "accept"))
-            return "Usage: coop.debug.mapevent.prisoner_prompt <commit|accept>";
+            return "Usage: coop.debug.map_event.prisoner_prompt <commit|accept>";
 
         if (args[0] == "commit")
         {
@@ -256,14 +253,13 @@ public class MapEventDebugCommands
                partyBaseId == id;
     }
 
-    [CommandLineArgumentFunction("start_player_field_battle", "coop.debug.mapevent")]
     public static string StartPlayerFieldBattle(List<string> args)
     {
         if (!ModInformation.IsServer)
             return "Run this command on the server.";
 
         if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.start_player_field_battle <attackerMobilePartyId> <defenderMobilePartyId>";
+            return "Usage: coop.debug.map_event.start_player_field_battle <attackerMobilePartyId> <defenderMobilePartyId>";
 
         if (playerFieldBattleFixture != null)
             return "A player field-battle fixture is already pending restoration.";
@@ -358,14 +354,13 @@ public class MapEventDebugCommands
             $"OriginalWarState: {fixture.WasAtWar}";
     }
 
-    [CommandLineArgumentFunction("restore_player_field_battle", "coop.debug.mapevent")]
     public static string RestorePlayerFieldBattle(List<string> args)
     {
         if (!ModInformation.IsServer)
             return "Run this command on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.restore_player_field_battle";
+            return "Usage: coop.debug.map_event.restore_player_field_battle";
 
         var fixture = playerFieldBattleFixture;
         if (fixture == null)
@@ -389,14 +384,13 @@ public class MapEventDebugCommands
         return true;
     }
 
-    [CommandLineArgumentFunction("request_player_field_battle", "coop.debug.mapevent")]
     public static string RequestPlayerFieldBattle(List<string> args)
     {
         if (!ModInformation.IsClient)
             return "Run this command on the attacking client.";
 
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.request_player_field_battle <defenderMobilePartyId>";
+            return "Usage: coop.debug.map_event.request_player_field_battle <defenderMobilePartyId>";
 
         var attacker = MobileParty.MainParty;
         if (attacker?.Party == null || !attacker.IsActive || attacker.MapEvent != null)
@@ -446,11 +440,10 @@ public class MapEventDebugCommands
             $"DefenderPartyId: {defender.StringId}";
     }
 
-    [CommandLineArgumentFunction("player_interaction_state", "coop.debug.mapevent")]
     public static string PlayerInteractionState(List<string> args)
     {
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.player_interaction_state";
+            return "Usage: coop.debug.map_event.player_interaction_state";
 
         return
             $"Active: {PlayerPartyInteractionDialogState.HasActiveState}\n" +
@@ -461,7 +454,6 @@ public class MapEventDebugCommands
             $"Proposal: {PlayerPartyInteractionDialogState.Proposal}";
     }
 
-    [CommandLineArgumentFunction("submit_player_interaction", "coop.debug.mapevent")]
     public static string SubmitPlayerInteraction(List<string> args)
     {
         if (!ModInformation.IsClient)
@@ -470,7 +462,7 @@ public class MapEventDebugCommands
         if (args.Count != 1 ||
             !Enum.TryParse(args[0], ignoreCase: true, out PlayerPartyInteractionOption option) ||
             option == PlayerPartyInteractionOption.None)
-            return "Usage: coop.debug.mapevent.submit_player_interaction <option>";
+            return "Usage: coop.debug.map_event.submit_player_interaction <option>";
 
         if (!PlayerPartyInteractionDialogState.HasActiveState)
             return "No player-party interaction is active.";
@@ -498,7 +490,6 @@ public class MapEventDebugCommands
     /// <summary>
     /// Starts the current battle through the normal client/server mission-start gate.
     /// </summary>
-    [CommandLineArgumentFunction("start_attack_mission", "coop.debug.mapevent")]
     public static string StartAttackMission(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -508,7 +499,7 @@ public class MapEventDebugCommands
 
         if (args.Count != 0)
         {
-            return "Usage: coop.debug.mapevent.start_attack_mission";
+            return "Usage: coop.debug.map_event.start_attack_mission";
         }
 
         var mainParty = MobileParty.MainParty;
@@ -536,11 +527,10 @@ public class MapEventDebugCommands
             : $"Server rejected attack mission for {mapEventId}";
     }
 
-    // coop.debug.mapevent.start_looter
+    // coop.debug.map_event.start_looter
     /// <summary>
     /// Starts combat with looter
     /// </summary>
-    [CommandLineArgumentFunction("start_looter", "coop.debug.mapevent")]
     public static string StartRandomLooterMapEvent(List<string> args)
     {
         //if (args.Count != 2)
@@ -564,14 +554,13 @@ public class MapEventDebugCommands
         return $"MapEvent Started";
     }
 
-    // coop.debug.mapevent.start_nearest_looter
+    // coop.debug.map_event.start_nearest_looter
     /// <summary>
     /// Forces an encounter between the player's party and the nearest active bandit/looter party, so
     /// the bandit surrender/recruit dialogue can be reached without chasing one down. Run on a client
     /// (uses the player's main party). Bring a much larger party than the bandits so they offer to
     /// surrender or join.
     /// </summary>
-    [CommandLineArgumentFunction("start_nearest_looter", "coop.debug.mapevent")]
     public static string StartNearestLooterMapEvent(List<string> args)
     {
         if (!TryGetObjectManager(out var objectManager))
@@ -605,11 +594,10 @@ public class MapEventDebugCommands
                $"{nearest.MemberRoster.TotalManCount} troops, {nearest.Position.ToVec2().Distance(mainPos):0.0} away.";
     }
 
-    // coop.debug.mapevent.start_nearest_bandit_attack PlayerOne [excludedPartyId]
+    // coop.debug.map_event.start_nearest_bandit_attack PlayerOne [excludedPartyId]
     /// <summary>
     /// Starts a server-authoritative bandit attack encounter against a connected player.
     /// </summary>
-    [CommandLineArgumentFunction("start_nearest_bandit_attack", "coop.debug.mapevent")]
     public static string StartNearestBanditAttack(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -619,7 +607,7 @@ public class MapEventDebugCommands
 
         if (args.Count < 1 || args.Count > 2)
         {
-            return "Usage: coop.debug.mapevent.start_nearest_bandit_attack <controllerId> [excludedPartyId]";
+            return "Usage: coop.debug.map_event.start_nearest_bandit_attack <controllerId> [excludedPartyId]";
         }
 
         if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
@@ -684,16 +672,15 @@ public class MapEventDebugCommands
                $"against player {args[0]} after removing {removedTroops} excess fixture troops.";
     }
 
-    // coop.debug.mapevent.bandit_attack_fixture_prepare PlayerOne mountain_bandits_24
+    // coop.debug.map_event.bandit_attack_fixture_prepare PlayerOne mountain_bandits_24
     /// <summary>Prepares a reversible exact-bandit attack fixture for evidence capture.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_prepare", "coop.debug.mapevent")]
     public static string PrepareBanditAttackFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_prepare <controllerId> <banditPartyId>";
+            return "Usage: coop.debug.map_event.bandit_attack_fixture_prepare <controllerId> <banditPartyId>";
 
         if (banditAttackFixture != null)
             return "A bandit attack fixture is already active.";
@@ -810,16 +797,15 @@ public class MapEventDebugCommands
         }
     }
 
-    // coop.debug.mapevent.bandit_attack_fixture_start PlayerOne mountain_bandits_24
+    // coop.debug.map_event.bandit_attack_fixture_start PlayerOne mountain_bandits_24
     /// <summary>Starts the prepared server-authoritative attack by the exact bandit party.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_start", "coop.debug.mapevent")]
     public static string StartBanditAttackFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_start <controllerId> <banditPartyId>";
+            return "Usage: coop.debug.map_event.bandit_attack_fixture_start <controllerId> <banditPartyId>";
 
         if (!TryGetObjectManager(out var objectManager))
             return "Unable to resolve ObjectManager";
@@ -880,13 +866,12 @@ public class MapEventDebugCommands
         }
     }
 
-    // coop.debug.mapevent.bandit_attack_fixture_state PlayerOne mountain_bandits_24
+    // coop.debug.map_event.bandit_attack_fixture_state PlayerOne mountain_bandits_24
     /// <summary>Reports the exact bandit attack state on the server or a client.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_state", "coop.debug.mapevent")]
     public static string GetBanditAttackFixtureState(List<string> args)
     {
         if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_state <controllerId> <banditPartyId>";
+            return "Usage: coop.debug.map_event.bandit_attack_fixture_state <controllerId> <banditPartyId>";
 
         if (!TryGetPlayerParty(
                 args[0],
@@ -922,16 +907,15 @@ public class MapEventDebugCommands
                $"menu={Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "none"}.";
     }
 
-    // coop.debug.mapevent.bandit_attack_fixture_restore PlayerOne
+    // coop.debug.map_event.bandit_attack_fixture_restore PlayerOne
     /// <summary>Finalizes the bandit attack and restores both parties' original behavior.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_restore", "coop.debug.mapevent")]
     public static string RestoreBanditAttackFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_restore <controllerId>";
+            return "Usage: coop.debug.map_event.bandit_attack_fixture_restore <controllerId>";
 
         if (banditAttackFixture == null || banditAttackFixture.ControllerId != args[0])
             return $"No active bandit attack fixture exists for {args[0]}.";
@@ -996,14 +980,13 @@ public class MapEventDebugCommands
         }
     }
 
-    [CommandLineArgumentFunction("finish_non_battle_encounter", "coop.debug.mapevent")]
     public static string FinishNonBattleEncounter(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.finish_non_battle_encounter";
+            return "Usage: coop.debug.map_event.finish_non_battle_encounter";
 
         if (PlayerEncounter.Current == null)
             return "No player encounter is active.";
@@ -1014,7 +997,6 @@ public class MapEventDebugCommands
         return "Finished the current non-battle encounter.";
     }
 
-    [CommandLineArgumentFunction("join_existing", "coop.debug.mapevent")]
     public static string JoinExistingBattle(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -1024,7 +1006,7 @@ public class MapEventDebugCommands
             !Enum.TryParse(args[1], true, out BattleSideEnum side) ||
             (side != BattleSideEnum.Attacker && side != BattleSideEnum.Defender))
         {
-            return "Usage: coop.debug.mapevent.join_existing <mapEventId> <Attacker|Defender>";
+            return "Usage: coop.debug.map_event.join_existing <mapEventId> <Attacker|Defender>";
         }
 
         if (!TryGetObjectManager(out var objectManager))
@@ -1065,16 +1047,15 @@ public class MapEventDebugCommands
         return $"Started the {side} join encounter for map event {args[0]}.";
     }
 
-    // coop.debug.mapevent.battle_reward_fixture_prepare testclient testclient2
+    // coop.debug.map_event.battle_reward_fixture_prepare testclient testclient2
     /// <summary>Closes the unfinished idle player encounter loaded by the #2308 live-test save.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_prepare", "coop.debug.mapevent")]
     public static string PrepareBattleRewardFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_prepare <initiatorControllerId> <lateJoinerControllerId>";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_prepare <initiatorControllerId> <lateJoinerControllerId>";
 
         if (args[0] == args[1])
             return "The initiator and late joiner must be different players.";
@@ -1119,9 +1100,8 @@ public class MapEventDebugCommands
         return $"Battle reward fixture preflight prepared: finalized={mapEventId}, battleState=None.";
     }
 
-    // coop.debug.mapevent.battle_reward_fixture_start testclient testclient2 army
+    // coop.debug.map_event.battle_reward_fixture_start testclient testclient2 army
     /// <summary>Creates the two-player late-join field battle from #2308.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_start", "coop.debug.mapevent")]
     public static string StartBattleRewardFixture(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -1129,7 +1109,7 @@ public class MapEventDebugCommands
 
         var createArmy = args.Count == 3 && string.Equals(args[2], "army", StringComparison.OrdinalIgnoreCase);
         if (args.Count != 2 && !createArmy)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_start <initiatorControllerId> <lateJoinerControllerId> [army]";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_start <initiatorControllerId> <lateJoinerControllerId> [army]";
 
         if (args[0] == args[1])
             return "The initiator and late joiner must be different players.";
@@ -1315,14 +1295,13 @@ public class MapEventDebugCommands
         }
     }
 
-    [CommandLineArgumentFunction("battle_reward_fixture_reinforce", "coop.debug.mapevent")]
     public static string ReinforceBattleRewardFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_reinforce";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_reinforce";
 
         var fixture = battleRewardFixture;
         if (fixture == null)
@@ -1356,16 +1335,15 @@ public class MapEventDebugCommands
                $"enemyParties={banditSide.Parties.Count}.";
     }
 
-    // coop.debug.mapevent.battle_reward_fixture_join
+    // coop.debug.map_event.battle_reward_fixture_join
     /// <summary>Adds the second player to the active #2308 battle and opens its encounter.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_join", "coop.debug.mapevent")]
     public static string JoinBattleRewardFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_join";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_join";
 
         var fixture = battleRewardFixture;
         if (fixture == null)
@@ -1411,14 +1389,13 @@ public class MapEventDebugCommands
                $"controller={fixture.LateJoiner.ControllerId}, party={fixture.LateJoiner.Party.StringId}.";
     }
 
-    [CommandLineArgumentFunction("battle_reward_fixture_begin_rout", "coop.debug.mapevent")]
     public static string BeginBattleRewardFixtureRout(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_begin_rout";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_begin_rout";
 
         var fixture = battleRewardFixture;
         if (fixture == null)
@@ -1443,14 +1420,13 @@ public class MapEventDebugCommands
         return $"Ordered fixture enemies to retreat while leaving up to 20 fighting: mapEvent={mapEventId}.";
     }
 
-    [CommandLineArgumentFunction("battle_reward_fixture_route_enemies", "coop.debug.mapevent")]
     public static string RouteBattleRewardFixtureEnemies(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_route_enemies";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_route_enemies";
 
         var fixture = battleRewardFixture;
         if (fixture == null)
@@ -1473,16 +1449,15 @@ public class MapEventDebugCommands
         return $"Ordered the battle authority to route fixture enemies: mapEvent={mapEventId}.";
     }
 
-    // coop.debug.mapevent.battle_reward_fixture_state
+    // coop.debug.map_event.battle_reward_fixture_state
     /// <summary>Reports contributions and roster reward deltas for the active #2308 fixture.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_state", "coop.debug.mapevent")]
     public static string GetBattleRewardFixtureState(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_state";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_state";
 
         var fixture = battleRewardFixture;
         if (fixture == null)
@@ -1505,16 +1480,15 @@ public class MapEventDebugCommands
                FormatBattleRewardPlayerState("lateJoiner", fixture.LateJoiner, fixture.LateJoinerMapEventParty) + ".";
     }
 
-    // coop.debug.mapevent.battle_reward_client_state
+    // coop.debug.map_event.battle_reward_client_state
     /// <summary>Reports the local player's staged or already-applied native battle rewards.</summary>
-    [CommandLineArgumentFunction("battle_reward_client_state", "coop.debug.mapevent")]
     public static string GetBattleRewardClientState(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_client_state";
+            return "Usage: coop.debug.map_event.battle_reward_client_state";
 
         var encounter = PlayerEncounter.Current;
         var mainParty = PartyBase.MainParty;
@@ -1535,16 +1509,15 @@ public class MapEventDebugCommands
                $"isArmyLeader={army != null && army.LeaderParty == mainMobileParty}.";
     }
 
-    // coop.debug.mapevent.battle_reward_fixture_restore
+    // coop.debug.map_event.battle_reward_fixture_restore
     /// <summary>Finalizes the #2308 battle, removes its bandits, and restores both players.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_restore", "coop.debug.mapevent")]
     public static string RestoreBattleRewardFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_restore";
+            return "Usage: coop.debug.map_event.battle_reward_fixture_restore";
 
         var fixture = battleRewardFixture;
         if (fixture == null)
@@ -1763,16 +1736,15 @@ public class MapEventDebugCommands
             roster.AddToCounts(element.Character, element.Number, false, element.WoundedNumber, element.Xp, true);
     }
 
-    // coop.debug.mapevent.wounded_allied_fixture_start PlayerOne
+    // coop.debug.map_event.wounded_allied_fixture_start PlayerOne
     /// <summary>Creates the wounded, troop-less player plus healthy allied force field encounter from #2097.</summary>
-    [CommandLineArgumentFunction("wounded_allied_fixture_start", "coop.debug.mapevent")]
     public static string StartWoundedAlliedFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.wounded_allied_fixture_start <controllerId>";
+            return "Usage: coop.debug.map_event.wounded_allied_fixture_start <controllerId>";
 
         if (woundedAlliedFixture != null)
             return $"Fixture already active for {woundedAlliedFixture.ControllerId}.";
@@ -1872,13 +1844,12 @@ public class MapEventDebugCommands
                $"alliedHealthy={alliedParty.Party.NumberOfHealthyMembers}, banditParty={banditParty.StringId}.";
     }
 
-    // coop.debug.mapevent.wounded_allied_fixture_state PlayerOne
+    // coop.debug.map_event.wounded_allied_fixture_state PlayerOne
     /// <summary>Reports the #2097 fixture state and the local patched order-attack option when applicable.</summary>
-    [CommandLineArgumentFunction("wounded_allied_fixture_state", "coop.debug.mapevent")]
     public static string GetWoundedAlliedFixtureState(List<string> args)
     {
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.wounded_allied_fixture_state <controllerId>";
+            return "Usage: coop.debug.map_event.wounded_allied_fixture_state <controllerId>";
 
         if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
             return error;
@@ -1919,16 +1890,15 @@ public class MapEventDebugCommands
                $"menu={Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "none"}, option={option}.";
     }
 
-    // coop.debug.mapevent.wounded_allied_fixture_restore PlayerOne
+    // coop.debug.map_event.wounded_allied_fixture_restore PlayerOne
     /// <summary>Finalizes the #2097 fixture and restores the player's original hero, morale, and roster state.</summary>
-    [CommandLineArgumentFunction("wounded_allied_fixture_restore", "coop.debug.mapevent")]
     public static string RestoreWoundedAlliedFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.wounded_allied_fixture_restore <controllerId>";
+            return "Usage: coop.debug.map_event.wounded_allied_fixture_restore <controllerId>";
 
         if (woundedAlliedFixture == null || woundedAlliedFixture.ControllerId != args[0])
             return $"No active fixture exists for {args[0]}.";
@@ -2049,14 +2019,13 @@ public class MapEventDebugCommands
         }
     }
 
-    [CommandLineArgumentFunction("leave_settlement", "coop.debug.mapevent")]
     public static string LeaveSettlement(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
 
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.leave_settlement <controllerId>";
+            return "Usage: coop.debug.map_event.leave_settlement <controllerId>";
 
         if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
             return "Unable to resolve PlayerManager";
@@ -2079,14 +2048,13 @@ public class MapEventDebugCommands
         return $"Moved player {args[0]} out of {settlement.Name}.";
     }
 
-    [CommandLineArgumentFunction("finish_current_encounter", "coop.debug.mapevent")]
     public static string FinishCurrentEncounter(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.finish_current_encounter";
+            return "Usage: coop.debug.map_event.finish_current_encounter";
 
         if (PlayerEncounter.Current == null)
             return "No active encounter.";
@@ -2095,14 +2063,13 @@ public class MapEventDebugCommands
         return "Finished the current local encounter.";
     }
 
-    [CommandLineArgumentFunction("enter_current_battle", "coop.debug.mapevent")]
     public static string EnterCurrentBattle(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.enter_current_battle";
+            return "Usage: coop.debug.map_event.enter_current_battle";
 
         if (PlayerEncounter.Current == null)
             return "No active encounter.";
@@ -2122,11 +2089,10 @@ public class MapEventDebugCommands
         return "Requested entry into the current battle.";
     }
 
-    // coop.debug.mapevent.finish_player_encounter PlayerOne
+    // coop.debug.map_event.finish_player_encounter PlayerOne
     /// <summary>
     /// Closes the connected player's encounter through the existing authoritative leave path.
     /// </summary>
-    [CommandLineArgumentFunction("finish_player_encounter", "coop.debug.mapevent")]
     public static string FinishPlayerEncounter(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -2136,7 +2102,7 @@ public class MapEventDebugCommands
 
         if (args.Count != 1)
         {
-            return "Usage: coop.debug.mapevent.finish_player_encounter <controllerId>";
+            return "Usage: coop.debug.map_event.finish_player_encounter <controllerId>";
         }
 
         if (!TryGetPlayerParty(
@@ -2161,11 +2127,10 @@ public class MapEventDebugCommands
         return $"Requested encounter finish for player {args[0]} (PartyBase id {partyBaseId}).";
     }
 
-    // coop.debug.mapevent.conversation_hold_state <partyBaseId>
+    // coop.debug.map_event.conversation_hold_state <partyBaseId>
     /// <summary>
     /// Reports whether the server currently holds an AI PartyBase for a conversation.
     /// </summary>
-    [CommandLineArgumentFunction("conversation_hold_state", "coop.debug.mapevent")]
     public static string ConversationHoldState(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -2175,19 +2140,18 @@ public class MapEventDebugCommands
 
         if (args.Count != 1)
         {
-            return "Usage: coop.debug.mapevent.conversation_hold_state <partyBaseId>";
+            return "Usage: coop.debug.map_event.conversation_hold_state <partyBaseId>";
         }
 
         var held = ConversationPartyTracker.Instance?.TryGetEngagement(args[0], out _) == true;
         return $"Conversation hold for PartyBase id {args[0]}: {(held ? "held" : "released")}.";
     }
 
-    // coop.debug.mapevent.late_join_mode_fixture PlayerOne PlayerTwo
+    // coop.debug.map_event.late_join_mode_fixture PlayerOne PlayerTwo
     /// <summary>
     /// Creates a server-authoritative battle, claims mission mode before the second player joins, then routes the
     /// second player's join through the real request handler.
     /// </summary>
-    [CommandLineArgumentFunction("late_join_mode_fixture", "coop.debug.mapevent")]
     public static string StartLateJoinModeFixture(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -2197,7 +2161,7 @@ public class MapEventDebugCommands
 
         if (args.Count != 2)
         {
-            return "Usage: coop.debug.mapevent.late_join_mode_fixture <firstControllerId> <joiningControllerId>";
+            return "Usage: coop.debug.map_event.late_join_mode_fixture <firstControllerId> <joiningControllerId>";
         }
 
         if (lateJoinModeFixture != null)
@@ -2324,15 +2288,14 @@ public class MapEventDebugCommands
                $"firstPlayer={args[0]}, joiningPlayer={args[1]}, firstSide=Attacker.";
     }
 
-    // coop.debug.mapevent.late_join_mode_join
+    // coop.debug.map_event.late_join_mode_join
     /// <summary>Routes the waiting player's attacker-side join after the first player has entered the mission.</summary>
-    [CommandLineArgumentFunction("late_join_mode_join", "coop.debug.mapevent")]
     public static string JoinLateJoinModeFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_join";
+            return "Usage: coop.debug.map_event.late_join_mode_join";
 
         var fixture = lateJoinModeFixture;
         if (fixture == null)
@@ -2378,15 +2341,14 @@ public class MapEventDebugCommands
                "side=Attacker, replayedMode=Mission, firstPlayerInMission=True, joiningPlayerInMission=False.";
     }
 
-    // coop.debug.mapevent.late_join_mode_enter
+    // coop.debug.map_event.late_join_mode_enter
     /// <summary>Routes the late joiner's Attack request through the real mission-start handler.</summary>
-    [CommandLineArgumentFunction("late_join_mode_enter", "coop.debug.mapevent")]
     public static string EnterLateJoinModeFixtureMission(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_enter";
+            return "Usage: coop.debug.map_event.late_join_mode_enter";
 
         var fixture = lateJoinModeFixture;
         if (fixture == null)
@@ -2418,15 +2380,14 @@ public class MapEventDebugCommands
     }
 
 #if DEBUG
-    // coop.debug.mapevent.late_join_mode_begin_field_battle
+    // coop.debug.map_event.late_join_mode_begin_field_battle
     /// <summary>Finishes the local deployment phase so live evidence shows the active field battle.</summary>
-    [CommandLineArgumentFunction("late_join_mode_begin_field_battle", "coop.debug.mapevent")]
     public static string BeginLateJoinModeFixtureFieldBattle(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_begin_field_battle";
+            return "Usage: coop.debug.map_event.late_join_mode_begin_field_battle";
 
         var mission = Mission.Current;
         if (mission == null)
@@ -2448,15 +2409,14 @@ public class MapEventDebugCommands
         return "Local deployment finished; the field battle is active and the local player is protected.";
     }
 
-    // coop.debug.mapevent.late_join_mode_disable_dying
+    // coop.debug.map_event.late_join_mode_disable_dying
     /// <summary>Prevents the live-test battle from resolving before both client views are captured.</summary>
-    [CommandLineArgumentFunction("late_join_mode_disable_dying", "coop.debug.mapevent")]
     public static string DisableLateJoinModeFixtureDying(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_disable_dying";
+            return "Usage: coop.debug.map_event.late_join_mode_disable_dying";
 
         var mission = Mission.Current;
         if (mission == null)
@@ -2480,15 +2440,14 @@ public class MapEventDebugCommands
         return true;
     }
 
-    // coop.debug.mapevent.late_join_mode_exit_missions
+    // coop.debug.map_event.late_join_mode_exit_missions
     /// <summary>Asks every fixture mission member to return to campaign before authoritative cleanup.</summary>
-    [CommandLineArgumentFunction("late_join_mode_exit_missions", "coop.debug.mapevent")]
     public static string ExitLateJoinModeFixtureMissions(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_exit_missions";
+            return "Usage: coop.debug.map_event.late_join_mode_exit_missions";
 
         var fixture = lateJoinModeFixture;
         if (fixture == null)
@@ -2516,13 +2475,12 @@ public class MapEventDebugCommands
     }
 
     /// <summary>Returns both fixture clients to campaign and restores the server-side battle state.</summary>
-    [CommandLineArgumentFunction("late_join_mode_restore", "coop.debug.mapevent")]
     public static string RestoreLateJoinModeFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_restore";
+            return "Usage: coop.debug.map_event.late_join_mode_restore";
 
         string exitResult = ExitLateJoinModeFixtureMissions(args);
         if (lateJoinModeFixture == null)
@@ -2533,14 +2491,13 @@ public class MapEventDebugCommands
     }
 #endif
 
-    // coop.debug.mapevent.late_join_mode_state PlayerTwo
+    // coop.debug.map_event.late_join_mode_state PlayerTwo
     /// <summary>Reports a player's map-event membership and known authoritative battle mode.</summary>
-    [CommandLineArgumentFunction("late_join_mode_state", "coop.debug.mapevent")]
     public static string GetLateJoinModeState(List<string> args)
     {
         if (args.Count != 1)
         {
-            return "Usage: coop.debug.mapevent.late_join_mode_state <controllerId>";
+            return "Usage: coop.debug.map_event.late_join_mode_state <controllerId>";
         }
 
         if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
@@ -2583,9 +2540,8 @@ public class MapEventDebugCommands
                $"missionActive={missionActive}, missionAgents={missionAgents}, deploymentActive={deploymentActive}.";
     }
 
-    // coop.debug.mapevent.late_join_mode_cleanup
+    // coop.debug.map_event.late_join_mode_cleanup
     /// <summary>Removes the fixture field battle and restores each party's movement state.</summary>
-    [CommandLineArgumentFunction("late_join_mode_cleanup", "coop.debug.mapevent")]
     public static string CleanupLateJoinModeFixture(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -2595,7 +2551,7 @@ public class MapEventDebugCommands
 
         if (args.Count != 0)
         {
-            return "Usage: coop.debug.mapevent.late_join_mode_cleanup";
+            return "Usage: coop.debug.map_event.late_join_mode_cleanup";
         }
 
         if (lateJoinModeFixture == null)
@@ -2672,11 +2628,10 @@ public class MapEventDebugCommands
         return behaviorSnapshot.TryApply(mobileParty, behavior, out _);
     }
 
-    // coop.debug.mapevent.peace_pursuit_fixture PlayerOne
+    // coop.debug.map_event.peace_pursuit_fixture PlayerOne
     /// <summary>
     /// Finds a neutral AI party that can be used without changing its original movement state.
     /// </summary>
-    [CommandLineArgumentFunction("peace_pursuit_fixture", "coop.debug.mapevent")]
     public static string GetPeacePursuitFixture(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -2686,7 +2641,7 @@ public class MapEventDebugCommands
 
         if (args.Count != 1)
         {
-            return "Usage: coop.debug.mapevent.peace_pursuit_fixture <controllerId>";
+            return "Usage: coop.debug.map_event.peace_pursuit_fixture <controllerId>";
         }
 
         if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
@@ -2703,16 +2658,15 @@ public class MapEventDebugCommands
         return FormatPeacePursuitState("Peace pursuit fixture", objectManager, neutralParty, playerParty);
     }
 
-    // coop.debug.mapevent.peace_pursuit_state PlayerOne mobileParty_1
+    // coop.debug.map_event.peace_pursuit_state PlayerOne mobileParty_1
     /// <summary>
     /// Reports the pursuit-test party state on the current machine.
     /// </summary>
-    [CommandLineArgumentFunction("peace_pursuit_state", "coop.debug.mapevent")]
     public static string GetPeacePursuitState(List<string> args)
     {
         if (args.Count != 2)
         {
-            return "Usage: coop.debug.mapevent.peace_pursuit_state <controllerId> <partyStringId>";
+            return "Usage: coop.debug.map_event.peace_pursuit_state <controllerId> <partyStringId>";
         }
 
         if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
@@ -2729,11 +2683,10 @@ public class MapEventDebugCommands
         return FormatPeacePursuitState("Peace pursuit state", objectManager, neutralParty, playerParty);
     }
 
-    // coop.debug.mapevent.test_peace_stops_pursuit PlayerOne mobileParty_1
+    // coop.debug.map_event.test_peace_stops_pursuit PlayerOne mobileParty_1
     /// <summary>
     /// Makes a selected neutral AI party pursue a connected player, then makes peace.
     /// </summary>
-    [CommandLineArgumentFunction("test_peace_stops_pursuit", "coop.debug.mapevent")]
     public static string TestPeaceStopsPursuit(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -2743,7 +2696,7 @@ public class MapEventDebugCommands
 
         if (args.Count != 2)
         {
-            return "Usage: coop.debug.mapevent.test_peace_stops_pursuit <controllerId> <partyStringId>";
+            return "Usage: coop.debug.map_event.test_peace_stops_pursuit <controllerId> <partyStringId>";
         }
 
         if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
@@ -2883,7 +2836,6 @@ public class MapEventDebugCommands
     /// <summary>
     /// Kills a random troop from the enemy side of the current map event.
     /// </summary>
-    [CommandLineArgumentFunction("kill_random_troop", "coop.debug.mapevent")]
     public static string KillRandomTroop(List<string> args)
     {
         var mapEvent = MobileParty.MainParty.MapEvent;
@@ -2945,7 +2897,6 @@ public class MapEventDebugCommands
     /// <summary>
     /// Kills all but one troop from the enemy side of the current map event.
     /// </summary>
-    [CommandLineArgumentFunction("kill_all_but_one", "coop.debug.mapevent")]
     public static string KillAllButOneTroop(List<string> args)
     {
         var mapEvent = MobileParty.MainParty.MapEvent;
@@ -3026,7 +2977,6 @@ public class MapEventDebugCommands
     /// <summary>
     /// Lists the fields and properties of the current PlayerEncounter.
     /// </summary>
-    [CommandLineArgumentFunction("list_player_encounter", "coop.debug.mapevent")]
     public static string ListPlayerEncounter(List<string> args)
     {
         var playerEncounter = PlayerEncounter.Current;
@@ -3053,7 +3003,6 @@ public class MapEventDebugCommands
     /// e.g. PlayerEncounter.Current still PRESENT, or MainParty.MapEvent lingering on an already-finalized event.
     /// Unlike <c>list_player_encounter</c> (full reflection dump) this is short enough to diff across clients.
     /// </summary>
-    [CommandLineArgumentFunction("encounter_state", "coop.debug.mapevent")]
     public static string EncounterState(List<string> args)
     {
         TryGetObjectManager(out var objectManager);
@@ -3090,14 +3039,13 @@ public class MapEventDebugCommands
     }
 
     /// <summary>Shows, closes, or reports the live retreat confirmation for automated battle-exit testing.</summary>
-    [CommandLineArgumentFunction("retreat_confirmation", "coop.debug.mapevent")]
     public static string RetreatConfirmation(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client in a battle mission.";
 
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.retreat_confirmation <show|accept|cancel|state>";
+            return "Usage: coop.debug.map_event.retreat_confirmation <show|accept|cancel|state>";
 
         var handler = Mission.Current?.GetMissionBehavior<BasicMissionHandler>();
         if (handler == null)
@@ -3128,19 +3076,18 @@ public class MapEventDebugCommands
             case "state":
                 return $"Retreat confirmation open: {handler.IsWarningWidgetOpened}";
             default:
-                return "Usage: coop.debug.mapevent.retreat_confirmation <show|accept|cancel|state>";
+                return "Usage: coop.debug.map_event.retreat_confirmation <show|accept|cancel|state>";
         }
     }
 
     /// <summary>Closes the current encounter conversation so vanilla can advance to battle choices.</summary>
-    [CommandLineArgumentFunction("complete_encounter_meeting", "coop.debug.mapevent")]
     public static string CompleteEncounterMeeting(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client at the encounter meeting.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.complete_encounter_meeting";
+            return "Usage: coop.debug.map_event.complete_encounter_meeting";
 
         if (Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId != "encounter_meeting")
             return "The encounter meeting is not active.";
@@ -3154,14 +3101,13 @@ public class MapEventDebugCommands
     }
 
     /// <summary>Runs the encounter menu's mission or simulation consequence for automated battle testing.</summary>
-    [CommandLineArgumentFunction("choose_battle_mode", "coop.debug.mapevent")]
     public static string ChooseBattleMode(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client at the encounter menu.";
 
         if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.choose_battle_mode <mission|simulation>";
+            return "Usage: coop.debug.map_event.choose_battle_mode <mission|simulation>";
 
         if (PlayerEncounter.Current == null)
             return "No active player encounter.";
@@ -3179,7 +3125,7 @@ public class MapEventDebugCommands
                 behavior.game_menu_encounter_order_attack_on_consequence(null);
                 return "Battle simulation requested.";
             default:
-                return "Usage: coop.debug.mapevent.choose_battle_mode <mission|simulation>";
+                return "Usage: coop.debug.map_event.choose_battle_mode <mission|simulation>";
         }
     }
 
@@ -3194,7 +3140,6 @@ public class MapEventDebugCommands
         return $"id={id} finalized={mapEvent.IsFinalized} state={mapEvent.BattleState} winner={mapEvent.WinningSide}";
     }
 
-    [CommandLineArgumentFunction("get_events", "coop.debug.mapevent")]
     public static string GetEvents(List<string> args)
     {
         var sb = new StringBuilder();
@@ -3231,12 +3176,11 @@ public class MapEventDebugCommands
             .ToArray() ?? Array.Empty<string>();
     }
 
-    [CommandLineArgumentFunction("get_event", "coop.debug.mapevent")]
     public static string GetEvent(List<string> args)
     {
         if (args.Count != 1)
         {
-            return "Usage: coop.debug.mapevent.get_event <mapEventId>";
+            return "Usage: coop.debug.map_event.get_event <mapEventId>";
         }
 
         if (!TryGetObjectManager(out var objectManager))

--- a/source/GameInterface/Services/MapEvents/Commands/PostBattleFreezeFixtureCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/PostBattleFreezeFixtureCommands.cs
@@ -28,7 +28,6 @@ using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.MapEvents.Commands;
 
@@ -41,13 +40,12 @@ internal class PostBattleFreezeFixtureCommands
 
     private static PostBattleFreezeFixture fixture;
 
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_start", "coop.debug.mapevent")]
     public static string StartFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_start <firstControllerId> <secondControllerId>";
+            return "Usage: coop.debug.map_event.post_battle_freeze_fixture_start <firstControllerId> <secondControllerId>";
         if (fixture != null)
             return "The post-battle freeze fixture is already active.";
 
@@ -189,13 +187,12 @@ internal class PostBattleFreezeFixtureCommands
         }
     }
 
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_open", "coop.debug.mapevent")]
     public static string OpenFixtureEncounters(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_open";
+            return "Usage: coop.debug.map_event.post_battle_freeze_fixture_open";
         if (fixture == null)
             return "The post-battle freeze fixture is not active.";
         if (fixture.EncountersOpened)
@@ -225,13 +222,12 @@ internal class PostBattleFreezeFixtureCommands
                $"{fixture.FirstControllerId} and {fixture.SecondControllerId}.";
     }
 
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_state", "coop.debug.mapevent")]
     public static string GetFixtureState(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server. Use the existing client observation commands on each client.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_state";
+            return "Usage: coop.debug.map_event.post_battle_freeze_fixture_state";
         if (fixture == null)
             return "The post-battle freeze fixture is not active.";
         if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControl))
@@ -240,13 +236,12 @@ internal class PostBattleFreezeFixtureCommands
         return FormatState("Post-battle freeze fixture state", fixture, timeControl);
     }
 
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_unpause", "coop.debug.mapevent")]
     public static string UnpauseFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_unpause";
+            return "Usage: coop.debug.map_event.post_battle_freeze_fixture_unpause";
         if (fixture == null)
             return "The post-battle freeze fixture is not active.";
         if (fixture.FirstPlayer.Party.MapEvent != null || fixture.SecondPlayer.Party.MapEvent != null)
@@ -257,16 +252,15 @@ internal class PostBattleFreezeFixtureCommands
         fixture.ProbeStartedAt = CampaignTime.Now;
         timeControl.ServerSetTimeControl(TimeControlEnum.Play_1x);
         return $"Post-battle unpause requested at {fixture.ProbeStartedAt.NumTicks} ticks. " +
-               "Submit coop.debug.mobileparty.move_offset 0.5 0 on both clients, then check fixture state.";
+               "Submit coop.debug.mobile_party.move_offset 0.5 0 on both clients, then check fixture state.";
     }
 
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_restore", "coop.debug.mapevent")]
     public static string RestoreFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "Run this command on the server.";
         if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_restore";
+            return "Usage: coop.debug.map_event.post_battle_freeze_fixture_restore";
         if (fixture == null)
             return "The post-battle freeze fixture is not active.";
         if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||

--- a/source/GameInterface/Services/Party/Commands/GarrisonTroopXpFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/GarrisonTroopXpFixtureCommands.cs
@@ -19,7 +19,6 @@ using TaleWorlds.CampaignSystem.Settlements.Buildings;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
@@ -37,10 +36,9 @@ internal static class GarrisonTroopXpFixtureCommands
     private static GarrisonFixture restoredFixture;
     private static string pendingNoopRestorationControllerId;
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_capture", "coop.debug.mobileparty")]
     public static string Capture(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_capture <controllerId>";
+        const string usage = "Usage: coop.debug.mobile_party.garrison_xp_fixture_capture <controllerId>";
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (args.Count != 1) return usage;
         if (fixture != null || restoredFixture != null || pendingNoopRestorationControllerId != null)
@@ -104,10 +102,9 @@ internal static class GarrisonTroopXpFixtureCommands
         return FormatCapture(pendingCapture);
     }
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_setup", "coop.debug.mobileparty")]
     public static string Setup(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_setup " +
+        const string usage = "Usage: coop.debug.mobile_party.garrison_xp_fixture_setup " +
             "<controllerId> <playerPartyId> <garrisonPartyId> <originalOwnerHeroId> <originalSettlementId|none> " +
             "<originalPositionX> <originalPositionY> <originalPositionIsOnLand> " +
             "<garrisonExists> <garrisonCount> <garrisonWounded> <garrisonXp> " +
@@ -212,10 +209,9 @@ internal static class GarrisonTroopXpFixtureCommands
         }
     }
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_state", "coop.debug.mobileparty")]
     public static string State(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_state " +
+        const string usage = "Usage: coop.debug.mobile_party.garrison_xp_fixture_state " +
             "<playerPartyId> <garrisonPartyId> <characterId>";
         if (args.Count != 3) return usage;
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
@@ -257,10 +253,9 @@ internal static class GarrisonTroopXpFixtureCommands
         });
     }
 
-    [CommandLineArgumentFunction("open_garrison_xp_fixture", "coop.debug.mobileparty")]
     public static string OpenGarrison(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.open_garrison_xp_fixture <garrisonPartyId>";
+        const string usage = "Usage: coop.debug.mobile_party.open_garrison_xp_fixture <garrisonPartyId>";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 1) return usage;
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
@@ -278,10 +273,9 @@ internal static class GarrisonTroopXpFixtureCommands
         return "GARRISON_XP_FIXTURE_SCREEN_OPENED";
     }
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_screen_state", "coop.debug.mobileparty")]
     public static string ScreenState(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_screen_state " +
+        const string usage = "Usage: coop.debug.mobile_party.garrison_xp_fixture_screen_state " +
             "<garrisonPartyId> <characterId> <baseline|staged|committed>";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 3 ||
@@ -341,10 +335,9 @@ internal static class GarrisonTroopXpFixtureCommands
         });
     }
 
-    [CommandLineArgumentFunction("stage_garrison_xp_withdrawal", "coop.debug.mobileparty")]
     public static string StageWithdrawal(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.stage_garrison_xp_withdrawal " +
+        const string usage = "Usage: coop.debug.mobile_party.stage_garrison_xp_withdrawal " +
             "<garrisonPartyId> <characterId>";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 2) return usage;
@@ -368,10 +361,9 @@ internal static class GarrisonTroopXpFixtureCommands
             : "GARRISON_XP_WITHDRAWAL_REJECTED";
     }
 
-    [CommandLineArgumentFunction("commit_garrison_xp_withdrawal", "coop.debug.mobileparty")]
     public static string CommitWithdrawal(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.commit_garrison_xp_withdrawal";
+        const string usage = "Usage: coop.debug.mobile_party.commit_garrison_xp_withdrawal";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 0) return usage;
         if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
@@ -386,10 +378,9 @@ internal static class GarrisonTroopXpFixtureCommands
             : "GARRISON_XP_WITHDRAWAL_COMMITTED";
     }
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_restore", "coop.debug.mobileparty")]
     public static string Restore(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_restore <controllerId>";
+        const string usage = "Usage: coop.debug.mobile_party.garrison_xp_fixture_restore <controllerId>";
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (args.Count != 1) return usage;
         if (fixture == null && pendingCapture?.ControllerId == args[0])
@@ -435,10 +426,9 @@ internal static class GarrisonTroopXpFixtureCommands
         });
     }
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_verify_restore", "coop.debug.mobileparty")]
     public static string VerifyRestore(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_verify_restore <controllerId>";
+        const string usage = "Usage: coop.debug.mobile_party.garrison_xp_fixture_verify_restore <controllerId>";
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (args.Count != 1) return usage;
         if (restoredFixture == null || restoredFixture.ControllerId != args[0])

--- a/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
@@ -15,7 +15,6 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
@@ -45,7 +44,6 @@ internal static class LargeBattleRosterFixtureCommands
         public PartyBehaviorUpdateData Behavior;
     }
 
-    [CommandLineArgumentFunction("large_battle_roster_begin", "coop.debug.mobileparty")]
     public static string Begin(List<string> args)
     {
         if (!ModInformation.IsServer)
@@ -55,7 +53,7 @@ internal static class LargeBattleRosterFixtureCommands
             || addedPerParty < 1
             || addedPerParty > 500)
         {
-            return "Usage: coop.debug.mobileparty.large_battle_roster_begin " +
+            return "Usage: coop.debug.mobile_party.large_battle_roster_begin " +
                    "<firstPartyOrControllerId> <secondPartyOrControllerId> <troopsPerParty:1-500>";
         }
         if (fixture != null)
@@ -107,7 +105,6 @@ internal static class LargeBattleRosterFixtureCommands
             FormatState("active", firstParty, secondParty, null, null);
     }
 
-    [CommandLineArgumentFunction("exact_battle_roster_begin", "coop.debug.mobileparty")]
     public static string BeginExact(List<string> args)
     {
         if (!ModInformation.IsServer)
@@ -116,14 +113,13 @@ internal static class LargeBattleRosterFixtureCommands
             || !int.TryParse(args[2], out int healthyPerParty)
             || (healthyPerParty != 5 && healthyPerParty != 900))
         {
-            return "Usage: coop.debug.mobileparty.exact_battle_roster_begin " +
+            return "Usage: coop.debug.mobile_party.exact_battle_roster_begin " +
                    "<firstPartyOrControllerId> <secondPartyOrControllerId> <healthyPerParty:5|900>";
         }
 
         return BeginExact(args[0], args[1], healthyPerParty, healthyPerParty);
     }
 
-    [CommandLineArgumentFunction("battle_size_roster_begin", "coop.debug.mobileparty")]
     public static string BeginBattleSize(List<string> args)
     {
         if (!ModInformation.IsServer)
@@ -136,7 +132,7 @@ internal static class LargeBattleRosterFixtureCommands
             || secondHealthyCount < 1
             || secondHealthyCount > 1000)
         {
-            return "Usage: coop.debug.mobileparty.battle_size_roster_begin " +
+            return "Usage: coop.debug.mobile_party.battle_size_roster_begin " +
                    "<firstPartyOrControllerId> <secondPartyOrControllerId> <firstHealthy:1-1000> <secondHealthy:1-1000>";
         }
 
@@ -247,9 +243,8 @@ internal static class LargeBattleRosterFixtureCommands
                FormatState("active", firstParty, secondParty, firstHealthyCount, secondHealthyCount);
     }
 
-    [CommandLineArgumentFunction("large_battle_roster_status", "coop.debug.mobileparty")]
     public static string Status(List<string> args) =>
-        Status(args, "coop.debug.mobileparty.large_battle_roster_status");
+        Status(args, "coop.debug.mobile_party.large_battle_roster_status");
 
     private static string Status(List<string> args, string commandName)
     {
@@ -286,13 +281,11 @@ internal static class LargeBattleRosterFixtureCommands
             fixture?.SecondExactHealthyCount);
     }
 
-    [CommandLineArgumentFunction("exact_battle_roster_status", "coop.debug.mobileparty")]
     public static string ExactStatus(List<string> args) =>
-        Status(args, "coop.debug.mobileparty.exact_battle_roster_status");
+        Status(args, "coop.debug.mobile_party.exact_battle_roster_status");
 
-    [CommandLineArgumentFunction("large_battle_roster_restore", "coop.debug.mobileparty")]
     public static string Restore(List<string> args) =>
-        Restore(args, "coop.debug.mobileparty.large_battle_roster_restore");
+        Restore(args, "coop.debug.mobile_party.large_battle_roster_restore");
 
     private static string Restore(List<string> args, string commandName)
     {
@@ -365,9 +358,8 @@ internal static class LargeBattleRosterFixtureCommands
                 null);
     }
 
-    [CommandLineArgumentFunction("exact_battle_roster_restore", "coop.debug.mobileparty")]
     public static string RestoreExact(List<string> args) =>
-        Restore(args, "coop.debug.mobileparty.exact_battle_roster_restore");
+        Restore(args, "coop.debug.mobile_party.exact_battle_roster_restore");
 
     private static bool TryGetObjectManager(
         out IObjectManager objectManager)

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -23,7 +23,6 @@ using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.ObjectSystem;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
@@ -73,7 +72,6 @@ internal class PartyCommands
     /// then pass that to imprison_companion / snapshot_prison to target your exact party when several share the
     /// "RandomPlayer" name.
     /// </summary>
-    [CommandLineArgumentFunction("whoami", "coop.debug.mobileparty")]
     public static string WhoAmICommand(List<string> strings)
     {
         if(!ModInformation.IsClient) return "Command can only be run on a client.";
@@ -89,11 +87,10 @@ internal class PartyCommands
     /// <summary>
     /// Reports an exact party position and movement mode for cross-client live-test comparisons.
     /// </summary>
-    [CommandLineArgumentFunction("position", "coop.debug.mobileparty")]
     public static string PositionCommand(List<string> strings)
     {
         if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.position <partyId>";
+            return "Usage: coop.debug.mobile_party.position <partyId>";
 
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out MobileParty party))
@@ -116,14 +113,13 @@ internal class PartyCommands
     /// Issues a local player-party point movement order so automated live tests can verify that a restored
     /// party accepts client control and sends the normal behavior update to the server.
     /// </summary>
-    [CommandLineArgumentFunction("move_offset", "coop.debug.mobileparty")]
     public static string MoveOffsetCommand(List<string> strings)
     {
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (strings.Count != 2 ||
             !float.TryParse(strings[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetX) ||
             !float.TryParse(strings[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetY))
-            return "Usage: coop.debug.mobileparty.move_offset <offsetX> <offsetY>";
+            return "Usage: coop.debug.mobile_party.move_offset <offsetX> <offsetY>";
 
         var party = Hero.MainHero?.PartyBelongedTo;
         if (party == null) return "The local player hero has no party.";
@@ -144,7 +140,6 @@ internal class PartyCommands
     /// <summary>
     /// Restores a party to an exact campaign-map position and hold state after an automated live test.
     /// </summary>
-    [CommandLineArgumentFunction("restore_position", "coop.debug.mobileparty")]
     public static string RestorePositionCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -152,7 +147,7 @@ internal class PartyCommands
             !float.TryParse(strings[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionX) ||
             !float.TryParse(strings[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionY) ||
             !bool.TryParse(strings[3], out var isOnLand))
-            return "Usage: coop.debug.mobileparty.restore_position <partyId> <x> <y> <isOnLand>";
+            return "Usage: coop.debug.mobile_party.restore_position <partyId> <x> <y> <isOnLand>";
 
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out MobileParty party))
@@ -172,14 +167,13 @@ internal class PartyCommands
         return $"Restored {party.StringId} to {party.Position.X:R},{party.Position.Y:R} in Hold mode.";
     }
 
-    [CommandLineArgumentFunction("move_to_settlement", "coop.debug.mobileparty")]
     public static string MoveToSettlementCommand(List<string> strings)
     {
         if (!ModInformation.IsServer)
             return "Command can only be run on the server.";
 
         if (strings.Count != 2)
-            return "Usage: coop.debug.mobileparty.move_to_settlement <partyId> <settlementId>";
+            return "Usage: coop.debug.mobile_party.move_to_settlement <partyId> <settlementId>";
 
         if (!TryGetObjectManager(out var objectManager))
             return "Unable to resolve ObjectManager.";
@@ -211,7 +205,6 @@ internal class PartyCommands
     /// <summary>
     /// View character ids in a hero's party by full name or hero id.
     /// </summary>
-    [CommandLineArgumentFunction("characterids", "coop.debug.mobileparty")]
     public static string ViewItemIdsCommand(List<string> strings)
     {
         if (strings.Count == 0) return "Hero name argument required.";
@@ -266,12 +259,11 @@ internal class PartyCommands
     /// <summary>
     /// Sets one member-roster troop's wounded count for live synchronization tests.
     /// </summary>
-    [CommandLineArgumentFunction("set_troop_wounded", "coop.debug.mobileparty")]
     public static string SetTroopWoundedCommand(List<string> strings)
     {
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (strings.Count != 3)
-            return "Usage: coop.debug.mobileparty.set_troop_wounded <party id> <character id> <wounded count>";
+            return "Usage: coop.debug.mobile_party.set_troop_wounded <party id> <character id> <wounded count>";
 
         if (!int.TryParse(strings[2], out var woundedCount))
             return "Please enter an integer for wounded count.";
@@ -298,7 +290,6 @@ internal class PartyCommands
     /// <summary>
     /// Sets one member-roster troop's exact state and reports the state it replaced.
     /// </summary>
-    [CommandLineArgumentFunction("set_troop_state", "coop.debug.mobileparty")]
     public static string SetTroopStateCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -359,7 +350,7 @@ internal class PartyCommands
         woundedCount = 0;
         xp = 0;
         if (strings.Count != 6)
-            return "Usage: coop.debug.mobileparty.set_troop_state <party id> <character id> <exists> <number> <wounded count> <xp>";
+            return "Usage: coop.debug.mobile_party.set_troop_state <party id> <character id> <exists> <number> <wounded count> <xp>";
 
         if (!bool.TryParse(strings[2], out shouldExist) ||
             !int.TryParse(strings[3], out number) ||
@@ -376,12 +367,11 @@ internal class PartyCommands
     /// <summary>
     /// Selects a real right-member row so live tests can observe its inline upgrade choices.
     /// </summary>
-    [CommandLineArgumentFunction("select_party_screen_troop", "coop.debug.mobileparty")]
     public static string SelectPartyScreenTroopCommand(List<string> strings)
     {
         if (ModInformation.IsServer) return "Command can only be run on a client.";
         if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.select_party_screen_troop <character id>";
+            return "Usage: coop.debug.mobile_party.select_party_screen_troop <character id>";
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
             return $"Character with id {strings[0]} not found.";
@@ -403,12 +393,11 @@ internal class PartyCommands
     /// <summary>
     /// Applies the same upgrade command created by the Party-screen row.
     /// </summary>
-    [CommandLineArgumentFunction("upgrade_party_screen_troop", "coop.debug.mobileparty")]
     public static string UpgradePartyScreenTroopCommand(List<string> strings)
     {
         if (ModInformation.IsServer) return "Command can only be run on a client.";
         if (strings.Count < 1 || strings.Count > 2)
-            return "Usage: coop.debug.mobileparty.upgrade_party_screen_troop <character id> [upgrade target index]";
+            return "Usage: coop.debug.mobile_party.upgrade_party_screen_troop <character id> [upgrade target index]";
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
             return $"Character with id {strings[0]} not found.";
@@ -451,12 +440,11 @@ internal class PartyCommands
     /// <summary>
     /// Creates a real pending Party-screen transfer for live synchronization tests.
     /// </summary>
-    [CommandLineArgumentFunction("stage_party_screen_transfer", "coop.debug.mobileparty")]
     public static string StagePartyScreenTransferCommand(List<string> strings)
     {
         if (ModInformation.IsServer) return "Command can only be run on a client.";
         if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.stage_party_screen_transfer <character id>";
+            return "Usage: coop.debug.mobile_party.stage_party_screen_transfer <character id>";
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
             return $"Character with id {strings[0]} not found.";
@@ -478,12 +466,11 @@ internal class PartyCommands
     /// <summary>
     /// Reports the visible roster, Done baseline, and rendered VM state for one open Party-screen row.
     /// </summary>
-    [CommandLineArgumentFunction("party_screen_troop_state", "coop.debug.mobileparty")]
     public static string PartyScreenTroopStateCommand(List<string> strings)
     {
         if (ModInformation.IsServer) return "Command can only be run on a client.";
         if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.party_screen_troop_state <character id>";
+            return "Usage: coop.debug.mobile_party.party_screen_troop_state <character id>";
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
             return $"Character with id {strings[0]} not found.";
@@ -522,7 +509,6 @@ internal class PartyCommands
     /// <summary>
     /// Add xp to all troops in a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("addtroopxp", "coop.debug.mobileparty")]
     public static string AddTroopXpCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -551,7 +537,6 @@ internal class PartyCommands
     /// <summary>
     /// Add troops to a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("addtroops", "coop.debug.mobileparty")]
     public static string AddRecruitsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -594,17 +579,16 @@ internal class PartyCommands
         return stringBuilder.ToString();
     }
 
-    // coop.debug.mobileparty.siege_buff
+    // coop.debug.mobile_party.siege_buff
     /// <summary>
     /// Fills a party to 2000 troops, maxes its morale, forces a high map speed, and stocks it with food so it
     /// can march to and win a siege for testing without starving. Server only; the troop and item adds replicate
-    /// via the roster sync. Get the party id from coop.debug.mobileparty.whoami on the client that owns the party.
+    /// via the roster sync. Get the party id from coop.debug.mobile_party.who_am_i on the client that owns the party.
     /// </summary>
-    [CommandLineArgumentFunction("siege_buff", "coop.debug.mobileparty")]
     public static string SiegeBuffCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
-        if (strings.Count != 1) return "Usage: coop.debug.mobileparty.siege_buff <partyId>";
+        if (strings.Count != 1) return "Usage: coop.debug.mobile_party.siege_buff <partyId>";
         if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out MobileParty party)) return $"Party with id {strings[0]} not found";
 
@@ -630,16 +614,15 @@ internal class PartyCommands
         return $"Buffed {party.Name} ({party.StringId}): {party.MemberRoster.TotalManCount} troops, max morale, boosted speed and party-size limit, {foodTypes} food type(s) x500";
     }
 
-    // coop.debug.mobileparty.declare_war
+    // coop.debug.mobile_party.declare_war
     /// <summary>
     /// Declares war between a party's faction and a settlement's faction, so the party can besiege that
     /// settlement. Works for an independent clan (no kingdom needed). Server only; the war replicates.
     /// </summary>
-    [CommandLineArgumentFunction("declare_war", "coop.debug.mobileparty")]
     public static string DeclareWarCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
-        if (strings.Count != 2) return "Usage: coop.debug.mobileparty.declare_war <partyId> <settlementId>";
+        if (strings.Count != 2) return "Usage: coop.debug.mobile_party.declare_war <partyId> <settlementId>";
         if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(strings[0], out MobileParty party)) return $"Party with id {strings[0]} not found";
         if (!objectManager.TryGetObject(strings[1], out Settlement settlement)) return $"Settlement with id {strings[1]} not found";
@@ -657,7 +640,6 @@ internal class PartyCommands
     /// <summary>
     /// Add prisoners to a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("addprisoners", "coop.debug.mobileparty")]
     public static string AddPrisonersCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -703,7 +685,6 @@ internal class PartyCommands
     /// <summary>
     /// Remove all prisoners from a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("removeprisoners", "coop.debug.mobileparty")]
     public static string RemovePrisonersCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -737,7 +718,6 @@ internal class PartyCommands
     /// Put a hero (e.g. a player companion) into a hero's party prison roster, to set up the
     /// companion-preserve test. Args: captor hero name, prisoner hero name.
     /// </summary>
-    [CommandLineArgumentFunction("imprison_companion", "coop.debug.mobileparty")]
     public static string ImprisonCompanionCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -773,7 +753,6 @@ internal class PartyCommands
     /// if the server freed them. Drives TroopRosterInterface.UpdateWithData on a prison roster: hero prisoners
     /// (player companions included) must be removed, not preserved, and the removal replicates to clients.
     /// </summary>
-    [CommandLineArgumentFunction("snapshot_prison", "coop.debug.mobileparty")]
     public static string SnapshotPrisonCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";

--- a/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
@@ -7,15 +7,23 @@ namespace GameInterface.Services.Party.Commands;
 public interface IPartyLegacyCommandResult
 {
     CoopCommandResult FromOutput(string output);
+
+    CoopCommandResult FromOutput(string output, string failurePrefix);
 }
 
 public sealed class PartyLegacyCommandResult : IPartyLegacyCommandResult
 {
     public CoopCommandResult FromOutput(string output)
     {
+        return FromOutput(output, null);
+    }
+
+    public CoopCommandResult FromOutput(string output, string failurePrefix)
+    {
         if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
 
-        bool succeeded = !LooksLikeFailure(output);
+        bool isKnownFailure = failurePrefix != null && output.StartsWith(failurePrefix, StringComparison.Ordinal);
+        bool succeeded = !isKnownFailure && !LooksLikeFailure(output);
         return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
     }
 
@@ -1036,7 +1044,7 @@ public sealed class AddTroopXpCommand : IAddTroopXpCommand
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
         string output = global::GameInterface.Services.Party.Commands.PartyCommands.AddTroopXpCommand(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return resultFactory.FromOutput(output, "Please enter an integer");
     }
 }
 

--- a/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
@@ -70,7 +70,15 @@ public sealed class PartyLegacyCommandResult : IPartyLegacyCommandResult
             if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
         }
 
-        return false;
+        return output.IndexOf("_REJECTED", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf("_NOT_COMMITTED", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" is not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" does not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" did not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" required", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" must ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" is already ", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }
 
@@ -1416,13 +1424,9 @@ public interface IStageClanPartyTransferCommand : ICoopCommand
 
 public sealed class StageClanPartyTransferCommand : IStageClanPartyTransferCommand
 {
-    private readonly IPartyLegacyCommandResult resultFactory;
-
     public StageClanPartyTransferCommand(IPartyLegacyCommandResult resultFactory)
     {
         if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
-
-        this.resultFactory = resultFactory;
     }
     public string Prefix => "coop.debug.mobile_party";
 
@@ -1438,8 +1442,7 @@ public sealed class StageClanPartyTransferCommand : IStageClanPartyTransferComma
 
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
-        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.StageTransfer(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.StageTransfer(new List<string>(args));
     }
 }
 
@@ -1483,13 +1486,9 @@ public interface ICommitClanPartyTransferCommand : ICoopCommand
 
 public sealed class CommitClanPartyTransferCommand : ICommitClanPartyTransferCommand
 {
-    private readonly IPartyLegacyCommandResult resultFactory;
-
     public CommitClanPartyTransferCommand(IPartyLegacyCommandResult resultFactory)
     {
         if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
-
-        this.resultFactory = resultFactory;
     }
     public string Prefix => "coop.debug.mobile_party";
 
@@ -1501,8 +1500,7 @@ public sealed class CommitClanPartyTransferCommand : ICommitClanPartyTransferCom
 
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
-        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.CommitTransfer(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.CommitTransfer(new List<string>(args));
     }
 }
 

--- a/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
@@ -78,7 +78,9 @@ public sealed class PartyLegacyCommandResult : IPartyLegacyCommandResult
                output.IndexOf(" did not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" required", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" must ", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               output.IndexOf(" is already ", StringComparison.OrdinalIgnoreCase) >= 0;
+               output.IndexOf(" is already ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" wrongly kept them", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.StartsWith("Please enter an integer", StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCoopCommands.cs
@@ -1,0 +1,1563 @@
+﻿using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.Party.Commands;
+
+public interface IPartyLegacyCommandResult
+{
+    CoopCommandResult FromOutput(string output);
+}
+
+public sealed class PartyLegacyCommandResult : IPartyLegacyCommandResult
+{
+    public CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool succeeded = !LooksLikeFailure(output);
+        return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
+    }
+
+    private static bool LooksLikeFailure(string output)
+    {
+        string[] failurePrefixes =
+        {
+            "Usage:",
+            "Failed",
+            "Unable",
+            "No ",
+            "Run this",
+            "Command can",
+            "The host has disabled",
+            "Cannot ",
+            "Could not",
+            "Refusing",
+            "Prepare ",
+            "Both ",
+            "Player parties must",
+            "Attacker and defender",
+            "Exists must",
+            "State requires",
+            "A ",
+            "The ",
+            "Party ",
+            "Character ",
+            "Settlement ",
+            "Object manager",
+            "Network ",
+            "Battle agent",
+            "Active mount",
+            "Upgrade ",
+            "Clan-party",
+            "Map event",
+            "Invalid ",
+            "Player parties",
+            "Player party",
+            "Player '",
+        };
+
+        foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return false;
+    }
+}
+
+public interface IGarrisonXpFixtureCaptureCommand : ICoopCommand
+{
+}
+
+public sealed class GarrisonXpFixtureCaptureCommand : IGarrisonXpFixtureCaptureCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public GarrisonXpFixtureCaptureCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "garrison_xp_fixture_capture";
+
+    public string Description => "Runs the garrison xp fixture capture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.Capture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IGarrisonXpFixtureSetupCommand : ICoopCommand
+{
+}
+
+public sealed class GarrisonXpFixtureSetupCommand : IGarrisonXpFixtureSetupCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public GarrisonXpFixtureSetupCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "garrison_xp_fixture_setup";
+
+    public string Description => "Runs the garrison xp fixture setup debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("player_party_id", "The player party id.", true),
+        new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+        new ExpectedArgs("original_owner_hero_id", "The original owner hero id.", true),
+        new ExpectedArgs("original_settlement_id", "The original settlement id.", true),
+        new ExpectedArgs("original_position_x", "The original position x.", true),
+        new ExpectedArgs("original_position_y", "The original position y.", true),
+        new ExpectedArgs("original_position_is_on_land", "The original position is on land.", true),
+        new ExpectedArgs("garrison_exists", "The garrison exists.", true),
+        new ExpectedArgs("garrison_count", "The garrison count.", true),
+        new ExpectedArgs("garrison_wounded", "The garrison wounded.", true),
+        new ExpectedArgs("garrison_xp", "The garrison xp.", true),
+        new ExpectedArgs("player_exists", "The player exists.", true),
+        new ExpectedArgs("player_count", "The player count.", true),
+        new ExpectedArgs("player_wounded", "The player wounded.", true),
+        new ExpectedArgs("player_xp", "The player xp.", true),
+        new ExpectedArgs("upgrade_xp", "The upgrade xp.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.Setup(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IGarrisonXpFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class GarrisonXpFixtureStateCommand : IGarrisonXpFixtureStateCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public GarrisonXpFixtureStateCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "garrison_xp_fixture_state";
+
+    public string Description => "Reports garrison xp fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("player_party_id", "The player party id.", true),
+        new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.State(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IOpenGarrisonXpFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class OpenGarrisonXpFixtureCommand : IOpenGarrisonXpFixtureCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public OpenGarrisonXpFixtureCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "open_garrison_xp_fixture";
+
+    public string Description => "Runs the open garrison xp fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.OpenGarrison(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IGarrisonXpFixtureScreenStateCommand : ICoopCommand
+{
+}
+
+public sealed class GarrisonXpFixtureScreenStateCommand : IGarrisonXpFixtureScreenStateCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public GarrisonXpFixtureScreenStateCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "garrison_xp_fixture_screen_state";
+
+    public string Description => "Reports garrison xp fixture screen state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+        new ExpectedArgs("expected_state", "The expected screen state.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.ScreenState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStageGarrisonXpWithdrawalCommand : ICoopCommand
+{
+}
+
+public sealed class StageGarrisonXpWithdrawalCommand : IStageGarrisonXpWithdrawalCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public StageGarrisonXpWithdrawalCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "stage_garrison_xp_withdrawal";
+
+    public string Description => "Runs the stage garrison xp withdrawal debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.StageWithdrawal(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ICommitGarrisonXpWithdrawalCommand : ICoopCommand
+{
+}
+
+public sealed class CommitGarrisonXpWithdrawalCommand : ICommitGarrisonXpWithdrawalCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public CommitGarrisonXpWithdrawalCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "commit_garrison_xp_withdrawal";
+
+    public string Description => "Runs the commit garrison xp withdrawal debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.CommitWithdrawal(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IGarrisonXpFixtureRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class GarrisonXpFixtureRestoreCommand : IGarrisonXpFixtureRestoreCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public GarrisonXpFixtureRestoreCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "garrison_xp_fixture_restore";
+
+    public string Description => "Restores or clears garrison xp fixture restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.Restore(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IGarrisonXpFixtureVerifyRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class GarrisonXpFixtureVerifyRestoreCommand : IGarrisonXpFixtureVerifyRestoreCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public GarrisonXpFixtureVerifyRestoreCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "garrison_xp_fixture_verify_restore";
+
+    public string Description => "Restores or clears garrison xp fixture verify restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.GarrisonTroopXpFixtureCommands.VerifyRestore(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface ILargeBattleRosterBeginCommand : ICoopCommand
+{
+}
+
+public sealed class LargeBattleRosterBeginCommand : ILargeBattleRosterBeginCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public LargeBattleRosterBeginCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "large_battle_roster_begin";
+
+    public string Description => "Runs the large battle roster begin debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+        new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+        new ExpectedArgs("troops_per_party", "The troops per party.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.LargeBattleRosterFixtureCommands.Begin(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IExactBattleRosterBeginCommand : ICoopCommand
+{
+}
+
+public sealed class ExactBattleRosterBeginCommand : IExactBattleRosterBeginCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ExactBattleRosterBeginCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "exact_battle_roster_begin";
+
+    public string Description => "Runs the exact battle roster begin debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+        new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+        new ExpectedArgs("healthy_per_party", "The healthy per party.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.LargeBattleRosterFixtureCommands.BeginExact(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IBattleSizeRosterBeginCommand : ICoopCommand
+{
+}
+
+public sealed class BattleSizeRosterBeginCommand : IBattleSizeRosterBeginCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public BattleSizeRosterBeginCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "battle_size_roster_begin";
+
+    public string Description => "Runs the battle size roster begin debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+        new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+        new ExpectedArgs("first_healthy", "The first healthy.", true),
+        new ExpectedArgs("second_healthy", "The second healthy.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.LargeBattleRosterFixtureCommands.BeginBattleSize(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface ILargeBattleRosterStatusCommand : ICoopCommand
+{
+}
+
+public sealed class LargeBattleRosterStatusCommand : ILargeBattleRosterStatusCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public LargeBattleRosterStatusCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "large_battle_roster_status";
+
+    public string Description => "Reports large battle roster status.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+        new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.LargeBattleRosterFixtureCommands.Status(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IExactBattleRosterStatusCommand : ICoopCommand
+{
+}
+
+public sealed class ExactBattleRosterStatusCommand : IExactBattleRosterStatusCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ExactBattleRosterStatusCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "exact_battle_roster_status";
+
+    public string Description => "Reports exact battle roster status.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+        new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.LargeBattleRosterFixtureCommands.ExactStatus(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface ILargeBattleRosterRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class LargeBattleRosterRestoreCommand : ILargeBattleRosterRestoreCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public LargeBattleRosterRestoreCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "large_battle_roster_restore";
+
+    public string Description => "Restores or clears large battle roster restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.LargeBattleRosterFixtureCommands.Restore(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IExactBattleRosterRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class ExactBattleRosterRestoreCommand : IExactBattleRosterRestoreCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ExactBattleRosterRestoreCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "exact_battle_roster_restore";
+
+    public string Description => "Restores or clears exact battle roster restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.LargeBattleRosterFixtureCommands.RestoreExact(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+public interface IWhoAmICommand : ICoopCommand
+{
+}
+
+public sealed class WhoAmICommand : IWhoAmICommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public WhoAmICommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "who_am_i";
+
+    public string Description => "Runs the whoami debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.WhoAmICommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IPositionCommand : ICoopCommand
+{
+}
+
+public sealed class PositionCommand : IPositionCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public PositionCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "position";
+
+    public string Description => "Runs the position debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.PositionCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IMoveOffsetCommand : ICoopCommand
+{
+}
+
+public sealed class MoveOffsetCommand : IMoveOffsetCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public MoveOffsetCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "move_offset";
+
+    public string Description => "Runs the move offset debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("offset_x", "The offset x.", true),
+        new ExpectedArgs("offset_y", "The offset y.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.MoveOffsetCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IRestorePositionCommand : ICoopCommand
+{
+}
+
+public sealed class RestorePositionCommand : IRestorePositionCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public RestorePositionCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "restore_position";
+
+    public string Description => "Restores or clears restore position.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The party id.", true),
+        new ExpectedArgs("x", "The x.", true),
+        new ExpectedArgs("y", "The y.", true),
+        new ExpectedArgs("is_on_land", "The is on land.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.RestorePositionCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IMoveToSettlementCommand : ICoopCommand
+{
+}
+
+public sealed class MoveToSettlementCommand : IMoveToSettlementCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public MoveToSettlementCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "move_to_settlement";
+
+    public string Description => "Runs the move to settlement debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The party id.", true),
+        new ExpectedArgs("settlement_id", "The settlement id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.MoveToSettlementCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ICharacterIdsCommand : ICoopCommand
+{
+}
+
+public sealed class CharacterIdsCommand : ICharacterIdsCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public CharacterIdsCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "character_ids";
+
+    public string Description => "Runs the characterids debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero name or id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.ViewItemIdsCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ISetTroopWoundedCommand : ICoopCommand
+{
+}
+
+public sealed class SetTroopWoundedCommand : ISetTroopWoundedCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public SetTroopWoundedCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "set_troop_wounded";
+
+    public string Description => "Runs the set troop wounded debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+        new ExpectedArgs("wounded_count", "The wounded count.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.SetTroopWoundedCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ISetTroopStateCommand : ICoopCommand
+{
+}
+
+public sealed class SetTroopStateCommand : ISetTroopStateCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public SetTroopStateCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "set_troop_state";
+
+    public string Description => "Reports set troop state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+        new ExpectedArgs("exists", "The exists.", true),
+        new ExpectedArgs("number", "The number.", true),
+        new ExpectedArgs("wounded_count", "The wounded count.", true),
+        new ExpectedArgs("xp", "The xp.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.SetTroopStateCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ISelectPartyScreenTroopCommand : ICoopCommand
+{
+}
+
+public sealed class SelectPartyScreenTroopCommand : ISelectPartyScreenTroopCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public SelectPartyScreenTroopCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "select_party_screen_troop";
+
+    public string Description => "Runs the select party screen troop debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("character_id", "The character id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.SelectPartyScreenTroopCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IUpgradePartyScreenTroopCommand : ICoopCommand
+{
+}
+
+public sealed class UpgradePartyScreenTroopCommand : IUpgradePartyScreenTroopCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public UpgradePartyScreenTroopCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "upgrade_party_screen_troop";
+
+    public string Description => "Runs the upgrade party screen troop debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("character_id", "The character id.", true),
+        new ExpectedArgs("upgrade_target_index", "The upgrade target index.", false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.UpgradePartyScreenTroopCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStagePartyScreenTransferCommand : ICoopCommand
+{
+}
+
+public sealed class StagePartyScreenTransferCommand : IStagePartyScreenTransferCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public StagePartyScreenTransferCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "stage_party_screen_transfer";
+
+    public string Description => "Runs the stage party screen transfer debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("character_id", "The character id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.StagePartyScreenTransferCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IPartyScreenTroopStateCommand : ICoopCommand
+{
+}
+
+public sealed class PartyScreenTroopStateCommand : IPartyScreenTroopStateCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public PartyScreenTroopStateCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "party_screen_troop_state";
+
+    public string Description => "Reports party screen troop state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("character_id", "The character id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.PartyScreenTroopStateCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IAddTroopXpCommand : ICoopCommand
+{
+}
+
+public sealed class AddTroopXpCommand : IAddTroopXpCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public AddTroopXpCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "add_troop_xp";
+
+    public string Description => "Runs the addtroopxp debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The hero name.", true),
+        new ExpectedArgs("xp_amount", "The xp amount.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.AddTroopXpCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IAddTroopsCommand : ICoopCommand
+{
+}
+
+public sealed class AddTroopsCommand : IAddTroopsCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public AddTroopsCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "add_troops";
+
+    public string Description => "Runs the addtroops debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The hero name.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.AddRecruitsCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ISiegeBuffCommand : ICoopCommand
+{
+}
+
+public sealed class SiegeBuffCommand : ISiegeBuffCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public SiegeBuffCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "siege_buff";
+
+    public string Description => "Runs the siege buff debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.SiegeBuffCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IDeclareWarCommand : ICoopCommand
+{
+}
+
+public sealed class DeclareWarCommand : IDeclareWarCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public DeclareWarCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "declare_war";
+
+    public string Description => "Runs the declare war debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The party id.", true),
+        new ExpectedArgs("settlement_id", "The settlement id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.DeclareWarCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IAddPrisonersCommand : ICoopCommand
+{
+}
+
+public sealed class AddPrisonersCommand : IAddPrisonersCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public AddPrisonersCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "add_prisoners";
+
+    public string Description => "Runs the addprisoners debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The hero name.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.AddPrisonersCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IRemovePrisonersCommand : ICoopCommand
+{
+}
+
+public sealed class RemovePrisonersCommand : IRemovePrisonersCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public RemovePrisonersCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "remove_prisoners";
+
+    public string Description => "Runs the removeprisoners debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The hero name.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.RemovePrisonersCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IImprisonCompanionCommand : ICoopCommand
+{
+}
+
+public sealed class ImprisonCompanionCommand : IImprisonCompanionCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ImprisonCompanionCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "imprison_companion";
+
+    public string Description => "Runs the imprison companion debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("captor_hero", "The captor hero.", true),
+        new ExpectedArgs("prisoner_hero", "The prisoner hero.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.ImprisonCompanionCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ISnapshotPrisonCommand : ICoopCommand
+{
+}
+
+public sealed class SnapshotPrisonCommand : ISnapshotPrisonCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public SnapshotPrisonCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "snapshot_prison";
+
+    public string Description => "Runs the snapshot prison debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero name or id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.PartyCommands.SnapshotPrisonCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IClanPartyXpFixtureCaptureCommand : ICoopCommand
+{
+}
+
+public sealed class ClanPartyXpFixtureCaptureCommand : IClanPartyXpFixtureCaptureCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ClanPartyXpFixtureCaptureCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "clan_party_xp_fixture_capture";
+
+    public string Description => "Runs the clan party xp fixture capture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.Capture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IClanPartyXpFixtureSetupCommand : ICoopCommand
+{
+}
+
+public sealed class ClanPartyXpFixtureSetupCommand : IClanPartyXpFixtureSetupCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ClanPartyXpFixtureSetupCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "clan_party_xp_fixture_setup";
+
+    public string Description => "Runs the clan party xp fixture setup debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+        new ExpectedArgs("player_party_id", "The player party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+        new ExpectedArgs("player_count", "The player count.", true),
+        new ExpectedArgs("player_wounded", "The player wounded.", true),
+        new ExpectedArgs("player_xp", "The player xp.", true),
+        new ExpectedArgs("companion_count", "The companion count.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.Setup(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IClanPartyXpFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class ClanPartyXpFixtureStateCommand : IClanPartyXpFixtureStateCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ClanPartyXpFixtureStateCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "clan_party_xp_fixture_state";
+
+    public string Description => "Reports clan party xp fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("player_party_id", "The player party id.", true),
+        new ExpectedArgs("clan_party_id", "The clan party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.State(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IOpenClanPartyTransferCommand : ICoopCommand
+{
+}
+
+public sealed class OpenClanPartyTransferCommand : IOpenClanPartyTransferCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public OpenClanPartyTransferCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "open_clan_party_transfer";
+
+    public string Description => "Runs the open clan party transfer debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("clan_party_id", "The clan party id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.OpenPartyScreen(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IStageClanPartyTransferCommand : ICoopCommand
+{
+}
+
+public sealed class StageClanPartyTransferCommand : IStageClanPartyTransferCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public StageClanPartyTransferCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "stage_clan_party_transfer";
+
+    public string Description => "Runs the stage clan party transfer debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("clan_party_id", "The clan party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.StageTransfer(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IClanPartyTransferScreenStateCommand : ICoopCommand
+{
+}
+
+public sealed class ClanPartyTransferScreenStateCommand : IClanPartyTransferScreenStateCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ClanPartyTransferScreenStateCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "clan_party_transfer_screen_state";
+
+    public string Description => "Reports clan party transfer screen state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("clan_party_id", "The clan party id.", true),
+        new ExpectedArgs("character_id", "The character id.", true),
+        new ExpectedArgs("expected_state", "The expected screen state.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.TransferScreenState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ICommitClanPartyTransferCommand : ICoopCommand
+{
+}
+
+public sealed class CommitClanPartyTransferCommand : ICommitClanPartyTransferCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public CommitClanPartyTransferCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "commit_clan_party_transfer";
+
+    public string Description => "Runs the commit clan party transfer debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.CommitTransfer(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IClanPartyXpFixtureRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class ClanPartyXpFixtureRestoreCommand : IClanPartyXpFixtureRestoreCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ClanPartyXpFixtureRestoreCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "clan_party_xp_fixture_restore";
+
+    public string Description => "Restores or clears clan party xp fixture restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.Restore(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IClanPartyXpFixtureVerifyRestoreCommand : ICoopCommand
+{
+}
+
+public sealed class ClanPartyXpFixtureVerifyRestoreCommand : IClanPartyXpFixtureVerifyRestoreCommand
+{
+    private readonly IPartyLegacyCommandResult resultFactory;
+
+    public ClanPartyXpFixtureVerifyRestoreCommand(IPartyLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.mobile_party";
+
+    public string Name => "clan_party_xp_fixture_verify_restore";
+
+    public string Description => "Restores or clears clan party xp fixture verify restore.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("controller_id", "The controller id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Party.Commands.TroopXpTransferFixtureCommands.VerifyRestore(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}

--- a/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common;
+using Common.Commands;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Players;
@@ -236,29 +237,30 @@ internal static class TroopXpTransferFixtureCommands
         return "CLAN_PARTY_TRANSFER_SCREEN_OPENED";
     }
 
-    public static string StageTransfer(List<string> args)
+    public static CoopCommandResult StageTransfer(List<string> args)
     {
         const string usage = "Usage: coop.debug.mobile_party.stage_clan_party_transfer <clanPartyId> <characterId>";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 2) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
+        if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+        if (args.Count != 2) return Failed(usage);
+        if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
         if (!objectManager.TryGetObject(args[0], out MobileParty clanParty))
-            return $"Clan party '{args[0]}' was not found.";
+            return Failed($"Clan party '{args[0]}' was not found.");
         if (!objectManager.TryGetObject(args[1], out CharacterObject character))
-            return $"Character '{args[1]}' was not found.";
+            return Failed($"Character '{args[1]}' was not found.");
         if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
             partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != clanParty)
-            return "The target clan-party transfer screen is not active.";
+            return Failed("The target clan-party transfer screen is not active.");
 
         var logic = partyState.PartyScreenLogic;
         var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
         var row = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        if (row == null) return $"Character '{args[1]}' is not rendered in the clan party's member roster.";
+        if (row == null)
+            return Failed($"Character '{args[1]}' is not rendered in the clan party's member roster.");
 
         partyVm.OnTransferTroop(row, -1, FixtureTroopCount, row.Side);
         partyVm.ExecuteRemoveZeroCounts();
-        if (!logic.IsThereAnyChanges()) return "CLAN_PARTY_TRANSFER_REJECTED";
-        return "CLAN_PARTY_TRANSFER_STAGED";
+        if (!logic.IsThereAnyChanges()) return Failed("CLAN_PARTY_TRANSFER_REJECTED");
+        return Succeeded("CLAN_PARTY_TRANSFER_STAGED");
     }
 
     public static string TransferScreenState(List<string> args)
@@ -313,23 +315,23 @@ internal static class TroopXpTransferFixtureCommands
         });
     }
 
-    public static string CommitTransfer(List<string> args)
+    public static CoopCommandResult CommitTransfer(List<string> args)
     {
         const string usage = "Usage: coop.debug.mobile_party.commit_clan_party_transfer";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 0) return usage;
+        if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+        if (args.Count != 0) return Failed(usage);
         if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
             !partyState.PartyScreenLogic.IsThereAnyChanges())
-            return "No staged clan-party transfer is active.";
+            return Failed("No staged clan-party transfer is active.");
         if (!((ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource is { } partyVm))
-            return "No active Party screen view model.";
+            return Failed("No active Party screen view model.");
 
         // ExecuteDone opens a confirmation inquiry when the save's player party is over its limit.
         // CloseScreenInternal is the inquiry's affirmative action and always exercises DoneLogic.
         partyVm.CloseScreenInternal();
         return Game.Current.GameStateManager.ActiveState is PartyState
-            ? "CLAN_PARTY_TRANSFER_NOT_COMMITTED"
-            : "CLAN_PARTY_TRANSFER_COMMITTED";
+            ? Failed("CLAN_PARTY_TRANSFER_NOT_COMMITTED")
+            : Succeeded("CLAN_PARTY_TRANSFER_COMMITTED");
     }
 
     public static string Restore(List<string> args)
@@ -552,6 +554,12 @@ internal static class TroopXpTransferFixtureCommands
         objectManager = null;
         return ContainerProvider.TryResolve(out objectManager);
     }
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 
     private static string JsonResult(object value) =>
         "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(value);

--- a/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
@@ -17,7 +17,6 @@ using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.Core;
 using TaleWorlds.Localization;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
@@ -35,10 +34,9 @@ internal static class TroopXpTransferFixtureCommands
     private static TroopXpTransferRestoration pendingRestorationVerification;
     private static string pendingNoopRestorationControllerId;
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_capture", "coop.debug.mobileparty")]
     public static string Capture(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_capture <controllerId>";
+        const string usage = "Usage: coop.debug.mobile_party.clan_party_xp_fixture_capture <controllerId>";
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (args.Count != 1) return usage;
         if (pendingSetupCapture != null || pendingFixture != null ||
@@ -70,10 +68,9 @@ internal static class TroopXpTransferFixtureCommands
         });
     }
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_setup", "coop.debug.mobileparty")]
     public static string Setup(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_setup " +
+        const string usage = "Usage: coop.debug.mobile_party.clan_party_xp_fixture_setup " +
             "<controllerId> <playerPartyId> <characterId> <playerCount> <playerWounded> <playerXp> <companionCount>";
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (args.Count != 7 ||
@@ -186,10 +183,9 @@ internal static class TroopXpTransferFixtureCommands
         }
     }
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_state", "coop.debug.mobileparty")]
     public static string State(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_state <playerPartyId> <clanPartyId> <characterId>";
+        const string usage = "Usage: coop.debug.mobile_party.clan_party_xp_fixture_state <playerPartyId> <clanPartyId> <characterId>";
         if (args.Count != 3) return usage;
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
         if (!objectManager.TryGetObject(args[0], out MobileParty playerParty))
@@ -222,10 +218,9 @@ internal static class TroopXpTransferFixtureCommands
         });
     }
 
-    [CommandLineArgumentFunction("open_clan_party_transfer", "coop.debug.mobileparty")]
     public static string OpenPartyScreen(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.open_clan_party_transfer <clanPartyId>";
+        const string usage = "Usage: coop.debug.mobile_party.open_clan_party_transfer <clanPartyId>";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 1) return usage;
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
@@ -241,10 +236,9 @@ internal static class TroopXpTransferFixtureCommands
         return "CLAN_PARTY_TRANSFER_SCREEN_OPENED";
     }
 
-    [CommandLineArgumentFunction("stage_clan_party_transfer", "coop.debug.mobileparty")]
     public static string StageTransfer(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.stage_clan_party_transfer <clanPartyId> <characterId>";
+        const string usage = "Usage: coop.debug.mobile_party.stage_clan_party_transfer <clanPartyId> <characterId>";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 2) return usage;
         if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
@@ -267,10 +261,9 @@ internal static class TroopXpTransferFixtureCommands
         return "CLAN_PARTY_TRANSFER_STAGED";
     }
 
-    [CommandLineArgumentFunction("clan_party_transfer_screen_state", "coop.debug.mobileparty")]
     public static string TransferScreenState(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_transfer_screen_state " +
+        const string usage = "Usage: coop.debug.mobile_party.clan_party_transfer_screen_state " +
             "<clanPartyId> <characterId> <baseline|staged>";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 3 || (args[2] != "baseline" && args[2] != "staged")) return usage;
@@ -320,10 +313,9 @@ internal static class TroopXpTransferFixtureCommands
         });
     }
 
-    [CommandLineArgumentFunction("commit_clan_party_transfer", "coop.debug.mobileparty")]
     public static string CommitTransfer(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.commit_clan_party_transfer";
+        const string usage = "Usage: coop.debug.mobile_party.commit_clan_party_transfer";
         if (!ModInformation.IsClient) return "Command can only be run on a client.";
         if (args.Count != 0) return usage;
         if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
@@ -340,10 +332,9 @@ internal static class TroopXpTransferFixtureCommands
             : "CLAN_PARTY_TRANSFER_COMMITTED";
     }
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_restore", "coop.debug.mobileparty")]
     public static string Restore(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_restore <controllerId>";
+        const string usage = "Usage: coop.debug.mobile_party.clan_party_xp_fixture_restore <controllerId>";
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (args.Count != 1) return usage;
         if (pendingFixture == null && pendingSetupCapture != null && pendingSetupCapture.ControllerId == args[0])
@@ -419,10 +410,9 @@ internal static class TroopXpTransferFixtureCommands
         });
     }
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_verify_restore", "coop.debug.mobileparty")]
     public static string VerifyRestore(List<string> args)
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_verify_restore <controllerId>";
+        const string usage = "Usage: coop.debug.mobile_party.clan_party_xp_fixture_verify_restore <controllerId>";
         if (!ModInformation.IsServer) return "Command can only be run on the server.";
         if (args.Count != 1) return usage;
         if (pendingRestorationVerification == null ||

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualCoopCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualCoopCommands.cs
@@ -62,7 +62,9 @@ public sealed class PartyVisualLegacyCommandResult : IPartyVisualLegacyCommandRe
             if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
         }
 
-        return false;
+        return output.IndexOf(" is unavailable", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" was not found", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }
 
@@ -72,13 +74,9 @@ public interface IBufferStateCommand : ICoopCommand
 
 public sealed class BufferStateCommand : IBufferStateCommand
 {
-    private readonly IPartyVisualLegacyCommandResult resultFactory;
-
     public BufferStateCommand(IPartyVisualLegacyCommandResult resultFactory)
     {
         if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
-
-        this.resultFactory = resultFactory;
     }
     public string Prefix => "coop.debug.party_visuals";
 
@@ -90,8 +88,7 @@ public sealed class BufferStateCommand : IBufferStateCommand
 
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
-        string output = global::GameInterface.Services.PartyVisuals.Commands.PartyVisualDebugCommands.BufferState(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return global::GameInterface.Services.PartyVisuals.Commands.PartyVisualDebugCommands.BufferState(new List<string>(args));
     }
 }
 

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualCoopCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualCoopCommands.cs
@@ -1,0 +1,193 @@
+﻿using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.PartyVisuals.Commands;
+
+public interface IPartyVisualLegacyCommandResult
+{
+    CoopCommandResult FromOutput(string output);
+}
+
+public sealed class PartyVisualLegacyCommandResult : IPartyVisualLegacyCommandResult
+{
+    public CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool succeeded = !LooksLikeFailure(output);
+        return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
+    }
+
+    private static bool LooksLikeFailure(string output)
+    {
+        string[] failurePrefixes =
+        {
+            "Usage:",
+            "Failed",
+            "Unable",
+            "No ",
+            "Run this",
+            "Command can",
+            "The host has disabled",
+            "Cannot ",
+            "Could not",
+            "Refusing",
+            "Prepare ",
+            "Both ",
+            "Player parties must",
+            "Attacker and defender",
+            "Exists must",
+            "State requires",
+            "A ",
+            "The ",
+            "Party ",
+            "Character ",
+            "Settlement ",
+            "Object manager",
+            "Network ",
+            "Battle agent",
+            "Active mount",
+            "Upgrade ",
+            "Clan-party",
+            "Map event",
+            "Invalid ",
+            "Player parties",
+            "Player party",
+            "Player '",
+        };
+
+        foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return false;
+    }
+}
+
+public interface IBufferStateCommand : ICoopCommand
+{
+}
+
+public sealed class BufferStateCommand : IBufferStateCommand
+{
+    private readonly IPartyVisualLegacyCommandResult resultFactory;
+
+    public BufferStateCommand(IPartyVisualLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.party_visuals";
+
+    public string Name => "buffer_state";
+
+    public string Description => "Reports buffer state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PartyVisuals.Commands.PartyVisualDebugCommands.BufferState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class FixtureStateCommand : IFixtureStateCommand
+{
+    private readonly IPartyVisualLegacyCommandResult resultFactory;
+
+    public FixtureStateCommand(IPartyVisualLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.party_visuals";
+
+    public string Name => "fixture_state";
+
+    public string Description => "Reports fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PartyVisuals.Commands.PartyVisualDebugCommands.FixtureState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IStageOverLimitFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class StageOverLimitFixtureCommand : IStageOverLimitFixtureCommand
+{
+    private readonly IPartyVisualLegacyCommandResult resultFactory;
+
+    public StageOverLimitFixtureCommand(IPartyVisualLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.party_visuals";
+
+    public string Name => "stage_over_limit_fixture";
+
+    public string Description => "Runs the stage over limit fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("target_eligible_party_count", "The target eligible party count.", true),
+        new ExpectedArgs("settlement_id", "The settlement id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PartyVisuals.Commands.PartyVisualDebugCommands.StageOverLimitFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IRestoreOverLimitFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class RestoreOverLimitFixtureCommand : IRestoreOverLimitFixtureCommand
+{
+    private readonly IPartyVisualLegacyCommandResult resultFactory;
+
+    public RestoreOverLimitFixtureCommand(IPartyVisualLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.party_visuals";
+
+    public string Name => "restore_over_limit_fixture";
+
+    public string Description => "Restores or clears restore over limit fixture.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PartyVisuals.Commands.PartyVisualDebugCommands.RestoreOverLimitFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -10,7 +10,6 @@ using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.PartyVisuals.Commands;
 
@@ -22,14 +21,13 @@ internal class PartyVisualDebugCommands
     private static int fixtureBaselineEligiblePartyCount = -1;
 #endif
 
-    [CommandLineArgumentFunction("buffer_state", "coop.debug.partyvisuals")]
     public static string BufferState(List<string> args)
     {
         if (ModInformation.IsServer)
             return "Run this command on a client.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.partyvisuals.buffer_state";
+            return "Usage: coop.debug.party_visuals.buffer_state";
 
         var manager = MobilePartyVisualManager.Current;
         if (manager == null)
@@ -63,16 +61,14 @@ internal class PartyVisualDebugCommands
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("fixture_state", "coop.debug.partyvisuals")]
     public static string FixtureState(List<string> args)
     {
         if (args.Count != 0)
-            return "Usage: coop.debug.partyvisuals.fixture_state";
+            return "Usage: coop.debug.party_visuals.fixture_state";
 
         return GetFixtureState(includeBaseline: true);
     }
 
-    [CommandLineArgumentFunction("stage_over_limit_fixture", "coop.debug.partyvisuals")]
     public static string StageOverLimitFixture(List<string> args)
     {
         if (ModInformation.IsClient)
@@ -82,7 +78,7 @@ internal class PartyVisualDebugCommands
             !int.TryParse(args[0], out int targetEligiblePartyCount) ||
             targetEligiblePartyCount < 2500)
         {
-            return "Usage: coop.debug.partyvisuals.stage_over_limit_fixture <targetEligiblePartyCount>=2500+ <settlementId>";
+            return "Usage: coop.debug.party_visuals.stage_over_limit_fixture <targetEligiblePartyCount>=2500+ <settlementId>";
         }
 
         if (stagedParties.Count != 0 || GetLiveFixturePartyCount() != 0)
@@ -127,14 +123,13 @@ internal class PartyVisualDebugCommands
         return GetFixtureState(includeBaseline: true);
     }
 
-    [CommandLineArgumentFunction("restore_over_limit_fixture", "coop.debug.partyvisuals")]
     public static string RestoreOverLimitFixture(List<string> args)
     {
         if (ModInformation.IsClient)
             return "restore_over_limit_fixture must be run on the server.";
 
         if (args.Count != 0)
-            return "Usage: coop.debug.partyvisuals.restore_over_limit_fixture";
+            return "Usage: coop.debug.party_visuals.restore_over_limit_fixture";
 
         int removedPartyCount = RestoreFixtureParties();
         string state = GetFixtureState(includeBaseline: false);

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Commands;
 using GameInterface.Services.PartyVisuals.Patches;
 using SandBox.View.Map.Managers;
 using System;
@@ -21,17 +22,17 @@ internal class PartyVisualDebugCommands
     private static int fixtureBaselineEligiblePartyCount = -1;
 #endif
 
-    public static string BufferState(List<string> args)
+    public static CoopCommandResult BufferState(List<string> args)
     {
         if (ModInformation.IsServer)
-            return "Run this command on a client.";
+            return Failed("Run this command on a client.");
 
         if (args.Count != 0)
-            return "Usage: coop.debug.party_visuals.buffer_state";
+            return Failed("Usage: coop.debug.party_visuals.buffer_state");
 
         var manager = MobilePartyVisualManager.Current;
         if (manager == null)
-            return "Mobile party visual manager is unavailable.";
+            return Failed("Mobile party visual manager is unavailable.");
 
         int visualCount = manager._visualsFlattened.Count;
         int bufferCapacity = manager._dirtyPartiesList.Length;
@@ -53,12 +54,16 @@ internal class PartyVisualDebugCommands
             campaignPartyCount,
         });
 
-        return $"visualCount={visualCount} bufferCapacity={bufferCapacity} dirtyCount={dirtyCount} " +
-               $"navalManagerActive={navalManagerActive} navalVisualCount={navalVisualCount} " +
-               $"navalBufferCapacity={navalBufferCapacity} navalDirtyCount={navalDirtyCount} " +
-               $"campaignPartyCount={campaignPartyCount}" + Environment.NewLine +
-               $"LIVE_TEST_JSON={structuredState}";
+        string output = $"visualCount={visualCount} bufferCapacity={bufferCapacity} dirtyCount={dirtyCount} " +
+                        $"navalManagerActive={navalManagerActive} navalVisualCount={navalVisualCount} " +
+                        $"navalBufferCapacity={navalBufferCapacity} navalDirtyCount={navalDirtyCount} " +
+                        $"campaignPartyCount={campaignPartyCount}" + Environment.NewLine +
+                        $"LIVE_TEST_JSON={structuredState}";
+        return new CoopCommandResult(true, output);
     }
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
 
 #if DEBUG
     public static string FixtureState(List<string> args)

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
@@ -17,7 +17,6 @@ using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.PlayerCaptivityService.Commands;
 
@@ -29,7 +28,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
     private static AiLordPeaceReleaseFixture fixture;
     private static StanceLinkSnapshot clientDiplomaticSnapshot;
 
-    [CommandLineArgumentFunction("observe_ai_lord_pair", "coop.debug.player_captivity")]
     public static string ObserveAiLordPair(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.observe_ai_lord_pair <prisonerHeroId> <captorHeroId>";
@@ -71,7 +69,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return output.ToString();
     }
 
-    [CommandLineArgumentFunction("focus_hero_party", "coop.debug.player_captivity")]
     public static string FocusHeroParty(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.focus_hero_party <heroId>";
@@ -91,7 +88,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return $"Following party '{party.StringId}' for hero '{hero.StringId}' on the campaign map.";
     }
 
-    [CommandLineArgumentFunction("snapshot_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
     public static string SnapshotAiLordDiplomacyFixture(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.snapshot_ai_lord_diplomacy_fixture <prisonerHeroId> <captorHeroId>";
@@ -108,7 +104,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
             clientDiplomaticSnapshot.OriginalFingerprint;
     }
 
-    [CommandLineArgumentFunction("restore_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
     public static string RestoreAiLordDiplomacyFixture(List<string> args)
     {
         if (!ModInformation.IsClient)
@@ -128,7 +123,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return "Client AI-lord diplomatic fixture restored.";
     }
 
-    [CommandLineArgumentFunction("capture_ai_lord_fixture", "coop.debug.player_captivity")]
     public static string CaptureAiLordFixture(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.capture_ai_lord_fixture <prisonerHeroId> <captorHeroId>";
@@ -228,7 +222,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         }
     }
 
-    [CommandLineArgumentFunction("observe_ai_lord_fixture", "coop.debug.player_captivity")]
     public static string ObserveAiLordFixture(List<string> args)
     {
         if (args.Count != 0)
@@ -239,7 +232,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
             : Observe(fixture);
     }
 
-    [CommandLineArgumentFunction("focus_party", "coop.debug.player_captivity")]
     public static string FocusParty(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.focus_party <mobilePartyId>";
@@ -256,7 +248,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return $"Following party '{party.StringId}' on the campaign map.";
     }
 
-    [CommandLineArgumentFunction("restore_ai_lord_fixture", "coop.debug.player_captivity")]
     public static string RestoreAiLordFixture(List<string> args)
     {
         if (ModInformation.IsClient)

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -30,7 +30,6 @@ using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.PlayerCaptivityService.Commands;
 
@@ -50,7 +49,6 @@ Example:
 
 Captures the given hero and assigns a random mobile party as the captor.";
 
-    [CommandLineArgumentFunction("random_capture_player", "coop.debug.player_captivity")]
     public static string RandomCapturePlayer(List<string> args)
     {
         var ctx = new CommandContext(
@@ -89,7 +87,6 @@ Example:
 Captures the given hero and assigns the given mobile party as the captor. The party argument accepts
 a co-op registry id or a local StringId.";
 
-    [CommandLineArgumentFunction("capture_player", "coop.debug.player_captivity")]
     public static string CapturePlayer(List<string> args)
     {
         var ctx = new CommandContext(
@@ -132,7 +129,6 @@ Example:
 Captures a registered co-op player through the real captivity path and records the transferred regular
 troops for separate fixture cleanup. This is intended for automated tests.";
 
-    [CommandLineArgumentFunction("capture_player_fixture", "coop.debug.player_captivity")]
     public static string CapturePlayerFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -218,7 +214,6 @@ Example:
 
 Restores the regular troops recorded by capture_player_fixture after the player has left captivity.";
 
-    [CommandLineArgumentFunction("restore_roster_fixture", "coop.debug.player_captivity")]
     public static string RestoreRosterFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -304,7 +299,6 @@ Example:
 
 Releases the given player hero from captivity.";
 
-    [CommandLineArgumentFunction("release_player", "coop.debug.player_captivity")]
     public static string ReleasePlayer(List<string> args)
     {
         var ctx = new CommandContext(
@@ -355,7 +349,6 @@ Releases the given player hero from captivity.";
 
 Snapshots the player's party, removes its non-hero members, and moves it beside the captor. Server only.";
 
-    [CommandLineArgumentFunction("prepare_visual_test_fixture", "coop.debug.player_captivity")]
     public static string PrepareVisualTestFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -443,7 +436,6 @@ Snapshots the player's party, removes its non-hero members, and moves it beside 
             $"Prepared position: {playerParty.Position.X:R},{playerParty.Position.Y:R}";
     }
 
-    [CommandLineArgumentFunction("restore_visual_test_fixture", "coop.debug.player_captivity")]
     public static string RestoreVisualTestFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -522,7 +514,6 @@ Example:
 
 Runs the client-side rescued-prisoner liberation consequence for the given hero.";
 
-    [CommandLineArgumentFunction("liberate_prisoner", "coop.debug.player_captivity")]
     public static string LiberatePrisoner(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -577,7 +568,6 @@ Example:
 
 Reports the hero's current captivity state on this process.";
 
-    [CommandLineArgumentFunction("status", "coop.debug.player_captivity")]
     public static string PrisonerStatus(List<string> args)
     {
         var ctx = new CommandContext(
@@ -611,7 +601,6 @@ Reports the hero's current captivity state on this process.";
 Moves a captured player into the active normal Party screen's left dismissal roster and presses Done.
 Run this on the client that controls the captor after opening the Party screen.";
 
-    [CommandLineArgumentFunction("discard_player_from_party_screen", "coop.debug.player_captivity")]
     public static string DiscardPlayerFromPartyScreen(List<string> args)
     {
         var ctx = new CommandContext(
@@ -724,7 +713,6 @@ Run this on the client that controls the captor after opening the Party screen."
 
 Reports captivity and registered party state without mutating it.";
 
-    [CommandLineArgumentFunction("observe_player", "coop.debug.player_captivity")]
     public static string ObservePlayer(List<string> args)
     {
         var ctx = new CommandContext("observe_player", ObservePlayerUsage, args);
@@ -790,7 +778,6 @@ Example:
 
 Ransoms the captive player hero for zero gold and releases them at a nearby neutral or allied settlement.";
 
-    [CommandLineArgumentFunction("ransom_player_at_settlement", "coop.debug.player_captivity")]
     public static string RansomPlayerAtSettlement(List<string> args)
     {
         var ctx = new CommandContext(
@@ -858,7 +845,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
             $"Seller gold change: {sellerGoldAfter - sellerGoldBefore}";
     }
 
-    [CommandLineArgumentFunction("captivity_state", "coop.debug.player_captivity")]
     public static string CaptivityState(List<string> args)
     {
         if (args.Count != 1)
@@ -893,7 +879,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         return result.ToString();
     }
 
-    [CommandLineArgumentFunction("party_fixture_state", "coop.debug.player_captivity")]
     public static string PartyFixtureState(List<string> args)
     {
         if (args.Count != 1)
@@ -919,7 +904,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         return result.ToString();
     }
 
-    [CommandLineArgumentFunction("restore_party_fixture_state", "coop.debug.player_captivity")]
     public static string RestorePartyFixtureState(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.restore_party_fixture_state <partyId> <settlementId|none> <x> <y> <isOnLand> <isActive>";

--- a/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
+++ b/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using TaleWorlds.CampaignSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Save.Commands
 {
@@ -15,7 +14,6 @@ namespace GameInterface.Services.Save.Commands
         private static int evidenceHoldMilliseconds;
 #endif
 
-        [CommandLineArgumentFunction("save_as", "coop.debug.save")]
         public static string SaveAs(List<string> args)
         {
             if (!ModInformation.IsServer)
@@ -33,7 +31,6 @@ namespace GameInterface.Services.Save.Commands
             return $"Enqueued save as {args[0]} on the server.";
         }
 
-        [CommandLineArgumentFunction("state", "coop.debug.save")]
         public static string State(List<string> args)
         {
             if (args.Count != 0)
@@ -50,7 +47,6 @@ namespace GameInterface.Services.Save.Commands
         /// client save block can be exercised on demand. On a client SetSaveArgs is blocked, so
         /// nothing is enqueued and no file is written; on the host a save file appears.
         /// </summary>
-        [CommandLineArgumentFunction("force_autosave", "coop.debug.save")]
         public static string ForceAutoSave(List<string> args)
         {
             if (Campaign.Current?.SaveHandler == null) return "No active campaign / SaveHandler.";

--- a/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
+++ b/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
@@ -12,7 +12,6 @@ using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.CraftingSystem;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Smithing.Commands;
 
@@ -34,7 +33,6 @@ internal class SmithingCommands
     /// <summary>
     /// Give debug crafting materials to heroes with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givesupplies", "coop.debug.crafting")]
     public static string SmithingSuppliesCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -96,7 +94,6 @@ internal class SmithingCommands
     /// Unlock all crafting pieces on a client
     /// OpenPart is patched to already update CoopSession and persist across sessions
     /// </summary>
-    [CommandLineArgumentFunction("unlockallcraftingpieces", "coop.debug.crafting")]
     public static string UnlockAllCraftingPiecesCommand(List<string> strings)
     {
         if (ModInformation.IsServer)
@@ -124,7 +121,6 @@ internal class SmithingCommands
     /// <summary>
     /// View town orders for a specified town
     /// </summary>
-    [CommandLineArgumentFunction("townorders", "coop.debug.crafting")]
     public static string ViewTownOrdersCommand(List<string> strings)
     {
         if (strings.Count == 0) return "Town name argument required.";
@@ -156,7 +152,6 @@ internal class SmithingCommands
     /// <summary>
     /// Add orders to a town by a hero in that town
     /// </summary>
-    [CommandLineArgumentFunction("addtownorder", "coop.debug.crafting")]
     public static string AddTestingTownOrderCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -190,7 +185,6 @@ internal class SmithingCommands
     /// <summary>
     /// Add all existing crafted items to a given hero
     /// </summary>
-    [CommandLineArgumentFunction("addcrafteditems", "coop.debug.crafting")]
     public static string AddCraftedItemCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -235,7 +229,6 @@ internal class SmithingCommands
     /// <summary>
     /// View crafting stamina of all heroes in party on client and all heroes on server
     /// </summary>
-    [CommandLineArgumentFunction("stamina", "coop.debug.crafting")]
     public static string ViewCraftingStaminaCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -260,7 +253,6 @@ internal class SmithingCommands
     /// <summary>
     /// View crafted item history, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("crafteditemhistory", "coop.debug.crafting")]
     public static string ViewCraftedItemHistoryCommand(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
@@ -297,7 +289,6 @@ internal class SmithingCommands
     /// <summary>
     /// View crafted pieces xp, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("craftingpiecesxp", "coop.debug.crafting")]
     public static string ViewPartsXpCommand(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
@@ -334,7 +325,6 @@ internal class SmithingCommands
     /// <summary>
     /// View unlocked crafted pieces, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("unlockedcraftingpieces", "coop.debug.crafting")]
     public static string ViewUnlockedCraftingPieces(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";

--- a/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
+++ b/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
@@ -1,0 +1,2519 @@
+﻿using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.SystemDeveloper.Commands;
+
+internal static class SystemDeveloperLegacyCommandResult
+{
+    public static CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool succeeded = !LooksLikeFailure(output);
+        return new CoopCommandResult(succeeded, output, succeeded ? null : "command_rejected");
+    }
+
+    private static bool LooksLikeFailure(string output)
+    {
+        string[] failurePrefixes =
+        {
+            "Usage:",
+            "Invalid ",
+            "Unable ",
+            "Error ",
+            "Failed",
+            "No ",
+            "Run ",
+            "Command can ",
+            "Command is ",
+            "The command ",
+            "The '",
+            "This command ",
+            "This function ",
+            "Could not ",
+            "Cannot ",
+        };
+
+        foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return output.IndexOf(" not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" was not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" can only be ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+}
+
+public interface ICampaignOptionsListCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsListCommand : ICampaignOptionsListCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "list";
+
+    public string Description => "Reports list.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.ListOptionsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsAutoAllocateClanMemberPerksCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsAutoAllocateClanMemberPerksCommand : ICampaignOptionsAutoAllocateClanMemberPerksCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "auto_allocate_clan_member_perks";
+
+    public string Description => "Runs the auto allocate clan member perks debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.AutoAllocateClanMemberPerksCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPlayerTroopsReceivedDamageCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPlayerTroopsReceivedDamageCommand : ICampaignOptionsPlayerTroopsReceivedDamageCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "player_troops_received_damage";
+
+    public string Description => "Runs the player troops received damage debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.PlayerTroopsReceivedDamageCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsRecruitmentDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsRecruitmentDifficultyCommand : ICampaignOptionsRecruitmentDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "recruitment_difficulty";
+
+    public string Description => "Runs the recruitment difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.RecruitmentDifficultyCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPlayerMapMovementSpeedCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPlayerMapMovementSpeedCommand : ICampaignOptionsPlayerMapMovementSpeedCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "player_map_movement_speed";
+
+    public string Description => "Runs the player map movement speed debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.PlayerMapMovementSpeedCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsStealthAndDisguiseDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsStealthAndDisguiseDifficultyCommand : ICampaignOptionsStealthAndDisguiseDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "stealth_and_disguise_difficulty";
+
+    public string Description => "Runs the stealth and disguise difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.StealthAndDisguiseDifficultyCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsCombatAiDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsCombatAiDifficultyCommand : ICampaignOptionsCombatAiDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "combat_ai_difficulty";
+
+    public string Description => "Runs the combat ai difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.CombatAIDifficultyCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsIsLifeDeathCycleDisabledCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsIsLifeDeathCycleDisabledCommand : ICampaignOptionsIsLifeDeathCycleDisabledCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "is_life_death_cycle_disabled";
+
+    public string Description => "Runs the is life death cycle disabled debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.IsLifeDeathCycleDisabledCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPersuasionSuccessChanceCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPersuasionSuccessChanceCommand : ICampaignOptionsPersuasionSuccessChanceCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "persuasion_success_chance";
+
+    public string Description => "Runs the persuasion success chance debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.PersuasionSuccessChanceCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsClanMemberDeathChanceCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsClanMemberDeathChanceCommand : ICampaignOptionsClanMemberDeathChanceCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "clan_member_death_chance";
+
+    public string Description => "Runs the clan member death chance debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.ClanMemberDeathChanceCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsIsIronmanModeCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsIsIronmanModeCommand : ICampaignOptionsIsIronmanModeCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "is_ironman_mode";
+
+    public string Description => "Runs the is ironman mode debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.IsIronmanModeCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsBattleDeathCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsBattleDeathCommand : ICampaignOptionsBattleDeathCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "battle_death";
+
+    public string Description => "Runs the battle death debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.BattleDeathCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPlayerReceivedDamageDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPlayerReceivedDamageDifficultyCommand : ICampaignOptionsPlayerReceivedDamageDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "player_received_damage_difficulty";
+
+    public string Description => "Runs the player received damage difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.SetPlayerReceivedDamageDifficulty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IModConfigListCommand : ICoopCommand
+{
+}
+
+public sealed class ModConfigListCommand : IModConfigListCommand
+{
+    public string Prefix => "coop.debug.mod_config";
+
+    public string Name => "list";
+
+    public string Description => "Reports list.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.ModOptionsCommands.ListOptionsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewProhibitedKingdomsCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewProhibitedKingdomsCommand : ICaravansViewProhibitedKingdomsCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_prohibited_kingdoms";
+
+    public string Description => "Reports view prohibited kingdoms.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewProhibitedKingdomsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewInteractedCaravansCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewInteractedCaravansCommand : ICaravansViewInteractedCaravansCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_interacted_caravans";
+
+    public string Description => "Reports view interacted caravans.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewInteractedCaravansCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewTakenTradeRumorsCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewTakenTradeRumorsCommand : ICaravansViewTakenTradeRumorsCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_taken_trade_rumors";
+
+    public string Description => "Reports view taken trade rumors.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewTakenTradeRumorsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewTradeActionLogsCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewTradeActionLogsCommand : ICaravansViewTradeActionLogsCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_trade_action_logs";
+
+    public string Description => "Reports view trade action logs.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewTradeActionLogs(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewLootedCaravansCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewLootedCaravansCommand : ICaravansViewLootedCaravansCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_looted_caravans";
+
+    public string Description => "Reports view looted caravans.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewLootedCaravans(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperStatsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperStatsCommand : IHeroDeveloperStatsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "stats";
+
+    public string Description => "Reports stats.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CharacterDevelopers.Commands.CharacterDeveloperCommands.HeroStatsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICharacterObjectsInfoCommand : ICoopCommand
+{
+}
+
+public sealed class CharacterObjectsInfoCommand : ICharacterObjectsInfoCommand
+{
+    public string Prefix => "coop.debug.character_objects";
+
+    public string Name => "info";
+
+    public string Description => "Reports info.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("character_id", "The registered character id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CharacterObjects.Commands.CharacterObjectCommands.Info(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICharacterObjectsListCommand : ICoopCommand
+{
+}
+
+public sealed class CharacterObjectsListCommand : ICharacterObjectsListCommand
+{
+    public string Prefix => "coop.debug.character_objects";
+
+    public string Name => "list";
+
+    public string Description => "Reports list.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CharacterObjects.Commands.CharacterObjectCommands.ListCharacterObjects(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICoopBugReportLogSharingCommand : ICoopCommand
+{
+}
+
+public sealed class CoopBugReportLogSharingCommand : ICoopBugReportLogSharingCommand
+{
+    public string Prefix => "coop";
+
+    public string Name => "bug_report_log_sharing";
+
+    public string Description => "Runs the bug report log sharing debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "status, enable, or disable.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.BugReportLogSharingCommand.Configure(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IFixCameraCommand : ICoopCommand
+{
+}
+
+public sealed class FixCameraCommand : IFixCameraCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "fix_camera";
+
+    public string Description => "Runs the fix camera debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.CameraReset.ChangeClanLeader(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IMapCameraFocusMainPartyCommand : ICoopCommand
+{
+}
+
+public sealed class MapCameraFocusMainPartyCommand : IMapCameraFocusMainPartyCommand
+{
+    public string Prefix => "coop.debug.map_camera";
+
+    public string Name => "focus_main_party";
+
+    public string Description => "Runs the focus main party debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.CameraReset.FocusMainParty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IMapCameraStateCommand : ICoopCommand
+{
+}
+
+public sealed class MapCameraStateCommand : IMapCameraStateCommand
+{
+    public string Prefix => "coop.debug.map_camera";
+
+    public string Name => "state";
+
+    public string Description => "Reports state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.CameraReset.GetState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IGameThreadInstrumentCommand : ICoopCommand
+{
+}
+
+public sealed class GameThreadInstrumentCommand : IGameThreadInstrumentCommand
+{
+    public string Prefix => "coop.debug.game_thread";
+
+    public string Name => "instrument";
+
+    public string Description => "Runs the instrument debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.GameThreadDebugCommand.Instrument(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IGameThreadStallCommand : ICoopCommand
+{
+}
+
+public sealed class GameThreadStallCommand : IGameThreadStallCommand
+{
+    public string Prefix => "coop.debug.game_thread";
+
+    public string Name => "stall";
+
+    public string Description => "Runs the stall debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("milliseconds", "The stall duration from 1 through 5000 milliseconds.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.GameThreadDebugCommand.Stall(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IMetricsPartySyncPerformanceLogsCommand : ICoopCommand
+{
+}
+
+public sealed class MetricsPartySyncPerformanceLogsCommand : IMetricsPartySyncPerformanceLogsCommand
+{
+    public string Prefix => "coop.debug.metrics";
+
+    public string Name => "party_sync_performance_logs";
+
+    public string Description => "Runs the party sync performance logs debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "on, off, or status.", isRequired: true),
+        new ExpectedArgs("seconds", "The logging duration in seconds when enabling.", isRequired: false),
+        new ExpectedArgs("file_name", "The output file name when enabling.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiCloseScreenCommand : ICoopCommand
+{
+}
+
+public sealed class UiCloseScreenCommand : IUiCloseScreenCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "close_screen";
+
+    public string Description => "Runs the close screen debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.CloseScreen(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiPrepareEvidenceMapCommand : ICoopCommand
+{
+}
+
+public sealed class UiPrepareEvidenceMapCommand : IUiPrepareEvidenceMapCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "prepare_evidence_map";
+
+    public string Description => "Runs the prepare evidence map debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.PrepareEvidenceMap(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiEvidenceMapStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiEvidenceMapStateCommand : IUiEvidenceMapStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "evidence_map_state";
+
+    public string Description => "Reports evidence map state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.EvidenceMapState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiLeaveSettlementEncounterCommand : ICoopCommand
+{
+}
+
+public sealed class UiLeaveSettlementEncounterCommand : IUiLeaveSettlementEncounterCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "leave_settlement_encounter";
+
+    public string Description => "Runs the leave settlement encounter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.LeaveSettlementEncounter(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IUiMapClickOffsetCommand : ICoopCommand
+{
+}
+
+public sealed class UiMapClickOffsetCommand : IUiMapClickOffsetCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "map_click_offset";
+
+    public string Description => "Runs the map click offset debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("offset_x", "The horizontal map offset.", isRequired: true),
+        new ExpectedArgs("offset_y", "The vertical map offset.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.MapClickOffset(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IUiMapMovementStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiMapMovementStateCommand : IUiMapMovementStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "map_movement_state";
+
+    public string Description => "Reports map movement state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.MapMovementState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+public interface IUiSwitchMenuCommand : ICoopCommand
+{
+}
+
+public sealed class UiSwitchMenuCommand : IUiSwitchMenuCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "switch_menu";
+
+    public string Description => "Runs the switch menu debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("menu_id", "The game menu id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.SwitchMenu(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiPopStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiPopStateCommand : IUiPopStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "pop_state";
+
+    public string Description => "Reports pop state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.PopState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiActiveStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiActiveStateCommand : IUiActiveStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "active_state";
+
+    public string Description => "Reports active state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.ActiveState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiLoadingWindowStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiLoadingWindowStateCommand : IUiLoadingWindowStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "loading_window_state";
+
+    public string Description => "Reports loading window state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.LoadingWindowState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiSavingOverlayStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiSavingOverlayStateCommand : IUiSavingOverlayStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "saving_overlay_state";
+
+    public string Description => "Reports saving overlay state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.SavingOverlayState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICoopUnstuckCommand : ICoopCommand
+{
+}
+
+public sealed class CoopUnstuckCommand : ICoopUnstuckCommand
+{
+    public string Prefix => "coop";
+
+    public string Name => "unstuck";
+
+    public string Description => "Runs the unstuck debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UnstuckCommand.Unstuck(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperAddSkillXpCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperAddSkillXpCommand : IHeroDeveloperAddSkillXpCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "add_skill_xp";
+
+    public string Description => "Runs the add skill xp debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        new ExpectedArgs("skill_name", "The skill object name.", isRequired: true),
+        new ExpectedArgs("xp_amount", "The amount of skill experience.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.AddSkillXpCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperAddAttributePointsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperAddAttributePointsCommand : IHeroDeveloperAddAttributePointsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "add_attribute_points";
+
+    public string Description => "Runs the add attribute points debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        new ExpectedArgs("point_count", "The number of attribute points.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.AddAttributePointsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperAddFocusPointsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperAddFocusPointsCommand : IHeroDeveloperAddFocusPointsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "add_focus_points";
+
+    public string Description => "Runs the add focus points debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        new ExpectedArgs("point_count", "The number of focus points.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.AddFocusPointsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperResetSkillsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperResetSkillsCommand : IHeroDeveloperResetSkillsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "reset_skills";
+
+    public string Description => "Runs the reset skills debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.ResetSkillsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryItemIdsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryItemIdsCommand : IInventoryItemIdsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "item_ids";
+
+    public string Description => "Runs the item ids debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.ViewItemIdsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryItemValuesCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryItemValuesCommand : IInventoryItemValuesCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "item_values";
+
+    public string Description => "Runs the item values debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.ViewItemValuesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryHeroEquipmentCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryHeroEquipmentCommand : IInventoryHeroEquipmentCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "hero_equipment";
+
+    public string Description => "Runs the hero equipment debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.HeroEquipmentCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryGiveAnimalsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryGiveAnimalsCommand : IInventoryGiveAnimalsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "give_animals";
+
+    public string Description => "Runs the give animals debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.GiveAnimalsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryGiveWarhorsesCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryGiveWarhorsesCommand : IInventoryGiveWarhorsesCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "give_warhorses";
+
+    public string Description => "Runs the give warhorses debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.GiveWarhorsesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryViewPlayerTradeDataCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryViewPlayerTradeDataCommand : IInventoryViewPlayerTradeDataCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "view_player_trade_data";
+
+    public string Description => "Reports view player trade data.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.TradeSkills.Commands.TradeSkillCommands.ViewPlayerTradeDataCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryViewPlayerTradeRumorsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryViewPlayerTradeRumorsCommand : IInventoryViewPlayerTradeRumorsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "view_player_trade_rumors";
+
+    public string Description => "Reports view player trade rumors.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.TradeSkills.Commands.TradeSkillCommands.ViewPlayerTradeRumorsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryViewEnteredSettlementsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryViewEnteredSettlementsCommand : IInventoryViewEnteredSettlementsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "view_entered_settlements";
+
+    public string Description => "Reports view entered settlements.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.TradeSkills.Commands.TradeSkillCommands.ViewPlayerEnteredSettlementsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IIssuesGiveCommand : ICoopCommand
+{
+}
+
+public sealed class IssuesGiveCommand : IIssuesGiveCommand
+{
+    public string Prefix => "coop.debug.issues";
+
+    public string Name => "give";
+
+    public string Description => "Runs the give debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+        new ExpectedArgs("quest_type_key", "The issue type key.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Issues.Commands.IssuesDebugCommand.Give(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IIssuesCompleteCommand : ICoopCommand
+{
+}
+
+public sealed class IssuesCompleteCommand : IIssuesCompleteCommand
+{
+    public string Prefix => "coop.debug.issues";
+
+    public string Name => "complete";
+
+    public string Description => "Runs the complete debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered issue owner hero id.", isRequired: true),
+        new ExpectedArgs("outcome", "success, cancel, fail, timeout, or betrayal.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Issues.Commands.IssuesDebugCommand.Complete(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IIssuesListTypesCommand : ICoopCommand
+{
+}
+
+public sealed class IssuesListTypesCommand : IIssuesListTypesCommand
+{
+    public string Prefix => "coop.debug.issues";
+
+    public string Name => "list_types";
+
+    public string Description => "Reports list types.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Issues.Commands.IssuesDebugCommand.ListTypes(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemObjectDataCommand : ICoopCommand
+{
+}
+
+public sealed class ItemObjectDataCommand : IItemObjectDataCommand
+{
+    public string Prefix => "coop.debug.item_object";
+
+    public string Name => "data";
+
+    public string Description => "Reports data.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("item_id", "The registered item object id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemObjects.Commands.ItemObjectCommands.ViewCraftedItemData(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersAddRandomItemCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersAddRandomItemCommand : IItemRostersAddRandomItemCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "add_random_item";
+
+    public string Description => "Runs the add random item debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.AddRandomItem(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersAddItemBurstCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersAddItemBurstCommand : IItemRostersAddItemBurstCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "add_item_burst";
+
+    public string Description => "Runs the add item burst debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+        new ExpectedArgs("count", "The positive number of items to add.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.AddItemBurst(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersInfoCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersInfoCommand : IItemRostersInfoCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "info";
+
+    public string Description => "Reports info.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.Info(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersExportCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersExportCommand : IItemRostersExportCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "export";
+
+    public string Description => "Runs the export debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.Export(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IPlayerCaptivityObserveAiLordPairCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityObserveAiLordPairCommand : IPlayerCaptivityObserveAiLordPairCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "observe_ai_lord_pair";
+
+    public string Description => "Runs the observe ai lord pair debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+        new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.ObserveAiLordPair(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityFocusHeroPartyCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityFocusHeroPartyCommand : IPlayerCaptivityFocusHeroPartyCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "focus_hero_party";
+
+    public string Description => "Runs the focus hero party debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.FocusHeroParty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivitySnapshotAiLordDiplomacyFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivitySnapshotAiLordDiplomacyFixtureCommand : IPlayerCaptivitySnapshotAiLordDiplomacyFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "snapshot_ai_lord_diplomacy_fixture";
+
+    public string Description => "Runs the snapshot ai lord diplomacy fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+        new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.SnapshotAiLordDiplomacyFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityRestoreAiLordDiplomacyFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreAiLordDiplomacyFixtureCommand : IPlayerCaptivityRestoreAiLordDiplomacyFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_ai_lord_diplomacy_fixture";
+
+    public string Description => "Runs the restore ai lord diplomacy fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.RestoreAiLordDiplomacyFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityCaptureAiLordFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCaptureAiLordFixtureCommand : IPlayerCaptivityCaptureAiLordFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "capture_ai_lord_fixture";
+
+    public string Description => "Runs the capture ai lord fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+        new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.CaptureAiLordFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityObserveAiLordFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityObserveAiLordFixtureCommand : IPlayerCaptivityObserveAiLordFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "observe_ai_lord_fixture";
+
+    public string Description => "Runs the observe ai lord fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.ObserveAiLordFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityFocusPartyCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityFocusPartyCommand : IPlayerCaptivityFocusPartyCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "focus_party";
+
+    public string Description => "Runs the focus party debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mobile_party_id", "The registered mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.FocusParty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityRestoreAiLordFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreAiLordFixtureCommand : IPlayerCaptivityRestoreAiLordFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_ai_lord_fixture";
+
+    public string Description => "Runs the restore ai lord fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.RestoreAiLordFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+public interface IPlayerCaptivityRandomCapturePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRandomCapturePlayerCommand : IPlayerCaptivityRandomCapturePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "random_capture_player";
+
+    public string Description => "Runs the random capture player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RandomCapturePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityCapturePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCapturePlayerCommand : IPlayerCaptivityCapturePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "capture_player";
+
+    public string Description => "Runs the capture player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.CapturePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityCapturePlayerFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCapturePlayerFixtureCommand : IPlayerCaptivityCapturePlayerFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "capture_player_fixture";
+
+    public string Description => "Runs the capture player fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.CapturePlayerFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRestoreRosterFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreRosterFixtureCommand : IPlayerCaptivityRestoreRosterFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_roster_fixture";
+
+    public string Description => "Runs the restore roster fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RestoreRosterFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityReleasePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityReleasePlayerCommand : IPlayerCaptivityReleasePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "release_player";
+
+    public string Description => "Runs the release player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.ReleasePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityPrepareVisualTestFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityPrepareVisualTestFixtureCommand : IPlayerCaptivityPrepareVisualTestFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "prepare_visual_test_fixture";
+
+    public string Description => "Runs the prepare visual test fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.PrepareVisualTestFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRestoreVisualTestFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreVisualTestFixtureCommand : IPlayerCaptivityRestoreVisualTestFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_visual_test_fixture";
+
+    public string Description => "Runs the restore visual test fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RestoreVisualTestFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityLiberatePrisonerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityLiberatePrisonerCommand : IPlayerCaptivityLiberatePrisonerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "liberate_prisoner";
+
+    public string Description => "Runs the liberate prisoner debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.LiberatePrisoner(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityStatusCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityStatusCommand : IPlayerCaptivityStatusCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "status";
+
+    public string Description => "Reports status.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.PrisonerStatus(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityDiscardPlayerFromPartyScreenCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityDiscardPlayerFromPartyScreenCommand : IPlayerCaptivityDiscardPlayerFromPartyScreenCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "discard_player_from_party_screen";
+
+    public string Description => "Runs the discard player from party screen debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.DiscardPlayerFromPartyScreen(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityObservePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityObservePlayerCommand : IPlayerCaptivityObservePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "observe_player";
+
+    public string Description => "Runs the observe player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.ObservePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRansomPlayerAtSettlementCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRansomPlayerAtSettlementCommand : IPlayerCaptivityRansomPlayerAtSettlementCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "ransom_player_at_settlement";
+
+    public string Description => "Runs the ransom player at settlement debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RansomPlayerAtSettlement(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityCaptivityStateCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCaptivityStateCommand : IPlayerCaptivityCaptivityStateCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "captivity_state";
+
+    public string Description => "Reports captivity state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.CaptivityState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityPartyFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityPartyFixtureStateCommand : IPlayerCaptivityPartyFixtureStateCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "party_fixture_state";
+
+    public string Description => "Reports party fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.PartyFixtureState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRestorePartyFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestorePartyFixtureStateCommand : IPlayerCaptivityRestorePartyFixtureStateCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_party_fixture_state";
+
+    public string Description => "Reports restore party fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+        new ExpectedArgs("settlement_id_or_none", "The settlement id, or none.", isRequired: true),
+        new ExpectedArgs("x", "The map x coordinate.", isRequired: true),
+        new ExpectedArgs("y", "The map y coordinate.", isRequired: true),
+        new ExpectedArgs("is_on_land", "Whether the position is on land.", isRequired: true),
+        new ExpectedArgs("is_active", "Whether the party is active.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RestorePartyFixtureState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISaveSaveAsCommand : ICoopCommand
+{
+}
+
+public sealed class SaveSaveAsCommand : ISaveSaveAsCommand
+{
+    public string Prefix => "coop.debug.save";
+
+    public string Name => "save_as";
+
+    public string Description => "Runs the save as debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("save_name", "A save name using 1 through 64 letters, digits, underscores, or hyphens.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Save.Commands.SaveDebugCommand.SaveAs(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISaveStateCommand : ICoopCommand
+{
+}
+
+public sealed class SaveStateCommand : ISaveStateCommand
+{
+    public string Prefix => "coop.debug.save";
+
+    public string Name => "state";
+
+    public string Description => "Reports state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Save.Commands.SaveDebugCommand.State(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISaveForceAutosaveCommand : ICoopCommand
+{
+}
+
+public sealed class SaveForceAutosaveCommand : ISaveForceAutosaveCommand
+{
+    public string Prefix => "coop.debug.save";
+
+    public string Name => "force_autosave";
+
+    public string Description => "Runs the force autosave debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("evidence_hold_milliseconds", "The optional evidence hold from 1 through 5000 milliseconds.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Save.Commands.SaveDebugCommand.ForceAutoSave(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingGiveSuppliesCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingGiveSuppliesCommand : ICraftingGiveSuppliesCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "give_supplies";
+
+    public string Description => "Runs the give supplies debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.SmithingSuppliesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingUnlockAllCraftingPiecesCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingUnlockAllCraftingPiecesCommand : ICraftingUnlockAllCraftingPiecesCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "unlock_all_crafting_pieces";
+
+    public string Description => "Runs the unlock all crafting pieces debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.UnlockAllCraftingPiecesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingTownOrdersCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingTownOrdersCommand : ICraftingTownOrdersCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "town_orders";
+
+    public string Description => "Runs the town orders debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("town_name", "The exact town display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewTownOrdersCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingAddTownOrderCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingAddTownOrderCommand : ICraftingAddTownOrderCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "add_town_order";
+
+    public string Description => "Runs the add town order debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.AddTestingTownOrderCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingAddCraftedItemsCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingAddCraftedItemsCommand : ICraftingAddCraftedItemsCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "add_crafted_items";
+
+    public string Description => "Runs the add crafted items debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.AddCraftedItemCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingStaminaCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingStaminaCommand : ICraftingStaminaCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "stamina";
+
+    public string Description => "Runs the stamina debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewCraftingStaminaCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingCraftedItemHistoryCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingCraftedItemHistoryCommand : ICraftingCraftedItemHistoryCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "crafted_item_history";
+
+    public string Description => "Runs the crafted item history debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewCraftedItemHistoryCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingCraftingPiecesXpCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingCraftingPiecesXpCommand : ICraftingCraftingPiecesXpCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "crafting_pieces_xp";
+
+    public string Description => "Runs the crafting pieces xp debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewPartsXpCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingUnlockedCraftingPiecesCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingUnlockedCraftingPiecesCommand : ICraftingUnlockedCraftingPiecesCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "unlocked_crafting_pieces";
+
+    public string Description => "Runs the unlocked crafting pieces debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewUnlockedCraftingPieces(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ITemplateCommand : ICoopCommand
+{
+}
+
+public sealed class TemplateCommand : ITemplateCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "template";
+
+    public string Description => "Runs the template debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Template.Commands.TemplateCommands.TemplateCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IGetTimeModeCommand : ICoopCommand
+{
+}
+
+public sealed class GetTimeModeCommand : IGetTimeModeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "get_time_mode";
+
+    public string Description => "Reports get time mode.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.GetTimeMode(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISetTimeModeCommand : ICoopCommand
+{
+}
+
+public sealed class SetTimeModeCommand : ISetTimeModeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "set_time_mode";
+
+    public string Description => "Runs the set time mode debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+#if DEBUG
+        new ExpectedArgs("force_live_test", "The DEBUG live-test override token.", isRequired: false),
+#endif
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.SetTimeMode(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IRequestTimeModeCommand : ICoopCommand
+{
+}
+
+public sealed class RequestTimeModeCommand : IRequestTimeModeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "request_time_mode";
+
+    public string Description => "Runs the request time mode debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.RequestTimeMode(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+public interface IAdvanceTimeCommand : ICoopCommand
+{
+}
+
+public sealed class AdvanceTimeCommand : IAdvanceTimeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "advance_time";
+
+    public string Description => "Runs the advance time debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("days", "The number of campaign days to advance.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.AdvanceTime(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamStatusCommand : ICoopCommand
+{
+}
+
+public sealed class SteamStatusCommand : ISteamStatusCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "status";
+
+    public string Description => "Reports status.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Status(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamHostLobbyCommand : ICoopCommand
+{
+}
+
+public sealed class SteamHostLobbyCommand : ISteamHostLobbyCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "host_lobby";
+
+    public string Description => "Runs the host lobby debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.HostLobby(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamInviteCommand : ICoopCommand
+{
+}
+
+public sealed class SteamInviteCommand : ISteamInviteCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "invite";
+
+    public string Description => "Runs the invite debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Invite(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamJoinCommand : ICoopCommand
+{
+}
+
+public sealed class SteamJoinCommand : ISteamJoinCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "join";
+
+    public string Description => "Runs the join debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("lobby_id", "The Steam lobby id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Join(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiTacticalSymbolsCommand : ICoopCommand
+{
+}
+
+public sealed class UiTacticalSymbolsCommand : IUiTacticalSymbolsCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "tactical_symbols";
+
+    public string Description => "Runs the tactical symbols debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}

--- a/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
+++ b/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
@@ -6,16 +6,21 @@ namespace GameInterface.Services.SystemDeveloper.Commands;
 
 internal static class SystemDeveloperLegacyCommandResult
 {
-    public static CoopCommandResult FromOutput(string output)
+    public static CoopCommandResult FromOutput(
+        string output,
+        params string[] commandFailurePrefixes)
     {
         if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
 
-        bool succeeded = !LooksLikeFailure(output);
+        bool succeeded = !LooksLikeFailure(output, commandFailurePrefixes);
         return new CoopCommandResult(succeeded, output, succeeded ? null : "command_rejected");
     }
 
-    private static bool LooksLikeFailure(string output)
+    private static bool LooksLikeFailure(
+        string output,
+        string[] commandFailurePrefixes)
     {
+        // Backing commands preserve string APIs, so every scoped rejection prefix is listed here.
         string[] failurePrefixes =
         {
             "Usage:",
@@ -33,9 +38,42 @@ internal static class SystemDeveloperLegacyCommandResult
             "This function ",
             "Could not ",
             "Cannot ",
+            "Managing campaign options ",
+            "An integer amount ",
+            "Close the current prompt ",
+            "Campaign map camera is unavailable",
+            "Campaign map screen is unavailable",
+            "Seconds must ",
+            "Leave the active ",
+            "Active state is already ",
+            "Saving overlay: UNAVAILABLE",
+            "Cheats are currently disabled ",
+            "Hero name argument required",
+            "Hero not found",
+            "Hero '",
+            "Item object not found",
+            "Town name argument required",
+            "Town not found",
+            "Unknown ",
+            "Quest type ",
+            "A client AI-lord ",
+            "An AI-lord ",
+            "A visual test fixture ",
+            "A save is already ",
+            "Captor ",
+            "PartyScreenLogic ",
+            "The active ",
+            "The evidence hold ",
+            "Autosaves are disabled",
+            "Not advertising",
+            "Tactical unit symbols configuration is unavailable",
         };
 
         foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        foreach (string prefix in commandFailurePrefixes)
         {
             if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
         }
@@ -43,7 +81,11 @@ internal static class SystemDeveloperLegacyCommandResult
         return output.IndexOf(" not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" was not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" can only be ", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0;
+               output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" failed.", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" cannot ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" did not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" does not ", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }
 
@@ -2445,7 +2487,9 @@ public sealed class SteamHostLobbyCommand : ISteamHostLobbyCommand
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
         string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.HostLobby(new List<string>(args));
-        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+        return SystemDeveloperLegacyCommandResult.FromOutput(
+            output,
+            "Steam integration inactive");
     }
 }
 
@@ -2490,7 +2534,9 @@ public sealed class SteamJoinCommand : ISteamJoinCommand
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
         string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Join(new List<string>(args));
-        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+        return SystemDeveloperLegacyCommandResult.FromOutput(
+            output,
+            "Steam integration inactive");
     }
 }
 

--- a/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
+++ b/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Template.Commands;
 
@@ -11,7 +10,6 @@ internal class TemplateCommands
     /// <summary>
     /// TODO fill me out
     /// </summary>
-    [CommandLineArgumentFunction("template", "coop.debug")]
     public static string TemplateCommand(List<string> strings)
     {
         return "This is a template command";

--- a/source/GameInterface/Services/Time/Commands/TimeCommands.cs
+++ b/source/GameInterface/Services/Time/Commands/TimeCommands.cs
@@ -7,13 +7,11 @@ using GameInterface.Services.Time.Interfaces;
 using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Time.Commands;
 
 internal class TimeCommands
 {
-    [CommandLineArgumentFunction("get_time_mode", "coop.debug")]
     public static string GetTimeMode(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
@@ -24,7 +22,6 @@ internal class TimeCommands
         return $"{timeControlInterface.GetTimeControl()}";
     }
 
-    [CommandLineArgumentFunction("set_time_mode", "coop.debug")]
     public static string SetTimeMode(List<string> strings)
     {
         if (!ModInformation.IsServer)
@@ -63,7 +60,6 @@ internal class TimeCommands
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("request_time_mode", "coop.debug")]
     public static string RequestTimeMode(List<string> strings)
     {
         if (ModInformation.IsServer)
@@ -77,7 +73,6 @@ internal class TimeCommands
     }
 #endif
 
-    [CommandLineArgumentFunction("advance_time", "coop.debug")]
     public static string AdvanceTime(List<string> strings)
     {
         // Time is authoritative on the server; advancing it elsewhere would just be

--- a/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
@@ -3,7 +3,6 @@ using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
 using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.UI.Commands;
 
@@ -16,7 +15,6 @@ namespace GameInterface.Services.UI.Commands;
 /// </summary>
 public class SteamDebugCommand
 {
-    [CommandLineArgumentFunction("status", "coop.debug.steam")]
     public static string Status(List<string> args)
     {
         if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive (Steam not running or not a Steam install)";
@@ -32,7 +30,6 @@ public class SteamDebugCommand
         return $"Steam integration active; advertising={advertiser.IsAdvertising}";
     }
 
-    [CommandLineArgumentFunction("host_lobby", "coop.debug.steam")]
     public static string HostLobby(List<string> args)
     {
         if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive";
@@ -53,7 +50,6 @@ public class SteamDebugCommand
         return $"Advertising session (address='{info.Address}', port={info.Port}, version={info.Version})";
     }
 
-    [CommandLineArgumentFunction("invite", "coop.debug.steam")]
     public static string Invite(List<string> args)
     {
         if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "No session advertiser; join a session first";
@@ -64,7 +60,6 @@ public class SteamDebugCommand
             : SessionInviteText.OverlayUnavailableHint;
     }
 
-    [CommandLineArgumentFunction("join", "coop.debug.steam")]
     public static string Join(List<string> args)
     {
         if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive";

--- a/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
@@ -1,8 +1,7 @@
-using Autofac;
+﻿using Autofac;
 using GameInterface.Services.UI.Handlers;
 using GameInterface.Utils.Commands;
 using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.UI.Commands;
 
@@ -11,7 +10,6 @@ public class TacticalUnitSymbolsDebugCommand
     private const string CommandName = "coop.debug.ui.tactical_symbols";
     private const string Usage = "Usage: coop.debug.ui.tactical_symbols <on|off|toggle|status>";
 
-    [CommandLineArgumentFunction("tactical_symbols", "coop.debug.ui")]
     public static string TacticalSymbols(List<string> args)
     {
         if (!CommandHelpers.IsServerOnlyCommand(out var error, CommandName)) return error;

--- a/source/Missions/Agents/Handlers/MovementCoopCommands.cs
+++ b/source/Missions/Agents/Handlers/MovementCoopCommands.cs
@@ -1,0 +1,234 @@
+﻿using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace Missions.Agents.Handlers;
+
+public interface IMovementLegacyCommandResult
+{
+    CoopCommandResult FromOutput(string output);
+}
+
+public sealed class MovementLegacyCommandResult : IMovementLegacyCommandResult
+{
+    public CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool succeeded = !LooksLikeFailure(output);
+        return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
+    }
+
+    private static bool LooksLikeFailure(string output)
+    {
+        string[] failurePrefixes =
+        {
+            "Usage:",
+            "Failed",
+            "Unable",
+            "No ",
+            "Run this",
+            "Command can",
+            "The host has disabled",
+            "Cannot ",
+            "Could not",
+            "Refusing",
+            "Prepare ",
+            "Both ",
+            "Player parties must",
+            "Attacker and defender",
+            "Exists must",
+            "State requires",
+            "A ",
+            "The ",
+            "Party ",
+            "Character ",
+            "Settlement ",
+            "Object manager",
+            "Network ",
+            "Battle agent",
+            "Active mount",
+            "Upgrade ",
+            "Clan-party",
+            "Map event",
+            "Invalid ",
+            "Player parties",
+            "Player party",
+            "Player '",
+        };
+
+        foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return false;
+    }
+}
+
+#if DEBUG
+public interface IStateCommand : ICoopCommand
+{
+}
+
+public sealed class StateCommand : IStateCommand
+{
+    private readonly IMovementLegacyCommandResult resultFactory;
+
+    public StateCommand(IMovementLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.movement";
+
+    public string Name => "state";
+
+    public string Description => "Reports state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Agents.Handlers.MovementDebugCommands.State(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IForceRateCommand : ICoopCommand
+{
+}
+
+public sealed class ForceRateCommand : IForceRateCommand
+{
+    private readonly IMovementLegacyCommandResult resultFactory;
+
+    public ForceRateCommand(IMovementLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.movement";
+
+    public string Name => "force_rate";
+
+    public string Description => "Runs the force rate debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("rate", "The rate.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Agents.Handlers.MovementDebugCommands.ForceRate(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IForceReceiverCapCommand : ICoopCommand
+{
+}
+
+public sealed class ForceReceiverCapCommand : IForceReceiverCapCommand
+{
+    private readonly IMovementLegacyCommandResult resultFactory;
+
+    public ForceReceiverCapCommand(IMovementLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.movement";
+
+    public string Name => "force_receiver_cap";
+
+    public string Description => "Runs the force receiver cap debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("receiver_cap", "The receiver cap.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Agents.Handlers.MovementDebugCommands.ForceReceiverCap(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface ISimulateReceivePressureCommand : ICoopCommand
+{
+}
+
+public sealed class SimulateReceivePressureCommand : ISimulateReceivePressureCommand
+{
+    private readonly IMovementLegacyCommandResult resultFactory;
+
+    public SimulateReceivePressureCommand(IMovementLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.movement";
+
+    public string Name => "simulate_receive_pressure";
+
+    public string Description => "Runs the simulate receive pressure debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("duration_seconds", "The duration seconds.", true),
+        new ExpectedArgs("queue_ms", "The queue ms.", true),
+        new ExpectedArgs("apply_ms", "The apply ms.", true),
+        new ExpectedArgs("snapshots", "The snapshots.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Agents.Handlers.MovementDebugCommands.SimulateReceivePressure(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IClearReceivePressureCommand : ICoopCommand
+{
+}
+
+public sealed class ClearReceivePressureCommand : IClearReceivePressureCommand
+{
+    private readonly IMovementLegacyCommandResult resultFactory;
+
+    public ClearReceivePressureCommand(IMovementLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.movement";
+
+    public string Name => "clear_receive_pressure";
+
+    public string Description => "Restores or clears clear receive pressure.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Agents.Handlers.MovementDebugCommands.ClearReceivePressure(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif

--- a/source/Missions/Agents/Handlers/MovementDebugCommands.cs
+++ b/source/Missions/Agents/Handlers/MovementDebugCommands.cs
@@ -3,13 +3,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using TaleWorlds.MountAndBlade;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace Missions.Agents.Handlers;
 
 internal static class MovementDebugCommands
 {
-    [CommandLineArgumentFunction("state", "coop.debug.movement")]
     public static string State(List<string> args)
     {
         if (args.Count != 0)
@@ -64,7 +62,6 @@ internal static class MovementDebugCommands
         });
     }
 
-    [CommandLineArgumentFunction("force_rate", "coop.debug.movement")]
     public static string ForceRate(List<string> args)
     {
         if (!TryParseRate(
@@ -84,7 +81,6 @@ internal static class MovementDebugCommands
             : "MOVEMENT_RATE_AUTOMATIC";
     }
 
-    [CommandLineArgumentFunction("force_receiver_cap", "coop.debug.movement")]
     public static string ForceReceiverCap(List<string> args)
     {
         if (!TryParseRate(
@@ -106,7 +102,6 @@ internal static class MovementDebugCommands
             : "MOVEMENT_RECEIVER_CAP_AUTOMATIC";
     }
 
-    [CommandLineArgumentFunction("simulate_receive_pressure", "coop.debug.movement")]
     public static string SimulateReceivePressure(List<string> args)
     {
         if (args.Count != 4 ||
@@ -140,7 +135,6 @@ internal static class MovementDebugCommands
         });
     }
 
-    [CommandLineArgumentFunction("clear_receive_pressure", "coop.debug.movement")]
     public static string ClearReceivePressure(List<string> args)
     {
         if (args.Count != 0)

--- a/source/Missions/Battles/BattleCoopCommands.cs
+++ b/source/Missions/Battles/BattleCoopCommands.cs
@@ -62,7 +62,19 @@ public sealed class BattleLegacyCommandResult : IBattleLegacyCommandResult
             if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
         }
 
-        return false;
+        return output.IndexOf(" is not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" was not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" has no ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" unavailable", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" already ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" inactive", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" no active ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" no reserve ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" no unused ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" blocked ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" finish ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" returned no ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" mission ended", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }
 
@@ -73,13 +85,9 @@ public interface IReplicationFixtureCommand : ICoopCommand
 
 public sealed class ReplicationFixtureCommand : IReplicationFixtureCommand
 {
-    private readonly IBattleLegacyCommandResult resultFactory;
-
     public ReplicationFixtureCommand(IBattleLegacyCommandResult resultFactory)
     {
         if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
-
-        this.resultFactory = resultFactory;
     }
     public string Prefix => "coop.debug.battle";
 
@@ -95,8 +103,7 @@ public sealed class ReplicationFixtureCommand : IReplicationFixtureCommand
 
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
-        string output = Missions.Battles.BattleDebugCommands.ReplicationFixture(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return Missions.Battles.BattleDebugCommands.ReplicationFixture(new List<string>(args));
     }
 }
 #endif
@@ -108,13 +115,9 @@ public interface IColumnReinforcementFixtureCommand : ICoopCommand
 
 public sealed class ColumnReinforcementFixtureCommand : IColumnReinforcementFixtureCommand
 {
-    private readonly IBattleLegacyCommandResult resultFactory;
-
     public ColumnReinforcementFixtureCommand(IBattleLegacyCommandResult resultFactory)
     {
         if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
-
-        this.resultFactory = resultFactory;
     }
     public string Prefix => "coop.debug.battle";
 
@@ -129,8 +132,7 @@ public sealed class ColumnReinforcementFixtureCommand : IColumnReinforcementFixt
 
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
-        string output = Missions.Battles.BattleDebugCommands.ColumnReinforcementFixture(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return Missions.Battles.BattleDebugCommands.ColumnReinforcementFixture(new List<string>(args));
     }
 }
 #endif
@@ -672,13 +674,9 @@ public interface IFocusLadderCommand : ICoopCommand
 
 public sealed class FocusLadderCommand : IFocusLadderCommand
 {
-    private readonly IBattleLegacyCommandResult resultFactory;
-
     public FocusLadderCommand(IBattleLegacyCommandResult resultFactory)
     {
         if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
-
-        this.resultFactory = resultFactory;
     }
     public string Prefix => "coop.debug.battle";
 
@@ -693,8 +691,7 @@ public sealed class FocusLadderCommand : IFocusLadderCommand
 
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
-        string output = Missions.Battles.BattleDebugCommands.FocusLadder(new List<string>(args));
-        return resultFactory.FromOutput(output);
+        return Missions.Battles.BattleDebugCommands.FocusLadder(new List<string>(args));
     }
 }
 

--- a/source/Missions/Battles/BattleCoopCommands.cs
+++ b/source/Missions/Battles/BattleCoopCommands.cs
@@ -1,0 +1,728 @@
+﻿using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace Missions.Battles;
+
+public interface IBattleLegacyCommandResult
+{
+    CoopCommandResult FromOutput(string output);
+}
+
+public sealed class BattleLegacyCommandResult : IBattleLegacyCommandResult
+{
+    public CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool succeeded = !LooksLikeFailure(output);
+        return new CoopCommandResult(succeeded, output, succeeded ? null : "command_failed");
+    }
+
+    private static bool LooksLikeFailure(string output)
+    {
+        string[] failurePrefixes =
+        {
+            "Usage:",
+            "Failed",
+            "Unable",
+            "No ",
+            "Run this",
+            "Command can",
+            "The host has disabled",
+            "Cannot ",
+            "Could not",
+            "Refusing",
+            "Prepare ",
+            "Both ",
+            "Player parties must",
+            "Attacker and defender",
+            "Exists must",
+            "State requires",
+            "A ",
+            "The ",
+            "Party ",
+            "Character ",
+            "Settlement ",
+            "Object manager",
+            "Network ",
+            "Battle agent",
+            "Active mount",
+            "Upgrade ",
+            "Clan-party",
+            "Map event",
+            "Invalid ",
+            "Player parties",
+            "Player party",
+            "Player '",
+        };
+
+        foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return false;
+    }
+}
+
+#if DEBUG
+public interface IReplicationFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class ReplicationFixtureCommand : IReplicationFixtureCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public ReplicationFixtureCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "replication_fixture";
+
+    public string Description => "Runs the replication fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "The mode.", true),
+        new ExpectedArgs("connected_controller_id", "The connected controller id.", false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.ReplicationFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IColumnReinforcementFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class ColumnReinforcementFixtureCommand : IColumnReinforcementFixtureCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public ColumnReinforcementFixtureCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "column_reinforcement_fixture";
+
+    public string Description => "Runs the column reinforcement fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("action", "The action.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.ColumnReinforcementFixture(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IActionPerformanceCommand : ICoopCommand
+{
+}
+
+public sealed class ActionPerformanceCommand : IActionPerformanceCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public ActionPerformanceCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "action_performance";
+
+    public string Description => "Runs the action performance debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("action", "The action.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.ActionPerformance(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IAnimationTraceCommand : ICoopCommand
+{
+}
+
+public sealed class AnimationTraceCommand : IAnimationTraceCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public AnimationTraceCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "animation_trace";
+
+    public string Description => "Runs the animation trace debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("action", "The action.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.AnimationTrace(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IWieldTestCommand : ICoopCommand
+{
+}
+
+public sealed class WieldTestCommand : IWieldTestCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public WieldTestCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "wield_test";
+
+    public string Description => "Runs the wield test debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("action", "The action.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.WieldTest(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IItemModifierStateCommand : ICoopCommand
+{
+}
+
+public sealed class ItemModifierStateCommand : IItemModifierStateCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public ItemModifierStateCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "item_modifier_state";
+
+    public string Description => "Reports item modifier state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.ItemModifierState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+#endif
+
+public interface IStateCommand : ICoopCommand
+{
+}
+
+public sealed class StateCommand : IStateCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public StateCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "state";
+
+    public string Description => "Reports state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.State(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ISizeStateCommand : ICoopCommand
+{
+}
+
+public sealed class SizeStateCommand : ISizeStateCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public SizeStateCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "size_state";
+
+    public string Description => "Reports size state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.SizeState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IChargeOwnedFormationsCommand : ICoopCommand
+{
+}
+
+public sealed class ChargeOwnedFormationsCommand : IChargeOwnedFormationsCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public ChargeOwnedFormationsCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "charge_owned_formations";
+
+    public string Description => "Runs the charge owned formations debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.ChargeOwnedFormations(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IMountStateCommand : ICoopCommand
+{
+}
+
+public sealed class MountStateCommand : IMountStateCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public MountStateCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "mount_state";
+
+    public string Description => "Reports mount state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("authority", "The authority.", false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.MountState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ICaptureMountPoseCommand : ICoopCommand
+{
+}
+
+public sealed class CaptureMountPoseCommand : ICaptureMountPoseCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public CaptureMountPoseCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "capture_mount_pose";
+
+    public string Description => "Runs the capture mount pose debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.CaptureMountPose(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IMountPoseSamplesCommand : ICoopCommand
+{
+}
+
+public sealed class MountPoseSamplesCommand : IMountPoseSamplesCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public MountPoseSamplesCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "mount_pose_samples";
+
+    public string Description => "Runs the mount pose samples debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.MountPoseSamplesState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IMoveCavalryCommand : ICoopCommand
+{
+}
+
+public sealed class MoveCavalryCommand : IMoveCavalryCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public MoveCavalryCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "move_cavalry";
+
+    public string Description => "Runs the move cavalry debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("distance", "The distance.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.MoveCavalry(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IHoldCavalryCommand : ICoopCommand
+{
+}
+
+public sealed class HoldCavalryCommand : IHoldCavalryCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public HoldCavalryCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "hold_cavalry";
+
+    public string Description => "Runs the hold cavalry debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.HoldCavalry(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ITurnCavalryCommand : ICoopCommand
+{
+}
+
+public sealed class TurnCavalryCommand : ITurnCavalryCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public TurnCavalryCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "turn_cavalry";
+
+    public string Description => "Runs the turn cavalry debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("degrees", "The degrees.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.TurnCavalry(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IFocusMountCommand : ICoopCommand
+{
+}
+
+public sealed class FocusMountCommand : IFocusMountCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public FocusMountCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "focus_mount";
+
+    public string Description => "Runs the focus mount debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.FocusMount(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IMountCameraStateCommand : ICoopCommand
+{
+}
+
+public sealed class MountCameraStateCommand : IMountCameraStateCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public MountCameraStateCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "mount_camera_state";
+
+    public string Description => "Reports mount camera state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.MountCameraState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IReleaseMountCameraCommand : ICoopCommand
+{
+}
+
+public sealed class ReleaseMountCameraCommand : IReleaseMountCameraCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public ReleaseMountCameraCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "release_mount_camera";
+
+    public string Description => "Restores or clears release mount camera.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.ReleaseMountCameraCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface ILadderStateCommand : ICoopCommand
+{
+}
+
+public sealed class LadderStateCommand : ILadderStateCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public LadderStateCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "ladder_state";
+
+    public string Description => "Reports ladder state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("machine_id", "The machine id.", false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.LadderState(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IFocusLadderCommand : ICoopCommand
+{
+}
+
+public sealed class FocusLadderCommand : IFocusLadderCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public FocusLadderCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "focus_ladder";
+
+    public string Description => "Runs the focus ladder debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("machine_id", "The machine id.", true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.FocusLadder(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}
+
+public interface IReleaseLadderCameraCommand : ICoopCommand
+{
+}
+
+public sealed class ReleaseLadderCameraCommand : IReleaseLadderCameraCommand
+{
+    private readonly IBattleLegacyCommandResult resultFactory;
+
+    public ReleaseLadderCameraCommand(IBattleLegacyCommandResult resultFactory)
+    {
+        if (resultFactory == null) throw new ArgumentNullException(nameof(resultFactory));
+
+        this.resultFactory = resultFactory;
+    }
+    public string Prefix => "coop.debug.battle";
+
+    public string Name => "release_ladder_camera";
+
+    public string Description => "Restores or clears release ladder camera.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = Missions.Battles.BattleDebugCommands.ReleaseLadderCameraCommand(new List<string>(args));
+        return resultFactory.FromOutput(output);
+    }
+}

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -23,7 +23,6 @@ using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.View.Screens;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace Missions.Battles;
 
@@ -126,7 +125,6 @@ internal static class BattleDebugCommands
         public Agent[] Agents { get; set; }
     }
 
-    [CommandLineArgumentFunction("replication_fixture", "coop.debug.battle")]
     public static string ReplicationFixture(List<string> args)
     {
         if (args.Count < 1 || args.Count > 2)
@@ -260,7 +258,6 @@ internal static class BattleDebugCommands
         replicationFixtureInitialAgentIndex = -1;
     }
 
-    [CommandLineArgumentFunction("column_reinforcement_fixture", "coop.debug.battle")]
     public static string ColumnReinforcementFixture(List<string> args)
     {
         if (args.Count != 1)
@@ -467,7 +464,6 @@ internal static class BattleDebugCommands
         columnReinforcementFixtureKilled = 0;
     }
 
-    [CommandLineArgumentFunction("action_performance", "coop.debug.battle")]
     public static string ActionPerformance(List<string> args)
     {
         if (args.Count != 1)
@@ -500,7 +496,6 @@ internal static class BattleDebugCommands
         }
     }
 
-    [CommandLineArgumentFunction("animation_trace", "coop.debug.battle")]
     public static string AnimationTrace(List<string> args)
     {
         if (args.Count != 1)
@@ -533,7 +528,6 @@ internal static class BattleDebugCommands
         }
     }
 
-    [CommandLineArgumentFunction("wield_test", "coop.debug.battle")]
     public static string WieldTest(List<string> args)
     {
         if (args.Count != 1)
@@ -640,7 +634,6 @@ internal static class BattleDebugCommands
 #endif
 
 #if DEBUG
-    [CommandLineArgumentFunction("item_modifier_state", "coop.debug.battle")]
     public static string ItemModifierState(List<string> args)
     {
         if (args.Count != 0)
@@ -726,7 +719,6 @@ internal static class BattleDebugCommands
     }
 #endif
 
-    [CommandLineArgumentFunction("state", "coop.debug.battle")]
     public static string State(List<string> args)
     {
         if (args.Count != 0)
@@ -792,7 +784,6 @@ internal static class BattleDebugCommands
             $"battleResolved={result?.BattleResolved ?? false} playerVictory={result?.PlayerVictory ?? false}";
     }
 
-    [CommandLineArgumentFunction("size_state", "coop.debug.battle")]
     public static string SizeState(List<string> args)
     {
         if (args.Count != 0)
@@ -833,7 +824,6 @@ internal static class BattleDebugCommands
             $"LIVE_TEST_JSON={structuredState}";
     }
 
-    [CommandLineArgumentFunction("charge_owned_formations", "coop.debug.battle")]
     public static string ChargeOwnedFormations(List<string> args)
     {
         if (args.Count != 0)
@@ -867,7 +857,6 @@ internal static class BattleDebugCommands
         return $"Charged {formations.Length} locally owned formation(s) with {ownedAgents.Length} active agent(s)";
     }
 
-    [CommandLineArgumentFunction("mount_state", "coop.debug.battle")]
     public static string MountState(List<string> args)
     {
         if (args.Count > 1)
@@ -958,7 +947,6 @@ internal static class BattleDebugCommands
         return output.ToString().TrimEnd();
     }
 
-    [CommandLineArgumentFunction("capture_mount_pose", "coop.debug.battle")]
     public static string CaptureMountPose(List<string> args)
     {
         if (args.Count != 1 || !Guid.TryParseExact(args[0], "N", out Guid mountId))
@@ -990,7 +978,6 @@ internal static class BattleDebugCommands
         return $"Capturing rendered horse-head pose for mount {mountId:N}";
     }
 
-    [CommandLineArgumentFunction("mount_pose_samples", "coop.debug.battle")]
     public static string MountPoseSamplesState(List<string> args)
     {
         if (args.Count != 1 || !Guid.TryParseExact(args[0], "N", out Guid mountId))
@@ -1081,7 +1068,6 @@ internal static class BattleDebugCommands
         });
     }
 
-    [CommandLineArgumentFunction("move_cavalry", "coop.debug.battle")]
     public static string MoveCavalry(List<string> args)
     {
         if (args.Count != 1
@@ -1144,7 +1130,6 @@ internal static class BattleDebugCommands
         return $"Moved {formations.Length} battle-host cavalry formations {distance:0.0} meters";
     }
 
-    [CommandLineArgumentFunction("hold_cavalry", "coop.debug.battle")]
     public static string HoldCavalry(List<string> args)
     {
         if (args.Count != 0)
@@ -1190,7 +1175,6 @@ internal static class BattleDebugCommands
         return $"Stopped {formations.Length} battle-host cavalry formations";
     }
 
-    [CommandLineArgumentFunction("turn_cavalry", "coop.debug.battle")]
     public static string TurnCavalry(List<string> args)
     {
         if (args.Count != 1
@@ -1350,7 +1334,6 @@ internal static class BattleDebugCommands
         return info.CurrentAuthority == filter;
     }
 
-    [CommandLineArgumentFunction("focus_mount", "coop.debug.battle")]
     public static string FocusMount(List<string> args)
     {
         if (args.Count != 1 || !Guid.TryParseExact(args[0], "N", out Guid mountId))
@@ -1408,7 +1391,6 @@ internal static class BattleDebugCommands
         return $"Focused the mission camera on mount {mountId:N}";
     }
 
-    [CommandLineArgumentFunction("mount_camera_state", "coop.debug.battle")]
     public static string MountCameraState(List<string> args)
     {
         if (args.Count != 0)
@@ -1467,7 +1449,6 @@ internal static class BattleDebugCommands
         return true;
     }
 
-    [CommandLineArgumentFunction("release_mount_camera", "coop.debug.battle")]
     public static string ReleaseMountCameraCommand(List<string> args)
     {
         if (args.Count != 0)
@@ -1497,7 +1478,6 @@ internal static class BattleDebugCommands
         return true;
     }
 
-    [CommandLineArgumentFunction("ladder_state", "coop.debug.battle")]
     public static string LadderState(List<string> args)
     {
         if (args.Count > 1 || (args.Count == 1 && !int.TryParse(args[0], out _)))
@@ -1567,7 +1547,6 @@ internal static class BattleDebugCommands
         return output.ToString();
     }
 
-    [CommandLineArgumentFunction("focus_ladder", "coop.debug.battle")]
     public static string FocusLadder(List<string> args)
     {
         if (args.Count != 1 || !int.TryParse(args[0], out int machineId))
@@ -1603,7 +1582,6 @@ internal static class BattleDebugCommands
         return $"Focused the mission camera on siege ladder {machineId}";
     }
 
-    [CommandLineArgumentFunction("release_ladder_camera", "coop.debug.battle")]
     public static string ReleaseLadderCameraCommand(List<string> args)
     {
         if (args.Count != 0)

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Commands;
 using GameInterface;
 using GameInterface.Registry.Auto;
 using GameInterface.Services.MapEvents;
@@ -125,21 +126,21 @@ internal static class BattleDebugCommands
         public Agent[] Agents { get; set; }
     }
 
-    public static string ReplicationFixture(List<string> args)
+    public static CoopCommandResult ReplicationFixture(List<string> args)
     {
         if (args.Count < 1 || args.Count > 2)
         {
-            return "Usage: coop.debug.battle.replication_fixture <catchup <connectedControllerId>|initial>";
+            return Failed("Usage: coop.debug.battle.replication_fixture <catchup <connectedControllerId>|initial>");
         }
 
         Mission mission = Mission.Current;
         CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
         if (mission == null || controller == null)
-            return "BATTLE_REPLICATION_FIXTURE no active coop battle";
+            return Failed("BATTLE_REPLICATION_FIXTURE no active coop battle");
         if (!BattleSpawnConfig.Enabled || !BattleSpawnGate.IsCoopBattleActive)
-            return "BATTLE_REPLICATION_FIXTURE coop spawn capture is not active";
+            return Failed("BATTLE_REPLICATION_FIXTURE coop spawn capture is not active");
         if (!controller.Deployment.IsActivated || !controller.Deployment.IsCommitted)
-            return "BATTLE_REPLICATION_FIXTURE finish local deployment first";
+            return Failed("BATTLE_REPLICATION_FIXTURE finish local deployment first");
 
         ResetReplicationFixtureForMission(mission);
         switch (args[0].ToLowerInvariant())
@@ -149,38 +150,38 @@ internal static class BattleDebugCommands
             case "initial":
                 return TriggerInitialReplicationFixture(controller, mission, args);
             default:
-                return "Usage: coop.debug.battle.replication_fixture <catchup <connectedControllerId>|initial>";
+                return Failed("Usage: coop.debug.battle.replication_fixture <catchup <connectedControllerId>|initial>");
         }
     }
 
-    private static string TriggerCatchUpReplicationFixture(
+    private static CoopCommandResult TriggerCatchUpReplicationFixture(
         CoopBattleController controller,
         List<string> args)
     {
         if (args.Count != 2)
-            return "Usage: coop.debug.battle.replication_fixture catchup <connectedControllerId>";
+            return Failed("Usage: coop.debug.battle.replication_fixture catchup <connectedControllerId>");
 
         string target = args[1];
         if (replicationFixtureCatchUpTargets.Contains(target))
-            return $"BATTLE_REPLICATION_FIXTURE_CATCHUP already queued peer={target}";
+            return Failed($"BATTLE_REPLICATION_FIXTURE_CATCHUP already queued peer={target}");
         if (!controller.TryDebugReplayOwnedAgentsToConnectedPeer(target, out string error))
-            return $"BATTLE_REPLICATION_FIXTURE_CATCHUP blocked reason={error}";
+            return Failed($"BATTLE_REPLICATION_FIXTURE_CATCHUP blocked reason={error}");
 
         replicationFixtureCatchUpTargets.Add(target);
-        return $"BATTLE_REPLICATION_FIXTURE_CATCHUP queued peer={target}";
+        return Succeeded($"BATTLE_REPLICATION_FIXTURE_CATCHUP queued peer={target}");
     }
 
-    private static string TriggerInitialReplicationFixture(
+    private static CoopCommandResult TriggerInitialReplicationFixture(
         CoopBattleController controller,
         Mission mission,
         List<string> args)
     {
         if (args.Count != 1)
-            return "Usage: coop.debug.battle.replication_fixture initial";
+            return Failed("Usage: coop.debug.battle.replication_fixture initial");
         if (replicationFixtureInitialAgentIndex >= 0)
-            return $"BATTLE_REPLICATION_FIXTURE_INITIAL already queued agentIndex={replicationFixtureInitialAgentIndex}";
+            return Failed($"BATTLE_REPLICATION_FIXTURE_INITIAL already queued agentIndex={replicationFixtureInitialAgentIndex}");
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL network agent registry is unavailable";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL network agent registry is unavailable");
 
         var ownedAgents = registry.GetAgents(controller.Session.OwnControllerId).ToArray();
         Agent source = ownedAgents
@@ -197,7 +198,7 @@ internal static class BattleDebugCommands
                 origin.Party != null &&
                 !string.IsNullOrEmpty(origin.MapEventPartyId));
         if (source == null)
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL no active locally owned troop is available";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL no active locally owned troop is available");
 
         var sourceOrigin = (CoopAgentOrigin)source.Origin;
         var character = (CharacterObject)source.Character;
@@ -209,7 +210,7 @@ internal static class BattleDebugCommands
         while (fixtureSeeds.Contains(fixtureSeed))
         {
             if (fixtureSeed == int.MinValue)
-                return "BATTLE_REPLICATION_FIXTURE_INITIAL no unused fixture seed is available";
+                return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL no unused fixture seed is available");
             fixtureSeed--;
         }
 
@@ -221,7 +222,7 @@ internal static class BattleDebugCommands
             sourceOrigin.Banner,
             new UniqueTroopDescriptor(fixtureSeed));
         if (mission.PlayerTeam == null)
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL the player team is unavailable";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL the player team is unavailable");
 
         bool isPlayerSide = source.Team == mission.PlayerTeam;
         Agent fixtureAgent;
@@ -242,11 +243,11 @@ internal static class BattleDebugCommands
                 formationIndex: source.Formation.FormationIndex);
         }
         if (fixtureAgent == null)
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL native spawn returned no agent";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL native spawn returned no agent");
 
         replicationFixtureInitialAgentIndex = fixtureAgent.Index;
-        return "BATTLE_REPLICATION_FIXTURE_INITIAL spawned through Mission.SpawnTroop; " +
-               $"agentIndex={fixtureAgent.Index} the normal capture and next controller tick will emit Initial";
+        return Succeeded("BATTLE_REPLICATION_FIXTURE_INITIAL spawned through Mission.SpawnTroop; " +
+                         $"agentIndex={fixtureAgent.Index} the normal capture and next controller tick will emit Initial");
     }
 
     private static void ResetReplicationFixtureForMission(Mission mission)
@@ -258,10 +259,10 @@ internal static class BattleDebugCommands
         replicationFixtureInitialAgentIndex = -1;
     }
 
-    public static string ColumnReinforcementFixture(List<string> args)
+    public static CoopCommandResult ColumnReinforcementFixture(List<string> args)
     {
         if (args.Count != 1)
-            return "Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>";
+            return Failed("Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>");
 
         switch (args[0].ToLowerInvariant())
         {
@@ -272,11 +273,11 @@ internal static class BattleDebugCommands
             case "restore":
                 return RestoreColumnReinforcementFixture();
             default:
-                return "Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>";
+                return Failed("Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>");
         }
     }
 
-    private static string StartColumnReinforcementFixture()
+    private static CoopCommandResult StartColumnReinforcementFixture()
     {
         if (columnReinforcementFixtureMission != null &&
             Mission.Current != columnReinforcementFixtureMission)
@@ -284,18 +285,18 @@ internal static class BattleDebugCommands
             ClearColumnReinforcementFixture();
         }
         if (columnReinforcementFixtureMission != null)
-            return "COLUMN_REINFORCEMENT_FIXTURE already active";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE already active");
 
         Mission mission = Mission.Current;
         CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
         DefaultBattleMissionAgentSpawnLogic spawnLogic =
             mission?.GetMissionBehavior<DefaultBattleMissionAgentSpawnLogic>();
         if (mission == null || controller == null || spawnLogic == null)
-            return "COLUMN_REINFORCEMENT_FIXTURE no active coop battle";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE no active coop battle");
         if (!controller.Deployment.IsActivated)
-            return "COLUMN_REINFORCEMENT_FIXTURE finish deployment first";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE finish deployment first");
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable");
 
         ColumnReinforcementCandidate candidate = null;
         foreach (BattleSideEnum side in new[] { BattleSideEnum.Defender, BattleSideEnum.Attacker })
@@ -343,7 +344,7 @@ internal static class BattleDebugCommands
 
         if (candidate == null)
         {
-            return "COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to an eligible locally controlled formation";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to an eligible locally controlled formation");
         }
 
         columnReinforcementFixtureMission = mission;
@@ -358,10 +359,10 @@ internal static class BattleDebugCommands
         foreach (Agent agent in candidate.Agents)
             BattleTeamKillCommands.Kill(agent);
 
-        return "COLUMN_REINFORCEMENT_FIXTURE_STARTED " +
-               $"side={candidate.Side} formation={candidate.FormationIndex} " +
-               $"killed={candidate.Agents.Length} active=0 " +
-               $"reserved={candidate.SpawnContext.ReservedTroopsCount} arrangement=Column";
+        return Succeeded("COLUMN_REINFORCEMENT_FIXTURE_STARTED " +
+                         $"side={candidate.Side} formation={candidate.FormationIndex} " +
+                         $"killed={candidate.Agents.Length} active=0 " +
+                         $"reserved={candidate.SpawnContext.ReservedTroopsCount} arrangement=Column");
     }
 
     private static ColumnReinforcementCandidate FindColumnReinforcementCandidate(
@@ -403,18 +404,18 @@ internal static class BattleDebugCommands
         return null;
     }
 
-    private static string GetColumnReinforcementFixtureState()
+    private static CoopCommandResult GetColumnReinforcementFixtureState()
     {
         if (columnReinforcementFixtureMission == null)
-            return "COLUMN_REINFORCEMENT_FIXTURE inactive";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE inactive");
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable");
         if (Mission.Current != columnReinforcementFixtureMission ||
             columnReinforcementFixtureFormation == null ||
             columnReinforcementFixtureSpawnContext == null)
         {
             ClearColumnReinforcementFixture();
-            return "COLUMN_REINFORCEMENT_FIXTURE mission ended";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE mission ended");
         }
 
         int active = Mission.Current.Agents.Count(agent => agent != null
@@ -427,21 +428,21 @@ internal static class BattleDebugCommands
             ? column.GetUnitPositionsOnVanguardFileIndex().Count
             : -1;
 
-        return "COLUMN_REINFORCEMENT_FIXTURE_STATE " +
-               $"side={columnReinforcementFixtureSide} " +
-               $"formation={columnReinforcementFixtureFormationIndex} " +
-               $"killed={columnReinforcementFixtureKilled} active={active} " +
-               $"replacementObserved={active > 0} " +
-               $"reserved={columnReinforcementFixtureSpawnContext.ReservedTroopsCount} " +
-               $"reinforcementActive={columnReinforcementFixtureSpawnContext.ReinforcementSpawnActive} " +
-               $"arrangement={columnReinforcementFixtureFormation.Arrangement.GetType().Name} " +
-               $"vanguardPositions={vanguardPositions}";
+        return Succeeded("COLUMN_REINFORCEMENT_FIXTURE_STATE " +
+                         $"side={columnReinforcementFixtureSide} " +
+                         $"formation={columnReinforcementFixtureFormationIndex} " +
+                         $"killed={columnReinforcementFixtureKilled} active={active} " +
+                         $"replacementObserved={active > 0} " +
+                         $"reserved={columnReinforcementFixtureSpawnContext.ReservedTroopsCount} " +
+                         $"reinforcementActive={columnReinforcementFixtureSpawnContext.ReinforcementSpawnActive} " +
+                         $"arrangement={columnReinforcementFixtureFormation.Arrangement.GetType().Name} " +
+                         $"vanguardPositions={vanguardPositions}");
     }
 
-    private static string RestoreColumnReinforcementFixture()
+    private static CoopCommandResult RestoreColumnReinforcementFixture()
     {
         if (columnReinforcementFixtureMission == null)
-            return "COLUMN_REINFORCEMENT_FIXTURE inactive";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE inactive");
 
         bool missionActive = Mission.Current == columnReinforcementFixtureMission;
         if (missionActive && columnReinforcementFixtureFormation != null)
@@ -449,8 +450,8 @@ internal static class BattleDebugCommands
 
         int killed = columnReinforcementFixtureKilled;
         ClearColumnReinforcementFixture();
-        return "COLUMN_REINFORCEMENT_FIXTURE_RESTORED " +
-               $"arrangementRestored={missionActive} casualtiesRemain={killed}";
+        return Succeeded("COLUMN_REINFORCEMENT_FIXTURE_RESTORED " +
+                         $"arrangementRestored={missionActive} casualtiesRemain={killed}");
     }
 
     private static void ClearColumnReinforcementFixture()
@@ -1547,11 +1548,11 @@ internal static class BattleDebugCommands
         return output.ToString();
     }
 
-    public static string FocusLadder(List<string> args)
+    public static CoopCommandResult FocusLadder(List<string> args)
     {
         if (args.Count != 1 || !int.TryParse(args[0], out int machineId))
         {
-            return "Usage: coop.debug.battle.focus_ladder <machineId>";
+            return Failed("Usage: coop.debug.battle.focus_ladder <machineId>");
         }
 
         var mission = Mission.Current;
@@ -1560,12 +1561,12 @@ internal static class BattleDebugCommands
             .FirstOrDefault(candidate => candidate.Id.Id == machineId);
         if (ladder == null)
         {
-            return $"Siege ladder {machineId} was not found";
+            return Failed($"Siege ladder {machineId} was not found");
         }
 
         if (!(ScreenManager.TopScreen is MissionScreen missionScreen) || missionScreen.CombatCamera == null)
         {
-            return "The mission screen is not active";
+            return Failed("The mission screen is not active");
         }
 
         ReleaseMountCamera();
@@ -1579,7 +1580,7 @@ internal static class BattleDebugCommands
         ladderCamera.LookAt(position, target, Vec3.Up);
         missionScreen.CustomCamera = ladderCamera;
 
-        return $"Focused the mission camera on siege ladder {machineId}";
+        return Succeeded($"Focused the mission camera on siege ladder {machineId}");
     }
 
     public static string ReleaseLadderCameraCommand(List<string> args)
@@ -1607,6 +1608,12 @@ internal static class BattleDebugCommands
         ladderCamera = null;
         return true;
     }
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 }
 
 internal sealed class DebugReplicationFixtureAgentOrigin : CoopAgentOrigin

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.Network.Session;
 using GameInterface;
 using GameInterface.Services.Locations;
@@ -44,6 +45,139 @@ public class MissionModule : Module
 
         foreach (HarmonyPatchCategoryRegistration registration in CreatePatchCategoryRegistrations())
             builder.RegisterInstance(registration);
+
+        builder.RegisterType<Missions.Agents.Handlers.MovementLegacyCommandResult>()
+            .As<Missions.Agents.Handlers.IMovementLegacyCommandResult>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.BattleLegacyCommandResult>()
+            .As<Missions.Battles.IBattleLegacyCommandResult>()
+            .InstancePerDependency();
+#if DEBUG
+        builder.RegisterType<Missions.Agents.Handlers.StateCommand>()
+            .As<Missions.Agents.Handlers.IStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Agents.Handlers.ForceRateCommand>()
+            .As<Missions.Agents.Handlers.IForceRateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Agents.Handlers.ForceReceiverCapCommand>()
+            .As<Missions.Agents.Handlers.IForceReceiverCapCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Agents.Handlers.SimulateReceivePressureCommand>()
+            .As<Missions.Agents.Handlers.ISimulateReceivePressureCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Agents.Handlers.ClearReceivePressureCommand>()
+            .As<Missions.Agents.Handlers.IClearReceivePressureCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Battles.ReplicationFixtureCommand>()
+            .As<Missions.Battles.IReplicationFixtureCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Battles.ColumnReinforcementFixtureCommand>()
+            .As<Missions.Battles.IColumnReinforcementFixtureCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Battles.ActionPerformanceCommand>()
+            .As<Missions.Battles.IActionPerformanceCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Battles.AnimationTraceCommand>()
+            .As<Missions.Battles.IAnimationTraceCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Battles.WieldTestCommand>()
+            .As<Missions.Battles.IWieldTestCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+#if DEBUG
+        builder.RegisterType<Missions.Battles.ItemModifierStateCommand>()
+            .As<Missions.Battles.IItemModifierStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
+        builder.RegisterType<Missions.Battles.StateCommand>()
+            .As<Missions.Battles.IStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.SizeStateCommand>()
+            .As<Missions.Battles.ISizeStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.ChargeOwnedFormationsCommand>()
+            .As<Missions.Battles.IChargeOwnedFormationsCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.MountStateCommand>()
+            .As<Missions.Battles.IMountStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.CaptureMountPoseCommand>()
+            .As<Missions.Battles.ICaptureMountPoseCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.MountPoseSamplesCommand>()
+            .As<Missions.Battles.IMountPoseSamplesCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.MoveCavalryCommand>()
+            .As<Missions.Battles.IMoveCavalryCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.HoldCavalryCommand>()
+            .As<Missions.Battles.IHoldCavalryCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.TurnCavalryCommand>()
+            .As<Missions.Battles.ITurnCavalryCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.FocusMountCommand>()
+            .As<Missions.Battles.IFocusMountCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.MountCameraStateCommand>()
+            .As<Missions.Battles.IMountCameraStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.ReleaseMountCameraCommand>()
+            .As<Missions.Battles.IReleaseMountCameraCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.LadderStateCommand>()
+            .As<Missions.Battles.ILadderStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.FocusLadderCommand>()
+            .As<Missions.Battles.IFocusLadderCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<Missions.Battles.ReleaseLadderCameraCommand>()
+            .As<Missions.Battles.IReleaseLadderCameraCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
 
         builder.RegisterType<LiteNetP2PClient>().As<IBattleNetwork>().InstancePerLifetimeScope();
         builder.RegisterType<MovementPacketCompressor>()


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

Battle, party, roster, and mission debug commands still use attributed static methods with command-specific argument handling.

## What is the new behavior?

Migrates 146 map-event, party-visual, party/roster, mission-movement, and mission-battle commands to the injected command framework. GameInterface and mission commands are registered in their owning modules.

Resolves #3425
Resolves #3427
Resolves #3428
Resolves #3442
Resolves #3443

Depends on #3485. MissionTestMod is no longer used, so #3444 is not part of this migration.

## Bot Changelog Entry

## Other information

Tests:

- Debug `Missions` and `GameInterface` builds
- `MigratedAttributedCommandTests` (6 passed)
- `MigratedMissionCommandTests` (5 passed)
- `ContainerBuildTests` (4 passed)
