### PR TITLE
Stabilize thread-sensitive tests

### DIFF
--- a/source/E2E.Tests/Services/Locations/LocationRemotePartySpawnOrderingTests.cs
+++ b/source/E2E.Tests/Services/Locations/LocationRemotePartySpawnOrderingTests.cs
@@ -31,37 +31,34 @@ public class LocationRemotePartySpawnOrderingTests
 
         bool registered = false;
         bool resolvedDuringReplay = false;
-        Thread spawnThread = null;
         int previousGameThreadId = GameThread.Instance.GameThreadId;
+        GameThread.Instance.DiscardQueuedActions();
         GameThread.Instance.MarkGameThread();
         try
         {
-            spawnThread = new Thread(() => GameThread.RunSafe(() =>
+            var producerThread = new Thread(() =>
             {
-                registered = partyPuppetRegistrar.TrySpawnAndRegister(
-                    () => remotePuppet,
-                    registry,
-                    "remote",
-                    agentId,
-                    out _);
-            }, blocking: true));
-            spawnThread.Start();
-            Assert.True(SpinWait.SpinUntil(
-                () => GameThread.Instance.QueueLength == 1,
-                TimeSpan.FromSeconds(2)));
-
-            var replayThread = new Thread(() => GameThread.RunSafe(() =>
-            {
-                resolvedDuringReplay = LocationNpcGate.IsPlayerPartyAgent(remotePuppet);
-            }));
-            replayThread.Start();
-            replayThread.Join();
-            Assert.True(SpinWait.SpinUntil(
-                () => GameThread.Instance.QueueLength == 2,
-                TimeSpan.FromSeconds(2)));
+                GameThread.RunSafe(() =>
+                {
+                    registered = partyPuppetRegistrar.TrySpawnAndRegister(
+                        () => remotePuppet,
+                        registry,
+                        "remote",
+                        agentId,
+                        out _);
+                });
+                GameThread.RunSafe(() =>
+                {
+                    resolvedDuringReplay = LocationNpcGate.IsPlayerPartyAgent(remotePuppet);
+                });
+            });
+            producerThread.Start();
+            Assert.True(
+                producerThread.Join(GameThread.BlockingTimeout),
+                "the producer should enqueue both actions without blocking");
+            Assert.Equal(2, GameThread.Instance.QueueLength);
 
             GameThread.Instance.Update(TimeSpan.Zero);
-            spawnThread.Join();
 
             Assert.True(registered);
             Assert.True(resolvedDuringReplay);
@@ -70,7 +67,6 @@ public class LocationRemotePartySpawnOrderingTests
         {
             if (GameThread.Instance.QueueLength > 0)
                 GameThread.Instance.Update(TimeSpan.Zero);
-            spawnThread?.Join(TimeSpan.FromSeconds(1));
             GameThread.Instance.DiscardQueuedActions();
             GameThread.Instance.RestoreGameThread(previousGameThreadId);
             LocationNpcGate.EndMission();

--- a/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
+++ b/source/GameInterface.Tests/Policies/CallOriginalPolicyTests.cs
@@ -1,4 +1,5 @@
 ﻿using GameInterface.Policies;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -60,8 +61,14 @@ public class CallOriginalPolicyTests
         {
             Assert.True(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
             Assert.True(CallOriginalPolicy.IsOriginalAllowed());
-            Assert.False(Task.Run(() => CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation)
-                .GetAwaiter().GetResult());
+
+            bool originalsAllowedOnWorkerThread = true;
+            var workerThread = new Thread(() =>
+                originalsAllowedOnWorkerThread = CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);
+            workerThread.Start();
+            workerThread.Join();
+
+            Assert.False(originalsAllowedOnWorkerThread);
         }
 
         Assert.False(CallOriginalPolicy.AreOriginalsAllowedForCurrentOperation);


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

`CallOriginalPolicyTests` uses `Task.Run(...).GetResult()` to check thread-local state, which can run on the invoking thread. `LocationRemotePartySpawnOrderingTests` also depends on worker scheduling within two seconds and an exact global queue length.

These failed intermittently across #3484 through #3487.

## What is the new behavior?

Uses a dedicated thread for the thread-local assertion. The location ordering test clears stale queued work and queues both actions from one producer thread before draining them in FIFO order.

## Bot Changelog Entry

## Other information

Tests:

- Release `CallOriginalPolicyTests` (6 passed)
- Release `LocationRemotePartySpawnOrderingTests` (1 passed)
- 100 repeated runs of each previously failing test
