### PR TITLE
Update and Normalize System and Developer Commands

### DIFF
--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -10,6 +11,7 @@ using Coop.Core.Client.Services.MobileParties;
 using Coop.Core.Client.Services.Session;
 using Coop.Core.Client.States;
 using Coop.Core.Common;
+using Coop.Core.Common.Commands;
 using Coop.Core.Common.Configuration;
 using Coop.Core.Common.Session;
 using Coop.Steam;
@@ -30,6 +32,21 @@ public class ClientModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<MissionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinStateCommand>()
+            .As<IJoinStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<ArmInactivePartyDeficitCommand>()
+            .As<IArmInactivePartyDeficitCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<DisconnectCommand>()
+            .As<IDisconnectCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
 
         builder.RegisterType<ClientContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ClientLogic>().As<ILogic>().As<IClientLogic>().InstancePerLifetimeScope();

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -27,7 +27,6 @@ internal static class JoinDebugCommands
     private static MobileParty stagedInactiveParty;
     private static bool stagedInactivePartyWasActive;
 
-    [CommandLineArgumentFunction("join_state", "coop.debug.connection")]
     public static string JoinState(List<string> args)
     {
         if (args.Count != 0)
@@ -65,7 +64,6 @@ internal static class JoinDebugCommands
               $"forcedInactiveParty={lastForcedPartyId}";
     }
 
-    [CommandLineArgumentFunction("arm_inactive_party_deficit", "coop.debug.connection")]
     public static string ArmInactivePartyDeficit(List<string> args)
     {
         if (args.Count != 1)
@@ -84,7 +82,6 @@ internal static class JoinDebugCommands
                "from the client campaign collection before validation.";
     }
 
-    [CommandLineArgumentFunction("stage_inactive_party", "coop.debug.connection")]
     public static string StageInactiveParty(List<string> args)
     {
         if (args.Count != 0)
@@ -125,7 +122,6 @@ internal static class JoinDebugCommands
         return GetStagedPartyResult(stagedInactiveParty);
     }
 
-    [CommandLineArgumentFunction("restore_inactive_party", "coop.debug.connection")]
     public static string RestoreInactiveParty(List<string> args)
     {
         if (args.Count != 0)
@@ -149,7 +145,6 @@ internal static class JoinDebugCommands
         return $"restoredParty={partyId} active={restoredActive}";
     }
 
-    [CommandLineArgumentFunction("disconnect", "coop.debug.connection")]
     public static string Disconnect(List<string> args)
     {
         if (args.Count != 0)
@@ -169,7 +164,10 @@ internal static class JoinDebugCommands
         return "Client session is returning to the main menu.";
     }
 
-    [CommandLineArgumentFunction("reconnect", "coop.debug.connection")]
+    // This command must be available before the session registrar exists so reconnect can create a session.
+    [CommandLineArgumentFunction(
+        LegacyConnectionCommandExceptions.ReconnectName,
+        LegacyConnectionCommandExceptions.Prefix)]
     public static string Reconnect(List<string> args)
     {
         if (args.Count != 0)

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Threading;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
-using static TaleWorlds.Library.CommandLineFunctionality;
 using ServerLoadingState = Coop.Core.Server.Connections.States.LoadingState;
 
 namespace Coop.Core.Common.Commands;
@@ -162,29 +161,6 @@ internal static class JoinDebugCommands
 
         clientLogic.Disconnect();
         return "Client session is returning to the main menu.";
-    }
-
-    // This command must be available before the session registrar exists so reconnect can create a session.
-    [CommandLineArgumentFunction(
-        LegacyConnectionCommandExceptions.ReconnectName,
-        LegacyConnectionCommandExceptions.Prefix)]
-    public static string Reconnect(List<string> args)
-    {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.reconnect";
-        }
-        if (ModInformation.IsServer)
-        {
-            return "reconnect must be run on a client.";
-        }
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
-        {
-            return "No client session was found.";
-        }
-
-        clientLogic.Connect();
-        return "Client session is reconnecting to the configured server.";
     }
 
     internal static void ForceArmedInactivePartyDeficit()

--- a/source/Coop.Core/Common/Commands/JoinDebugCoopCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCoopCommands.cs
@@ -1,0 +1,132 @@
+﻿#if DEBUG
+using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace Coop.Core.Common.Commands;
+
+internal static class JoinDebugLegacyCommandResult
+{
+    public static CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool failed = output.StartsWith("Usage:", StringComparison.OrdinalIgnoreCase) ||
+                      output.StartsWith("Failed", StringComparison.OrdinalIgnoreCase) ||
+                      output.StartsWith("No ", StringComparison.OrdinalIgnoreCase) ||
+                      output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                      output.IndexOf("client-only", StringComparison.OrdinalIgnoreCase) >= 0;
+        return failed
+            ? new CoopCommandResult(false, output, "command_rejected")
+            : new CoopCommandResult(true, output);
+    }
+}
+
+public interface IJoinStateCommand : ICoopCommand
+{
+}
+
+public sealed class JoinStateCommand : IJoinStateCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "join_state";
+
+    public string Description => "Reports the current campaign join state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.JoinState(new List<string>(args)));
+    }
+}
+
+public interface IArmInactivePartyDeficitCommand : ICoopCommand
+{
+}
+
+public sealed class ArmInactivePartyDeficitCommand : IArmInactivePartyDeficitCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "arm_inactive_party_deficit";
+
+    public string Description => "Arms the next client join baseline to omit an inactive party.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_string_id", "The inactive party StringId."),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.ArmInactivePartyDeficit(new List<string>(args)));
+    }
+}
+
+public interface IStageInactivePartyCommand : ICoopCommand
+{
+}
+
+public sealed class StageInactivePartyCommand : IStageInactivePartyCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "stage_inactive_party";
+
+    public string Description => "Stages an isolated server party as inactive for join testing.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.StageInactiveParty(new List<string>(args)));
+    }
+}
+
+public interface IRestoreInactivePartyCommand : ICoopCommand
+{
+}
+
+public sealed class RestoreInactivePartyCommand : IRestoreInactivePartyCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "restore_inactive_party";
+
+    public string Description => "Restores the staged inactive server party.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.RestoreInactiveParty(new List<string>(args)));
+    }
+}
+
+public interface IDisconnectCommand : ICoopCommand
+{
+}
+
+public sealed class DisconnectCommand : IDisconnectCommand
+{
+    public string Prefix => "coop.debug.connection";
+
+    public string Name => "disconnect";
+
+    public string Description => "Disconnects the active client session.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        return JoinDebugLegacyCommandResult.FromOutput(
+            JoinDebugCommands.Disconnect(new List<string>(args)));
+    }
+}
+#endif

--- a/source/Coop.Core/Common/Commands/LegacyConnectionCommandExceptions.cs
+++ b/source/Coop.Core/Common/Commands/LegacyConnectionCommandExceptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Coop.Core.Common.Commands;
+
+/// <summary>
+/// Identifies commands that must remain available outside the session command registrar lifecycle.
+/// </summary>
+public static class LegacyConnectionCommandExceptions
+{
+    public const string Prefix = "coop.debug.connection";
+
+    public const string StartName = "start";
+
+    public const string ReconnectName = "reconnect";
+}

--- a/source/Coop.Core/Common/Commands/LegacyConnectionCommands.cs
+++ b/source/Coop.Core/Common/Commands/LegacyConnectionCommands.cs
@@ -1,0 +1,69 @@
+﻿#if DEBUG
+using Common;
+using Coop.Core.Client;
+using GameInterface;
+using System;
+using System.Collections.Generic;
+using static TaleWorlds.Library.CommandLineFunctionality;
+
+namespace Coop.Core.Common.Commands;
+
+/// <summary>
+/// Connection commands that must remain available while no session container exists.
+/// </summary>
+public static class LegacyConnectionCommands
+{
+    [CommandLineArgumentFunction(
+        LegacyConnectionCommandExceptions.StartName,
+        LegacyConnectionCommandExceptions.Prefix)]
+    public static string Start(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.start";
+        }
+        if (ModInformation.IsServer)
+        {
+            return "start must be run on a client.";
+        }
+        if (ContainerProvider.TryResolve<global::Common.LogicStates.ILogic>(out _))
+        {
+            return "Client co-op connection is already starting or running.";
+        }
+
+        StartClientSession();
+        return "Client co-op connection started.";
+    }
+
+    [CommandLineArgumentFunction(
+        LegacyConnectionCommandExceptions.ReconnectName,
+        LegacyConnectionCommandExceptions.Prefix)]
+    public static string Reconnect(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            return "Usage: coop.debug.connection.reconnect";
+        }
+        if (ModInformation.IsServer)
+        {
+            return "reconnect must be run on a client.";
+        }
+        if (ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+        {
+            clientLogic.Connect();
+            return "Client session is reconnecting to the configured server.";
+        }
+
+        StartClientSession();
+        return "Client co-op session restarted after teardown.";
+    }
+
+    private static void StartClientSession()
+    {
+        if (!ProcessLifetimeClientSessionStarter.Start())
+        {
+            throw new InvalidOperationException("Client co-op connection start was refused.");
+        }
+    }
+}
+#endif

--- a/source/Coop.Core/Common/Commands/ProcessLifetimeClientSessionStarter.cs
+++ b/source/Coop.Core/Common/Commands/ProcessLifetimeClientSessionStarter.cs
@@ -1,0 +1,37 @@
+﻿#if DEBUG
+using System;
+using System.Threading;
+
+namespace Coop.Core.Common.Commands;
+
+/// <summary>
+/// Bridges pre-session commands to the process-owned co-op session lifecycle.
+/// </summary>
+public static class ProcessLifetimeClientSessionStarter
+{
+    private static Func<bool> startClientSession;
+
+    public static void Configure(Func<bool> starter)
+    {
+        if (starter == null) throw new ArgumentNullException(nameof(starter));
+
+        Volatile.Write(ref startClientSession, starter);
+    }
+
+    public static bool Start()
+    {
+        Func<bool> starter = Volatile.Read(ref startClientSession);
+        if (starter == null)
+        {
+            throw new InvalidOperationException("The process client-session starter is unavailable.");
+        }
+
+        return starter();
+    }
+
+    internal static void Reset()
+    {
+        Volatile.Write(ref startClientSession, null);
+    }
+}
+#endif

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -8,6 +9,7 @@ using Common.PacketHandlers;
 using Coop.Core.Client.Services.Kingdoms;
 using Coop.Core.Client.Services.MobileParties;
 using Coop.Core.Common;
+using Coop.Core.Common.Commands;
 using Coop.Core.Common.Configuration;
 using Coop.Core.Common.Session;
 using Coop.Core.Server.Connections;
@@ -39,6 +41,21 @@ public class ServerModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<ConnectionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinStateCommand>()
+            .As<IJoinStateCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<StageInactivePartyCommand>()
+            .As<IStageInactivePartyCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+        builder.RegisterType<RestoreInactivePartyCommand>()
+            .As<IRestoreInactivePartyCommand>()
+            .As<ICoopCommand>()
+            .InstancePerDependency();
+#endif
 
         // The mission/P2P stack is composed into the server container too (it is also in ClientModule) so the
         // server-authoritative battle classes — notably BattleHostHandler, which elects the battle host — run

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -32,6 +32,15 @@ namespace Coop.Tests.Autofac
             var commandRegistry = container.Resolve<ICoopCommandRegistry>();
             Assert.True(commandRegistry.Contains("coop.debug.map_event.click_deployment_ready"));
             Assert.True(commandRegistry.Contains("coop.debug.battle.state"));
+            Assert.True(commandRegistry.Contains("coop.debug.hero.id"));
+            Assert.True(commandRegistry.Contains("coop.debug.campaign_options.list"));
+            Assert.True(commandRegistry.Contains("coop.debug.player_captivity.capture_player"));
+#if DEBUG
+            Assert.True(commandRegistry.Contains("coop.debug.connection.join_state"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.arm_inactive_party_deficit"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.disconnect"));
+            Assert.False(commandRegistry.Contains("coop.debug.connection.stage_inactive_party"));
+#endif
         }
 
         [Fact]
@@ -53,6 +62,15 @@ namespace Coop.Tests.Autofac
             var commandRegistry = container.Resolve<ICoopCommandRegistry>();
             Assert.True(commandRegistry.Contains("coop.debug.map_event.click_deployment_ready"));
             Assert.True(commandRegistry.Contains("coop.debug.battle.state"));
+            Assert.True(commandRegistry.Contains("coop.debug.hero.id"));
+            Assert.True(commandRegistry.Contains("coop.debug.campaign_options.list"));
+            Assert.True(commandRegistry.Contains("coop.debug.player_captivity.capture_player"));
+#if DEBUG
+            Assert.True(commandRegistry.Contains("coop.debug.connection.join_state"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.stage_inactive_party"));
+            Assert.True(commandRegistry.Contains("coop.debug.connection.restore_inactive_party"));
+            Assert.False(commandRegistry.Contains("coop.debug.connection.disconnect"));
+#endif
         }
 
         [Theory]

--- a/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
+++ b/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
@@ -1,0 +1,37 @@
+﻿#if DEBUG
+using Coop.Core.Common.Commands;
+using System.Reflection;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.CommandTests;
+
+public class LegacyConnectionCommandExceptionTests
+{
+    [Fact]
+    public void LifecycleCommands_DocumentOnlyStartAndReconnectAsLegacyExceptions()
+    {
+        Assert.Equal("coop.debug.connection.start",
+            $"{LegacyConnectionCommandExceptions.Prefix}.{LegacyConnectionCommandExceptions.StartName}");
+        Assert.Equal("coop.debug.connection.reconnect",
+            $"{LegacyConnectionCommandExceptions.Prefix}.{LegacyConnectionCommandExceptions.ReconnectName}");
+
+        MethodInfo reconnect = typeof(JoinDebugCommands).GetMethod(nameof(JoinDebugCommands.Reconnect))!;
+        Assert.NotNull(reconnect.GetCustomAttribute<CommandLineFunctionality.CommandLineArgumentFunction>());
+
+        string[] migratedMethods =
+        {
+            nameof(JoinDebugCommands.JoinState),
+            nameof(JoinDebugCommands.ArmInactivePartyDeficit),
+            nameof(JoinDebugCommands.StageInactiveParty),
+            nameof(JoinDebugCommands.RestoreInactiveParty),
+            nameof(JoinDebugCommands.Disconnect),
+        };
+        Assert.All(migratedMethods, methodName =>
+        {
+            MethodInfo method = typeof(JoinDebugCommands).GetMethod(methodName)!;
+            Assert.Empty(method.GetCustomAttributes<CommandLineFunctionality.CommandLineArgumentFunction>());
+        });
+    }
+}
+#endif

--- a/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
+++ b/source/Coop.Tests/Common/Commands/LegacyConnectionCommandExceptionTests.cs
@@ -1,13 +1,32 @@
 ﻿#if DEBUG
+using Autofac;
+using Common;
+using Coop.Core.Client;
 using Coop.Core.Common.Commands;
+using GameInterface;
+using Moq;
+using System;
+using System.Collections.Generic;
 using System.Reflection;
 using TaleWorlds.Library;
 using Xunit;
 
 namespace Coop.Tests.CommandTests;
 
-public class LegacyConnectionCommandExceptionTests
+[Collection(ModInformationRoleCollection.Name)]
+public class LegacyConnectionCommandExceptionTests : IDisposable
 {
+    private readonly bool wasServer = ModInformation.IsServer;
+    private IContainer sessionContainer;
+
+    public void Dispose()
+    {
+        ContainerProvider.Clear();
+        sessionContainer?.Dispose();
+        ProcessLifetimeClientSessionStarter.Reset();
+        ModInformation.IsServer = wasServer;
+    }
+
     [Fact]
     public void LifecycleCommands_DocumentOnlyStartAndReconnectAsLegacyExceptions()
     {
@@ -16,8 +35,8 @@ public class LegacyConnectionCommandExceptionTests
         Assert.Equal("coop.debug.connection.reconnect",
             $"{LegacyConnectionCommandExceptions.Prefix}.{LegacyConnectionCommandExceptions.ReconnectName}");
 
-        MethodInfo reconnect = typeof(JoinDebugCommands).GetMethod(nameof(JoinDebugCommands.Reconnect))!;
-        Assert.NotNull(reconnect.GetCustomAttribute<CommandLineFunctionality.CommandLineArgumentFunction>());
+        AssertLegacyAttribute(nameof(LegacyConnectionCommands.Start));
+        AssertLegacyAttribute(nameof(LegacyConnectionCommands.Reconnect));
 
         string[] migratedMethods =
         {
@@ -32,6 +51,71 @@ public class LegacyConnectionCommandExceptionTests
             MethodInfo method = typeof(JoinDebugCommands).GetMethod(methodName)!;
             Assert.Empty(method.GetCustomAttributes<CommandLineFunctionality.CommandLineArgumentFunction>());
         });
+    }
+
+    [Fact]
+    public void Reconnect_WhileSessionExists_ReconnectsExistingClientLogic()
+    {
+        ModInformation.IsServer = false;
+        var clientLogic = new Mock<IClientLogic>();
+        int processStarts = 0;
+        ProcessLifetimeClientSessionStarter.Configure(() =>
+        {
+            processStarts++;
+            return true;
+        });
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(clientLogic.Object).As<IClientLogic>();
+        sessionContainer = builder.Build();
+        ContainerProvider.SetContainer(sessionContainer);
+
+        string result = LegacyConnectionCommands.Reconnect(new List<string>());
+
+        Assert.Equal("Client session is reconnecting to the configured server.", result);
+        clientLogic.Verify(logic => logic.Connect(), Times.Once);
+        Assert.Equal(0, processStarts);
+    }
+
+    [Fact]
+    public void Reconnect_AfterSessionTeardown_StartsNewClientSession()
+    {
+        ModInformation.IsServer = false;
+        int processStarts = 0;
+        ProcessLifetimeClientSessionStarter.Configure(() =>
+        {
+            processStarts++;
+            return true;
+        });
+        ContainerProvider.Clear();
+
+        string result = LegacyConnectionCommands.Reconnect(new List<string>());
+
+        Assert.Equal("Client co-op session restarted after teardown.", result);
+        Assert.Equal(1, processStarts);
+    }
+
+    [Fact]
+    public void Start_WithoutSession_StartsNewClientSession()
+    {
+        ModInformation.IsServer = false;
+        int processStarts = 0;
+        ProcessLifetimeClientSessionStarter.Configure(() =>
+        {
+            processStarts++;
+            return true;
+        });
+        ContainerProvider.Clear();
+
+        string result = LegacyConnectionCommands.Start(new List<string>());
+
+        Assert.Equal("Client co-op connection started.", result);
+        Assert.Equal(1, processStarts);
+    }
+
+    private static void AssertLegacyAttribute(string methodName)
+    {
+        MethodInfo method = typeof(LegacyConnectionCommands).GetMethod(methodName)!;
+        Assert.NotNull(method.GetCustomAttribute<CommandLineFunctionality.CommandLineArgumentFunction>());
     }
 }
 #endif

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -25,9 +25,6 @@ using GameInterface.Utils;
 using HarmonyLib;
 using Serilog;
 using System;
-#if DEBUG
-using System.Collections.Generic;
-#endif
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -42,9 +39,6 @@ using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.View;
 using TaleWorlds.ScreenSystem;
-#if DEBUG
-using static TaleWorlds.Library.CommandLineFunctionality;
-#endif
 using Module = TaleWorlds.MountAndBlade.Module;
 
 namespace Coop
@@ -483,6 +477,11 @@ namespace Coop
                 CrashDiagnostics.SetPhase,
                 activeLogFilePath);
 
+#if DEBUG
+            global::Coop.Core.Common.Commands.ProcessLifetimeClientSessionStarter.Configure(
+                () => Coop.StartAsClient());
+#endif
+
             Updateables.Add(GameThread.Instance);
 
 #if DEBUG
@@ -801,39 +800,4 @@ namespace Coop
         }
     }
 
-#if DEBUG
-    /// <summary>
-    /// Starts a deferred live-test client through the normal connection path.
-    /// </summary>
-    internal static class JoinFixtureCommands
-    {
-        // This command must be available before the session registrar exists so start can create a session.
-        [CommandLineArgumentFunction(
-            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.StartName,
-            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.Prefix)]
-        public static string Start(List<string> args)
-        {
-            if (args.Count != 0)
-            {
-                return "Usage: coop.debug.connection.start";
-            }
-
-            if (ModInformation.IsServer)
-            {
-                return "start must be run on a client.";
-            }
-
-            if (ContainerProvider.TryResolve<Common.LogicStates.ILogic>(out _))
-            {
-                return "Client co-op connection is already starting or running.";
-            }
-
-            if (!CoopMod.Coop.StartAsClient())
-            {
-                throw new InvalidOperationException("Client co-op connection start was refused.");
-            }
-            return "Client co-op connection started.";
-        }
-    }
-#endif
 }

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -807,7 +807,10 @@ namespace Coop
     /// </summary>
     internal static class JoinFixtureCommands
     {
-        [CommandLineArgumentFunction("start", "coop.debug.connection")]
+        // This command must be available before the session registrar exists so start can create a session.
+        [CommandLineArgumentFunction(
+            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.StartName,
+            Coop.Core.Common.Commands.LegacyConnectionCommandExceptions.Prefix)]
         public static string Start(List<string> args)
         {
             if (args.Count != 0)

--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -4,6 +4,7 @@ using Common.LiveTesting;
 using Common.Logging;
 using Common.LogicStates;
 using Coop.Core.Client;
+using Coop.Core.Common.Commands;
 using Coop.Core.Server;
 using GameInterface;
 using GameInterface.Services.LiveTesting;
@@ -192,7 +193,7 @@ namespace Coop.LiveTesting
                 {
                     if (string.Equals(command, "coop.debug.connection.start", StringComparison.Ordinal))
                     {
-                        string output = Coop.JoinFixtureCommands.Start(arguments);
+                        string output = LegacyConnectionCommands.Start(arguments);
                         bool hasFallbackStructuredResult = TryParseStructuredResult(
                             output,
                             out var fallbackStructuredResult);

--- a/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
@@ -1,0 +1,104 @@
+﻿using Common.Commands;
+using GameInterface.Services.SystemDeveloper.Commands;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+public class SystemDeveloperCommandTests
+{
+    [Fact]
+    public void Commands_HaveValidUniqueNormalizedMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var registry = new CoopCommandRegistry(commands, new LoggerConfiguration().CreateLogger());
+
+#if DEBUG
+        Assert.Equal(106, commands.Length);
+#else
+        Assert.Equal(95, commands.Length);
+#endif
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.All(commands, AssertNormalizedMetadata);
+    }
+
+    [Fact]
+    public void MultiWordArguments_UseFixedLogicalSlots()
+    {
+        AssertArgumentNames(new HeroDeveloperAddSkillXpCommand(),
+            "hero_name_or_id", "skill_name", "xp_amount");
+        AssertArgumentNames(new PlayerCaptivityCapturePlayerCommand(),
+            "hero_id", "captor_party_id");
+        AssertArgumentNames(new GameThreadStallCommand(), "milliseconds");
+
+        IExpectedArgs mode = new CampaignOptionsPlayerTroopsReceivedDamageCommand().ExpectedArgs.Single();
+        Assert.False(mode.IsRequired);
+    }
+
+    [Fact]
+    public void Registry_RejectsExtraUnquotedHeroNameTokens()
+    {
+        var command = new HeroDeveloperAddAttributePointsCommand();
+        var registry = new CoopCommandRegistry(
+            new[] { command },
+            new LoggerConfiguration().CreateLogger());
+        var argsFactory = new CoopCommandArgsFactory();
+
+        CoopCommandResult result = registry.ProcessCommand(
+            "coop.debug.hero_developer.add_attribute_points",
+            argsFactory.FromValues(new[] { "Hero", "With", "Spaces", "2" }));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("Failed: no active campaign.", false)]
+    [InlineData("Command can only be run on the server.", false)]
+    [InlineData("Advanced campaign time forward by 2 days.", true)]
+    public void LegacyResult_MapsSuccessAndFailure(string output, bool succeeded)
+    {
+        CoopCommandResult result = SystemDeveloperLegacyCommandResult.FromOutput(output);
+
+        Assert.Equal(succeeded, result.Succeeded);
+        Assert.Equal(succeeded ? null : "command_rejected", result.ErrorCode);
+        Assert.Equal(output, result.Output);
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return typeof(CampaignOptionsListCommand).Assembly.GetTypes()
+            .Where(type => type.IsClass && !type.IsAbstract)
+            .Where(type => type.Namespace == "GameInterface.Services.SystemDeveloper.Commands")
+            .Where(type => typeof(ICoopCommand).IsAssignableFrom(type))
+            .Select(type => (ICoopCommand)Activator.CreateInstance(type))
+            .ToArray();
+    }
+
+    private static void AssertNormalizedMetadata(ICoopCommand command)
+    {
+        Assert.Matches("^[a-z0-9_]+(?:\\.[a-z0-9_]+)*$", command.Prefix);
+        Assert.Matches("^[a-z0-9_]+$", command.Name);
+        Assert.False(string.IsNullOrWhiteSpace(command.Description));
+        Assert.NotNull(command.ExpectedArgs);
+
+        bool optionalFound = false;
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (IExpectedArgs expectedArg in command.ExpectedArgs)
+        {
+            Assert.Matches("^[a-z0-9_]+$", expectedArg.Name);
+            Assert.True(names.Add(expectedArg.Name));
+            Assert.False(string.IsNullOrWhiteSpace(expectedArg.Description));
+            Assert.False(expectedArg.IsRequired && optionalFound);
+            optionalFound |= !expectedArg.IsRequired;
+        }
+    }
+
+    private static void AssertArgumentNames(ICoopCommand command, params string[] expected)
+    {
+        Assert.Equal(expected, command.ExpectedArgs.Select(argument => argument.Name));
+    }
+}

--- a/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/SystemDeveloperCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using Common.Commands;
+﻿using Common;
+using Common.Commands;
 using GameInterface.Services.SystemDeveloper.Commands;
 using Serilog;
 using System;
@@ -8,6 +9,7 @@ using Xunit;
 
 namespace GameInterface.Tests.Utils.Commands;
 
+[Collection(ModInformationRoleCollection.Name)]
 public class SystemDeveloperCommandTests
 {
     [Fact]
@@ -55,9 +57,43 @@ public class SystemDeveloperCommandTests
         Assert.Equal("invalid_arguments", result.ErrorCode);
     }
 
+    [Fact]
+    public void CampaignOptionRoleFailure_ReturnsFailedResultThroughRegistry()
+    {
+        bool wasServer = ModInformation.IsServer;
+        ModInformation.IsServer = false;
+        try
+        {
+            var command = new CampaignOptionsAutoAllocateClanMemberPerksCommand();
+            var registry = new CoopCommandRegistry(
+                new[] { command },
+                new LoggerConfiguration().CreateLogger());
+            var argsFactory = new CoopCommandArgsFactory();
+
+            CoopCommandResult result = registry.ProcessCommand(
+                "coop.debug.campaign_options.auto_allocate_clan_member_perks",
+                argsFactory.FromValues(new[] { "true" }));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_rejected", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+    }
+
     [Theory]
     [InlineData("Failed: no active campaign.", false)]
     [InlineData("Command can only be run on the server.", false)]
+    [InlineData("Managing campaign options is disabled on clients; the host does this.", false)]
+    [InlineData("An integer amount of xp is required.", false)]
+    [InlineData("Hero not found.", false)]
+    [InlineData("A save is already queued.", false)]
+    [InlineData("Unknown quest type key 'missing'.", false)]
+    [InlineData("Tactical unit symbols configuration is unavailable.", false)]
+    [InlineData("Close screen failed.\nException: InvalidOperationException", false)]
+    [InlineData("Diagnostic bug-report log sharing is disabled.", true)]
     [InlineData("Advanced campaign time forward by 2 days.", true)]
     public void LegacyResult_MapsSuccessAndFailure(string output, bool succeeded)
     {
@@ -66,6 +102,20 @@ public class SystemDeveloperCommandTests
         Assert.Equal(succeeded, result.Succeeded);
         Assert.Equal(succeeded ? null : "command_rejected", result.ErrorCode);
         Assert.Equal(output, result.Output);
+    }
+
+    [Fact]
+    public void LegacyResult_CommandSpecificFailure_DoesNotChangeStatusResult()
+    {
+        const string output = "Steam integration inactive";
+
+        CoopCommandResult hostResult = SystemDeveloperLegacyCommandResult.FromOutput(
+            output,
+            "Steam integration inactive");
+        CoopCommandResult statusResult = SystemDeveloperLegacyCommandResult.FromOutput(output);
+
+        Assert.False(hostResult.Succeeded);
+        Assert.True(statusResult.Succeeded);
     }
 
     private static ICoopCommand[] CreateCommands()

--- a/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using static TaleWorlds.CampaignSystem.CampaignOptions;
-using static TaleWorlds.Library.CommandLineFunctionality;
 using static TaleWorlds.MountAndBlade.BannerlordConfig;
 
 namespace GameInterface.Services.CampaignService.Commands;
@@ -17,7 +16,6 @@ namespace GameInterface.Services.CampaignService.Commands;
 /// </summary>
 internal class CampaignOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.campaignoptions")]
     public static string ListOptionsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new();
@@ -39,7 +37,6 @@ internal class CampaignOptionsCommands
         return stringBuilder.ToString();
     }
 
-    [CommandLineArgumentFunction("AutoAllocateClanMemberPerks", "coop.debug.campaignoptions")]
     public static string AutoAllocateClanMemberPerksCommand(List<string> strings)
     {
         return HandleBooleanOptionCommand(
@@ -49,7 +46,6 @@ internal class CampaignOptionsCommands
             value => AutoAllocateClanMemberPerks = value);
     }
 
-    [CommandLineArgumentFunction("PlayerTroopsReceivedDamage", "coop.debug.campaignoptions")]
     public static string PlayerTroopsReceivedDamageCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -59,7 +55,6 @@ internal class CampaignOptionsCommands
             value => PlayerTroopsReceivedDamage = value);
     }
 
-    [CommandLineArgumentFunction("RecruitmentDifficulty", "coop.debug.campaignoptions")]
     public static string RecruitmentDifficultyCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -69,7 +64,6 @@ internal class CampaignOptionsCommands
             value => RecruitmentDifficulty = value);
     }
 
-    [CommandLineArgumentFunction("PlayerMapMovementSpeed", "coop.debug.campaignoptions")]
     public static string PlayerMapMovementSpeedCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -79,7 +73,6 @@ internal class CampaignOptionsCommands
             value => PlayerMapMovementSpeed = value);
     }
 
-    [CommandLineArgumentFunction("StealthAndDisguiseDifficulty", "coop.debug.campaignoptions")]
     public static string StealthAndDisguiseDifficultyCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -89,7 +82,6 @@ internal class CampaignOptionsCommands
             value => StealthAndDisguiseDifficulty = value);
     }
 
-    [CommandLineArgumentFunction("CombatAIDifficulty", "coop.debug.campaignoptions")]
     public static string CombatAIDifficultyCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -99,7 +91,6 @@ internal class CampaignOptionsCommands
             value => CombatAIDifficulty = value);
     }
 
-    [CommandLineArgumentFunction("IsLifeDeathCycleDisabled", "coop.debug.campaignoptions")]
     public static string IsLifeDeathCycleDisabledCommand(List<string> strings)
     {
         return HandleBooleanOptionCommand(
@@ -109,7 +100,6 @@ internal class CampaignOptionsCommands
             value => IsLifeDeathCycleDisabled = value);
     }
 
-    [CommandLineArgumentFunction("PersuasionSuccessChance", "coop.debug.campaignoptions")]
     public static string PersuasionSuccessChanceCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -119,7 +109,6 @@ internal class CampaignOptionsCommands
             value => PersuasionSuccessChance = value);
     }
 
-    [CommandLineArgumentFunction("ClanMemberDeathChance", "coop.debug.campaignoptions")]
     public static string ClanMemberDeathChanceCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -129,7 +118,6 @@ internal class CampaignOptionsCommands
             value => ClanMemberDeathChance = value);
     }
 
-    [CommandLineArgumentFunction("IsIronmanMode", "coop.debug.campaignoptions")]
     public static string IsIronmanModeCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -141,7 +129,6 @@ internal class CampaignOptionsCommands
         return "This option can only be set at game start.";
     }
 
-    [CommandLineArgumentFunction("BattleDeath", "coop.debug.campaignoptions")]
     public static string BattleDeathCommand(List<string> strings)
     {
         return HandleDifficultyOptionCommand(
@@ -151,7 +138,6 @@ internal class CampaignOptionsCommands
             value => BattleDeath = value);
     }
 
-    [CommandLineArgumentFunction("PlayerReceivedDamageDifficulty", "coop.debug.campaignoptions")]
     public static string SetPlayerReceivedDamageDifficulty(List<string> strings)
     {
         Difficulty oldValue = (Difficulty)PlayerReceivedDamageDifficulty;

--- a/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
@@ -2,13 +2,11 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.CampaignService.Commands;
 
 internal class ModOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.modconfig")]
     public static string ListOptionsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new();

--- a/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
+++ b/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
@@ -9,7 +9,6 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Caravans.Commands;
 
@@ -31,7 +30,6 @@ internal class CaravansCommands
     /// <summary>
     /// View prohibited kingdoms for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_prohibited_kingdoms", "coop.debug.caravans")]
     public static string ViewProhibitedKingdomsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -70,7 +68,6 @@ internal class CaravansCommands
     /// <summary>
     /// View interacted caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_interacted_caravans", "coop.debug.caravans")]
     public static string ViewInteractedCaravansCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -109,7 +106,6 @@ internal class CaravansCommands
     /// <summary>
     /// View player trade rumor taken caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_taken_trade_rumors", "coop.debug.caravans")]
     public static string ViewTakenTradeRumorsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -145,7 +141,6 @@ internal class CaravansCommands
         return "Failed to retrieve trade rumor taken caravans";
     }
 
-    [CommandLineArgumentFunction("view_trade_action_logs", "coop.debug.caravans")]
     public static string ViewTradeActionLogs(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -175,7 +170,6 @@ internal class CaravansCommands
         return "Failed to retrieve trade action logs";
     }
 
-    [CommandLineArgumentFunction("view_looted_caravans", "coop.debug.caravans")]
     public static string ViewLootedCaravans(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();

--- a/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
@@ -6,7 +6,6 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CharacterDevelopment;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.CharacterDevelopers.Commands;
 
@@ -17,7 +16,6 @@ internal class CharacterDeveloperCommands
     /// <summary>
     /// Output attributes, focuses, skills and perks of a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("stats", "coop.debug.herodeveloper")]
     public static string HeroStatsCommand(List<string> strings)
     {
         if (strings.Count == 0)

--- a/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
+++ b/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.ObjectSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.CharacterObjects.Commands;
 internal class CharacterObjectCommands
@@ -16,7 +15,6 @@ internal class CharacterObjectCommands
     /// the synced _characterTraits / _occupation / _persona fields live) so a server screenshot and a client
     /// screenshot can be compared field-for-field to confirm CharacterObject syncs still replicate.
     /// </summary>
-    [CommandLineArgumentFunction("info", "coop.debug.characterObjects")]
     public static string Info(List<string> args)
     {
         if (args.Count != 1) return "Usage: coop.debug.characterObjects.info <charId>";
@@ -35,7 +33,6 @@ internal class CharacterObjectCommands
     }
 
     // coop.debug.characterObjects.list
-    [CommandLineArgumentFunction("list", "coop.debug.characterObjects")]
     public static string ListCharacterObjects(List<string> args)
     {
         var characters = MBObjectManager.Instance.GetObjectTypeList<CharacterObject>();

--- a/source/GameInterface/Services/GameDebug/Commands/BugReportLogSharingCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/BugReportLogSharingCommand.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -13,7 +12,6 @@ namespace GameInterface.Services.GameDebug.Commands;
 public class BugReportLogSharingCommand
 {
     // coop.bug_report_log_sharing status|enable|disable
-    [CommandLineArgumentFunction("bug_report_log_sharing", "coop")]
     public static string Configure(List<string> args)
     {
         if (!ModInformation.IsClient) return "Command can only be run on a client.";

--- a/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
@@ -1,20 +1,17 @@
 ﻿using SandBox.View.Map;
 using System.Collections.Generic;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
 internal class CameraReset
 {
-    [CommandLineArgumentFunction("fix_camera", "coop.debug")]
     public static string ChangeClanLeader(List<string> strings)
     {
         Game.Current.GameStateManager.UnregisterActiveStateDisableRequest(MapScreen.Instance);
         return "Camera reset";
     }
 
-    [CommandLineArgumentFunction("focus_main_party", "coop.debug.map_camera")]
     public static string FocusMainParty(List<string> strings)
     {
         if (strings.Count != 0)
@@ -32,7 +29,6 @@ internal class CameraReset
         return GetCameraState(cameraView);
     }
 
-    [CommandLineArgumentFunction("state", "coop.debug.map_camera")]
     public static string GetState(List<string> strings)
     {
         if (strings.Count != 0)

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Common;
 using System.Collections.Generic;
 using System.Threading;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -17,7 +16,6 @@ public class GameThreadDebugCommand
     /// Turns the game-thread drain instrumentation on or off, or reports its current state. With no
     /// argument it flips the current setting.
     /// </summary>
-    [CommandLineArgumentFunction("instrument", "coop.debug.gamethread")]
     public static string Instrument(List<string> args)
     {
         var arg = args.Count > 0 ? args[0].ToLowerInvariant() : "toggle";
@@ -47,7 +45,6 @@ public class GameThreadDebugCommand
                "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.";
     }
 
-    [CommandLineArgumentFunction("stall", "coop.debug.gamethread")]
     public static string Stall(List<string> args)
     {
         if (ModInformation.IsClient)

--- a/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
@@ -1,9 +1,8 @@
-using Common;
+﻿using Common;
 using GameInterface.Services.GameDebug.Metrics;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -11,7 +10,6 @@ public class PartySyncPerformanceLogsCommand
 {
     private const string Usage = "Usage: coop.debug.metrics.party_sync_performance_logs on <seconds> <filename> | off | status";
 
-    [CommandLineArgumentFunction("party_sync_performance_logs", "coop.debug.metrics")]
     public static string PartySyncPerformanceLogs(List<string> args)
     {
         if (ModInformation.IsServer)

--- a/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
@@ -17,7 +17,6 @@ using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.Core;
 using TaleWorlds.Engine;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -35,7 +34,6 @@ internal class UiDebugCommands
 
 Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle encounter screen left open.";
 
-    [CommandLineArgumentFunction("close_screen", "coop.debug.ui")]
     public static string CloseScreen(List<string> args)
     {
         var ctx = new CommandContext("close_screen", CloseScreenUsage, args);
@@ -57,7 +55,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return "Called GameMenu.ExitToLast().";
     }
 
-    [CommandLineArgumentFunction("prepare_evidence_map", "coop.debug.ui")]
     public static string PrepareEvidenceMap(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -88,7 +85,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return GetEvidenceMapState(mapScreen);
     }
 
-    [CommandLineArgumentFunction("evidence_map_state", "coop.debug.ui")]
     public static string EvidenceMapState(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -128,7 +124,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
                $"loading={LoadingWindow.IsLoadingWindowActive}";
     }
 
-    [CommandLineArgumentFunction("leave_settlement_encounter", "coop.debug.ui")]
     public static string LeaveSettlementEncounter(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -167,7 +162,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("map_click_offset", "coop.debug.ui")]
     public static string MapClickOffset(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -223,7 +217,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
             $"behavior={mainParty.DefaultBehavior}; target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}.";
     }
 
-    [CommandLineArgumentFunction("map_movement_state", "coop.debug.ui")]
     public static string MapMovementState(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -245,7 +238,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
     }
 #endif
 
-    [CommandLineArgumentFunction("switch_menu", "coop.debug.ui")]
     public static string SwitchMenu(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -269,7 +261,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return $"Switched to game menu {args[0]}.";
     }
 
-    [CommandLineArgumentFunction("pop_state", "coop.debug.ui")]
     public static string PopState(List<string> args)
     {
         if (args.Count != 0)
@@ -286,7 +277,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return $"Queued pop for {activeState.GetType().Name}.";
     }
 
-    [CommandLineArgumentFunction("active_state", "coop.debug.ui")]
     public static string ActiveState(List<string> args)
     {
         if (args.Count != 0)
@@ -295,7 +285,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return Game.Current?.GameStateManager?.ActiveState?.GetType().Name ?? "none";
     }
 
-    [CommandLineArgumentFunction("loading_window_state", "coop.debug.ui")]
     public static string LoadingWindowState(List<string> args)
     {
         if (args.Count != 0)
@@ -304,7 +293,6 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
         return $"Loading window: {(LoadingWindow.IsLoadingWindowActive ? "ACTIVE" : "INACTIVE")}.";
     }
 
-    [CommandLineArgumentFunction("saving_overlay_state", "coop.debug.ui")]
     public static string SavingOverlayState(List<string> args)
     {
         if (args.Count != 0)

--- a/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
@@ -4,7 +4,6 @@ using GameInterface.Services.MobileParties.Messages.Unstuck;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
@@ -14,7 +13,6 @@ public class UnstuckCommand
     /// <summary>
     /// Requests a server-authoritative unstuck of the local player party. Client only.
     /// </summary>
-    [CommandLineArgumentFunction("unstuck", "coop")]
     public static string Unstuck(List<string> args)
     {
         if (!ModInformation.IsClient) return "Command can only be run on a client.";

--- a/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
@@ -7,7 +7,6 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.HeroDevelopers.Commands;
 
@@ -20,7 +19,6 @@ internal class HeroDeveloperCommands
     /// Examples: 
     /// coop.debug.herodeveloper.addskillxp RandomPlayer OneHanded 3000
     /// </summary>
-    [CommandLineArgumentFunction("addskillxp", "coop.debug.herodeveloper")]
     public static string AddSkillXpCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -52,7 +50,6 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addattributepoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addattributepoints", "coop.debug.herodeveloper")]
     public static string AddAttributePointsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -82,7 +79,6 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addfocuspoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addfocuspoints", "coop.debug.herodeveloper")]
     public static string AddFocusPointsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -112,7 +108,6 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.resetskills
     /// </summary>
-    [CommandLineArgumentFunction("resetskills", "coop.debug.herodeveloper")]
     public static string ResetSkillsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";

--- a/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
+++ b/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Inventory.Commands;
 
@@ -29,7 +28,6 @@ internal class InventoryCommands
     /// <summary>
     /// View item ids in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemids", "coop.debug.inventory")]
     public static string ViewItemIdsCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -61,7 +59,6 @@ internal class InventoryCommands
     /// <summary>
     /// View item values in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemvalues", "coop.debug.inventory")]
     public static string ViewItemValuesCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -93,7 +90,6 @@ internal class InventoryCommands
     /// <summary>
     /// Output equipment ids of battle, civilian and stealth equipment for a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("heroequipment", "coop.debug.inventory")]
     public static string HeroEquipmentCommand(List<string> strings)
     {
         if (strings.Count == 0)
@@ -130,7 +126,6 @@ internal class InventoryCommands
     /// <summary>
     /// Give debug animals to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("giveanimals", "coop.debug.inventory")]
     public static string GiveAnimalsCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -186,7 +181,6 @@ internal class InventoryCommands
     /// <summary>
     /// Give war horses to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givewarhorses", "coop.debug.inventory")]
     public static string GiveWarhorsesCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";

--- a/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
+++ b/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Inventory.TradeSkills.Commands;
 
@@ -13,7 +12,6 @@ internal class TradeSkillCommands
     /// <summary>
     /// View trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_data", "coop.debug.inventory")]
     public static string ViewPlayerTradeDataCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -52,7 +50,6 @@ internal class TradeSkillCommands
     /// <summary>
     /// View trade rumors for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_rumors", "coop.debug.inventory")]
     public static string ViewPlayerTradeRumorsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -95,7 +92,6 @@ internal class TradeSkillCommands
     /// <summary>
     /// View entered settlements trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_entered_settlements", "coop.debug.inventory")]
     public static string ViewPlayerEnteredSettlementsCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();

--- a/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
+++ b/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
@@ -1,4 +1,4 @@
-using GameInterface.Services.Issues.Generic;
+﻿using GameInterface.Services.Issues.Generic;
 using GameInterface.Utils.Commands;
 using System;
 using System.Collections.Generic;
@@ -6,13 +6,11 @@ using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Issues;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Issues.Commands;
 
 public static class IssuesDebugCommand
 {
-    [CommandLineArgumentFunction("give", "coop.debug.issues")]
     public static string Give(List<string> args)
     {
         if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.give")) return error;
@@ -103,7 +101,6 @@ public static class IssuesDebugCommand
             $"Issue StringId: '{hero.Issue?.StringId}'. Quest StringId: '{hero.Issue?.IssueQuest?.StringId ?? "none"}'.";
     }
 
-    [CommandLineArgumentFunction("complete", "coop.debug.issues")]
     public static string Complete(List<string> args)
     {
         if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.complete")) return error;
@@ -166,7 +163,6 @@ public static class IssuesDebugCommand
         return $"Completed quest for hero '{hero.Name}' (StringId '{hero.StringId}') with outcome '{outcome}'.";
     }
 
-    [CommandLineArgumentFunction("list_types", "coop.debug.issues")]
     public static string ListTypes(List<string> args)
     {
         var sb = new StringBuilder();

--- a/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
+++ b/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
@@ -3,7 +3,6 @@ using GameInterface.Services.ObjectManager;
 using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.ItemObjects.Commands
 {
@@ -20,7 +19,6 @@ namespace GameInterface.Services.ItemObjects.Commands
         /// <summary>
         /// View select properties of an item object retrieved by string id
         /// </summary>
-        [CommandLineArgumentFunction("data", "coop.debug.itemobject")]
         public static string ViewCraftedItemData(List<string> strings)
         {
             if (strings.Count == 0)

--- a/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
+++ b/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
@@ -11,13 +11,11 @@ using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.ObjectSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.ItemRosters.Commands
 {
     internal class ItemRosterDebugCommands
     {
-        [CommandLineArgumentFunction("add_random_item", "coop.debug.itemrosters")]
         public static string AddRandomItem(List<string> args)
         {
             if (args.Count < 1)
@@ -41,7 +39,6 @@ namespace GameInterface.Services.ItemRosters.Commands
             return $"Added {randomItem.Name} to {settlement.Name}'s ItemRoster";
         }
 
-        [CommandLineArgumentFunction("add_item_burst", "coop.debug.itemrosters")]
         public static string AddItemBurst(List<string> args)
         {
             if (ModInformation.IsClient)
@@ -82,7 +79,6 @@ namespace GameInterface.Services.ItemRosters.Commands
             return $"Added {count}x {randomItem.Name} to {settlement.Name}'s ItemRoster in one tick";
         }
 
-        [CommandLineArgumentFunction("info", "coop.debug.itemrosters")]
         public static string Info(List<string> args)
         {
             if (args.Count < 1)
@@ -101,7 +97,6 @@ namespace GameInterface.Services.ItemRosters.Commands
                 owner, roster.Count, roster.Sum((i) => { return i.Amount; }), ItemRosterHash(roster));
         }
 
-        [CommandLineArgumentFunction("export", "coop.debug.itemrosters")]
         public static string Export(List<string> args)
         {
             if (args.Count < 1)

--- a/source/GameInterface/Services/LoadingScreen/Handlers/CoopLoadingScreenHandler.cs
+++ b/source/GameInterface/Services/LoadingScreen/Handlers/CoopLoadingScreenHandler.cs
@@ -45,21 +45,4 @@
 //        messageBroker.Unsubscribe<HideLoadingScreen>(Handle);
 //    }
 
-//    /*The part below is to test the show and hide mechanics in console, can be used as follows in console:
-//     * tutorial.testShow
-//     * tutorial.testHide                                                                       */
-
-//    [CommandLineFunctionality.CommandLineArgumentFunction("ShowLoadingScreen", "Coop.Debug")]
-//    public static string testShow(List<string> strings)
-//    {
-//        MessageBroker.Instance.Publish(null, new ShowLoadingScreen());
-//        return "Command Executed!";
-//    }
-
-//    [CommandLineFunctionality.CommandLineArgumentFunction("HideLoadingScreen", "Coop.Debug")]
-//    public static string testHide(List<string> strings)
-//    {
-//        MessageBroker.Instance.Publish(null, new HideLoadingScreen());
-//        return "Command Executed!";
-//    }
 //}

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
@@ -17,7 +17,6 @@ using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.PlayerCaptivityService.Commands;
 
@@ -29,7 +28,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
     private static AiLordPeaceReleaseFixture fixture;
     private static StanceLinkSnapshot clientDiplomaticSnapshot;
 
-    [CommandLineArgumentFunction("observe_ai_lord_pair", "coop.debug.player_captivity")]
     public static string ObserveAiLordPair(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.observe_ai_lord_pair <prisonerHeroId> <captorHeroId>";
@@ -71,7 +69,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return output.ToString();
     }
 
-    [CommandLineArgumentFunction("focus_hero_party", "coop.debug.player_captivity")]
     public static string FocusHeroParty(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.focus_hero_party <heroId>";
@@ -91,7 +88,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return $"Following party '{party.StringId}' for hero '{hero.StringId}' on the campaign map.";
     }
 
-    [CommandLineArgumentFunction("snapshot_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
     public static string SnapshotAiLordDiplomacyFixture(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.snapshot_ai_lord_diplomacy_fixture <prisonerHeroId> <captorHeroId>";
@@ -108,7 +104,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
             clientDiplomaticSnapshot.OriginalFingerprint;
     }
 
-    [CommandLineArgumentFunction("restore_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
     public static string RestoreAiLordDiplomacyFixture(List<string> args)
     {
         if (!ModInformation.IsClient)
@@ -128,7 +123,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return "Client AI-lord diplomatic fixture restored.";
     }
 
-    [CommandLineArgumentFunction("capture_ai_lord_fixture", "coop.debug.player_captivity")]
     public static string CaptureAiLordFixture(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.capture_ai_lord_fixture <prisonerHeroId> <captorHeroId>";
@@ -228,7 +222,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         }
     }
 
-    [CommandLineArgumentFunction("observe_ai_lord_fixture", "coop.debug.player_captivity")]
     public static string ObserveAiLordFixture(List<string> args)
     {
         if (args.Count != 0)
@@ -239,7 +232,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
             : Observe(fixture);
     }
 
-    [CommandLineArgumentFunction("focus_party", "coop.debug.player_captivity")]
     public static string FocusParty(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.focus_party <mobilePartyId>";
@@ -256,7 +248,6 @@ internal static class AiLordPeaceReleaseFixtureCommands
         return $"Following party '{party.StringId}' on the campaign map.";
     }
 
-    [CommandLineArgumentFunction("restore_ai_lord_fixture", "coop.debug.player_captivity")]
     public static string RestoreAiLordFixture(List<string> args)
     {
         if (ModInformation.IsClient)

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -30,7 +30,6 @@ using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.PlayerCaptivityService.Commands;
 
@@ -50,7 +49,6 @@ Example:
 
 Captures the given hero and assigns a random mobile party as the captor.";
 
-    [CommandLineArgumentFunction("random_capture_player", "coop.debug.player_captivity")]
     public static string RandomCapturePlayer(List<string> args)
     {
         var ctx = new CommandContext(
@@ -89,7 +87,6 @@ Example:
 Captures the given hero and assigns the given mobile party as the captor. The party argument accepts
 a co-op registry id or a local StringId.";
 
-    [CommandLineArgumentFunction("capture_player", "coop.debug.player_captivity")]
     public static string CapturePlayer(List<string> args)
     {
         var ctx = new CommandContext(
@@ -132,7 +129,6 @@ Example:
 Captures a registered co-op player through the real captivity path and records the transferred regular
 troops for separate fixture cleanup. This is intended for automated tests.";
 
-    [CommandLineArgumentFunction("capture_player_fixture", "coop.debug.player_captivity")]
     public static string CapturePlayerFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -218,7 +214,6 @@ Example:
 
 Restores the regular troops recorded by capture_player_fixture after the player has left captivity.";
 
-    [CommandLineArgumentFunction("restore_roster_fixture", "coop.debug.player_captivity")]
     public static string RestoreRosterFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -304,7 +299,6 @@ Example:
 
 Releases the given player hero from captivity.";
 
-    [CommandLineArgumentFunction("release_player", "coop.debug.player_captivity")]
     public static string ReleasePlayer(List<string> args)
     {
         var ctx = new CommandContext(
@@ -355,7 +349,6 @@ Releases the given player hero from captivity.";
 
 Snapshots the player's party, removes its non-hero members, and moves it beside the captor. Server only.";
 
-    [CommandLineArgumentFunction("prepare_visual_test_fixture", "coop.debug.player_captivity")]
     public static string PrepareVisualTestFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -443,7 +436,6 @@ Snapshots the player's party, removes its non-hero members, and moves it beside 
             $"Prepared position: {playerParty.Position.X:R},{playerParty.Position.Y:R}";
     }
 
-    [CommandLineArgumentFunction("restore_visual_test_fixture", "coop.debug.player_captivity")]
     public static string RestoreVisualTestFixture(List<string> args)
     {
         var ctx = new CommandContext(
@@ -522,7 +514,6 @@ Example:
 
 Runs the client-side rescued-prisoner liberation consequence for the given hero.";
 
-    [CommandLineArgumentFunction("liberate_prisoner", "coop.debug.player_captivity")]
     public static string LiberatePrisoner(List<string> args)
     {
         if (ModInformation.IsServer)
@@ -577,7 +568,6 @@ Example:
 
 Reports the hero's current captivity state on this process.";
 
-    [CommandLineArgumentFunction("status", "coop.debug.player_captivity")]
     public static string PrisonerStatus(List<string> args)
     {
         var ctx = new CommandContext(
@@ -611,7 +601,6 @@ Reports the hero's current captivity state on this process.";
 Moves a captured player into the active normal Party screen's left dismissal roster and presses Done.
 Run this on the client that controls the captor after opening the Party screen.";
 
-    [CommandLineArgumentFunction("discard_player_from_party_screen", "coop.debug.player_captivity")]
     public static string DiscardPlayerFromPartyScreen(List<string> args)
     {
         var ctx = new CommandContext(
@@ -724,7 +713,6 @@ Run this on the client that controls the captor after opening the Party screen."
 
 Reports captivity and registered party state without mutating it.";
 
-    [CommandLineArgumentFunction("observe_player", "coop.debug.player_captivity")]
     public static string ObservePlayer(List<string> args)
     {
         var ctx = new CommandContext("observe_player", ObservePlayerUsage, args);
@@ -790,7 +778,6 @@ Example:
 
 Ransoms the captive player hero for zero gold and releases them at a nearby neutral or allied settlement.";
 
-    [CommandLineArgumentFunction("ransom_player_at_settlement", "coop.debug.player_captivity")]
     public static string RansomPlayerAtSettlement(List<string> args)
     {
         var ctx = new CommandContext(
@@ -858,7 +845,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
             $"Seller gold change: {sellerGoldAfter - sellerGoldBefore}";
     }
 
-    [CommandLineArgumentFunction("captivity_state", "coop.debug.player_captivity")]
     public static string CaptivityState(List<string> args)
     {
         if (args.Count != 1)
@@ -893,7 +879,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         return result.ToString();
     }
 
-    [CommandLineArgumentFunction("party_fixture_state", "coop.debug.player_captivity")]
     public static string PartyFixtureState(List<string> args)
     {
         if (args.Count != 1)
@@ -919,7 +904,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         return result.ToString();
     }
 
-    [CommandLineArgumentFunction("restore_party_fixture_state", "coop.debug.player_captivity")]
     public static string RestorePartyFixtureState(List<string> args)
     {
         const string usage = "Usage: coop.debug.player_captivity.restore_party_fixture_state <partyId> <settlementId|none> <x> <y> <isOnLand> <isActive>";

--- a/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
+++ b/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using TaleWorlds.CampaignSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Save.Commands
 {
@@ -15,7 +14,6 @@ namespace GameInterface.Services.Save.Commands
         private static int evidenceHoldMilliseconds;
 #endif
 
-        [CommandLineArgumentFunction("save_as", "coop.debug.save")]
         public static string SaveAs(List<string> args)
         {
             if (!ModInformation.IsServer)
@@ -33,7 +31,6 @@ namespace GameInterface.Services.Save.Commands
             return $"Enqueued save as {args[0]} on the server.";
         }
 
-        [CommandLineArgumentFunction("state", "coop.debug.save")]
         public static string State(List<string> args)
         {
             if (args.Count != 0)
@@ -50,7 +47,6 @@ namespace GameInterface.Services.Save.Commands
         /// client save block can be exercised on demand. On a client SetSaveArgs is blocked, so
         /// nothing is enqueued and no file is written; on the host a save file appears.
         /// </summary>
-        [CommandLineArgumentFunction("force_autosave", "coop.debug.save")]
         public static string ForceAutoSave(List<string> args)
         {
             if (Campaign.Current?.SaveHandler == null) return "No active campaign / SaveHandler.";

--- a/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
+++ b/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
@@ -12,7 +12,6 @@ using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.CraftingSystem;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Smithing.Commands;
 
@@ -34,7 +33,6 @@ internal class SmithingCommands
     /// <summary>
     /// Give debug crafting materials to heroes with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givesupplies", "coop.debug.crafting")]
     public static string SmithingSuppliesCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -96,7 +94,6 @@ internal class SmithingCommands
     /// Unlock all crafting pieces on a client
     /// OpenPart is patched to already update CoopSession and persist across sessions
     /// </summary>
-    [CommandLineArgumentFunction("unlockallcraftingpieces", "coop.debug.crafting")]
     public static string UnlockAllCraftingPiecesCommand(List<string> strings)
     {
         if (ModInformation.IsServer)
@@ -124,7 +121,6 @@ internal class SmithingCommands
     /// <summary>
     /// View town orders for a specified town
     /// </summary>
-    [CommandLineArgumentFunction("townorders", "coop.debug.crafting")]
     public static string ViewTownOrdersCommand(List<string> strings)
     {
         if (strings.Count == 0) return "Town name argument required.";
@@ -156,7 +152,6 @@ internal class SmithingCommands
     /// <summary>
     /// Add orders to a town by a hero in that town
     /// </summary>
-    [CommandLineArgumentFunction("addtownorder", "coop.debug.crafting")]
     public static string AddTestingTownOrderCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -190,7 +185,6 @@ internal class SmithingCommands
     /// <summary>
     /// Add all existing crafted items to a given hero
     /// </summary>
-    [CommandLineArgumentFunction("addcrafteditems", "coop.debug.crafting")]
     public static string AddCraftedItemCommand(List<string> strings)
     {
         if (ModInformation.IsClient) return "Command can only be run on the server.";
@@ -235,7 +229,6 @@ internal class SmithingCommands
     /// <summary>
     /// View crafting stamina of all heroes in party on client and all heroes on server
     /// </summary>
-    [CommandLineArgumentFunction("stamina", "coop.debug.crafting")]
     public static string ViewCraftingStaminaCommand(List<string> strings)
     {
         StringBuilder stringBuilder = new StringBuilder();
@@ -260,7 +253,6 @@ internal class SmithingCommands
     /// <summary>
     /// View crafted item history, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("crafteditemhistory", "coop.debug.crafting")]
     public static string ViewCraftedItemHistoryCommand(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
@@ -297,7 +289,6 @@ internal class SmithingCommands
     /// <summary>
     /// View crafted pieces xp, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("craftingpiecesxp", "coop.debug.crafting")]
     public static string ViewPartsXpCommand(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
@@ -334,7 +325,6 @@ internal class SmithingCommands
     /// <summary>
     /// View unlocked crafted pieces, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("unlockedcraftingpieces", "coop.debug.crafting")]
     public static string ViewUnlockedCraftingPieces(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";

--- a/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
+++ b/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
@@ -1,0 +1,2519 @@
+﻿using Common.Commands;
+using System;
+using System.Collections.Generic;
+
+namespace GameInterface.Services.SystemDeveloper.Commands;
+
+internal static class SystemDeveloperLegacyCommandResult
+{
+    public static CoopCommandResult FromOutput(string output)
+    {
+        if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
+
+        bool succeeded = !LooksLikeFailure(output);
+        return new CoopCommandResult(succeeded, output, succeeded ? null : "command_rejected");
+    }
+
+    private static bool LooksLikeFailure(string output)
+    {
+        string[] failurePrefixes =
+        {
+            "Usage:",
+            "Invalid ",
+            "Unable ",
+            "Error ",
+            "Failed",
+            "No ",
+            "Run ",
+            "Command can ",
+            "Command is ",
+            "The command ",
+            "The '",
+            "This command ",
+            "This function ",
+            "Could not ",
+            "Cannot ",
+        };
+
+        foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        return output.IndexOf(" not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" was not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" can only be ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+}
+
+public interface ICampaignOptionsListCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsListCommand : ICampaignOptionsListCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "list";
+
+    public string Description => "Reports list.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.ListOptionsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsAutoAllocateClanMemberPerksCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsAutoAllocateClanMemberPerksCommand : ICampaignOptionsAutoAllocateClanMemberPerksCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "auto_allocate_clan_member_perks";
+
+    public string Description => "Runs the auto allocate clan member perks debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.AutoAllocateClanMemberPerksCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPlayerTroopsReceivedDamageCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPlayerTroopsReceivedDamageCommand : ICampaignOptionsPlayerTroopsReceivedDamageCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "player_troops_received_damage";
+
+    public string Description => "Runs the player troops received damage debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.PlayerTroopsReceivedDamageCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsRecruitmentDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsRecruitmentDifficultyCommand : ICampaignOptionsRecruitmentDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "recruitment_difficulty";
+
+    public string Description => "Runs the recruitment difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.RecruitmentDifficultyCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPlayerMapMovementSpeedCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPlayerMapMovementSpeedCommand : ICampaignOptionsPlayerMapMovementSpeedCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "player_map_movement_speed";
+
+    public string Description => "Runs the player map movement speed debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.PlayerMapMovementSpeedCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsStealthAndDisguiseDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsStealthAndDisguiseDifficultyCommand : ICampaignOptionsStealthAndDisguiseDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "stealth_and_disguise_difficulty";
+
+    public string Description => "Runs the stealth and disguise difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.StealthAndDisguiseDifficultyCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsCombatAiDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsCombatAiDifficultyCommand : ICampaignOptionsCombatAiDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "combat_ai_difficulty";
+
+    public string Description => "Runs the combat ai difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.CombatAIDifficultyCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsIsLifeDeathCycleDisabledCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsIsLifeDeathCycleDisabledCommand : ICampaignOptionsIsLifeDeathCycleDisabledCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "is_life_death_cycle_disabled";
+
+    public string Description => "Runs the is life death cycle disabled debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.IsLifeDeathCycleDisabledCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPersuasionSuccessChanceCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPersuasionSuccessChanceCommand : ICampaignOptionsPersuasionSuccessChanceCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "persuasion_success_chance";
+
+    public string Description => "Runs the persuasion success chance debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.PersuasionSuccessChanceCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsClanMemberDeathChanceCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsClanMemberDeathChanceCommand : ICampaignOptionsClanMemberDeathChanceCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "clan_member_death_chance";
+
+    public string Description => "Runs the clan member death chance debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.ClanMemberDeathChanceCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsIsIronmanModeCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsIsIronmanModeCommand : ICampaignOptionsIsIronmanModeCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "is_ironman_mode";
+
+    public string Description => "Runs the is ironman mode debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.IsIronmanModeCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsBattleDeathCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsBattleDeathCommand : ICampaignOptionsBattleDeathCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "battle_death";
+
+    public string Description => "Runs the battle death debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.BattleDeathCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICampaignOptionsPlayerReceivedDamageDifficultyCommand : ICoopCommand
+{
+}
+
+public sealed class CampaignOptionsPlayerReceivedDamageDifficultyCommand : ICampaignOptionsPlayerReceivedDamageDifficultyCommand
+{
+    public string Prefix => "coop.debug.campaign_options";
+
+    public string Name => "player_received_damage_difficulty";
+
+    public string Description => "Runs the player received damage difficulty debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("value", "The option value.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.CampaignOptionsCommands.SetPlayerReceivedDamageDifficulty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IModConfigListCommand : ICoopCommand
+{
+}
+
+public sealed class ModConfigListCommand : IModConfigListCommand
+{
+    public string Prefix => "coop.debug.mod_config";
+
+    public string Name => "list";
+
+    public string Description => "Reports list.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CampaignService.Commands.ModOptionsCommands.ListOptionsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewProhibitedKingdomsCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewProhibitedKingdomsCommand : ICaravansViewProhibitedKingdomsCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_prohibited_kingdoms";
+
+    public string Description => "Reports view prohibited kingdoms.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewProhibitedKingdomsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewInteractedCaravansCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewInteractedCaravansCommand : ICaravansViewInteractedCaravansCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_interacted_caravans";
+
+    public string Description => "Reports view interacted caravans.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewInteractedCaravansCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewTakenTradeRumorsCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewTakenTradeRumorsCommand : ICaravansViewTakenTradeRumorsCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_taken_trade_rumors";
+
+    public string Description => "Reports view taken trade rumors.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewTakenTradeRumorsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewTradeActionLogsCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewTradeActionLogsCommand : ICaravansViewTradeActionLogsCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_trade_action_logs";
+
+    public string Description => "Reports view trade action logs.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewTradeActionLogs(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICaravansViewLootedCaravansCommand : ICoopCommand
+{
+}
+
+public sealed class CaravansViewLootedCaravansCommand : ICaravansViewLootedCaravansCommand
+{
+    public string Prefix => "coop.debug.caravans";
+
+    public string Name => "view_looted_caravans";
+
+    public string Description => "Reports view looted caravans.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Caravans.Commands.CaravansCommands.ViewLootedCaravans(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperStatsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperStatsCommand : IHeroDeveloperStatsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "stats";
+
+    public string Description => "Reports stats.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CharacterDevelopers.Commands.CharacterDeveloperCommands.HeroStatsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICharacterObjectsInfoCommand : ICoopCommand
+{
+}
+
+public sealed class CharacterObjectsInfoCommand : ICharacterObjectsInfoCommand
+{
+    public string Prefix => "coop.debug.character_objects";
+
+    public string Name => "info";
+
+    public string Description => "Reports info.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("character_id", "The registered character id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CharacterObjects.Commands.CharacterObjectCommands.Info(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICharacterObjectsListCommand : ICoopCommand
+{
+}
+
+public sealed class CharacterObjectsListCommand : ICharacterObjectsListCommand
+{
+    public string Prefix => "coop.debug.character_objects";
+
+    public string Name => "list";
+
+    public string Description => "Reports list.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.CharacterObjects.Commands.CharacterObjectCommands.ListCharacterObjects(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICoopBugReportLogSharingCommand : ICoopCommand
+{
+}
+
+public sealed class CoopBugReportLogSharingCommand : ICoopBugReportLogSharingCommand
+{
+    public string Prefix => "coop";
+
+    public string Name => "bug_report_log_sharing";
+
+    public string Description => "Runs the bug report log sharing debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "status, enable, or disable.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.BugReportLogSharingCommand.Configure(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IFixCameraCommand : ICoopCommand
+{
+}
+
+public sealed class FixCameraCommand : IFixCameraCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "fix_camera";
+
+    public string Description => "Runs the fix camera debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.CameraReset.ChangeClanLeader(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IMapCameraFocusMainPartyCommand : ICoopCommand
+{
+}
+
+public sealed class MapCameraFocusMainPartyCommand : IMapCameraFocusMainPartyCommand
+{
+    public string Prefix => "coop.debug.map_camera";
+
+    public string Name => "focus_main_party";
+
+    public string Description => "Runs the focus main party debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.CameraReset.FocusMainParty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IMapCameraStateCommand : ICoopCommand
+{
+}
+
+public sealed class MapCameraStateCommand : IMapCameraStateCommand
+{
+    public string Prefix => "coop.debug.map_camera";
+
+    public string Name => "state";
+
+    public string Description => "Reports state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.CameraReset.GetState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IGameThreadInstrumentCommand : ICoopCommand
+{
+}
+
+public sealed class GameThreadInstrumentCommand : IGameThreadInstrumentCommand
+{
+    public string Prefix => "coop.debug.game_thread";
+
+    public string Name => "instrument";
+
+    public string Description => "Runs the instrument debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.GameThreadDebugCommand.Instrument(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IGameThreadStallCommand : ICoopCommand
+{
+}
+
+public sealed class GameThreadStallCommand : IGameThreadStallCommand
+{
+    public string Prefix => "coop.debug.game_thread";
+
+    public string Name => "stall";
+
+    public string Description => "Runs the stall debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("milliseconds", "The stall duration from 1 through 5000 milliseconds.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.GameThreadDebugCommand.Stall(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IMetricsPartySyncPerformanceLogsCommand : ICoopCommand
+{
+}
+
+public sealed class MetricsPartySyncPerformanceLogsCommand : IMetricsPartySyncPerformanceLogsCommand
+{
+    public string Prefix => "coop.debug.metrics";
+
+    public string Name => "party_sync_performance_logs";
+
+    public string Description => "Runs the party sync performance logs debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "on, off, or status.", isRequired: true),
+        new ExpectedArgs("seconds", "The logging duration in seconds when enabling.", isRequired: false),
+        new ExpectedArgs("file_name", "The output file name when enabling.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiCloseScreenCommand : ICoopCommand
+{
+}
+
+public sealed class UiCloseScreenCommand : IUiCloseScreenCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "close_screen";
+
+    public string Description => "Runs the close screen debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.CloseScreen(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiPrepareEvidenceMapCommand : ICoopCommand
+{
+}
+
+public sealed class UiPrepareEvidenceMapCommand : IUiPrepareEvidenceMapCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "prepare_evidence_map";
+
+    public string Description => "Runs the prepare evidence map debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.PrepareEvidenceMap(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiEvidenceMapStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiEvidenceMapStateCommand : IUiEvidenceMapStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "evidence_map_state";
+
+    public string Description => "Reports evidence map state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.EvidenceMapState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiLeaveSettlementEncounterCommand : ICoopCommand
+{
+}
+
+public sealed class UiLeaveSettlementEncounterCommand : IUiLeaveSettlementEncounterCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "leave_settlement_encounter";
+
+    public string Description => "Runs the leave settlement encounter debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.LeaveSettlementEncounter(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IUiMapClickOffsetCommand : ICoopCommand
+{
+}
+
+public sealed class UiMapClickOffsetCommand : IUiMapClickOffsetCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "map_click_offset";
+
+    public string Description => "Runs the map click offset debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("offset_x", "The horizontal map offset.", isRequired: true),
+        new ExpectedArgs("offset_y", "The vertical map offset.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.MapClickOffset(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IUiMapMovementStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiMapMovementStateCommand : IUiMapMovementStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "map_movement_state";
+
+    public string Description => "Reports map movement state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.MapMovementState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+public interface IUiSwitchMenuCommand : ICoopCommand
+{
+}
+
+public sealed class UiSwitchMenuCommand : IUiSwitchMenuCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "switch_menu";
+
+    public string Description => "Runs the switch menu debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("menu_id", "The game menu id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.SwitchMenu(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiPopStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiPopStateCommand : IUiPopStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "pop_state";
+
+    public string Description => "Reports pop state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.PopState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiActiveStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiActiveStateCommand : IUiActiveStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "active_state";
+
+    public string Description => "Reports active state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.ActiveState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiLoadingWindowStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiLoadingWindowStateCommand : IUiLoadingWindowStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "loading_window_state";
+
+    public string Description => "Reports loading window state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.LoadingWindowState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiSavingOverlayStateCommand : ICoopCommand
+{
+}
+
+public sealed class UiSavingOverlayStateCommand : IUiSavingOverlayStateCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "saving_overlay_state";
+
+    public string Description => "Reports saving overlay state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UiDebugCommands.SavingOverlayState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICoopUnstuckCommand : ICoopCommand
+{
+}
+
+public sealed class CoopUnstuckCommand : ICoopUnstuckCommand
+{
+    public string Prefix => "coop";
+
+    public string Name => "unstuck";
+
+    public string Description => "Runs the unstuck debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.GameDebug.Commands.UnstuckCommand.Unstuck(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperAddSkillXpCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperAddSkillXpCommand : IHeroDeveloperAddSkillXpCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "add_skill_xp";
+
+    public string Description => "Runs the add skill xp debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        new ExpectedArgs("skill_name", "The skill object name.", isRequired: true),
+        new ExpectedArgs("xp_amount", "The amount of skill experience.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.AddSkillXpCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperAddAttributePointsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperAddAttributePointsCommand : IHeroDeveloperAddAttributePointsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "add_attribute_points";
+
+    public string Description => "Runs the add attribute points debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        new ExpectedArgs("point_count", "The number of attribute points.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.AddAttributePointsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperAddFocusPointsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperAddFocusPointsCommand : IHeroDeveloperAddFocusPointsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "add_focus_points";
+
+    public string Description => "Runs the add focus points debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        new ExpectedArgs("point_count", "The number of focus points.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.AddFocusPointsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IHeroDeveloperResetSkillsCommand : ICoopCommand
+{
+}
+
+public sealed class HeroDeveloperResetSkillsCommand : IHeroDeveloperResetSkillsCommand
+{
+    public string Prefix => "coop.debug.hero_developer";
+
+    public string Name => "reset_skills";
+
+    public string Description => "Runs the reset skills debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.HeroDevelopers.Commands.HeroDeveloperCommands.ResetSkillsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryItemIdsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryItemIdsCommand : IInventoryItemIdsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "item_ids";
+
+    public string Description => "Runs the item ids debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.ViewItemIdsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryItemValuesCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryItemValuesCommand : IInventoryItemValuesCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "item_values";
+
+    public string Description => "Runs the item values debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.ViewItemValuesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryHeroEquipmentCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryHeroEquipmentCommand : IInventoryHeroEquipmentCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "hero_equipment";
+
+    public string Description => "Runs the hero equipment debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.HeroEquipmentCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryGiveAnimalsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryGiveAnimalsCommand : IInventoryGiveAnimalsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "give_animals";
+
+    public string Description => "Runs the give animals debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.GiveAnimalsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryGiveWarhorsesCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryGiveWarhorsesCommand : IInventoryGiveWarhorsesCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "give_warhorses";
+
+    public string Description => "Runs the give warhorses debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.Commands.InventoryCommands.GiveWarhorsesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryViewPlayerTradeDataCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryViewPlayerTradeDataCommand : IInventoryViewPlayerTradeDataCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "view_player_trade_data";
+
+    public string Description => "Reports view player trade data.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.TradeSkills.Commands.TradeSkillCommands.ViewPlayerTradeDataCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryViewPlayerTradeRumorsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryViewPlayerTradeRumorsCommand : IInventoryViewPlayerTradeRumorsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "view_player_trade_rumors";
+
+    public string Description => "Reports view player trade rumors.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.TradeSkills.Commands.TradeSkillCommands.ViewPlayerTradeRumorsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IInventoryViewEnteredSettlementsCommand : ICoopCommand
+{
+}
+
+public sealed class InventoryViewEnteredSettlementsCommand : IInventoryViewEnteredSettlementsCommand
+{
+    public string Prefix => "coop.debug.inventory";
+
+    public string Name => "view_entered_settlements";
+
+    public string Description => "Reports view entered settlements.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Inventory.TradeSkills.Commands.TradeSkillCommands.ViewPlayerEnteredSettlementsCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IIssuesGiveCommand : ICoopCommand
+{
+}
+
+public sealed class IssuesGiveCommand : IIssuesGiveCommand
+{
+    public string Prefix => "coop.debug.issues";
+
+    public string Name => "give";
+
+    public string Description => "Runs the give debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+        new ExpectedArgs("quest_type_key", "The issue type key.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Issues.Commands.IssuesDebugCommand.Give(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IIssuesCompleteCommand : ICoopCommand
+{
+}
+
+public sealed class IssuesCompleteCommand : IIssuesCompleteCommand
+{
+    public string Prefix => "coop.debug.issues";
+
+    public string Name => "complete";
+
+    public string Description => "Runs the complete debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered issue owner hero id.", isRequired: true),
+        new ExpectedArgs("outcome", "success, cancel, fail, timeout, or betrayal.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Issues.Commands.IssuesDebugCommand.Complete(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IIssuesListTypesCommand : ICoopCommand
+{
+}
+
+public sealed class IssuesListTypesCommand : IIssuesListTypesCommand
+{
+    public string Prefix => "coop.debug.issues";
+
+    public string Name => "list_types";
+
+    public string Description => "Reports list types.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Issues.Commands.IssuesDebugCommand.ListTypes(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemObjectDataCommand : ICoopCommand
+{
+}
+
+public sealed class ItemObjectDataCommand : IItemObjectDataCommand
+{
+    public string Prefix => "coop.debug.item_object";
+
+    public string Name => "data";
+
+    public string Description => "Reports data.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("item_id", "The registered item object id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemObjects.Commands.ItemObjectCommands.ViewCraftedItemData(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersAddRandomItemCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersAddRandomItemCommand : IItemRostersAddRandomItemCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "add_random_item";
+
+    public string Description => "Runs the add random item debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.AddRandomItem(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersAddItemBurstCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersAddItemBurstCommand : IItemRostersAddItemBurstCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "add_item_burst";
+
+    public string Description => "Runs the add item burst debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+        new ExpectedArgs("count", "The positive number of items to add.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.AddItemBurst(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersInfoCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersInfoCommand : IItemRostersInfoCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "info";
+
+    public string Description => "Reports info.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.Info(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IItemRostersExportCommand : ICoopCommand
+{
+}
+
+public sealed class ItemRostersExportCommand : IItemRostersExportCommand
+{
+    public string Prefix => "coop.debug.item_rosters";
+
+    public string Name => "export";
+
+    public string Description => "Runs the export debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.ItemRosters.Commands.ItemRosterDebugCommands.Export(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IPlayerCaptivityObserveAiLordPairCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityObserveAiLordPairCommand : IPlayerCaptivityObserveAiLordPairCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "observe_ai_lord_pair";
+
+    public string Description => "Runs the observe ai lord pair debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+        new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.ObserveAiLordPair(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityFocusHeroPartyCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityFocusHeroPartyCommand : IPlayerCaptivityFocusHeroPartyCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "focus_hero_party";
+
+    public string Description => "Runs the focus hero party debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.FocusHeroParty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivitySnapshotAiLordDiplomacyFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivitySnapshotAiLordDiplomacyFixtureCommand : IPlayerCaptivitySnapshotAiLordDiplomacyFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "snapshot_ai_lord_diplomacy_fixture";
+
+    public string Description => "Runs the snapshot ai lord diplomacy fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+        new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.SnapshotAiLordDiplomacyFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityRestoreAiLordDiplomacyFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreAiLordDiplomacyFixtureCommand : IPlayerCaptivityRestoreAiLordDiplomacyFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_ai_lord_diplomacy_fixture";
+
+    public string Description => "Runs the restore ai lord diplomacy fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.RestoreAiLordDiplomacyFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityCaptureAiLordFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCaptureAiLordFixtureCommand : IPlayerCaptivityCaptureAiLordFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "capture_ai_lord_fixture";
+
+    public string Description => "Runs the capture ai lord fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+        new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.CaptureAiLordFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityObserveAiLordFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityObserveAiLordFixtureCommand : IPlayerCaptivityObserveAiLordFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "observe_ai_lord_fixture";
+
+    public string Description => "Runs the observe ai lord fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.ObserveAiLordFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityFocusPartyCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityFocusPartyCommand : IPlayerCaptivityFocusPartyCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "focus_party";
+
+    public string Description => "Runs the focus party debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mobile_party_id", "The registered mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.FocusParty(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+#if DEBUG
+public interface IPlayerCaptivityRestoreAiLordFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreAiLordFixtureCommand : IPlayerCaptivityRestoreAiLordFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_ai_lord_fixture";
+
+    public string Description => "Runs the restore ai lord fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.AiLordPeaceReleaseFixtureCommands.RestoreAiLordFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+public interface IPlayerCaptivityRandomCapturePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRandomCapturePlayerCommand : IPlayerCaptivityRandomCapturePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "random_capture_player";
+
+    public string Description => "Runs the random capture player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RandomCapturePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityCapturePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCapturePlayerCommand : IPlayerCaptivityCapturePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "capture_player";
+
+    public string Description => "Runs the capture player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.CapturePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityCapturePlayerFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCapturePlayerFixtureCommand : IPlayerCaptivityCapturePlayerFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "capture_player_fixture";
+
+    public string Description => "Runs the capture player fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.CapturePlayerFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRestoreRosterFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreRosterFixtureCommand : IPlayerCaptivityRestoreRosterFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_roster_fixture";
+
+    public string Description => "Runs the restore roster fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RestoreRosterFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityReleasePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityReleasePlayerCommand : IPlayerCaptivityReleasePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "release_player";
+
+    public string Description => "Runs the release player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.ReleasePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityPrepareVisualTestFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityPrepareVisualTestFixtureCommand : IPlayerCaptivityPrepareVisualTestFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "prepare_visual_test_fixture";
+
+    public string Description => "Runs the prepare visual test fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.PrepareVisualTestFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRestoreVisualTestFixtureCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestoreVisualTestFixtureCommand : IPlayerCaptivityRestoreVisualTestFixtureCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_visual_test_fixture";
+
+    public string Description => "Runs the restore visual test fixture debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RestoreVisualTestFixture(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityLiberatePrisonerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityLiberatePrisonerCommand : IPlayerCaptivityLiberatePrisonerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "liberate_prisoner";
+
+    public string Description => "Runs the liberate prisoner debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.LiberatePrisoner(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityStatusCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityStatusCommand : IPlayerCaptivityStatusCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "status";
+
+    public string Description => "Reports status.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.PrisonerStatus(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityDiscardPlayerFromPartyScreenCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityDiscardPlayerFromPartyScreenCommand : IPlayerCaptivityDiscardPlayerFromPartyScreenCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "discard_player_from_party_screen";
+
+    public string Description => "Runs the discard player from party screen debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.DiscardPlayerFromPartyScreen(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityObservePlayerCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityObservePlayerCommand : IPlayerCaptivityObservePlayerCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "observe_player";
+
+    public string Description => "Runs the observe player debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.ObservePlayer(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRansomPlayerAtSettlementCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRansomPlayerAtSettlementCommand : IPlayerCaptivityRansomPlayerAtSettlementCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "ransom_player_at_settlement";
+
+    public string Description => "Runs the ransom player at settlement debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RansomPlayerAtSettlement(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityCaptivityStateCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityCaptivityStateCommand : IPlayerCaptivityCaptivityStateCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "captivity_state";
+
+    public string Description => "Reports captivity state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.CaptivityState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityPartyFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityPartyFixtureStateCommand : IPlayerCaptivityPartyFixtureStateCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "party_fixture_state";
+
+    public string Description => "Reports party fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.PartyFixtureState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IPlayerCaptivityRestorePartyFixtureStateCommand : ICoopCommand
+{
+}
+
+public sealed class PlayerCaptivityRestorePartyFixtureStateCommand : IPlayerCaptivityRestorePartyFixtureStateCommand
+{
+    public string Prefix => "coop.debug.player_captivity";
+
+    public string Name => "restore_party_fixture_state";
+
+    public string Description => "Reports restore party fixture state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+        new ExpectedArgs("settlement_id_or_none", "The settlement id, or none.", isRequired: true),
+        new ExpectedArgs("x", "The map x coordinate.", isRequired: true),
+        new ExpectedArgs("y", "The map y coordinate.", isRequired: true),
+        new ExpectedArgs("is_on_land", "Whether the position is on land.", isRequired: true),
+        new ExpectedArgs("is_active", "Whether the party is active.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.PlayerCaptivityService.Commands.PlayerCaptivityCommands.RestorePartyFixtureState(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISaveSaveAsCommand : ICoopCommand
+{
+}
+
+public sealed class SaveSaveAsCommand : ISaveSaveAsCommand
+{
+    public string Prefix => "coop.debug.save";
+
+    public string Name => "save_as";
+
+    public string Description => "Runs the save as debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("save_name", "A save name using 1 through 64 letters, digits, underscores, or hyphens.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Save.Commands.SaveDebugCommand.SaveAs(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISaveStateCommand : ICoopCommand
+{
+}
+
+public sealed class SaveStateCommand : ISaveStateCommand
+{
+    public string Prefix => "coop.debug.save";
+
+    public string Name => "state";
+
+    public string Description => "Reports state.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Save.Commands.SaveDebugCommand.State(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISaveForceAutosaveCommand : ICoopCommand
+{
+}
+
+public sealed class SaveForceAutosaveCommand : ISaveForceAutosaveCommand
+{
+    public string Prefix => "coop.debug.save";
+
+    public string Name => "force_autosave";
+
+    public string Description => "Runs the force autosave debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("evidence_hold_milliseconds", "The optional evidence hold from 1 through 5000 milliseconds.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Save.Commands.SaveDebugCommand.ForceAutoSave(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingGiveSuppliesCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingGiveSuppliesCommand : ICraftingGiveSuppliesCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "give_supplies";
+
+    public string Description => "Runs the give supplies debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.SmithingSuppliesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingUnlockAllCraftingPiecesCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingUnlockAllCraftingPiecesCommand : ICraftingUnlockAllCraftingPiecesCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "unlock_all_crafting_pieces";
+
+    public string Description => "Runs the unlock all crafting pieces debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.UnlockAllCraftingPiecesCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingTownOrdersCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingTownOrdersCommand : ICraftingTownOrdersCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "town_orders";
+
+    public string Description => "Runs the town orders debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("town_name", "The exact town display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewTownOrdersCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingAddTownOrderCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingAddTownOrderCommand : ICraftingAddTownOrderCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "add_town_order";
+
+    public string Description => "Runs the add town order debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.AddTestingTownOrderCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingAddCraftedItemsCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingAddCraftedItemsCommand : ICraftingAddCraftedItemsCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "add_crafted_items";
+
+    public string Description => "Runs the add crafted items debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.AddCraftedItemCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingStaminaCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingStaminaCommand : ICraftingStaminaCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "stamina";
+
+    public string Description => "Runs the stamina debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewCraftingStaminaCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingCraftedItemHistoryCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingCraftedItemHistoryCommand : ICraftingCraftedItemHistoryCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "crafted_item_history";
+
+    public string Description => "Runs the crafted item history debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewCraftedItemHistoryCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingCraftingPiecesXpCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingCraftingPiecesXpCommand : ICraftingCraftingPiecesXpCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "crafting_pieces_xp";
+
+    public string Description => "Runs the crafting pieces xp debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewPartsXpCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ICraftingUnlockedCraftingPiecesCommand : ICoopCommand
+{
+}
+
+public sealed class CraftingUnlockedCraftingPiecesCommand : ICraftingUnlockedCraftingPiecesCommand
+{
+    public string Prefix => "coop.debug.crafting";
+
+    public string Name => "unlocked_crafting_pieces";
+
+    public string Description => "Runs the unlocked crafting pieces debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Smithing.Commands.SmithingCommands.ViewUnlockedCraftingPieces(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ITemplateCommand : ICoopCommand
+{
+}
+
+public sealed class TemplateCommand : ITemplateCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "template";
+
+    public string Description => "Runs the template debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Template.Commands.TemplateCommands.TemplateCommand(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IGetTimeModeCommand : ICoopCommand
+{
+}
+
+public sealed class GetTimeModeCommand : IGetTimeModeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "get_time_mode";
+
+    public string Description => "Reports get time mode.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.GetTimeMode(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISetTimeModeCommand : ICoopCommand
+{
+}
+
+public sealed class SetTimeModeCommand : ISetTimeModeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "set_time_mode";
+
+    public string Description => "Runs the set time mode debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+#if DEBUG
+        new ExpectedArgs("force_live_test", "The DEBUG live-test override token.", isRequired: false),
+#endif
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.SetTimeMode(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+#if DEBUG
+public interface IRequestTimeModeCommand : ICoopCommand
+{
+}
+
+public sealed class RequestTimeModeCommand : IRequestTimeModeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "request_time_mode";
+
+    public string Description => "Runs the request time mode debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.RequestTimeMode(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+#endif
+
+public interface IAdvanceTimeCommand : ICoopCommand
+{
+}
+
+public sealed class AdvanceTimeCommand : IAdvanceTimeCommand
+{
+    public string Prefix => "coop.debug";
+
+    public string Name => "advance_time";
+
+    public string Description => "Runs the advance time debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("days", "The number of campaign days to advance.", isRequired: false),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.Time.Commands.TimeCommands.AdvanceTime(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamStatusCommand : ICoopCommand
+{
+}
+
+public sealed class SteamStatusCommand : ISteamStatusCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "status";
+
+    public string Description => "Reports status.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Status(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamHostLobbyCommand : ICoopCommand
+{
+}
+
+public sealed class SteamHostLobbyCommand : ISteamHostLobbyCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "host_lobby";
+
+    public string Description => "Runs the host lobby debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.HostLobby(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamInviteCommand : ICoopCommand
+{
+}
+
+public sealed class SteamInviteCommand : ISteamInviteCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "invite";
+
+    public string Description => "Runs the invite debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Invite(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface ISteamJoinCommand : ICoopCommand
+{
+}
+
+public sealed class SteamJoinCommand : ISteamJoinCommand
+{
+    public string Prefix => "coop.debug.steam";
+
+    public string Name => "join";
+
+    public string Description => "Runs the join debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("lobby_id", "The Steam lobby id.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Join(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}
+
+public interface IUiTacticalSymbolsCommand : ICoopCommand
+{
+}
+
+public sealed class UiTacticalSymbolsCommand : IUiTacticalSymbolsCommand
+{
+    public string Prefix => "coop.debug.ui";
+
+    public string Name => "tactical_symbols";
+
+    public string Description => "Runs the tactical symbols debug operation.";
+
+    public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+    {
+        new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: true),
+    };
+
+    public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+    {
+        string output = global::GameInterface.Services.UI.Commands.TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string>(args));
+        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+    }
+}

--- a/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
+++ b/source/GameInterface/Services/SystemDeveloper/Commands/SystemDeveloperCoopCommands.cs
@@ -6,16 +6,21 @@ namespace GameInterface.Services.SystemDeveloper.Commands;
 
 internal static class SystemDeveloperLegacyCommandResult
 {
-    public static CoopCommandResult FromOutput(string output)
+    public static CoopCommandResult FromOutput(
+        string output,
+        params string[] commandFailurePrefixes)
     {
         if (output == null) return new CoopCommandResult(false, "Command returned no output.", "command_failed");
 
-        bool succeeded = !LooksLikeFailure(output);
+        bool succeeded = !LooksLikeFailure(output, commandFailurePrefixes);
         return new CoopCommandResult(succeeded, output, succeeded ? null : "command_rejected");
     }
 
-    private static bool LooksLikeFailure(string output)
+    private static bool LooksLikeFailure(
+        string output,
+        string[] commandFailurePrefixes)
     {
+        // Backing commands preserve string APIs, so every scoped rejection prefix is listed here.
         string[] failurePrefixes =
         {
             "Usage:",
@@ -33,9 +38,42 @@ internal static class SystemDeveloperLegacyCommandResult
             "This function ",
             "Could not ",
             "Cannot ",
+            "Managing campaign options ",
+            "An integer amount ",
+            "Close the current prompt ",
+            "Campaign map camera is unavailable",
+            "Campaign map screen is unavailable",
+            "Seconds must ",
+            "Leave the active ",
+            "Active state is already ",
+            "Saving overlay: UNAVAILABLE",
+            "Cheats are currently disabled ",
+            "Hero name argument required",
+            "Hero not found",
+            "Hero '",
+            "Item object not found",
+            "Town name argument required",
+            "Town not found",
+            "Unknown ",
+            "Quest type ",
+            "A client AI-lord ",
+            "An AI-lord ",
+            "A visual test fixture ",
+            "A save is already ",
+            "Captor ",
+            "PartyScreenLogic ",
+            "The active ",
+            "The evidence hold ",
+            "Autosaves are disabled",
+            "Not advertising",
+            "Tactical unit symbols configuration is unavailable",
         };
 
         foreach (string prefix in failurePrefixes)
+        {
+            if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        foreach (string prefix in commandFailurePrefixes)
         {
             if (output.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
         }
@@ -43,7 +81,11 @@ internal static class SystemDeveloperLegacyCommandResult
         return output.IndexOf(" not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" was not found", StringComparison.OrdinalIgnoreCase) >= 0 ||
                output.IndexOf(" can only be ", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0;
+               output.IndexOf(" must be run ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" failed.", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" cannot ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" did not ", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               output.IndexOf(" does not ", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }
 
@@ -2445,7 +2487,9 @@ public sealed class SteamHostLobbyCommand : ISteamHostLobbyCommand
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
         string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.HostLobby(new List<string>(args));
-        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+        return SystemDeveloperLegacyCommandResult.FromOutput(
+            output,
+            "Steam integration inactive");
     }
 }
 
@@ -2490,7 +2534,9 @@ public sealed class SteamJoinCommand : ISteamJoinCommand
     public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
     {
         string output = global::GameInterface.Services.UI.Commands.SteamDebugCommand.Join(new List<string>(args));
-        return SystemDeveloperLegacyCommandResult.FromOutput(output);
+        return SystemDeveloperLegacyCommandResult.FromOutput(
+            output,
+            "Steam integration inactive");
     }
 }
 

--- a/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
+++ b/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Template.Commands;
 
@@ -11,7 +10,6 @@ internal class TemplateCommands
     /// <summary>
     /// TODO fill me out
     /// </summary>
-    [CommandLineArgumentFunction("template", "coop.debug")]
     public static string TemplateCommand(List<string> strings)
     {
         return "This is a template command";

--- a/source/GameInterface/Services/Time/Commands/TimeCommands.cs
+++ b/source/GameInterface/Services/Time/Commands/TimeCommands.cs
@@ -7,13 +7,11 @@ using GameInterface.Services.Time.Interfaces;
 using System;
 using System.Collections.Generic;
 using TaleWorlds.CampaignSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Time.Commands;
 
 internal class TimeCommands
 {
-    [CommandLineArgumentFunction("get_time_mode", "coop.debug")]
     public static string GetTimeMode(List<string> strings)
     {
         if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
@@ -24,7 +22,6 @@ internal class TimeCommands
         return $"{timeControlInterface.GetTimeControl()}";
     }
 
-    [CommandLineArgumentFunction("set_time_mode", "coop.debug")]
     public static string SetTimeMode(List<string> strings)
     {
         if (!ModInformation.IsServer)
@@ -63,7 +60,6 @@ internal class TimeCommands
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("request_time_mode", "coop.debug")]
     public static string RequestTimeMode(List<string> strings)
     {
         if (ModInformation.IsServer)
@@ -77,7 +73,6 @@ internal class TimeCommands
     }
 #endif
 
-    [CommandLineArgumentFunction("advance_time", "coop.debug")]
     public static string AdvanceTime(List<string> strings)
     {
         // Time is authoritative on the server; advancing it elsewhere would just be

--- a/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
@@ -3,7 +3,6 @@ using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
 using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.UI.Commands;
 
@@ -16,7 +15,6 @@ namespace GameInterface.Services.UI.Commands;
 /// </summary>
 public class SteamDebugCommand
 {
-    [CommandLineArgumentFunction("status", "coop.debug.steam")]
     public static string Status(List<string> args)
     {
         if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive (Steam not running or not a Steam install)";
@@ -32,7 +30,6 @@ public class SteamDebugCommand
         return $"Steam integration active; advertising={advertiser.IsAdvertising}";
     }
 
-    [CommandLineArgumentFunction("host_lobby", "coop.debug.steam")]
     public static string HostLobby(List<string> args)
     {
         if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive";
@@ -53,7 +50,6 @@ public class SteamDebugCommand
         return $"Advertising session (address='{info.Address}', port={info.Port}, version={info.Version})";
     }
 
-    [CommandLineArgumentFunction("invite", "coop.debug.steam")]
     public static string Invite(List<string> args)
     {
         if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "No session advertiser; join a session first";
@@ -64,7 +60,6 @@ public class SteamDebugCommand
             : SessionInviteText.OverlayUnavailableHint;
     }
 
-    [CommandLineArgumentFunction("join", "coop.debug.steam")]
     public static string Join(List<string> args)
     {
         if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive";

--- a/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
@@ -1,8 +1,7 @@
-using Autofac;
+﻿using Autofac;
 using GameInterface.Services.UI.Handlers;
 using GameInterface.Utils.Commands;
 using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.UI.Commands;
 
@@ -11,7 +10,6 @@ public class TacticalUnitSymbolsDebugCommand
     private const string CommandName = "coop.debug.ui.tactical_symbols";
     private const string Usage = "Usage: coop.debug.ui.tactical_symbols <on|off|toggle|status>";
 
-    [CommandLineArgumentFunction("tactical_symbols", "coop.debug.ui")]
     public static string TacticalSymbols(List<string> args)
     {
         if (!CommandHelpers.IsServerOnlyCommand(out var error, CommandName)) return error;


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

System, developer, item, save, UI, and connection debug commands still use attributed static methods with command-specific argument handling.

## What is the new behavior?

Migrates 111 commands to the injected command framework with normalized names, fixed quoted arguments, structured results, and role-specific registration. `coop.debug.connection.start` and `reconnect` remain attributed because they must work outside the session container lifecycle.

Resolves #3405
Resolves #3406
Resolves #3411
Resolves #3412
Resolves #3413
Resolves #3414
Resolves #3417
Resolves #3418
Resolves #3419
Resolves #3420
Resolves #3421
Resolves #3423
Resolves #3429
Resolves #3431
Resolves #3434
Resolves #3435
Resolves #3436
Resolves #3439

Depends on #3486.

## Bot Changelog Entry

## Other information

Tests:

- Debug `GameInterface` build
- `SystemDeveloperCommandTests` (16 passed)
- `LegacyConnectionCommandExceptionTests|ContainerBuildTests` (8 passed)
