### PR TITLE
Keep empty battle host successor lists non-null

### DIFF
--- a/source/E2E.Tests/Services/Missions/NetworkBattleHostAssignedSerializationTests.cs
+++ b/source/E2E.Tests/Services/Missions/NetworkBattleHostAssignedSerializationTests.cs
@@ -1,0 +1,28 @@
+﻿using Missions.Messages;
+using ProtoBuf;
+using System;
+using System.IO;
+using Xunit;
+
+namespace E2E.Tests.Services.Missions;
+
+/// <summary>
+/// Verifies battle-host assignments preserve a usable successor list across protobuf serialization.
+/// </summary>
+public class NetworkBattleHostAssignedSerializationTests
+{
+    [Fact]
+    public void EmptySuccessorList_RoundTripsAsEmptyArray()
+    {
+        var original = new NetworkBattleHostAssigned("map-event", "host", Array.Empty<string>(), 1);
+
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, original);
+        stream.Position = 0;
+
+        var result = Serializer.Deserialize<NetworkBattleHostAssigned>(stream);
+
+        Assert.NotNull(result.SuccessorControllerIds);
+        Assert.Empty(result.SuccessorControllerIds);
+    }
+}

--- a/source/Missions/Messages/NetworkBattleHostAssigned.cs
+++ b/source/Missions/Messages/NetworkBattleHostAssigned.cs
@@ -1,4 +1,4 @@
-using Common.Messaging;
+﻿using Common.Messaging;
 using ProtoBuf;
 using System;
 
@@ -19,15 +19,17 @@ public class NetworkBattleHostAssigned : IEvent
     [ProtoMember(2)]
     public readonly string HostControllerId;
     [ProtoMember(3)]
-    public readonly string[] SuccessorControllerIds = Array.Empty<string>();
+    private readonly string[] successorControllerIds;
     [ProtoMember(4)]
     public readonly int Epoch;
+
+    public string[] SuccessorControllerIds => successorControllerIds ?? Array.Empty<string>();
 
     public NetworkBattleHostAssigned(string mapEventId, string hostControllerId, string[] successorControllerIds, int epoch)
     {
         MapEventId = mapEventId;
         HostControllerId = hostControllerId;
-        SuccessorControllerIds = successorControllerIds;
+        this.successorControllerIds = successorControllerIds ?? Array.Empty<string>();
         Epoch = epoch;
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

An empty battle host successor array can be omitted by protobuf. Because the message skips its constructor during deserialization, receivers then see a null list and host migration can fail while processing the assignment.

## What is the new behavior?

The serialized backing field is normalized by a non-null public accessor, including when protobuf omits an empty array.

## Bot Changelog Entry

- Fixed battle host migration when no backup host is available.

## Other information

Tested with a protobuf round-trip regression for an empty successor list.