### PR TITLE
Accept direct connection ports in server address

### DIFF
--- a/UIMovies/CoopConnectionUIMovie.xml
+++ b/UIMovies/CoopConnectionUIMovie.xml
@@ -70,29 +70,6 @@
                         <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="270" HeightSizePolicy="StretchToParent"
                                     Brush="Clan.TabControl.Text" Brush.FontSize="28"
                                     Brush.TextHorizontalAlignment="Right" Brush.TextVerticalAlignment="Center"
-                                    MarginRight="20" Text="@PortText"/>
-                        <EditableTextWidget WidthSizePolicy="Fixed" SuggestedWidth="390" HeightSizePolicy="Fixed" SuggestedHeight="58"
-                                            VerticalAlignment="Center" Brush="ScoreboardPanels_2" Brush.AlphaFactor="0.75"
-                                            Brush.FontSize="28" Brush.TextHorizontalAlignment="Center"
-                                            Brush.TextVerticalAlignment="Center" Text="@Port"/>
-                        <HintWidget DataSource="{PortHint}" WidthSizePolicy="Fixed" SuggestedWidth="44"
-                                    HeightSizePolicy="StretchToParent" MarginLeft="14"
-                                    Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint">
-                          <Children>
-                            <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
-                                        DoNotAcceptEvents="true" Brush="Clan.TabControl.Text"
-                                        Brush.TextVerticalAlignment="Center" Text="(i)"/>
-                          </Children>
-                        </HintWidget>
-                      </Children>
-                    </ListPanel>
-
-                    <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="760" HeightSizePolicy="Fixed" SuggestedHeight="76"
-                               HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
-                      <Children>
-                        <TextWidget WidthSizePolicy="Fixed" SuggestedWidth="270" HeightSizePolicy="StretchToParent"
-                                    Brush="Clan.TabControl.Text" Brush.FontSize="28"
-                                    Brush.TextHorizontalAlignment="Right" Brush.TextVerticalAlignment="Center"
                                     MarginRight="20" Text="@PasswordText"/>
                         <EditableTextWidget WidthSizePolicy="Fixed" SuggestedWidth="390" HeightSizePolicy="Fixed" SuggestedHeight="58"
                                             VerticalAlignment="Center" Brush="ScoreboardPanels_2" Brush.AlphaFactor="0.75"

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -2,6 +2,7 @@
 using Common.Messaging;
 using Common.Network.Session;
 using GameInterface.Services.UI;
+using GameInterface.Services.UI.Messages;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +12,63 @@ namespace GameInterface.Tests.Services.UI;
 
 public class CoopConnectMenuVMTests
 {
+    [Theory]
+    [InlineData("localhost", "localhost", 4200)]
+    [InlineData("localhost:4300", "localhost", 4300)]
+    [InlineData("127.0.0.1:4400", "127.0.0.1", 4400)]
+    [InlineData("::1", "::1", 4200)]
+    [InlineData("[::1]:4500", "::1", 4500)]
+    public void TryParseServerAddress_UsesAttachedPortOrDefault(
+        string enteredAddress,
+        string expectedHost,
+        int expectedPort)
+    {
+        bool parsed = CoopConnectMenuVM.TryParseServerAddress(
+            enteredAddress,
+            out string host,
+            out int port);
+
+        Assert.True(parsed);
+        Assert.Equal(expectedHost, host);
+        Assert.Equal(expectedPort, port);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("localhost:")]
+    [InlineData("localhost:0")]
+    [InlineData("localhost:65536")]
+    [InlineData("[::1]:invalid")]
+    public void TryParseServerAddress_RejectsInvalidAddressesAndPorts(string enteredAddress)
+    {
+        Assert.False(CoopConnectMenuVM.TryParseServerAddress(
+            enteredAddress,
+            out _,
+            out _));
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1", 4200)]
+    [InlineData("127.0.0.1:4300", 4300)]
+    public void DirectConnect_PublishesAttachedPortOrDefault(string enteredAddress, int expectedPort)
+    {
+        var browser = new TestSteamLobbyBrowser();
+        using var messageBroker = new MessageBroker();
+        AttemptJoin? publishedJoin = null;
+        Action<MessagePayload<AttemptJoin>> capture = payload => publishedJoin = payload.What;
+        messageBroker.Subscribe(capture);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker)
+        {
+            Ip = enteredAddress,
+        };
+
+        viewModel.ActionConnect();
+
+        Assert.NotNull(publishedJoin);
+        Assert.Equal("127.0.0.1", publishedJoin.Address.ToString());
+        Assert.Equal(expectedPort, publishedJoin.Port);
+    }
+
     [Fact]
     public void SteamLobbyPages_SliceResultsAndStopAtBoundaries()
     {

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -2,6 +2,7 @@
 using Common.Messaging;
 using Common.Network.Session;
 using GameInterface.Services.UI;
+using GameInterface.Services.UI.CoopOptions;
 using GameInterface.Services.UI.Messages;
 using System;
 using System.Collections.Generic;
@@ -50,14 +51,15 @@ public class CoopConnectMenuVMTests
     [Theory]
     [InlineData("127.0.0.1", 4200)]
     [InlineData("127.0.0.1:4300", 4300)]
-    public void DirectConnect_PublishesAttachedPortOrDefault(string enteredAddress, int expectedPort)
+    public void DirectConnect_PublishesAndSavesAttachedPortOrDefault(string enteredAddress, int expectedPort)
     {
         var browser = new TestSteamLobbyBrowser();
+        var optionsStore = new TestCoopOptionsStore();
         using var messageBroker = new MessageBroker();
         AttemptJoin? publishedJoin = null;
         Action<MessagePayload<AttemptJoin>> capture = payload => publishedJoin = payload.What;
         messageBroker.Subscribe(capture);
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker)
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, optionsStore)
         {
             Ip = enteredAddress,
         };
@@ -67,6 +69,28 @@ public class CoopConnectMenuVMTests
         Assert.NotNull(publishedJoin);
         Assert.Equal("127.0.0.1", publishedJoin.Address.ToString());
         Assert.Equal(expectedPort, publishedJoin.Port);
+        Assert.True(optionsStore.LoadOrDefault().TryGetSection(
+            CoopConnectMenuVM.OptionsTabId,
+            CoopConnectMenuVM.OptionsSectionId,
+            out DirectConnectionOptions saved));
+        Assert.Equal(enteredAddress, saved.LastServerAddress);
+    }
+
+    [Fact]
+    public void DirectConnect_LoadsLastSavedServerAddress()
+    {
+        var savedOptions = new CoopOptionsData();
+        savedOptions.SetSection(
+            CoopConnectMenuVM.OptionsTabId,
+            CoopConnectMenuVM.OptionsSectionId,
+            new DirectConnectionOptions { LastServerAddress = "203.0.113.7:4300" });
+        var browser = new TestSteamLobbyBrowser();
+        var optionsStore = new TestCoopOptionsStore(savedOptions);
+        using var messageBroker = new MessageBroker();
+
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, optionsStore);
+
+        Assert.Equal("203.0.113.7:4300", viewModel.Ip);
     }
 
     [Fact]
@@ -382,6 +406,31 @@ public class CoopConnectMenuVMTests
     private static string[] VisibleHosts(CoopConnectMenuVM viewModel)
     {
         return viewModel.SteamLobbies.Select(lobby => lobby.HostText).ToArray();
+    }
+
+    private sealed class TestCoopOptionsStore : ICoopOptionsStore
+    {
+        private CoopOptionsData options;
+
+        public TestCoopOptionsStore(CoopOptionsData? options = null)
+        {
+            this.options = options ?? new CoopOptionsData();
+        }
+
+        public string FilePath => string.Empty;
+
+        public bool TryLoad(out CoopOptionsData loaded)
+        {
+            loaded = options;
+            return true;
+        }
+
+        public CoopOptionsData LoadOrDefault() => options;
+
+        public void Save(CoopOptionsData saved)
+        {
+            options = saved;
+        }
     }
 
     private sealed class TestSteamLobbyBrowser : ISteamLobbyBrowser

--- a/source/GameInterface.Tests/Services/UI/CoopConnectionUIMovieTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectionUIMovieTests.cs
@@ -8,6 +8,21 @@ namespace GameInterface.Tests.Services.UI;
 public class CoopConnectionUIMovieTests
 {
     [Fact]
+    public void DirectConnection_UsesOneAddressInputWithoutSeparatePortInput()
+    {
+        var document = XDocument.Load(FindMoviePath());
+
+        Assert.Single(document.Descendants("EditableTextWidget"),
+            element => element.Attribute("Text")?.Value == "@Ip");
+        Assert.DoesNotContain(document.Descendants("EditableTextWidget"),
+            element => element.Attribute("Text")?.Value == "@Port");
+        Assert.DoesNotContain(document.Descendants("TextWidget"),
+            element => element.Attribute("Text")?.Value == "@PortText");
+        Assert.DoesNotContain(document.Descendants("HintWidget"),
+            element => element.Attribute("DataSource")?.Value == "{PortHint}");
+    }
+
+    [Fact]
     public void IncompatibleStatusHint_KeepsRowBindingsOutsideHintDataSource()
     {
         var document = XDocument.Load(FindMoviePath());

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -31,6 +31,7 @@ using TaleWorlds.CampaignSystem.ViewModelCollection.KingdomManagement.Decisions.
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.ScreenSystem;
+using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Kingdoms.Commands;
 

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -1,7 +1,9 @@
-﻿using Common.Messaging;
+﻿using Common.Logging;
+using Common.Messaging;
 using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
+using GameInterface.Services.UI.CoopOptions;
 using GameInterface.Services.UI.Donate;
 using GameInterface.Services.UI.Messages;
 using System;
@@ -9,6 +11,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text.Json.Serialization;
+using Serilog;
 using TaleWorlds.Core.ViewModelCollection.Information;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
@@ -28,16 +32,22 @@ public enum SteamLobbyPasswordFilter
 /// <summary>View model for direct connection and public standalone Steam-lobby discovery.</summary>
 public class CoopConnectMenuVM : ViewModel, IDisposable
 {
+    private static readonly ILogger Logger = LogManager.GetLogger<CoopConnectMenuVM>();
+
     public const string DirectTabId = "direct";
     public const string SteamLobbiesTabId = "steam_lobbies";
+    public const string OptionsTabId = "Connection";
+    public const string OptionsSectionId = "DirectConnection";
     public const int SteamLobbyPageSize = 4;
 
+    private const string DefaultServerAddress = "localhost";
     private const int DefaultConnectionPort = 4200;
 
     public event Action SteamLobbiesTabActivated;
 
     private readonly ISteamLobbyBrowser steamLobbyBrowser;
     private readonly IMessageBroker messageBroker;
+    private readonly ICoopOptionsStore optionsStore;
     private readonly List<SteamLobbyListItemVM> discoveredSteamLobbies = new();
 
     private CoopConnectionTabVM selectedTab;
@@ -98,18 +108,28 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         _ => "Any Password",
     };
 
-    public string connectIP = "localhost";
+    public string connectIP = DefaultServerAddress;
     public string connectPassword = "";
 
     public CoopConnectMenuVM()
-        : this(SessionDiscovery.SteamLobbyBrowser, MessageBroker.Instance)
+        : this(SessionDiscovery.SteamLobbyBrowser, MessageBroker.Instance, new CoopOptionsStore())
     {
     }
 
     public CoopConnectMenuVM(ISteamLobbyBrowser steamLobbyBrowser, IMessageBroker messageBroker)
+        : this(steamLobbyBrowser, messageBroker, new CoopOptionsStore())
+    {
+    }
+
+    public CoopConnectMenuVM(
+        ISteamLobbyBrowser steamLobbyBrowser,
+        IMessageBroker messageBroker,
+        ICoopOptionsStore optionsStore)
     {
         this.steamLobbyBrowser = steamLobbyBrowser;
         this.messageBroker = messageBroker ?? throw new ArgumentNullException(nameof(messageBroker));
+        this.optionsStore = optionsStore ?? throw new ArgumentNullException(nameof(optionsStore));
+        connectIP = LoadLastServerAddress();
 
         Tabs = new MBBindingList<CoopConnectionTabVM>
         {
@@ -381,6 +401,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
             }
 
             messageBroker.Publish(this, new AttemptJoin(ip, port, connectPassword, steamInvites));
+            SaveLastServerAddress();
         }
         catch (Exception ex)
         {
@@ -553,6 +574,45 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         messageBroker.Publish(this, new JoinSteamLobby(lobbyId));
     }
 
+    private string LoadLastServerAddress()
+    {
+        try
+        {
+            var options = optionsStore.LoadOrDefault();
+            if (options.TryGetSection(
+                    OptionsTabId,
+                    OptionsSectionId,
+                    out DirectConnectionOptions saved) &&
+                TryParseServerAddress(saved.LastServerAddress, out _, out _))
+            {
+                return saved.LastServerAddress.Trim();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Last direct connection address could not be loaded");
+        }
+
+        return DefaultServerAddress;
+    }
+
+    private void SaveLastServerAddress()
+    {
+        try
+        {
+            var options = optionsStore.LoadOrDefault();
+            options.SetSection(
+                OptionsTabId,
+                OptionsSectionId,
+                new DirectConnectionOptions { LastServerAddress = connectIP.Trim() });
+            optionsStore.Save(options);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warning(ex, "Last direct connection address could not be saved");
+        }
+    }
+
     internal static bool TryParseServerAddress(string enteredAddress, out string host, out int port)
     {
         host = string.Empty;
@@ -598,4 +658,11 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         return string.Equals(address, "localhost", StringComparison.OrdinalIgnoreCase) ||
             (IPAddress.TryParse(address, out var ip) && IPAddress.IsLoopback(ip));
     }
+}
+
+/// <summary>Persisted address from the last direct connection attempt.</summary>
+public class DirectConnectionOptions
+{
+    [JsonPropertyName("lastServerAddress")]
+    public string LastServerAddress { get; set; }
 }

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -32,6 +32,8 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public const string SteamLobbiesTabId = "steam_lobbies";
     public const int SteamLobbyPageSize = 4;
 
+    private const int DefaultConnectionPort = 4200;
+
     public event Action SteamLobbiesTabActivated;
 
     private readonly ISteamLobbyBrowser steamLobbyBrowser;
@@ -77,17 +79,12 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string ConnectedPlayersColumnText => "Connected Players";
     public string PasswordColumnText => "Access";
     public string CompatibilityColumnText => "Status";
-    public string IpText => "Server IP Address:";
-    public string PortText => "Port:";
+    public string IpText => "Server Address:";
     public string PasswordText => "Password:";
 
     [DataSourceProperty]
     public HintViewModel ServerAddressHint { get; } = new HintViewModel(new TextObject(
-        "The address of the co-op server to join. Keep localhost if you are the host; otherwise, type the address your friend shared to join their game."));
-
-    [DataSourceProperty]
-    public HintViewModel PortHint { get; } = new HintViewModel(new TextObject(
-        "The port the co-op server listens on. Leave 4200 unless the host changed it."));
+        "The co-op server's IP address or host name. Add a custom port after a colon, such as localhost:4300. Port 4200 is used when omitted."));
 
     [DataSourceProperty]
     public HintViewModel PasswordHint { get; } = new HintViewModel(new TextObject(
@@ -102,7 +99,6 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     };
 
     public string connectIP = "localhost";
-    public string connectPort = "4200";
     public string connectPassword = "";
 
     public CoopConnectMenuVM()
@@ -271,20 +267,6 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     }
 
     [DataSourceProperty]
-    public string Port
-    {
-        get => connectPort;
-        set
-        {
-            // TODO update config
-            if (value == connectPort) return;
-
-            connectPort = value;
-            OnPropertyChanged(nameof(Port));
-        }
-    }
-
-    [DataSourceProperty]
     public string Password
     {
         get => connectPassword;
@@ -362,9 +344,10 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     public void ActionConnect()
     {
-        if (!int.TryParse(connectPort, out var port) || port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
+        if (!TryParseServerAddress(connectIP, out var host, out var port))
         {
-            InformationManager.DisplayMessage(new InformationMessage("ERROR: The connection port is invalid"));
+            InformationManager.DisplayMessage(new InformationMessage(
+                "ERROR: Enter a valid server address with an optional port"));
             return;
         }
 
@@ -377,17 +360,17 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
         try
         {
-            bool steamInvites = SessionDiscovery.SteamAvailable && IsLoopbackAddress(connectIP);
+            bool steamInvites = SessionDiscovery.SteamAvailable && IsLoopbackAddress(host);
 
             IPAddress ip;
 
-            if (IPAddress.TryParse(connectIP, out var enteredIp))
+            if (IPAddress.TryParse(host, out var enteredIp))
             {
                 ip = enteredIp;
             }
             else
             {
-                var addresses = Dns.GetHostAddresses(connectIP);
+                var addresses = Dns.GetHostAddresses(host);
                 ip = addresses.FirstOrDefault(x => x.AddressFamily == AddressFamily.InterNetwork);
 
                 if (ip == null)
@@ -568,6 +551,46 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         if (disposed || lobbyId == 0) return;
 
         messageBroker.Publish(this, new JoinSteamLobby(lobbyId));
+    }
+
+    internal static bool TryParseServerAddress(string enteredAddress, out string host, out int port)
+    {
+        host = string.Empty;
+        port = DefaultConnectionPort;
+
+        if (string.IsNullOrWhiteSpace(enteredAddress)) return false;
+
+        string address = enteredAddress.Trim();
+        if (address[0] == '[')
+        {
+            int closingBracket = address.IndexOf(']');
+            if (closingBracket <= 1) return false;
+
+            host = address.Substring(1, closingBracket - 1);
+            string suffix = address.Substring(closingBracket + 1);
+            if (suffix.Length == 0) return true;
+
+            return suffix[0] == ':' && TryParsePort(suffix.Substring(1), out port);
+        }
+
+        int firstColon = address.IndexOf(':');
+        int lastColon = address.LastIndexOf(':');
+        if (firstColon >= 0 && firstColon == lastColon)
+        {
+            host = address.Substring(0, firstColon).Trim();
+            return host.Length > 0 && TryParsePort(address.Substring(firstColon + 1), out port);
+        }
+
+        if (firstColon >= 0 && !IPAddress.TryParse(address, out _)) return false;
+
+        host = address;
+        return true;
+    }
+
+    private static bool TryParsePort(string enteredPort, out int port)
+    {
+        return int.TryParse(enteredPort, out port) &&
+            port > IPEndPoint.MinPort && port <= IPEndPoint.MaxPort;
     }
 
     private static bool IsLoopbackAddress(string address)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

Direct connection asks for the server address and port in separate fields.

## What is the new behavior?

Direct connection uses one server address field. An address without a port uses 4200, and a custom port can be entered as `localhost:4300`. The last address used is saved in `coop_options.json` and filled in when the page is opened again.

## How to test

1. Open Join Co-op and select Direct.
2. Join a server on port 4200 with `localhost`.
3. Join a server on port 4300 with `localhost:4300`.
4. Reopen Join Co-op and confirm `localhost:4300` is filled in.

## Bot Changelog Entry

- Direct connection now accepts the port as part of the server address, uses port 4200 when omitted, and remembers the last address used.