### PR TITLE
Use Supabase RPCs for server statistics

### DIFF
--- a/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryStatus.cs
+++ b/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryStatus.cs
@@ -1,14 +1,24 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Coop.Core.Server.Services.Telemetry;
 
 /// <summary>Describes one campaign server heartbeat.</summary>
 public sealed class ServerTelemetryStatus
 {
+    [JsonPropertyName("p_session_id")]
     public string SessionId { get; }
+
+    [JsonPropertyName("p_mod_version")]
     public string ModVersion { get; }
+
+    [JsonPropertyName("p_commit_hash")]
     public string Commit { get; }
+
+    [JsonPropertyName("p_started_at")]
     public DateTime StartedAt { get; }
+
+    [JsonPropertyName("p_player_count")]
     public int PlayerCount { get; }
 
     public ServerTelemetryStatus(

--- a/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryUploader.cs
+++ b/source/Coop.Core/Server/Services/Telemetry/ServerTelemetryUploader.cs
@@ -22,13 +22,13 @@ public interface IBattlesFoughtUploader
     Task<ServerTelemetryUploadResult> RecordBattleStartedAsync(CancellationToken cancellationToken);
 }
 
-/// <summary>Posts authenticated server statistics to the configured edge functions.</summary>
+/// <summary>Posts authenticated server statistics to the configured RPC functions.</summary>
 public class ServerTelemetryUploader : IServerTelemetryUploader, IBattlesFoughtUploader, IDisposable
 {
     public const string Endpoint =
-        "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/upsert-platform-statistics";
+        "https://wfvqnijwuyqjibhlcrhz.supabase.co/rest/v1/rpc/report_server_statistics";
     public const string BattlesFoughtEndpoint =
-        "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/battles-fought-upsert";
+        "https://wfvqnijwuyqjibhlcrhz.supabase.co/rest/v1/rpc/increment_battles_fought";
     internal const string PublishableKey = "sb_publishable_tseZMeJ-RYeSHI0KwU2p0g_PE4GVtN6";
 
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions

--- a/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryUploaderTests.cs
+++ b/source/Coop.Tests/Server/Services/Telemetry/ServerTelemetryUploaderTests.cs
@@ -42,17 +42,17 @@ public class ServerTelemetryUploaderTests
         using var json = JsonDocument.Parse(handler.Body ?? string.Empty);
         var root = json.RootElement;
         Assert.Equal(
-            new[] { "sessionId", "modVersion", "commit", "startedAt", "playerCount" },
+            new[] { "p_session_id", "p_mod_version", "p_commit_hash", "p_started_at", "p_player_count" },
             root.EnumerateObject().Select(property => property.Name).ToArray());
-        Assert.Equal("41fa0000000000000000000000000000", root.GetProperty("sessionId").GetString());
-        Assert.Equal("0.1.4", root.GetProperty("modVersion").GetString());
-        Assert.Equal("abc123", root.GetProperty("commit").GetString());
-        Assert.Equal("2026-08-29T22:15:00Z", root.GetProperty("startedAt").GetString());
-        Assert.Equal(5, root.GetProperty("playerCount").GetInt32());
+        Assert.Equal("41fa0000000000000000000000000000", root.GetProperty("p_session_id").GetString());
+        Assert.Equal("0.1.4", root.GetProperty("p_mod_version").GetString());
+        Assert.Equal("abc123", root.GetProperty("p_commit_hash").GetString());
+        Assert.Equal("2026-08-29T22:15:00Z", root.GetProperty("p_started_at").GetString());
+        Assert.Equal(5, root.GetProperty("p_player_count").GetInt32());
     }
 
     [Fact]
-    public async Task RecordBattleStartedAsync_PostsToBattlesFoughtEdgeFunction()
+    public async Task RecordBattleStartedAsync_PostsToBattlesFoughtRpc()
     {
         const string testEndpoint = "https://telemetry.example.test/api/v1/battles-fought";
         var handler = new RecordingHttpHandler();
@@ -74,7 +74,7 @@ public class ServerTelemetryUploaderTests
     }
 
     [Fact]
-    public async Task DefaultConfigurationUsesPublicEdgeFunction()
+    public async Task DefaultConfigurationUsesPublicRpcEndpoints()
     {
         var handler = new RecordingHttpHandler();
         using var httpClient = new HttpClient(handler);
@@ -93,14 +93,14 @@ public class ServerTelemetryUploaderTests
         Assert.True(result.EndpointConfigured);
         Assert.Equal(1, handler.RequestCount);
         Assert.Equal(
-            "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/upsert-platform-statistics",
+            "https://wfvqnijwuyqjibhlcrhz.supabase.co/rest/v1/rpc/report_server_statistics",
             ServerTelemetryUploader.Endpoint);
         Assert.Equal(ServerTelemetryUploader.Endpoint, handler.RequestUri?.ToString());
         Assert.Equal(
             "sb_publishable_tseZMeJ-RYeSHI0KwU2p0g_PE4GVtN6",
             ServerTelemetryUploader.PublishableKey);
         Assert.Equal(
-            "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/battles-fought-upsert",
+            "https://wfvqnijwuyqjibhlcrhz.supabase.co/rest/v1/rpc/increment_battles_fought",
             ServerTelemetryUploader.BattlesFoughtEndpoint);
     }
 


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Server heartbeats and battle counts are sent to the retired edge-function endpoints.

## What is the new behavior?

Server heartbeats and battle counts use the new Supabase RPC endpoints. Heartbeat JSON properties match the RPC parameter names.

## How to test

`dotnet test source/Coop.Tests/Coop.Tests.csproj -c Release --filter FullyQualifiedName~ServerTelemetryUploaderTests`