### PR TITLE
Migrate battle, party, and mission commands in place

### DIFF
--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -11,6 +12,9 @@ using Coop.Core.Client.Services.Session;
 using Coop.Core.Client.States;
 using Coop.Core.Common;
 using Coop.Core.Common.Configuration;
+#if DEBUG
+using Coop.Core.Common.Commands;
+#endif
 using Coop.Core.Common.Session;
 using Coop.Steam;
 using GameInterface.Policies;
@@ -30,6 +34,12 @@ public class ClientModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<MissionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinDebugCommands.JoinStateCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.ArmInactivePartyDeficitCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.DisconnectCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+#endif
 
         builder.RegisterType<ClientContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ClientLogic>().As<ILogic>().As<IClientLogic>().InstancePerLifetimeScope();

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -1,4 +1,6 @@
 ﻿#if DEBUG
+using System;
+using Common.Commands;
 using Common;
 using Coop.Core.Client;
 using Coop.Core.Client.States;
@@ -19,154 +21,193 @@ namespace Coop.Core.Common.Commands;
 /// <summary>
 /// Stages and observes campaign-join scenarios in DEBUG builds.
 /// </summary>
-internal static class JoinDebugCommands
+public static class JoinDebugCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    private static Func<bool> startClientSession;
     private static int forceNextInactivePartyDeficit;
     private static string desiredInactivePartyId;
     private static string lastForcedPartyId = "none";
     private static MobileParty stagedInactiveParty;
     private static bool stagedInactivePartyWasActive;
 
-    [CommandLineArgumentFunction("join_state", "coop.debug.connection")]
-    public static string JoinState(List<string> args)
+    public sealed class JoinStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.join_state";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        if (ModInformation.IsServer)
+        public string Name => "join_state";
+
+        public string Description => "Reports the current campaign join state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (!ContainerProvider.TryResolve<IConnectionCollection>(out var connections))
+            if (ModInformation.IsServer)
             {
-                return "Failed to get connection collection";
+                if (!ContainerProvider.TryResolve<IConnectionCollection>(out var connections))
+                {
+                    return Failed("Failed to get connection collection");
+                }
+
+                string connectionState = string.Join(" | ", connections.Select(connection =>
+                {
+                    string state = connection.State?.GetType().Name ?? "none";
+                    string details = connection.State is ServerLoadingState loading
+                        ? loading.DebugJoinState
+                        : "joinCatchUpPending=false";
+                    return $"peer={connection.Peer.Id} state={state} {details}";
+                }));
+                return Succeeded($"{GetPartyCounts()} | {connectionState}");
             }
 
-            string connectionState = string.Join(" | ", connections.Select(connection =>
+            if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
             {
-                string state = connection.State?.GetType().Name ?? "none";
-                string details = connection.State is ServerLoadingState loading
-                    ? loading.DebugJoinState
-                    : "joinCatchUpPending=false";
-                return $"peer={connection.Peer.Id} state={state} {details}";
-            }));
-            return $"{GetPartyCounts()} | {connectionState}";
-        }
+                return Failed("Failed to get client logic");
+            }
 
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
-        {
-            return "Failed to get client logic";
+            return Succeeded(clientLogic.State is CampaignState campaignState
+                ? $"{campaignState.DebugJoinState} {GetPartyCounts()} " +
+                  $"forcedInactiveParty={lastForcedPartyId}"
+                : $"state={clientLogic.State?.GetType().Name ?? "none"} {GetPartyCounts()} " +
+                  $"forcedInactiveParty={lastForcedPartyId}");
         }
-
-        return clientLogic.State is CampaignState campaignState
-            ? $"{campaignState.DebugJoinState} {GetPartyCounts()} " +
-              $"forcedInactiveParty={lastForcedPartyId}"
-            : $"state={clientLogic.State?.GetType().Name ?? "none"} {GetPartyCounts()} " +
-              $"forcedInactiveParty={lastForcedPartyId}";
     }
 
-    [CommandLineArgumentFunction("arm_inactive_party_deficit", "coop.debug.connection")]
-    public static string ArmInactivePartyDeficit(List<string> args)
+    public sealed class ArmInactivePartyDeficitCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.connection.arm_inactive_party_deficit <partyStringId>";
-        }
-        if (ModInformation.IsServer)
-        {
-            return "The inactive-party deficit fixture is client-only.";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        desiredInactivePartyId = args[0];
-        lastForcedPartyId = "armed";
-        Interlocked.Exchange(ref forceNextInactivePartyDeficit, 1);
-        return $"The next complete join baseline will remove inactive party '{args[0]}' " +
-               "from the client campaign collection before validation.";
+        public string Name => "arm_inactive_party_deficit";
+
+        public string Description => "Arms the next client join baseline to omit an inactive party.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_string_id", "The inactive party StringId."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+            {
+                return Failed("The inactive-party deficit fixture is client-only.");
+            }
+
+            desiredInactivePartyId = args[0];
+            lastForcedPartyId = "armed";
+            Interlocked.Exchange(ref forceNextInactivePartyDeficit, 1);
+            return Succeeded($"The next complete join baseline will remove inactive party '{args[0]}' " +
+                   "from the client campaign collection before validation.");
+        }
     }
 
-    [CommandLineArgumentFunction("stage_inactive_party", "coop.debug.connection")]
-    public static string StageInactiveParty(List<string> args)
+    public sealed class StageInactivePartyCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.stage_inactive_party";
-        }
-        if (!ModInformation.IsServer)
-        {
-            return "stage_inactive_party must be run on the server.";
-        }
-        if (stagedInactiveParty != null)
-        {
-            return GetStagedPartyResult(stagedInactiveParty);
-        }
+        public string Prefix => "coop.debug.connection";
 
-        var parties = Campaign.Current?.CampaignObjectManager?.MobileParties;
-        stagedInactiveParty = parties?.FirstOrDefault(party =>
-                party?.IsActive == true &&
-                party.Ai != null &&
-                !party.IsPlayerParty() &&
-                party.Army == null &&
-                party.AttachedTo == null &&
-                party.MapEvent == null &&
-                party.CurrentSettlement == null &&
-                party.BesiegedSettlement == null &&
-                party.BesiegerCamp == null &&
-                !party.IsTransitionInProgress &&
-                !party.StartTransitionNextFrameToExitFromPort &&
-                !party.IsInRaftState &&
-                !IsReferencedByActiveParty(party, parties));
-        if (stagedInactiveParty == null)
-        {
-            return "No isolated active non-player field party was available for the fixture.";
-        }
+        public string Name => "stage_inactive_party";
 
-        stagedInactivePartyWasActive = stagedInactiveParty.IsActive;
-        stagedInactiveParty.IsActive = false;
-        return GetStagedPartyResult(stagedInactiveParty);
+        public string Description => "Stages an isolated server party as inactive for join testing.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+            {
+                return Failed("stage_inactive_party must be run on the server.");
+            }
+            if (stagedInactiveParty != null)
+            {
+                return Succeeded(GetStagedPartyResult(stagedInactiveParty));
+            }
+
+            var parties = Campaign.Current?.CampaignObjectManager?.MobileParties;
+            stagedInactiveParty = parties?.FirstOrDefault(party =>
+                    party?.IsActive == true &&
+                    party.Ai != null &&
+                    !party.IsPlayerParty() &&
+                    party.Army == null &&
+                    party.AttachedTo == null &&
+                    party.MapEvent == null &&
+                    party.CurrentSettlement == null &&
+                    party.BesiegedSettlement == null &&
+                    party.BesiegerCamp == null &&
+                    !party.IsTransitionInProgress &&
+                    !party.StartTransitionNextFrameToExitFromPort &&
+                    !party.IsInRaftState &&
+                    !IsReferencedByActiveParty(party, parties));
+            if (stagedInactiveParty == null)
+            {
+                return Failed("No isolated active non-player field party was available for the fixture.");
+            }
+
+            stagedInactivePartyWasActive = stagedInactiveParty.IsActive;
+            stagedInactiveParty.IsActive = false;
+            return Succeeded(GetStagedPartyResult(stagedInactiveParty));
+        }
     }
 
-    [CommandLineArgumentFunction("restore_inactive_party", "coop.debug.connection")]
-    public static string RestoreInactiveParty(List<string> args)
+    public sealed class RestoreInactivePartyCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.restore_inactive_party";
-        }
-        if (!ModInformation.IsServer)
-        {
-            return "restore_inactive_party must be run on the server.";
-        }
-        if (stagedInactiveParty == null)
-        {
-            return "No inactive-party fixture is staged.";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        string partyId = stagedInactiveParty.StringId;
-        stagedInactiveParty.IsActive = stagedInactivePartyWasActive;
-        bool restoredActive = stagedInactiveParty.IsActive;
-        stagedInactiveParty = null;
-        stagedInactivePartyWasActive = false;
-        return $"restoredParty={partyId} active={restoredActive}";
+        public string Name => "restore_inactive_party";
+
+        public string Description => "Restores the staged inactive server party.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+            {
+                return Failed("restore_inactive_party must be run on the server.");
+            }
+            if (stagedInactiveParty == null)
+            {
+                return Failed("No inactive-party fixture is staged.");
+            }
+
+            string partyId = stagedInactiveParty.StringId;
+            stagedInactiveParty.IsActive = stagedInactivePartyWasActive;
+            bool restoredActive = stagedInactiveParty.IsActive;
+            stagedInactiveParty = null;
+            stagedInactivePartyWasActive = false;
+            return Succeeded($"restoredParty={partyId} active={restoredActive}");
+        }
     }
 
-    [CommandLineArgumentFunction("disconnect", "coop.debug.connection")]
-    public static string Disconnect(List<string> args)
+    public sealed class DisconnectCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.disconnect";
-        }
-        if (ModInformation.IsServer)
-        {
-            return "disconnect must be run on a client.";
-        }
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
-        {
-            return "No active client session was found.";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        clientLogic.Disconnect();
-        return "Client session is returning to the main menu.";
+        public string Name => "disconnect";
+
+        public string Description => "Disconnects the active client session.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+            {
+                return Failed("disconnect must be run on a client.");
+            }
+            if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+            {
+                return Failed("No active client session was found.");
+            }
+
+            clientLogic.Disconnect();
+            return Succeeded("Client session is returning to the main menu.");
+        }
     }
 
     [CommandLineArgumentFunction("reconnect", "coop.debug.connection")]
@@ -180,13 +221,31 @@ internal static class JoinDebugCommands
         {
             return "reconnect must be run on a client.";
         }
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+        if (ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
         {
-            return "No client session was found.";
+            clientLogic.Connect();
+            return "Client session is reconnecting to the configured server.";
         }
 
-        clientLogic.Connect();
-        return "Client session is reconnecting to the configured server.";
+        Func<bool> starter = Volatile.Read(ref startClientSession);
+        if (starter == null)
+            return "The process client-session starter is unavailable.";
+        if (!starter())
+            throw new InvalidOperationException("Client co-op connection start was refused.");
+
+        return "Client co-op session restarted after teardown.";
+    }
+
+    public static void ConfigureClientSessionStarter(Func<bool> starter)
+    {
+        if (starter == null) throw new ArgumentNullException(nameof(starter));
+
+        Volatile.Write(ref startClientSession, starter);
+    }
+
+    internal static void ResetClientSessionStarter()
+    {
+        Volatile.Write(ref startClientSession, null);
     }
 
     internal static void ForceArmedInactivePartyDeficit()

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -9,6 +10,9 @@ using Coop.Core.Client.Services.Kingdoms;
 using Coop.Core.Client.Services.MobileParties;
 using Coop.Core.Common;
 using Coop.Core.Common.Configuration;
+#if DEBUG
+using Coop.Core.Common.Commands;
+#endif
 using Coop.Core.Common.Session;
 using Coop.Core.Server.Connections;
 using Coop.Core.Server.Policies;
@@ -40,6 +44,12 @@ public class ServerModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<ConnectionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinDebugCommands.JoinStateCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.StageInactivePartyCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.RestoreInactivePartyCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+#endif
 
         // The mission/P2P stack is composed into the server container too (it is also in ClientModule) so the
         // server-authoritative battle classes — notably BattleHostHandler, which elects the battle host — run

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -9,6 +9,7 @@ using Coop.Core.Server;
 using Coop.Core.Server.Services.Telemetry;
 using Coop.Tests.Mocks;
 using GameInterface;
+using Missions;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -33,9 +34,20 @@ namespace Coop.Tests.Autofac
             var logic = container.Resolve<ILogic>();
             Assert.NotNull(logic);
 
-            ICoopCommand[] commands = container.Resolve<IEnumerable<ICoopCommand>>().ToArray();
-            Assert.Contains(commands, command =>
+            ICoopCommand[] registeredCommands = container.Resolve<IEnumerable<ICoopCommand>>().ToArray();
+            Assert.Contains(registeredCommands, command =>
                 $"{command.Prefix}.{command.Name}" == "coop.debug.workshop.set_workshop_custom_name");
+            Assert.Contains(registeredCommands, command =>
+                $"{command.Prefix}.{command.Name}" == "coop.debug.map_event.kms");
+
+            ICoopCommand[] missionCommands = registeredCommands
+                .Where(command => command.GetType().Assembly == typeof(MissionModule).Assembly)
+                .ToArray();
+#if DEBUG
+            Assert.Equal(26, missionCommands.Length);
+#else
+            Assert.Equal(15, missionCommands.Length);
+#endif
         }
 
         [Fact]

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -45,6 +45,12 @@ namespace Coop.Tests.Autofac
                 .ToArray();
 #if DEBUG
             Assert.Equal(26, missionCommands.Length);
+            Assert.Equal(
+                new[] { "arm_inactive_party_deficit", "disconnect", "join_state" },
+                registeredCommands
+                    .Where(command => command.Prefix == "coop.debug.connection")
+                    .Select(command => command.Name)
+                    .OrderBy(name => name));
 #else
             Assert.Equal(15, missionCommands.Length);
 #endif
@@ -66,6 +72,16 @@ namespace Coop.Tests.Autofac
 
             var logic = container.Resolve<ILogic>();
             Assert.NotNull(logic);
+
+#if DEBUG
+            ICoopCommand[] registeredCommands = container.Resolve<IEnumerable<ICoopCommand>>().ToArray();
+            Assert.Equal(
+                new[] { "join_state", "restore_inactive_party", "stage_inactive_party" },
+                registeredCommands
+                    .Where(command => command.Prefix == "coop.debug.connection")
+                    .Select(command => command.Name)
+                    .OrderBy(name => name));
+#endif
         }
 
         [Theory]

--- a/source/Coop.Tests/Common/Commands/ConnectionDirectCommandTests.cs
+++ b/source/Coop.Tests/Common/Commands/ConnectionDirectCommandTests.cs
@@ -1,0 +1,94 @@
+﻿#if DEBUG
+using Common;
+using Common.Commands;
+using Coop.Core.Common.Commands;
+using GameInterface;
+using System;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.Commands;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class ConnectionDirectCommandTests
+{
+    [Fact]
+    public void SessionCommands_AreDirectCommandsInTheOwningType()
+    {
+        Type[] commandTypes = typeof(JoinDebugCommands).GetNestedTypes(BindingFlags.Public)
+            .Where(type => typeof(ICoopCommand).IsAssignableFrom(type))
+            .ToArray();
+
+        Assert.Equal(5, commandTypes.Length);
+        Assert.All(commandTypes, type =>
+        {
+            Assert.Equal(typeof(object), type.BaseType);
+            Assert.Equal(new[] { typeof(ICoopCommand) }, type.GetInterfaces());
+            Assert.EndsWith("CoopCommand", type.Name);
+        });
+    }
+
+    [Fact]
+    public void Reconnect_RemainsAProcessLifetimeAttributedCommand()
+    {
+        MethodInfo method = typeof(JoinDebugCommands).GetMethod(
+            nameof(JoinDebugCommands.Reconnect),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        Assert.True(method.IsDefined(
+            typeof(CommandLineFunctionality.CommandLineArgumentFunction),
+            inherit: false));
+    }
+
+    [Fact]
+    public void ReconnectWithoutSession_RestartsThroughProcessLifetimeStarter()
+    {
+        bool wasServer = ModInformation.IsServer;
+        bool started = false;
+        try
+        {
+            ModInformation.IsServer = false;
+            ContainerProvider.Clear();
+            JoinDebugCommands.ConfigureClientSessionStarter(() =>
+            {
+                started = true;
+                return true;
+            });
+
+            string output = JoinDebugCommands.Reconnect(new System.Collections.Generic.List<string>());
+
+            Assert.True(started);
+            Assert.Equal("Client co-op session restarted after teardown.", output);
+        }
+        finally
+        {
+            JoinDebugCommands.ResetClientSessionStarter();
+            ModInformation.IsServer = wasServer;
+        }
+    }
+
+    [Fact]
+    public void DisconnectServerRejection_IsExplicitFailure()
+    {
+        bool wasServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            var command = new JoinDebugCommands.DisconnectCoopCommand();
+
+            CoopCommandResult result = command.ProcessCommand(
+                new CoopCommandArgsFactory().FromValues(Array.Empty<string>()));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+    }
+}
+#endif

--- a/source/Coop.Tests/Common/Commands/MissionDirectCommandTests.cs
+++ b/source/Coop.Tests/Common/Commands/MissionDirectCommandTests.cs
@@ -1,0 +1,163 @@
+﻿using Common.Commands;
+using Serilog;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Coop.Tests.Commands;
+
+public class MissionDirectCommandTests
+{
+    private static readonly HashSet<string> OwningTypes = new HashSet<string>
+    {
+        "MovementDebugCommands",
+        "BattleDebugCommands",
+    };
+
+    [Fact]
+    public void MissionCommands_AreDirectNormalizedCommands()
+    {
+        Type[] commandTypes = GetCommandTypes();
+#if DEBUG
+        Assert.Equal(26, commandTypes.Length);
+#else
+        Assert.Equal(15, commandTypes.Length);
+#endif
+        ICoopCommand[] commands = commandTypes
+            .Select(type => (ICoopCommand)Activator.CreateInstance(type))
+            .ToArray();
+        var registry = new CoopCommandRegistry(commands, new LoggerConfiguration().CreateLogger());
+
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.All(commandTypes, type =>
+        {
+            Assert.Equal(typeof(object), type.BaseType);
+            Assert.Equal(new[] { typeof(ICoopCommand) }, type.GetInterfaces());
+            Assert.EndsWith("CoopCommand", type.Name);
+        });
+        Assert.All(commands, command =>
+        {
+            Assert.Matches("^coop(?:\\.[a-z0-9_]+)+$", command.Prefix);
+            Assert.Matches("^[a-z0-9]+(?:_[a-z0-9]+)*$", command.Name);
+            Assert.False(string.IsNullOrWhiteSpace(command.Description));
+            Assert.NotNull(command.ExpectedArgs);
+        });
+    }
+
+    [Fact]
+    public void ProcessCommand_ReadsCountOnlyForOptionalArguments()
+    {
+        string[] countReaders = GetCommandTypes()
+            .Where(type => CallsArgumentCount(type.GetMethod(nameof(ICoopCommand.ProcessCommand))))
+            .Select(type => ((ICoopCommand)Activator.CreateInstance(type)).Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(new[] { "ladder_state", "mount_state" }, countReaders);
+    }
+
+    [Fact]
+    public void MissionRegistry_RejectsInvalidArgumentCount()
+    {
+        ICoopCommand command = CreateCommand("move_cavalry");
+        var registry = new CoopCommandRegistry(
+            new[] { command },
+            new LoggerConfiguration().CreateLogger());
+
+        CoopCommandResult result = registry.ProcessCommand(
+            $"{command.Prefix}.{command.Name}",
+            new TestArgs(Array.Empty<string>()));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+    }
+
+    [Fact]
+    public void FocusLadder_InvalidMachineId_IsExplicitFailure()
+    {
+        ICoopCommand command = CreateCommand("focus_ladder");
+
+        CoopCommandResult result = command.ProcessCommand(new TestArgs(new[] { "not-an-id" }));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("command_failed", result.ErrorCode);
+    }
+
+#if DEBUG
+    [Fact]
+    public void BattleFixture_MissingMission_IsExplicitFailure()
+    {
+        ICoopCommand command = CreateCommand("replication_fixture");
+
+        CoopCommandResult result = command.ProcessCommand(new TestArgs(new[] { "initial" }));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("command_failed", result.ErrorCode);
+    }
+#endif
+
+    private static bool CallsArgumentCount(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody().GetILAsByteArray();
+        for (int index = 0; index <= il.Length - sizeof(int); index++)
+        {
+            try
+            {
+                MethodBase referencedMethod = method.Module.ResolveMethod(BitConverter.ToInt32(il, index));
+                if (referencedMethod.Name == "get_Count" &&
+                    (referencedMethod.DeclaringType == typeof(ICoopCommandArgs) ||
+                     referencedMethod.DeclaringType == typeof(IReadOnlyCollection<string>)))
+                {
+                    return true;
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private static ICoopCommand CreateCommand(string name)
+    {
+        Type type = Assert.Single(GetCommandTypes(), candidate =>
+        {
+            var command = (ICoopCommand)Activator.CreateInstance(candidate);
+            return command.Name == name;
+        });
+        return (ICoopCommand)Activator.CreateInstance(type);
+    }
+
+    private static Type[] GetCommandTypes()
+    {
+        return typeof(global::Missions.MissionModule).Assembly.GetTypes()
+            .Where(type => type.IsClass &&
+                           !type.IsAbstract &&
+                           type.DeclaringType != null &&
+                           OwningTypes.Contains(type.DeclaringType.Name) &&
+                           typeof(ICoopCommand).IsAssignableFrom(type))
+            .ToArray();
+    }
+
+    private sealed class TestArgs : ICoopCommandArgs
+    {
+        private readonly IReadOnlyList<string> values;
+
+        public TestArgs(IReadOnlyList<string> values)
+        {
+            this.values = values;
+        }
+
+        public int Count => values.Count;
+
+        public string this[int index] => values[index];
+
+        public IEnumerator<string> GetEnumerator() => values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -483,6 +483,11 @@ namespace Coop
                 CrashDiagnostics.SetPhase,
                 activeLogFilePath);
 
+#if DEBUG
+            global::Coop.Core.Common.Commands.JoinDebugCommands.ConfigureClientSessionStarter(
+                () => Coop.StartAsClient());
+#endif
+
             Updateables.Add(GameThread.Instance);
 
 #if DEBUG

--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -4,6 +4,7 @@ using Common.LiveTesting;
 using Common.Logging;
 using Common.LogicStates;
 using Coop.Core.Client;
+using Coop.Core.Common.Commands;
 using Coop.Core.Server;
 using GameInterface;
 using GameInterface.Services.LiveTesting;
@@ -190,9 +191,18 @@ namespace Coop.LiveTesting
             {
                 if (!ContainerProvider.TryResolve<ILiveTestCommandDispatcher>(out var dispatcher))
                 {
+                    string output = null;
                     if (string.Equals(command, "coop.debug.connection.start", StringComparison.Ordinal))
                     {
-                        string output = Coop.JoinFixtureCommands.Start(arguments);
+                        output = Coop.JoinFixtureCommands.Start(arguments);
+                    }
+                    else if (string.Equals(command, "coop.debug.connection.reconnect", StringComparison.Ordinal))
+                    {
+                        output = JoinDebugCommands.Reconnect(arguments);
+                    }
+
+                    if (output != null)
+                    {
                         bool hasFallbackStructuredResult = TryParseStructuredResult(
                             output,
                             out var fallbackStructuredResult);

--- a/source/E2E.Tests/Services/Issues/IssuesDebugCommandTests.cs
+++ b/source/E2E.Tests/Services/Issues/IssuesDebugCommandTests.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
@@ -41,7 +42,7 @@ public class IssuesDebugCommandTests : IDisposable
             Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
             setupHero.StayingInSettlement = settlement;
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" });
+            var giveResult = Give(new List<string> { heroId, "BettingFraud" });
             Assert.True(giveResult.Contains("Gave quest type 'BettingFraud'"), giveResult);
 
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
@@ -49,7 +50,7 @@ public class IssuesDebugCommandTests : IDisposable
             Assert.NotNull(issue.IssueQuest);
             Assert.True(Campaign.Current.IssueManager.Issues.ContainsKey(hero));
 
-            var completeResult = IssuesDebugCommand.Complete(new List<string> { heroId });
+            var completeResult = Complete(new List<string> { heroId });
             Assert.Contains("Completed quest for hero", completeResult);
 
             Assert.Null(hero.Issue);
@@ -69,9 +70,9 @@ public class IssuesDebugCommandTests : IDisposable
             Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
             setupHero.StayingInSettlement = settlement;
 
-            Assert.Contains("Gave quest type", IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" }));
+            Assert.Contains("Gave quest type", Give(new List<string> { heroId, "BettingFraud" }));
 
-            var secondResult = IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" });
+            var secondResult = Give(new List<string> { heroId, "BettingFraud" });
 
             Assert.Contains("already has an active issue", secondResult);
         });
@@ -95,14 +96,14 @@ public class IssuesDebugCommandTests : IDisposable
             village.Hearth = 650f;
             hero.StayingInSettlement = settlement;
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "VillageNeedsTools" });
+            var giveResult = Give(new List<string> { heroId, "VillageNeedsTools" });
             Assert.True(giveResult.Contains("Gave quest type 'VillageNeedsTools'"), giveResult);
 
             var issue = Assert.IsType<VillageNeedsToolsIssueBehavior.VillageNeedsToolsIssue>(hero.Issue);
             Assert.NotNull(issue.IssueQuest);
             Assert.Same(DefaultItems.Tools, issue._requestedItem);
 
-            var completeResult = IssuesDebugCommand.Complete(new List<string> { heroId, "cancel" });
+            var completeResult = Complete(new List<string> { heroId, "cancel" });
             Assert.Contains("outcome 'cancel'", completeResult);
 
             Assert.Null(hero.Issue);
@@ -129,13 +130,13 @@ public class IssuesDebugCommandTests : IDisposable
             boundTown.Culture = ObjectHelper.SkipConstructor<CultureObject>();
             hero.StayingInSettlement = settlement;
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "RuralNotableInnAndOut" });
+            var giveResult = Give(new List<string> { heroId, "RuralNotableInnAndOut" });
             Assert.Contains("Gave quest type 'RuralNotableInnAndOut'", giveResult);
 
             var issue = Assert.IsType<RuralNotableInnAndOutIssueBehavior.RuralNotableInnAndOutIssue>(hero.Issue);
             Assert.NotNull(issue.IssueQuest);
 
-            var completeResult = IssuesDebugCommand.Complete(new List<string> { heroId, "fail" });
+            var completeResult = Complete(new List<string> { heroId, "fail" });
             Assert.Contains("outcome 'fail'", completeResult);
 
             Assert.Null(hero.Issue);
@@ -155,7 +156,7 @@ public class IssuesDebugCommandTests : IDisposable
 
             Assert.Null(hero.CurrentSettlement);
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "NotableWantsDaughterFound" });
+            var giveResult = Give(new List<string> { heroId, "NotableWantsDaughterFound" });
 
             Assert.Contains("NotableWantsDaughterFound", giveResult);
             Assert.Contains("StartIssueQuest threw", giveResult);
@@ -165,7 +166,7 @@ public class IssuesDebugCommandTests : IDisposable
 
             hero.StayingInSettlement = settlement;
 
-            var retryResult = IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" });
+            var retryResult = Give(new List<string> { heroId, "BettingFraud" });
             Assert.Contains("Gave quest type 'BettingFraud'", retryResult);
         });
     }
@@ -173,11 +174,30 @@ public class IssuesDebugCommandTests : IDisposable
     [Fact]
     public void ListTypes_ReportsAllFortyThreeVanillaIssueTypes_WithExactlyOneNotWired()
     {
-        var result = IssuesDebugCommand.ListTypes(new List<string>());
+        var result = ListTypes(new List<string>());
         var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(43, lines.Length);
         Assert.Single(lines, line => line.Contains("[not wired"));
         Assert.Contains(lines, line => line.StartsWith("ProdigalSon ") && line.Contains("[not wired"));
     }
+
+    private static string Give(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesGiveCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
+    private static string Complete(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesCompleteCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
+    private static string ListTypes(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesListTypesCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
 }

--- a/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
+++ b/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using Common.Util;
+﻿using Common.Commands;
+using Common.Util;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Services.MapEvents;
 using E2E.Tests.Util;
@@ -49,7 +50,7 @@ public class UnstuckCommandTests : MapEventTestBase
         string output = null;
         Server.Call(() =>
         {
-            output = UnstuckCommand.Unstuck(new List<string>());
+            output = ExecuteUnstuck();
         });
 
         Assert.Equal("Command can only be run on a client.", output);
@@ -64,7 +65,7 @@ public class UnstuckCommandTests : MapEventTestBase
         string output = null;
         Client.Call(() =>
         {
-            output = UnstuckCommand.Unstuck(new List<string>());
+            output = ExecuteUnstuck();
         });
 
         Assert.Contains("Unstuck request sent", output);
@@ -378,4 +379,11 @@ public class UnstuckCommandTests : MapEventTestBase
 
         return new PlayerIds(heroId, characterId, partyId);
     }
+
+    private static string ExecuteUnstuck()
+    {
+        var command = new UnstuckCommand.UnstuckCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(Array.Empty<string>())).Output;
+    }
+
 }

--- a/source/GameInterface.Tests/Services/GameDebug/GameThreadDebugCommandTests.cs
+++ b/source/GameInterface.Tests/Services/GameDebug/GameThreadDebugCommandTests.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Commands;
 using GameInterface.Services.GameDebug.Commands;
 using GameInterface.Tests;
 using System;
@@ -24,7 +25,7 @@ public class GameThreadDebugCommandTests : IDisposable
 
         Assert.Equal(
             "gamethread.stall must be run on the server",
-            GameThreadDebugCommand.Stall(new List<string> { "1" }));
+            Stall(new List<string> { "1" }));
     }
 
     [Theory]
@@ -36,8 +37,8 @@ public class GameThreadDebugCommandTests : IDisposable
         ModInformation.IsServer = true;
 
         Assert.StartsWith(
-            "Usage:",
-            GameThreadDebugCommand.Stall(new List<string> { duration }));
+            "Stall duration must be",
+            Stall(new List<string> { duration }));
     }
 
     [Fact]
@@ -47,6 +48,11 @@ public class GameThreadDebugCommandTests : IDisposable
 
         Assert.Equal(
             "Stalled the server game thread for 1 ms",
-            GameThreadDebugCommand.Stall(new List<string> { "1" }));
+            Stall(new List<string> { "1" }));
+    }
+    private static string Stall(List<string> args)
+    {
+        var command = new GameThreadDebugCommand.GameThreadStallCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
     }
 }

--- a/source/GameInterface.Tests/Services/GameDebug/Metrics/PartySyncPerformanceLogsTests.cs
+++ b/source/GameInterface.Tests/Services/GameDebug/Metrics/PartySyncPerformanceLogsTests.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common;
+using Common.Commands;
 using Common.Messaging;
 using Common.Network;
 using Common.Tests.Utils;
@@ -53,7 +54,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         logger.Setup(l => l.Enable(TimeSpan.FromSeconds(60), "test_log")).Returns("enabled");
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "60", "test_log" });
+        var result = ExecuteCommand(new List<string> { "on", "60", "test_log" });
 
         Assert.Equal("enabled", result);
         logger.Verify(l => l.Enable(TimeSpan.FromSeconds(60), "test_log"), Times.Once);
@@ -64,7 +65,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         logger.Setup(l => l.Disable()).Returns("disabled");
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "off" });
+        var result = ExecuteCommand(new List<string> { "off" });
 
         Assert.Equal("disabled", result);
         logger.Verify(l => l.Disable(), Times.Once);
@@ -75,7 +76,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         logger.Setup(l => l.Status()).Returns("status");
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "status" });
+        var result = ExecuteCommand(new List<string> { "status" });
 
         Assert.Equal("status", result);
         logger.Verify(l => l.Status(), Times.Once);
@@ -84,16 +85,16 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     [Fact]
     public void On_MissingArgs_ReturnsUsage()
     {
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "60" });
+        var result = ExecuteCommand(new List<string> { "on", "60" });
 
-        Assert.Contains("Usage:", result);
+        Assert.Contains("requires seconds and a file name", result);
         logger.Verify(l => l.Enable(It.IsAny<TimeSpan>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
     public void On_NonPositiveSeconds_ReturnsError()
     {
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "0", "test_log" });
+        var result = ExecuteCommand(new List<string> { "on", "0", "test_log" });
 
         Assert.Equal("Seconds must be a positive number", result);
         logger.Verify(l => l.Enable(It.IsAny<TimeSpan>(), It.IsAny<string>()), Times.Never);
@@ -106,7 +107,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
         using var realContainer = CreateLoggerContainer(fileWriter);
         ContainerProvider.SetContainer(realContainer);
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "60", "test_log" });
+        var result = ExecuteCommand(new List<string> { "on", "60", "test_log" });
 
         Assert.Contains("test_log.csv", result);
         var write = Assert.Single(fileWriter.Writes);
@@ -118,10 +119,16 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         ModInformation.IsServer = true;
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "status" });
+        var result = ExecuteCommand(new List<string> { "status" });
 
         Assert.Equal("party_sync_performance_logs can only be called by a client", result);
         logger.Verify(l => l.Status(), Times.Never);
+    }
+
+    private static string ExecuteCommand(List<string> args)
+    {
+        var command = new PartySyncPerformanceLogsCommand.MetricsPartySyncPerformanceLogsCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
     }
 
     private static IContainer CreateLoggerContainer(FakeFileWriter fileWriter)

--- a/source/GameInterface.Tests/Services/Issues/IssuesDebugCommandTests.cs
+++ b/source/GameInterface.Tests/Services/Issues/IssuesDebugCommandTests.cs
@@ -1,5 +1,6 @@
-using Autofac;
+﻿using Autofac;
 using Common;
+using Common.Commands;
 using Common.Util;
 using GameInterface.Services.Issues.Commands;
 using GameInterface.Services.ObjectManager;
@@ -44,7 +45,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "some_hero", "BettingFraud" });
+            var result = Give(new List<string> { "some_hero", "BettingFraud" });
 
             Assert.Equal(
                 "The 'coop.debug.issues.give' command cannot be used on the client. It is intended for server use only.",
@@ -65,7 +66,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "no_such_hero", "BettingFraud" });
+            var result = Give(new List<string> { "no_such_hero", "BettingFraud" });
 
             Assert.Contains("No Hero found with id", result);
         }
@@ -86,7 +87,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "hero_1", "NotARealQuestType" });
+            var result = Give(new List<string> { "hero_1", "NotARealQuestType" });
 
             Assert.Contains("Unknown quest type key 'NotARealQuestType'", result);
             Assert.Contains("list_types", result);
@@ -108,7 +109,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "hero_1", "ProdigalSon" });
+            var result = Give(new List<string> { "hero_1", "ProdigalSon" });
 
             Assert.Contains("is a known vanilla Issue type but is not wired for give", result);
         }
@@ -131,7 +132,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "hero_1", "BettingFraud" });
+            var result = Give(new List<string> { "hero_1", "BettingFraud" });
 
             Assert.Contains("already has an active issue", result);
         }
@@ -149,7 +150,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "some_hero" });
+            var result = Complete(new List<string> { "some_hero" });
 
             Assert.Equal(
                 "The 'coop.debug.issues.complete' command cannot be used on the client. It is intended for server use only.",
@@ -170,7 +171,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "no_such_hero" });
+            var result = Complete(new List<string> { "no_such_hero" });
 
             Assert.Contains("No Hero found with id", result);
         }
@@ -191,7 +192,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "hero_1" });
+            var result = Complete(new List<string> { "hero_1" });
 
             Assert.Contains("has no active issue", result);
         }
@@ -214,7 +215,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "hero_1" });
+            var result = Complete(new List<string> { "hero_1" });
 
             Assert.Contains("no live quest yet", result);
             Assert.Contains("coop.debug.issues.give", result);
@@ -224,4 +225,17 @@ public class IssuesDebugCommandTests : System.IDisposable
             ModInformation.IsServer = wasServer;
         }
     }
+
+    private static string Give(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesGiveCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
+    private static string Complete(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesCompleteCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
 }

--- a/source/GameInterface.Tests/Services/Party/PartyCommandsTests.cs
+++ b/source/GameInterface.Tests/Services/Party/PartyCommandsTests.cs
@@ -1,7 +1,7 @@
 ﻿using Common;
+using Common.Commands;
 using GameInterface.Services.Party.Commands;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace GameInterface.Tests.Services.Party;
@@ -25,8 +25,11 @@ public class PartyCommandsTests : IDisposable
     {
         ModInformation.IsServer = true;
 
-        var result = PartyCommands.WhoAmICommand(new List<string>());
-        
-        Assert.Equal("Command can only be run on a client.", result);
+        var command = new PartyCommands.WhoAmICoopCommand();
+        CoopCommandResult result = command.ProcessCommand(
+            new CoopCommandArgsFactory().FromValues(Array.Empty<string>()));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("Command can only be run on a client.", result.Output);
     }
 }

--- a/source/GameInterface.Tests/Services/UI/TacticalUnitSymbolsConfigTests.cs
+++ b/source/GameInterface.Tests/Services/UI/TacticalUnitSymbolsConfigTests.cs
@@ -1,5 +1,6 @@
-using Autofac;
+﻿using Autofac;
 using Common;
+using Common.Commands;
 using Common.Messaging;
 using Common.Network;
 using Coop.Tests.Mocks;
@@ -32,7 +33,7 @@ public class TacticalUnitSymbolsConfigTests
 
         try
         {
-            var result = TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string> { "on" });
+            var result = ExecuteTacticalSymbols(new List<string> { "on" });
 
             Assert.Equal(
                 "The 'coop.debug.ui.tactical_symbols' command cannot be used on the client. It is intended for server use only.",
@@ -54,7 +55,7 @@ public class TacticalUnitSymbolsConfigTests
 
         try
         {
-            var result = TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string> { "status" });
+            var result = ExecuteTacticalSymbols(new List<string> { "status" });
 
             Assert.Equal("Tactical unit symbols are hidden.", result);
         }
@@ -88,7 +89,7 @@ public class TacticalUnitSymbolsConfigTests
             using var container = builder.Build();
             ContainerProvider.SetContainer(container);
 
-            var result = TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string> { "on" });
+            var result = ExecuteTacticalSymbols(new List<string> { "on" });
 
             Assert.Equal("Tactical unit symbols are visible.", result);
             Assert.False(TacticalUnitSymbolsSettings.HideTacticalUnitSymbols);
@@ -149,4 +150,11 @@ public class TacticalUnitSymbolsConfigTests
             TacticalUnitSymbolsSettings.SetHideTacticalUnitSymbols(previous);
         }
     }
+
+    private static string ExecuteTacticalSymbols(List<string> args)
+    {
+        var command = new TacticalUnitSymbolsDebugCommand.UiTacticalSymbolsCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
 }

--- a/source/GameInterface.Tests/Utils/Commands/DirectMigratedCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/DirectMigratedCommandTests.cs
@@ -1,0 +1,203 @@
+﻿using Common;
+using Common.Commands;
+using GameInterface;
+using Serilog;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+[Collection(global::GameInterface.Tests.ModInformationRoleCollection.Name)]
+public class DirectMigratedCommandTests
+{
+    private static readonly HashSet<string> OwningTypes = new HashSet<string>
+    {
+        "BattleTeamKillCommands",
+        "KillPlayerAgentCommands",
+        "MapEventDebugCommands",
+        "PostBattleFreezeFixtureCommands",
+        "GarrisonTroopXpFixtureCommands",
+        "LargeBattleRosterFixtureCommands",
+        "PartyCommands",
+        "TroopXpTransferFixtureCommands",
+        "PartyVisualDebugCommands",
+    };
+
+    [Fact]
+    public void MigratedCommands_ReplaceAllAttributedMethodsWithDirectCommands()
+    {
+        Type[] commandTypes = GetCommandTypes();
+
+#if DEBUG
+        Assert.Equal(120, commandTypes.Length);
+#else
+        Assert.Equal(101, commandTypes.Length);
+#endif
+        Assert.All(commandTypes, type =>
+        {
+            Assert.Equal(typeof(object), type.BaseType);
+            Assert.Equal(new[] { typeof(ICoopCommand) }, type.GetInterfaces());
+            Assert.EndsWith("CoopCommand", type.Name);
+        });
+
+        MethodInfo[] attributedMethods = typeof(GameInterfaceModule).Assembly.GetTypes()
+            .Where(type => OwningTypes.Contains(type.Name))
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            .Where(method => method.IsDefined(
+                typeof(CommandLineFunctionality.CommandLineArgumentFunction), inherit: false))
+            .ToArray();
+
+        Assert.Empty(attributedMethods);
+    }
+
+    [Fact]
+    public void MigratedCommands_HaveUniqueNormalizedMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var registry = new CoopCommandRegistry(commands, new LoggerConfiguration().CreateLogger());
+
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.Equal(
+            commands.Length,
+            commands.Select(command => $"{command.Prefix}.{command.Name}").Distinct().Count());
+        Assert.All(commands, command =>
+        {
+            Assert.Matches("^coop(?:\\.[a-z0-9_]+)+$", command.Prefix);
+            Assert.Matches("^[a-z0-9]+(?:_[a-z0-9]+)*$", command.Name);
+            Assert.False(string.IsNullOrWhiteSpace(command.Description));
+            Assert.NotNull(command.ExpectedArgs);
+            Assert.All(command.ExpectedArgs, expectedArg =>
+            {
+                Assert.Matches("^[a-z0-9]+(?:_[a-z0-9]+)*$", expectedArg.Name);
+                Assert.False(string.IsNullOrWhiteSpace(expectedArg.Description));
+            });
+        });
+    }
+
+    [Fact]
+    public void ProcessCommand_ReadsCountOnlyForOptionalArguments()
+    {
+        string[] countReaders = GetCommandTypes()
+            .Where(type => CallsArgumentCount(type.GetMethod(nameof(ICoopCommand.ProcessCommand))))
+            .Select(type => ((ICoopCommand)Activator.CreateInstance(type)).Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                "battle_reward_fixture_start",
+                "start_nearest_bandit_attack",
+                "upgrade_party_screen_troop",
+            },
+            countReaders);
+    }
+
+    [Fact]
+    public void Registry_RejectsInvalidArgumentCountBeforeCommandLogic()
+    {
+        ICoopCommand command = Assert.Single(
+            CreateCommands(),
+            candidate => candidate.Name == "set_troop_state");
+        var registry = new CoopCommandRegistry(
+            new[] { command },
+            new LoggerConfiguration().CreateLogger());
+
+        CoopCommandResult result = registry.ProcessCommand(
+            $"{command.Prefix}.{command.Name}",
+            new TestArgs(Array.Empty<string>()));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+        Assert.Contains("<party_id>", result.Output);
+    }
+
+    [Theory]
+    [InlineData("set_troop_wounded", "party", "troop", "not-an-integer")]
+    [InlineData("stage_clan_party_transfer", "party", "troop")]
+    public void ExplicitRejectionBranches_ReturnFailures(string commandName, params string[] args)
+    {
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            ICoopCommand command = Assert.Single(
+                CreateCommands(),
+                candidate => candidate.Name == commandName);
+
+            CoopCommandResult result = command.ProcessCommand(new TestArgs(args));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
+    }
+
+    private static bool CallsArgumentCount(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody().GetILAsByteArray();
+        for (int index = 0; index <= il.Length - sizeof(int); index++)
+        {
+            try
+            {
+                MethodBase referencedMethod = method.Module.ResolveMethod(BitConverter.ToInt32(il, index));
+                if (referencedMethod.Name == "get_Count" &&
+                    (referencedMethod.DeclaringType == typeof(ICoopCommandArgs) ||
+                     referencedMethod.DeclaringType == typeof(IReadOnlyCollection<string>)))
+                {
+                    return true;
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private static Type[] GetCommandTypes()
+    {
+        return typeof(GameInterfaceModule).Assembly.GetTypes()
+            .Where(type => type.IsClass &&
+                           !type.IsAbstract &&
+                           type.DeclaringType != null &&
+                           OwningTypes.Contains(type.DeclaringType.Name) &&
+                           typeof(ICoopCommand).IsAssignableFrom(type))
+            .ToArray();
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return GetCommandTypes()
+            .Select(type => (ICoopCommand)Activator.CreateInstance(type))
+            .ToArray();
+    }
+
+    private sealed class TestArgs : ICoopCommandArgs
+    {
+        private readonly IReadOnlyList<string> values;
+
+        public TestArgs(IReadOnlyList<string> values)
+        {
+            this.values = values;
+        }
+
+        public int Count => values.Count;
+
+        public string this[int index] => values[index];
+
+        public IEnumerator<string> GetEnumerator() => values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/source/GameInterface.Tests/Utils/Commands/SystemDeveloperDirectCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/SystemDeveloperDirectCommandTests.cs
@@ -1,0 +1,235 @@
+﻿using Common;
+using Common.Commands;
+using GameInterface.Services.CampaignService.Commands;
+using GameInterface.Services.GameDebug.Commands;
+using GameInterface.Services.UI.Commands;
+using Serilog;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class SystemDeveloperDirectCommandTests
+{
+    private static readonly HashSet<string> OwningTypes = new HashSet<string>
+    {
+        "CampaignOptionsCommands",
+        "ModOptionsCommands",
+        "CaravansCommands",
+        "CharacterDeveloperCommands",
+        "CharacterObjectCommands",
+        "CameraReset",
+        "GameThreadDebugCommand",
+        "PartySyncPerformanceLogsCommand",
+        "UiDebugCommands",
+        "UnstuckCommand",
+        "HeroDeveloperCommands",
+        "InventoryCommands",
+        "TradeSkillCommands",
+        "IssuesDebugCommand",
+        "ItemObjectCommands",
+        "ItemRosterDebugCommands",
+        "AiLordPeaceReleaseFixtureCommands",
+        "PlayerCaptivityCommands",
+        "SaveDebugCommand",
+        "SmithingCommands",
+        "TemplateCommands",
+        "TimeCommands",
+        "SteamDebugCommand",
+        "TacticalUnitSymbolsDebugCommand",
+    };
+
+    [Fact]
+    public void MigratedCommands_AreDirectCommandsInTheirOwningTypes()
+    {
+        Type[] commandTypes = GetCommandTypes();
+
+#if DEBUG
+        Assert.Equal(103, commandTypes.Length);
+#else
+        Assert.Equal(92, commandTypes.Length);
+#endif
+        Assert.All(commandTypes, type =>
+        {
+            Assert.Equal(typeof(object), type.BaseType);
+            Assert.Equal(new[] { typeof(ICoopCommand) }, type.GetInterfaces());
+            Assert.EndsWith("CoopCommand", type.Name);
+        });
+    }
+
+    [Fact]
+    public void MigratedCommands_HaveUniqueNormalizedMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var registry = new CoopCommandRegistry(commands, new LoggerConfiguration().CreateLogger());
+
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.All(commands, command =>
+        {
+            Assert.Matches("^coop(?:\\.[a-z0-9_]+)*$", command.Prefix);
+            Assert.Matches("^[a-z0-9]+(?:_[a-z0-9]+)*$", command.Name);
+            Assert.False(string.IsNullOrWhiteSpace(command.Description));
+            Assert.NotNull(command.ExpectedArgs);
+        });
+    }
+
+    [Fact]
+    public void ProcessLifetimeCommands_KeepAttributedEntryPoints()
+    {
+        AssertAttributed(typeof(SteamDebugCommand), nameof(SteamDebugCommand.Status));
+        AssertAttributed(typeof(SteamDebugCommand), nameof(SteamDebugCommand.Join));
+        AssertAttributed(typeof(BugReportLogSharingCommand), nameof(BugReportLogSharingCommand.Configure));
+
+        string[] migratedSteamCommands = CreateCommands()
+            .Where(command => command.GetType().DeclaringType == typeof(SteamDebugCommand))
+            .Select(command => command.Name)
+            .OrderBy(name => name)
+            .ToArray();
+        Assert.Equal(new[] { "host_lobby", "invite" }, migratedSteamCommands);
+    }
+
+    [Fact]
+    public void ProcessCommand_ReadsCountOnlyForOptionalOrConditionalArguments()
+    {
+        string[] countReaders = GetCommandTypes()
+            .Where(type => CallsArgumentCount(type.GetMethod(nameof(ICoopCommand.ProcessCommand))))
+            .Select(type => ((ICoopCommand)Activator.CreateInstance(type)).Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+#if DEBUG
+        Assert.Equal(
+            new[]
+            {
+                "advance_time",
+                "complete",
+                "force_autosave",
+                "instrument",
+                "is_ironman_mode",
+                "set_time_mode",
+            },
+            countReaders);
+#else
+        Assert.Equal(
+            new[]
+            {
+                "advance_time",
+                "complete",
+                "force_autosave",
+                "instrument",
+                "is_ironman_mode",
+            },
+            countReaders);
+#endif
+    }
+
+    [Fact]
+    public void Registry_RejectsInvalidArgumentCountBeforeCommandLogic()
+    {
+        ICoopCommand command = Assert.Single(
+            CreateCommands(),
+            candidate => candidate.Name == "add_attribute_points");
+        var registry = new CoopCommandRegistry(new[] { command }, new LoggerConfiguration().CreateLogger());
+
+        CoopCommandResult result = registry.ProcessCommand(
+            $"{command.Prefix}.{command.Name}",
+            new TestArgs(new[] { "Hero", "With", "Spaces", "2" }));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+    }
+
+    [Fact]
+    public void CampaignOptionClientRejection_IsExplicitFailure()
+    {
+        bool wasServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = false;
+            ICoopCommand command = new CampaignOptionsCommands.CampaignOptionsAutoAllocateClanMemberPerksCoopCommand();
+
+            CoopCommandResult result = command.ProcessCommand(new TestArgs(new[] { "true" }));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+    }
+
+    private static void AssertAttributed(Type owner, string methodName)
+    {
+        MethodInfo method = owner.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
+        Assert.True(method.IsDefined(
+            typeof(CommandLineFunctionality.CommandLineArgumentFunction),
+            inherit: false));
+    }
+
+    private static bool CallsArgumentCount(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody().GetILAsByteArray();
+        for (int index = 0; index <= il.Length - sizeof(int); index++)
+        {
+            try
+            {
+                MethodBase referencedMethod = method.Module.ResolveMethod(BitConverter.ToInt32(il, index));
+                if (referencedMethod.Name == "get_Count" &&
+                    (referencedMethod.DeclaringType == typeof(ICoopCommandArgs) ||
+                     referencedMethod.DeclaringType == typeof(IReadOnlyCollection<string>)))
+                {
+                    return true;
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private static Type[] GetCommandTypes()
+    {
+        return typeof(GameInterfaceModule).Assembly.GetTypes()
+            .Where(type => type.IsClass &&
+                           !type.IsAbstract &&
+                           type.DeclaringType != null &&
+                           OwningTypes.Contains(type.DeclaringType.Name) &&
+                           typeof(ICoopCommand).IsAssignableFrom(type))
+            .ToArray();
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return GetCommandTypes()
+            .Select(type => (ICoopCommand)Activator.CreateInstance(type))
+            .ToArray();
+    }
+
+    private sealed class TestArgs : ICoopCommandArgs
+    {
+        private readonly IReadOnlyList<string> values;
+
+        public TestArgs(IReadOnlyList<string> values)
+        {
+            this.values = values;
+        }
+
+        public int Count => values.Count;
+
+        public string this[int index] => values[index];
+
+        public IEnumerator<string> GetEnumerator() => values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.CampaignService.Messages;
 using Newtonsoft.Json.Linq;
@@ -17,198 +18,364 @@ namespace GameInterface.Services.CampaignService.Commands;
 /// </summary>
 internal class CampaignOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.campaignoptions")]
-    public static string ListOptionsCommand(List<string> strings)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class CampaignOptionsListCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new();
+        public string Prefix => "coop.debug.campaign_options";
 
-        stringBuilder.AppendLine($"PlayerReceivedDamageDifficulty: {(Difficulty)PlayerReceivedDamageDifficulty}");
+        public string Name => "list";
 
-        // Different order to match vanilla campaign options menu
-        stringBuilder.AppendLine($"PlayerTroopsReceivedDamage: {PlayerTroopsReceivedDamage}");
-        stringBuilder.AppendLine($"RecruitmentDifficulty: {RecruitmentDifficulty}");
-        stringBuilder.AppendLine($"PlayerMapMovementSpeed: {PlayerMapMovementSpeed}");
-        stringBuilder.AppendLine($"PersuasionSuccessChance: {PersuasionSuccessChance}");
-        stringBuilder.AppendLine($"CombatAIDifficulty: {CombatAIDifficulty}");
-        stringBuilder.AppendLine($"ClanMemberDeathChance: {ClanMemberDeathChance}");
-        stringBuilder.AppendLine($"BattleDeath: {BattleDeath}");
-        stringBuilder.AppendLine($"StealthAndDisguiseDifficulty: {StealthAndDisguiseDifficulty}");
-        stringBuilder.AppendLine($"AutoAllocateClanMemberPerks: {AutoAllocateClanMemberPerks}");
-        stringBuilder.AppendLine($"IsIronmanMode: {IsIronmanMode}");
+        public string Description => "Reports list.";
 
-        return stringBuilder.ToString();
-    }
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-    [CommandLineArgumentFunction("AutoAllocateClanMemberPerks", "coop.debug.campaignoptions")]
-    public static string AutoAllocateClanMemberPerksCommand(List<string> strings)
-    {
-        return HandleBooleanOptionCommand(
-            strings,
-            nameof(AutoAllocateClanMemberPerks),
-            () => AutoAllocateClanMemberPerks,
-            value => AutoAllocateClanMemberPerks = value);
-    }
-
-    [CommandLineArgumentFunction("PlayerTroopsReceivedDamage", "coop.debug.campaignoptions")]
-    public static string PlayerTroopsReceivedDamageCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(PlayerTroopsReceivedDamage),
-            () => PlayerTroopsReceivedDamage,
-            value => PlayerTroopsReceivedDamage = value);
-    }
-
-    [CommandLineArgumentFunction("RecruitmentDifficulty", "coop.debug.campaignoptions")]
-    public static string RecruitmentDifficultyCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(RecruitmentDifficulty),
-            () => RecruitmentDifficulty,
-            value => RecruitmentDifficulty = value);
-    }
-
-    [CommandLineArgumentFunction("PlayerMapMovementSpeed", "coop.debug.campaignoptions")]
-    public static string PlayerMapMovementSpeedCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(PlayerMapMovementSpeed),
-            () => PlayerMapMovementSpeed,
-            value => PlayerMapMovementSpeed = value);
-    }
-
-    [CommandLineArgumentFunction("StealthAndDisguiseDifficulty", "coop.debug.campaignoptions")]
-    public static string StealthAndDisguiseDifficultyCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(StealthAndDisguiseDifficulty),
-            () => StealthAndDisguiseDifficulty,
-            value => StealthAndDisguiseDifficulty = value);
-    }
-
-    [CommandLineArgumentFunction("CombatAIDifficulty", "coop.debug.campaignoptions")]
-    public static string CombatAIDifficultyCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(CombatAIDifficulty),
-            () => CombatAIDifficulty,
-            value => CombatAIDifficulty = value);
-    }
-
-    [CommandLineArgumentFunction("IsLifeDeathCycleDisabled", "coop.debug.campaignoptions")]
-    public static string IsLifeDeathCycleDisabledCommand(List<string> strings)
-    {
-        return HandleBooleanOptionCommand(
-            strings,
-            nameof(IsLifeDeathCycleDisabled),
-            () => IsLifeDeathCycleDisabled,
-            value => IsLifeDeathCycleDisabled = value);
-    }
-
-    [CommandLineArgumentFunction("PersuasionSuccessChance", "coop.debug.campaignoptions")]
-    public static string PersuasionSuccessChanceCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(PersuasionSuccessChance),
-            () => PersuasionSuccessChance,
-            value => PersuasionSuccessChance = value);
-    }
-
-    [CommandLineArgumentFunction("ClanMemberDeathChance", "coop.debug.campaignoptions")]
-    public static string ClanMemberDeathChanceCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(ClanMemberDeathChance),
-            () => ClanMemberDeathChance,
-            value => ClanMemberDeathChance = value);
-    }
-
-    [CommandLineArgumentFunction("IsIronmanMode", "coop.debug.campaignoptions")]
-    public static string IsIronmanModeCommand(List<string> strings)
-    {
-        if (strings.Count == 0)
-            return $"{nameof(IsIronmanMode)} is {(IsIronmanMode ? "enabled" : "disabled")}.";
-
-        if (ModInformation.IsClient)
-            return "Managing campaign options is disabled on clients; the host does this.";
-
-        return "This option can only be set at game start.";
-    }
-
-    [CommandLineArgumentFunction("BattleDeath", "coop.debug.campaignoptions")]
-    public static string BattleDeathCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(BattleDeath),
-            () => BattleDeath,
-            value => BattleDeath = value);
-    }
-
-    [CommandLineArgumentFunction("PlayerReceivedDamageDifficulty", "coop.debug.campaignoptions")]
-    public static string SetPlayerReceivedDamageDifficulty(List<string> strings)
-    {
-        Difficulty oldValue = (Difficulty)PlayerReceivedDamageDifficulty;
-
-        var result = HandleDifficultyOptionCommand(
-            strings,
-            nameof(PlayerReceivedDamageDifficulty),
-            () => (Difficulty)PlayerReceivedDamageDifficulty,
-            value => PlayerReceivedDamageDifficulty = (int)value);
-
-        // Player received damage is not a campaign option. Need to update for clients separately
-        if (oldValue != (Difficulty)PlayerReceivedDamageDifficulty)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            UpdateOtherOptions();
-        }
+            StringBuilder stringBuilder = new();
 
-        return result;
+            stringBuilder.AppendLine($"PlayerReceivedDamageDifficulty: {(Difficulty)PlayerReceivedDamageDifficulty}");
+
+            // Different order to match vanilla campaign options menu
+            stringBuilder.AppendLine($"PlayerTroopsReceivedDamage: {PlayerTroopsReceivedDamage}");
+            stringBuilder.AppendLine($"RecruitmentDifficulty: {RecruitmentDifficulty}");
+            stringBuilder.AppendLine($"PlayerMapMovementSpeed: {PlayerMapMovementSpeed}");
+            stringBuilder.AppendLine($"PersuasionSuccessChance: {PersuasionSuccessChance}");
+            stringBuilder.AppendLine($"CombatAIDifficulty: {CombatAIDifficulty}");
+            stringBuilder.AppendLine($"ClanMemberDeathChance: {ClanMemberDeathChance}");
+            stringBuilder.AppendLine($"BattleDeath: {BattleDeath}");
+            stringBuilder.AppendLine($"StealthAndDisguiseDifficulty: {StealthAndDisguiseDifficulty}");
+            stringBuilder.AppendLine($"AutoAllocateClanMemberPerks: {AutoAllocateClanMemberPerks}");
+            stringBuilder.AppendLine($"IsIronmanMode: {IsIronmanMode}");
+
+            return Succeeded(stringBuilder.ToString());
+        }
     }
 
-    private static string HandleBooleanOptionCommand(List<string> strings, string optionName, Func<bool> getter, Action<bool> setter)
+    public sealed class CampaignOptionsAutoAllocateClanMemberPerksCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "auto_allocate_clan_member_perks";
+
+        public string Description => "Runs the auto allocate clan member perks debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleBooleanOptionCommand(
+                strings,
+                nameof(AutoAllocateClanMemberPerks),
+                () => AutoAllocateClanMemberPerks,
+                value => AutoAllocateClanMemberPerks = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPlayerTroopsReceivedDamageCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "player_troops_received_damage";
+
+        public string Description => "Runs the player troops received damage debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(PlayerTroopsReceivedDamage),
+                () => PlayerTroopsReceivedDamage,
+                value => PlayerTroopsReceivedDamage = value);
+        }
+    }
+
+    public sealed class CampaignOptionsRecruitmentDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "recruitment_difficulty";
+
+        public string Description => "Runs the recruitment difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(RecruitmentDifficulty),
+                () => RecruitmentDifficulty,
+                value => RecruitmentDifficulty = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPlayerMapMovementSpeedCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "player_map_movement_speed";
+
+        public string Description => "Runs the player map movement speed debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(PlayerMapMovementSpeed),
+                () => PlayerMapMovementSpeed,
+                value => PlayerMapMovementSpeed = value);
+        }
+    }
+
+    public sealed class CampaignOptionsStealthAndDisguiseDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "stealth_and_disguise_difficulty";
+
+        public string Description => "Runs the stealth and disguise difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(StealthAndDisguiseDifficulty),
+                () => StealthAndDisguiseDifficulty,
+                value => StealthAndDisguiseDifficulty = value);
+        }
+    }
+
+    public sealed class CampaignOptionsCombatAiDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "combat_ai_difficulty";
+
+        public string Description => "Runs the combat ai difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(CombatAIDifficulty),
+                () => CombatAIDifficulty,
+                value => CombatAIDifficulty = value);
+        }
+    }
+
+    public sealed class CampaignOptionsIsLifeDeathCycleDisabledCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "is_life_death_cycle_disabled";
+
+        public string Description => "Runs the is life death cycle disabled debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleBooleanOptionCommand(
+                strings,
+                nameof(IsLifeDeathCycleDisabled),
+                () => IsLifeDeathCycleDisabled,
+                value => IsLifeDeathCycleDisabled = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPersuasionSuccessChanceCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "persuasion_success_chance";
+
+        public string Description => "Runs the persuasion success chance debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(PersuasionSuccessChance),
+                () => PersuasionSuccessChance,
+                value => PersuasionSuccessChance = value);
+        }
+    }
+
+    public sealed class CampaignOptionsClanMemberDeathChanceCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "clan_member_death_chance";
+
+        public string Description => "Runs the clan member death chance debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(ClanMemberDeathChance),
+                () => ClanMemberDeathChance,
+                value => ClanMemberDeathChance = value);
+        }
+    }
+
+    public sealed class CampaignOptionsIsIronmanModeCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "is_ironman_mode";
+
+        public string Description => "Runs the is ironman mode debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (strings.Count == 0)
+                return Succeeded($"{nameof(IsIronmanMode)} is {(IsIronmanMode ? "enabled" : "disabled")}.");
+
+            if (ModInformation.IsClient)
+                return Failed("Managing campaign options is disabled on clients; the host does this.");
+
+            return Failed("This option can only be set at game start.");
+        }
+    }
+
+    public sealed class CampaignOptionsBattleDeathCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "battle_death";
+
+        public string Description => "Runs the battle death debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(BattleDeath),
+                () => BattleDeath,
+                value => BattleDeath = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPlayerReceivedDamageDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "player_received_damage_difficulty";
+
+        public string Description => "Runs the player received damage difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            Difficulty oldValue = (Difficulty)PlayerReceivedDamageDifficulty;
+
+            var result = HandleDifficultyOptionCommand(
+                strings,
+                nameof(PlayerReceivedDamageDifficulty),
+                () => (Difficulty)PlayerReceivedDamageDifficulty,
+                value => PlayerReceivedDamageDifficulty = (int)value);
+
+            // Player received damage is not a campaign option. Need to update for clients separately
+            if (oldValue != (Difficulty)PlayerReceivedDamageDifficulty)
+            {
+                UpdateOtherOptions();
+            }
+
+            return result;
+        }
+    }
+
+    private static CoopCommandResult HandleBooleanOptionCommand(IReadOnlyList<string> strings, string optionName, Func<bool> getter, Action<bool> setter)
     {
         if (strings.Count == 0)
-            return $"{optionName} is currently {(getter() ? "enabled" : "disabled")}.";
+            return Succeeded($"{optionName} is currently {(getter() ? "enabled" : "disabled")}.");
 
         if (ModInformation.IsClient)
-            return "Managing campaign options is disabled on clients; the host does this.";
-
-        if (strings.Count != 1)
-            return $"Usage: coop.debug.campaignoptions.{optionName} <true|false|1|0>";
+            return Failed("Managing campaign options is disabled on clients; the host does this.");
 
         if (!TryParseBool(strings[0], out var value))
-            return $"Invalid value '{strings[0]}'. Valid values: true, false, 1, 0.";
+            return Failed($"Invalid value '{strings[0]}'. Valid values: true, false, 1, 0.");
 
         setter(value);
         UpdateCampaignOptions();
 
-        return $"{optionName} {(value ? "enabled" : "disabled")}.";
+        return Succeeded($"{optionName} {(value ? "enabled" : "disabled")}.");
     }
 
-    private static string HandleDifficultyOptionCommand(List<string> strings, string optionName, Func<Difficulty> getter, Action<Difficulty> setter)
+    private static CoopCommandResult HandleDifficultyOptionCommand(IReadOnlyList<string> strings, string optionName, Func<Difficulty> getter, Action<Difficulty> setter)
     {
         if (strings.Count == 0)
-            return $"{optionName} is currently {getter()}.";
+            return Succeeded($"{optionName} is currently {getter()}.");
 
         if (ModInformation.IsClient)
-            return "Managing campaign options is disabled on clients; the host does this.";
-
-        if (strings.Count != 1)
-            return $"Usage: coop.debug.campaignoptions.{optionName} <veryeasy|easy|realistic|0|1|2>";
+            return Failed("Managing campaign options is disabled on clients; the host does this.");
 
         if (!TryParseDifficulty(strings[0], out var value))
-            return $"Invalid value '{strings[0]}'. Valid values: veryeasy, easy, realistic, 0, 1, 2.";
+            return Failed($"Invalid value '{strings[0]}'. Valid values: veryeasy, easy, realistic, 0, 1, 2.");
 
         setter(value);
         UpdateCampaignOptions();
 
-        return $"{optionName} set to {value}.";
+        return Succeeded($"{optionName} set to {value}.");
     }
 
     private static bool TryParseBool(string input, out bool value)

--- a/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
@@ -1,4 +1,6 @@
-﻿using GameInterface.Configuration;
+﻿using System;
+using Common.Commands;
+using GameInterface.Configuration;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
@@ -8,21 +10,37 @@ namespace GameInterface.Services.CampaignService.Commands;
 
 internal class ModOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.modconfig")]
-    public static string ListOptionsCommand(List<string> strings)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class ModConfigListCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new();
+        public string Prefix => "coop.debug.mod_config";
 
-        var modOptions = ModConfigProvider.ModOptions;
+        public string Name => "list";
 
-        foreach (PropertyInfo property in typeof(ModOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        public string Description => "Reports list.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            string name = property.Name;
-            string value = property.GetValue(modOptions)?.ToString() ?? "null";
+            StringBuilder stringBuilder = new();
 
-            stringBuilder.AppendLine($"{name}: {value}");
+            var modOptions = ModConfigProvider.ModOptions;
+
+            foreach (PropertyInfo property in typeof(ModOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                string name = property.Name;
+                string value = property.GetValue(modOptions)?.ToString() ?? "null";
+
+                stringBuilder.AppendLine($"{name}: {value}");
+            }
+
+            return Succeeded(stringBuilder.ToString());
         }
-
-        return stringBuilder.ToString();
     }
 }

--- a/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
+++ b/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System;
+using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using GameInterface.CoopSessionData;
@@ -15,6 +17,12 @@ namespace GameInterface.Services.Caravans.Commands;
 
 internal class CaravansCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<CaravansCommands>();
 
     /// <summary>
@@ -31,164 +39,214 @@ internal class CaravansCommands
     /// <summary>
     /// View prohibited kingdoms for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_prohibited_kingdoms", "coop.debug.caravans")]
-    public static string ViewProhibitedKingdomsCommand(List<string> strings)
+    public sealed class CaravansViewProhibitedKingdomsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.caravans";
+
+        public string Name => "view_prohibited_kingdoms";
+
+        public string Description => "Reports view prohibited kingdoms.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerProhibitedKingdom in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerProhibitedKingdomsForPlayerCaravans)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerProhibitedKingdom.Key == null || playerProhibitedKingdom.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerProhibitedKingdom.Key}");
-                foreach (var prohibitedKingdom in playerProhibitedKingdom.Value)
+                foreach (var playerProhibitedKingdom in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerProhibitedKingdomsForPlayerCaravans)
                 {
-                    stringBuilder.AppendLine($"{prohibitedKingdom}");
+                    if (playerProhibitedKingdom.Key == null || playerProhibitedKingdom.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerProhibitedKingdom.Key}");
+                    foreach (var prohibitedKingdom in playerProhibitedKingdom.Value)
+                    {
+                        stringBuilder.AppendLine($"{prohibitedKingdom}");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var prohibitedKingdom in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._prohibitedKingdomsForPlayerCaravans)
+            else
             {
-                stringBuilder.AppendLine($"{prohibitedKingdom.StringId}");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var prohibitedKingdom in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._prohibitedKingdomsForPlayerCaravans)
+                {
+                    stringBuilder.AppendLine($"{prohibitedKingdom.StringId}");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve prohibited kingdoms");
         }
-        return "Failed to retrieve prohibited kingdoms";
     }
 
     /// <summary>
     /// View interacted caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_interacted_caravans", "coop.debug.caravans")]
-    public static string ViewInteractedCaravansCommand(List<string> strings)
+    public sealed class CaravansViewInteractedCaravansCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.caravans";
+
+        public string Name => "view_interacted_caravans";
+
+        public string Description => "Reports view interacted caravans.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerInteractedCaravan in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerInteractedCaravans)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerInteractedCaravan.Key == null || playerInteractedCaravan.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerInteractedCaravan.Key}");
-                foreach (var interactedCaravan in playerInteractedCaravan.Value)
+                foreach (var playerInteractedCaravan in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerInteractedCaravans)
                 {
-                    stringBuilder.AppendLine($"{interactedCaravan.Key} ({interactedCaravan.Value})");
+                    if (playerInteractedCaravan.Key == null || playerInteractedCaravan.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerInteractedCaravan.Key}");
+                    foreach (var interactedCaravan in playerInteractedCaravan.Value)
+                    {
+                        stringBuilder.AppendLine($"{interactedCaravan.Key} ({interactedCaravan.Value})");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var interactedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._interactedCaravans)
+            else
             {
-                stringBuilder.AppendLine($"{interactedCaravan.Key.StringId} ({(int)interactedCaravan.Value})");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var interactedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._interactedCaravans)
+                {
+                    stringBuilder.AppendLine($"{interactedCaravan.Key.StringId} ({(int)interactedCaravan.Value})");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve interacted caravans");
         }
-        return "Failed to retrieve interacted caravans";
     }
 
     /// <summary>
     /// View player trade rumor taken caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_taken_trade_rumors", "coop.debug.caravans")]
-    public static string ViewTakenTradeRumorsCommand(List<string> strings)
+    public sealed class CaravansViewTakenTradeRumorsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.caravans";
+
+        public string Name => "view_taken_trade_rumors";
+
+        public string Description => "Reports view taken trade rumors.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerTakenTradeRumorCaravan in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerTradeRumorTakenCaravans)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerTakenTradeRumorCaravan.Key == null || playerTakenTradeRumorCaravan.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerTakenTradeRumorCaravan.Key}");
-                foreach (var takenTradeRumorCaravan in playerTakenTradeRumorCaravan.Value)
+                foreach (var playerTakenTradeRumorCaravan in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerTradeRumorTakenCaravans)
                 {
-                    stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key} ({takenTradeRumorCaravan.Value})");
+                    if (playerTakenTradeRumorCaravan.Key == null || playerTakenTradeRumorCaravan.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerTakenTradeRumorCaravan.Key}");
+                    foreach (var takenTradeRumorCaravan in playerTakenTradeRumorCaravan.Value)
+                    {
+                        stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key} ({takenTradeRumorCaravan.Value})");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var takenTradeRumorCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeRumorTakenCaravans)
+            else
             {
-                stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key.StringId} ({takenTradeRumorCaravan.Value.NumTicks})");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var takenTradeRumorCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeRumorTakenCaravans)
+                {
+                    stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key.StringId} ({takenTradeRumorCaravan.Value.NumTicks})");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve trade rumor taken caravans");
         }
-        return "Failed to retrieve trade rumor taken caravans";
     }
 
-    [CommandLineArgumentFunction("view_trade_action_logs", "coop.debug.caravans")]
-    public static string ViewTradeActionLogs(List<string> strings)
+    public sealed class CaravansViewTradeActionLogsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var caravanTradeActionLogs in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeActionLogs)
-        {
-            // Do not output data for caravans in a settlement, logs only refresh for clients when caravans leave a settlement
-            if (caravanTradeActionLogs.Key.CurrentSettlement != null) continue;
+        public string Prefix => "coop.debug.caravans";
 
-            stringBuilder.AppendLine($"{caravanTradeActionLogs.Key.StringId}:");
-            foreach (var tradeActionLog in caravanTradeActionLogs.Value)
+        public string Name => "view_trade_action_logs";
+
+        public string Description => "Reports view trade action logs.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var caravanTradeActionLogs in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeActionLogs)
             {
-                stringBuilder.AppendLine($"- " +
-                    $"{tradeActionLog.BoughtSettlement?.StringId}, " +
-                    $"{tradeActionLog.SoldSettlement?.StringId}, " +
-                    $"{tradeActionLog.BuyPrice}, " +
-                    $"{tradeActionLog.SellPrice}, " +
-                    $"{tradeActionLog.ItemRosterElement.EquipmentElement.Item.StringId}, " +
-                    $"{tradeActionLog.BoughtTime.NumTicks}");
-            }
-        }
+                // Do not output data for caravans in a settlement, logs only refresh for clients when caravans leave a settlement
+                if (caravanTradeActionLogs.Key.CurrentSettlement != null) continue;
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+                stringBuilder.AppendLine($"{caravanTradeActionLogs.Key.StringId}:");
+                foreach (var tradeActionLog in caravanTradeActionLogs.Value)
+                {
+                    stringBuilder.AppendLine($"- " +
+                        $"{tradeActionLog.BoughtSettlement?.StringId}, " +
+                        $"{tradeActionLog.SoldSettlement?.StringId}, " +
+                        $"{tradeActionLog.BuyPrice}, " +
+                        $"{tradeActionLog.SellPrice}, " +
+                        $"{tradeActionLog.ItemRosterElement.EquipmentElement.Item.StringId}, " +
+                        $"{tradeActionLog.BoughtTime.NumTicks}");
+                }
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve trade action logs");
         }
-        return "Failed to retrieve trade action logs";
     }
 
-    [CommandLineArgumentFunction("view_looted_caravans", "coop.debug.caravans")]
-    public static string ViewLootedCaravans(List<string> strings)
+    public sealed class CaravansViewLootedCaravansCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var lootedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._lootedCaravans)
-        {
-            stringBuilder.AppendLine($"{lootedCaravan.Key.StringId} ({lootedCaravan.Value.NumTicks})");
-        }
+        public string Prefix => "coop.debug.caravans";
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
+        public string Name => "view_looted_caravans";
+
+        public string Description => "Reports view looted caravans.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            return result;
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var lootedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._lootedCaravans)
+            {
+                stringBuilder.AppendLine($"{lootedCaravan.Key.StringId} ({lootedCaravan.Value.NumTicks})");
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve looted caravans");
         }
-        return "Failed to retrieve looted caravans";
     }
 }

--- a/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Common.Commands;
+using Common.Logging;
 using GameInterface.Services.CharacterDevelopers.Handlers;
 using Serilog;
 using System.Collections.Generic;
@@ -12,74 +13,89 @@ namespace GameInterface.Services.CharacterDevelopers.Commands;
 
 internal class CharacterDeveloperCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<CharacterDeveloperHandler>();
 
     /// <summary>
     /// Output attributes, focuses, skills and perks of a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("stats", "coop.debug.herodeveloper")]
-    public static string HeroStatsCommand(List<string> strings)
+    public sealed class HeroDeveloperStatsCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.hero_developer";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "stats";
+
+        public string Description => "Reports stats.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                string heroData = hero.Name + ":\n";
-
-                heroData += " Level: " + hero.Level + "\n";
-
-                heroData += " Total XP: " + hero.HeroDeveloper.TotalXp + "\n";
-
-                heroData += " Unspent Focus Points: " + hero.HeroDeveloper.UnspentFocusPoints + "\n";
-
-                heroData += " Unspent Attribute Points: " + hero.HeroDeveloper.UnspentAttributePoints + "\n";
-
-                heroData += " Attributes: {";
-                foreach (CharacterAttribute attribute in hero._characterAttributes._attributes.Keys)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    heroData += attribute.Name + ": " + hero.GetAttributeValue(attribute) + ",";
-                }
+                    string heroData = hero.Name + ":\n";
 
-                heroData += "\n Skill XPs: {";
-                foreach (var skillXp in hero.HeroDeveloper._skillXps)
-                {
-                    heroData += skillXp.Key.Name + ": " + skillXp.Value + ",";
-                }
+                    heroData += " Level: " + hero.Level + "\n";
 
-                heroData += "}\n Focuses: {";
-                foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
-                {
-                    heroData += skill.Name + ": " + hero.HeroDeveloper.GetFocus(skill) + ",";
-                }
+                    heroData += " Total XP: " + hero.HeroDeveloper.TotalXp + "\n";
 
-                heroData += "}\n Skills: {";
-                foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
-                {
-                    heroData += skill.Name + ": " + hero.GetSkillValue(skill) + ",";
-                }
+                    heroData += " Unspent Focus Points: " + hero.HeroDeveloper.UnspentFocusPoints + "\n";
 
-                heroData += "}\n Perks: {";
-                foreach (PerkObject perk in hero._heroPerks._attributes.Keys)
-                {
-                    heroData += perk.Name + ",";
-                }
-                heroData += "}";
+                    heroData += " Unspent Attribute Points: " + hero.HeroDeveloper.UnspentAttributePoints + "\n";
 
-                stringBuilder.AppendLine(heroData);
+                    heroData += " Attributes: {";
+                    foreach (CharacterAttribute attribute in hero._characterAttributes._attributes.Keys)
+                    {
+                        heroData += attribute.Name + ": " + hero.GetAttributeValue(attribute) + ",";
+                    }
+
+                    heroData += "\n Skill XPs: {";
+                    foreach (var skillXp in hero.HeroDeveloper._skillXps)
+                    {
+                        heroData += skillXp.Key.Name + ": " + skillXp.Value + ",";
+                    }
+
+                    heroData += "}\n Focuses: {";
+                    foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
+                    {
+                        heroData += skill.Name + ": " + hero.HeroDeveloper.GetFocus(skill) + ",";
+                    }
+
+                    heroData += "}\n Skills: {";
+                    foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
+                    {
+                        heroData += skill.Name + ": " + hero.GetSkillValue(skill) + ",";
+                    }
+
+                    heroData += "}\n Perks: {";
+                    foreach (PerkObject perk in hero._heroPerks._attributes.Keys)
+                    {
+                        heroData += perk.Name + ",";
+                    }
+                    heroData += "}";
+
+                    stringBuilder.AppendLine(heroData);
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 }

--- a/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
+++ b/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
@@ -1,4 +1,5 @@
-﻿using GameInterface.Services.ObjectManager;
+﻿using Common.Commands;
+using GameInterface.Services.ObjectManager;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,53 +11,81 @@ using static TaleWorlds.Library.CommandLineFunctionality;
 namespace GameInterface.Services.CharacterObjects.Commands;
 internal class CharacterObjectCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     // coop.debug.characterObjects.info <charId>
     /// <summary>
     /// Reflection-dumps every field of a CharacterObject (walking up to its BasicCharacterObject base, where
     /// the synced _characterTraits / _occupation / _persona fields live) so a server screenshot and a client
     /// screenshot can be compared field-for-field to confirm CharacterObject syncs still replicate.
     /// </summary>
-    [CommandLineArgumentFunction("info", "coop.debug.characterObjects")]
-    public static string Info(List<string> args)
+    public sealed class CharacterObjectsInfoCoopCommand : ICoopCommand
     {
-        if (args.Count != 1) return "Usage: coop.debug.characterObjects.info <charId>";
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false) return "Unable to resolve object manager";
-        if (objectManager.TryGetObject<CharacterObject>(args[0], out var character) == false) return $"Unable to find character with id: {args[0]}";
+        public string Prefix => "coop.debug.character_objects";
 
-        var stringBuilder = new StringBuilder();
-        for (Type type = typeof(CharacterObject); type != null && type != typeof(object); type = type.BaseType)
+        public string Name => "info";
+
+        public string Description => "Reports info.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            foreach (var field in type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            new ExpectedArgs("character_id", "The registered character id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false) return Failed("Unable to resolve object manager");
+            if (objectManager.TryGetObject<CharacterObject>(args[0], out var character) == false) return Failed($"Unable to find character with id: {args[0]}");
+
+            var stringBuilder = new StringBuilder();
+            for (Type type = typeof(CharacterObject); type != null && type != typeof(object); type = type.BaseType)
             {
-                stringBuilder.AppendLine($"{type.Name}.{field.Name} = {field.GetValue(character)}");
+                foreach (var field in type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    stringBuilder.AppendLine($"{type.Name}.{field.Name} = {field.GetValue(character)}");
+                }
             }
+            return Succeeded(stringBuilder.ToString());
         }
-        return stringBuilder.ToString();
     }
 
     // coop.debug.characterObjects.list
-    [CommandLineArgumentFunction("list", "coop.debug.characterObjects")]
-    public static string ListCharacterObjects(List<string> args)
+    public sealed class CharacterObjectsListCoopCommand : ICoopCommand
     {
-        var characters = MBObjectManager.Instance.GetObjectTypeList<CharacterObject>();
+        public string Prefix => "coop.debug.character_objects";
 
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
-        {
-            return "Unable to resolve object manager";
-        }
+        public string Name => "list";
 
-        var stringBuilder = new StringBuilder();
-        foreach (var character in characters)
+        public string Description => "Reports list.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (objectManager.TryGetId(character, out var id) == false)
+            var characters = MBObjectManager.Instance.GetObjectTypeList<CharacterObject>();
+
+            if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
             {
-                stringBuilder.Append($"Unable to get id for {character.StringId}");
-                continue;
+                return Failed("Unable to resolve object manager");
             }
 
-            stringBuilder.AppendLine(id);
-        }
+            var stringBuilder = new StringBuilder();
+            foreach (var character in characters)
+            {
+                if (objectManager.TryGetId(character, out var id) == false)
+                {
+                    stringBuilder.Append($"Unable to get id for {character.StringId}");
+                    continue;
+                }
 
-        return stringBuilder.ToString();
+                stringBuilder.AppendLine(id);
+            }
+
+            return Succeeded(stringBuilder.ToString());
+        }
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
@@ -1,4 +1,6 @@
-﻿using SandBox.View.Map;
+﻿using System;
+using Common.Commands;
+using SandBox.View.Map;
 using System.Collections.Generic;
 using TaleWorlds.Core;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -7,43 +9,72 @@ namespace GameInterface.Services.GameDebug.Commands;
 
 internal class CameraReset
 {
-    [CommandLineArgumentFunction("fix_camera", "coop.debug")]
-    public static string ChangeClanLeader(List<string> strings)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class FixCameraCoopCommand : ICoopCommand
     {
-        Game.Current.GameStateManager.UnregisterActiveStateDisableRequest(MapScreen.Instance);
-        return "Camera reset";
+        public string Prefix => "coop.debug";
+
+        public string Name => "fix_camera";
+
+        public string Description => "Runs the fix camera debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            Game.Current.GameStateManager.UnregisterActiveStateDisableRequest(MapScreen.Instance);
+            return Succeeded("Camera reset");
+        }
     }
 
-    [CommandLineArgumentFunction("focus_main_party", "coop.debug.map_camera")]
-    public static string FocusMainParty(List<string> strings)
+    public sealed class MapCameraFocusMainPartyCoopCommand : ICoopCommand
     {
-        if (strings.Count != 0)
-        {
-            return "Usage: coop.debug.map_camera.focus_main_party";
-        }
+        public string Prefix => "coop.debug.map_camera";
 
-        MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
-        if (cameraView == null)
-        {
-            return "Campaign map camera is unavailable";
-        }
+        public string Name => "focus_main_party";
 
-        cameraView.TeleportCameraToMainParty();
-        return GetCameraState(cameraView);
+        public string Description => "Runs the focus main party debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
+            if (cameraView == null)
+            {
+                return Failed("Campaign map camera is unavailable");
+            }
+
+            cameraView.TeleportCameraToMainParty();
+            return Succeeded(GetCameraState(cameraView));
+        }
     }
 
-    [CommandLineArgumentFunction("state", "coop.debug.map_camera")]
-    public static string GetState(List<string> strings)
+    public sealed class MapCameraStateCoopCommand : ICoopCommand
     {
-        if (strings.Count != 0)
-        {
-            return "Usage: coop.debug.map_camera.state";
-        }
+        public string Prefix => "coop.debug.map_camera";
 
-        MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
-        return cameraView == null
-            ? "Campaign map camera is unavailable"
-            : GetCameraState(cameraView);
+        public string Name => "state";
+
+        public string Description => "Reports state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
+            if (cameraView == null)
+                return Failed("Campaign map camera is unavailable");
+
+            return Succeeded(GetCameraState(cameraView));
+        }
     }
 
     private static string GetCameraState(MapCameraView cameraView)

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using System.Collections.Generic;
 using System.Threading;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -12,58 +13,89 @@ namespace GameInterface.Services.GameDebug.Commands;
 /// </summary>
 public class GameThreadDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     // coop.debug.gamethread.instrument [on|off|toggle|status]
     /// <summary>
     /// Turns the game-thread drain instrumentation on or off, or reports its current state. With no
     /// argument it flips the current setting.
     /// </summary>
-    [CommandLineArgumentFunction("instrument", "coop.debug.gamethread")]
-    public static string Instrument(List<string> args)
+    public sealed class GameThreadInstrumentCoopCommand : ICoopCommand
     {
-        var arg = args.Count > 0 ? args[0].ToLowerInvariant() : "toggle";
+        public string Prefix => "coop.debug.game_thread";
 
-        switch (arg)
+        public string Name => "instrument";
+
+        public string Description => "Runs the instrument debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "on":
-            case "true":
-            case "1":
-                GameThread.Instrument = true;
-                break;
-            case "off":
-            case "false":
-            case "0":
-                GameThread.Instrument = false;
-                break;
-            case "toggle":
-                GameThread.Instrument = !GameThread.Instrument;
-                break;
-            case "status":
-                break;
-            default:
-                return "Usage: coop.debug.gamethread.instrument [on|off|toggle|status]";
-        }
+            new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: false),
+        };
 
-        return $"GameThread drain instrumentation is {(GameThread.Instrument ? "ON" : "OFF")}. " +
-               "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var arg = args.Count > 0 ? args[0].ToLowerInvariant() : "toggle";
+
+            switch (arg)
+            {
+                case "on":
+                case "true":
+                case "1":
+                    GameThread.Instrument = true;
+                    break;
+                case "off":
+                case "false":
+                case "0":
+                    GameThread.Instrument = false;
+                    break;
+                case "toggle":
+                    GameThread.Instrument = !GameThread.Instrument;
+                    break;
+                case "status":
+                    break;
+                default:
+                    return Failed($"Invalid mode '{args[0]}'. Expected on, off, toggle, or status.");
+            }
+
+            return Succeeded($"GameThread drain instrumentation is {(GameThread.Instrument ? "ON" : "OFF")}. " +
+                   "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.");
+        }
     }
 
-    [CommandLineArgumentFunction("stall", "coop.debug.gamethread")]
-    public static string Stall(List<string> args)
+    public sealed class GameThreadStallCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "gamethread.stall must be run on the server";
-        }
+        public string Prefix => "coop.debug.game_thread";
 
-        if (args.Count != 1 ||
-            int.TryParse(args[0], out int milliseconds) == false ||
-            milliseconds < 1 ||
-            milliseconds > 5000)
-        {
-            return "Usage: coop.debug.gamethread.stall <milliseconds from 1 to 5000>";
-        }
+        public string Name => "stall";
 
-        Thread.Sleep(milliseconds);
-        return $"Stalled the server game thread for {milliseconds} ms";
+        public string Description => "Runs the stall debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("milliseconds", "The stall duration from 1 through 5000 milliseconds.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+            {
+                return Failed("gamethread.stall must be run on the server");
+            }
+
+            if (int.TryParse(args[0], out int milliseconds) == false ||
+                milliseconds < 1 ||
+                milliseconds > 5000)
+            {
+                return Failed("Stall duration must be an integer from 1 through 5000 milliseconds.");
+            }
+
+            Thread.Sleep(milliseconds);
+            return Succeeded($"Stalled the server game thread for {milliseconds} ms");
+        }
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
@@ -1,62 +1,84 @@
+﻿using Common.Commands;
 using Common;
 using GameInterface.Services.GameDebug.Metrics;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
 public class PartySyncPerformanceLogsCommand
 {
-    private const string Usage = "Usage: coop.debug.metrics.party_sync_performance_logs on <seconds> <filename> | off | status";
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 
-    [CommandLineArgumentFunction("party_sync_performance_logs", "coop.debug.metrics")]
-    public static string PartySyncPerformanceLogs(List<string> args)
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class MetricsPartySyncPerformanceLogsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-        {
-            return "party_sync_performance_logs can only be called by a client";
-        }
+        public string Prefix => "coop.debug.metrics";
 
-        if (ContainerProvider.TryResolve<IPartySyncPerformanceLogger>(out var logger) == false)
-        {
-            return $"Unable to get {nameof(IPartySyncPerformanceLogger)}";
-        }
+        public string Name => "party_sync_performance_logs";
 
-        if (args.Count == 0)
-        {
-            return Usage;
-        }
+        public string Description => "Runs the party sync performance logs debug operation.";
 
-        var mode = args[0].ToLowerInvariant();
-
-        switch (mode)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "on":
-                return Enable(logger, args);
-            case "off":
-                return logger.Disable();
-            case "status":
-                return logger.Status();
-            default:
-                return Usage;
+            new ExpectedArgs("mode", "on, off, or status.", isRequired: true),
+            new ExpectedArgs("seconds", "The logging duration in seconds when enabling.", isRequired: false),
+            new ExpectedArgs("file_name", "The output file name when enabling.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+            {
+                return Failed("party_sync_performance_logs can only be called by a client");
+            }
+
+            if (ContainerProvider.TryResolve<IPartySyncPerformanceLogger>(out var logger) == false)
+            {
+                return Failed($"Unable to get {nameof(IPartySyncPerformanceLogger)}");
+            }
+
+            var mode = args[0].ToLowerInvariant();
+
+            switch (mode)
+            {
+                case "on":
+                    return Enable(logger, args);
+                case "off":
+                    return Succeeded(logger.Disable());
+                case "status":
+                    return Succeeded(logger.Status());
+                default:
+                    return Failed($"Invalid mode '{args[0]}'. Expected on, off, or status.");
+            }
         }
     }
 
-    private static string Enable(IPartySyncPerformanceLogger logger, List<string> args)
+    private static CoopCommandResult Enable(IPartySyncPerformanceLogger logger, IReadOnlyList<string> args)
     {
         if (args.Count != 3)
-        {
-            return Usage;
-        }
+            return Failed("Enabling performance logs requires seconds and a file name.");
 
         if (!double.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) ||
             seconds <= 0d)
         {
-            return "Seconds must be a positive number";
+            return Failed("Seconds must be a positive number");
         }
 
-        return logger.Enable(TimeSpan.FromSeconds(seconds), args[2]);
+        string fileName = args[2];
+        if (string.IsNullOrWhiteSpace(fileName))
+            return Failed("File name must not be empty.");
+        if (Path.GetFileName(fileName) != fileName || fileName.Contains(".."))
+            return Failed("File name must not include a path.");
+        if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            return Failed("File name contains invalid characters.");
+
+        return Succeeded(logger.Enable(TimeSpan.FromSeconds(seconds), fileName));
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using Common.Util;
 using GameInterface.Services.Settlements.Interfaces;
@@ -27,80 +28,103 @@ namespace GameInterface.Services.GameDebug.Commands;
 /// </summary>
 internal class UiDebugCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     public static readonly ILogger Logger = LogManager.GetLogger<UiDebugCommands>();
 
-    private const string CloseScreenUsage =
-@"Usage:
-  coop.debug.ui.close_screen
-
-Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle encounter screen left open.";
-
-    [CommandLineArgumentFunction("close_screen", "coop.debug.ui")]
-    public static string CloseScreen(List<string> args)
+    public sealed class UiCloseScreenCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext("close_screen", CloseScreenUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Prefix => "coop.debug.ui";
 
-        if (Campaign.Current == null)
-            return "Failed: no active campaign.";
+        public string Name => "close_screen";
 
-        try
+        public string Description => "Runs the close screen debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            GameMenu.ExitToLast();
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException("Close screen", ex);
-        }
+            if (Campaign.Current == null)
+                return Failed("Failed: no active campaign.");
 
-        return "Called GameMenu.ExitToLast().";
-    }
-
-    [CommandLineArgumentFunction("prepare_evidence_map", "coop.debug.ui")]
-    public static string PrepareEvidenceMap(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.prepare_evidence_map";
-
-        MapScreen mapScreen = MapScreen.Instance;
-        if (mapScreen == null)
-            return "Campaign map screen is unavailable.";
-
-        try
-        {
-            // Hide only the client presentation; keep the saved encounter and map event unchanged.
-            if (mapScreen.IsInMenu)
+            try
             {
-                mapScreen._latestMenuContext = null;
-                mapScreen.ExitMenuContext();
+                GameMenu.ExitToLast();
             }
-            mapScreen.RemoveEncounterOverlay();
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException("Prepare evidence map", ex);
-        }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Close screen", ex));
+            }
 
-        return GetEvidenceMapState(mapScreen);
+            return Succeeded("Called GameMenu.ExitToLast().");
+        }
     }
 
-    [CommandLineArgumentFunction("evidence_map_state", "coop.debug.ui")]
-    public static string EvidenceMapState(List<string> args)
+    public sealed class UiPrepareEvidenceMapCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.ui";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.evidence_map_state";
+        public string Name => "prepare_evidence_map";
 
-        MapScreen mapScreen = MapScreen.Instance;
-        return mapScreen == null
-            ? "Campaign map screen is unavailable."
-            : GetEvidenceMapState(mapScreen);
+        public string Description => "Runs the prepare evidence map debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            MapScreen mapScreen = MapScreen.Instance;
+            if (mapScreen == null)
+                return Failed("Campaign map screen is unavailable.");
+
+            try
+            {
+                // Hide only the client presentation; keep the saved encounter and map event unchanged.
+                if (mapScreen.IsInMenu)
+                {
+                    mapScreen._latestMenuContext = null;
+                    mapScreen.ExitMenuContext();
+                }
+                mapScreen.RemoveEncounterOverlay();
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Prepare evidence map", ex));
+            }
+
+            return Succeeded(GetEvidenceMapState(mapScreen));
+        }
+    }
+
+    public sealed class UiEvidenceMapStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.ui";
+
+        public string Name => "evidence_map_state";
+
+        public string Description => "Reports evidence map state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            MapScreen mapScreen = MapScreen.Instance;
+            if (mapScreen == null)
+                return Failed("Campaign map screen is unavailable.");
+
+            return Succeeded(GetEvidenceMapState(mapScreen));
+        }
     }
 
     private static string GetEvidenceMapState(MapScreen mapScreen)
@@ -128,194 +152,264 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
                $"loading={LoadingWindow.IsLoadingWindowActive}";
     }
 
-    [CommandLineArgumentFunction("leave_settlement_encounter", "coop.debug.ui")]
-    public static string LeaveSettlementEncounter(List<string> args)
+    public sealed class UiLeaveSettlementEncounterCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.ui";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.leave_settlement_encounter";
+        public string Name => "leave_settlement_encounter";
 
-        if (Campaign.Current == null)
-            return "Failed: no active campaign.";
+        public string Description => "Runs the leave settlement encounter debug operation.";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null)
-            return "Failed: no main party.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        if (PlayerEncounter.Battle != null || mainParty.MapEvent != null)
-            return "Cannot leave the settlement encounter after a battle has started.";
-
-        if (PlayerEncounter.Current == null || PlayerEncounter.EncounterSettlement == null)
-            return "No active settlement encounter to leave.";
-
-        if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
-            return "Unable to resolve the settlement interface.";
-
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            using (new AllowedThread())
-                settlementInterface.EndSettlementEncounter();
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException("Leave settlement encounter", ex);
-        }
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
 
-        return "Cleared the local settlement encounter and returned to the campaign map.";
+
+            if (Campaign.Current == null)
+                return Failed("Failed: no active campaign.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null)
+                return Failed("Failed: no main party.");
+
+            if (PlayerEncounter.Battle != null || mainParty.MapEvent != null)
+                return Failed("Cannot leave the settlement encounter after a battle has started.");
+
+            if (PlayerEncounter.Current == null || PlayerEncounter.EncounterSettlement == null)
+                return Failed("No active settlement encounter to leave.");
+
+            if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
+                return Failed("Unable to resolve the settlement interface.");
+
+            try
+            {
+                using (new AllowedThread())
+                    settlementInterface.EndSettlementEncounter();
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Leave settlement encounter", ex));
+            }
+
+            return Succeeded("Cleared the local settlement encounter and returned to the campaign map.");
+        }
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("map_click_offset", "coop.debug.ui")]
-    public static string MapClickOffset(List<string> args)
+    public sealed class UiMapClickOffsetCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 2 ||
-            !float.TryParse(args[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetX) ||
-            !float.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetY))
-            return "Usage: coop.debug.ui.map_click_offset <offsetX> <offsetY>";
+        public string Prefix => "coop.debug.ui";
 
-        var mapScreen = MapScreen.Instance;
-        var mainParty = MobileParty.MainParty;
-        if (mapScreen == null || mainParty == null)
-            return "Failed: campaign map or main party is unavailable.";
-        if (PlayerEncounter.Current != null || mainParty.CurrentSettlement != null)
-            return "Leave the active settlement encounter before clicking the campaign map.";
-        if (mainParty.MapEvent != null)
-            return "Cannot click-to-move while the main party is in a map event.";
+        public string Name => "map_click_offset";
 
-        var current = mainParty.Position;
-        var offsets = new[]
+        public string Description => "Runs the map click offset debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            new Vec2(offsetX, offsetY),
-            new Vec2(-offsetY, offsetX),
-            new Vec2(-offsetX, -offsetY),
-            new Vec2(offsetY, -offsetX),
+            new ExpectedArgs("offset_x", "The horizontal map offset.", isRequired: true),
+            new ExpectedArgs("offset_y", "The vertical map offset.", isRequired: true),
         };
-        CampaignVec2 target = default;
-        bool targetFound = false;
-        foreach (var offset in offsets)
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var candidate = new CampaignVec2(
-                new Vec2(current.X + offset.x, current.Y + offset.y),
-                current.IsOnLand);
-            if (!candidate.Face.IsValid() ||
-                !mapScreen.MapScene.DoesPathExistBetweenFaces(
-                    candidate.Face.FaceIndex,
-                    mainParty.CurrentNavigationFace.FaceIndex,
-                    false))
-                continue;
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+            if (!float.TryParse(args[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetX) ||
+                !float.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetY))
+                return Failed("Offsets must be valid numbers.");
 
-            target = candidate;
-            targetFound = true;
-            break;
+            var mapScreen = MapScreen.Instance;
+            var mainParty = MobileParty.MainParty;
+            if (mapScreen == null || mainParty == null)
+                return Failed("Failed: campaign map or main party is unavailable.");
+            if (PlayerEncounter.Current != null || mainParty.CurrentSettlement != null)
+                return Failed("Leave the active settlement encounter before clicking the campaign map.");
+            if (mainParty.MapEvent != null)
+                return Failed("Cannot click-to-move while the main party is in a map event.");
+
+            var current = mainParty.Position;
+            var offsets = new[]
+            {
+                new Vec2(offsetX, offsetY),
+                new Vec2(-offsetY, offsetX),
+                new Vec2(-offsetX, -offsetY),
+                new Vec2(offsetY, -offsetX),
+            };
+            CampaignVec2 target = default;
+            bool targetFound = false;
+            foreach (var offset in offsets)
+            {
+                var candidate = new CampaignVec2(
+                    new Vec2(current.X + offset.x, current.Y + offset.y),
+                    current.IsOnLand);
+                if (!candidate.Face.IsValid() ||
+                    !mapScreen.MapScene.DoesPathExistBetweenFaces(
+                        candidate.Face.FaceIndex,
+                        mainParty.CurrentNavigationFace.FaceIndex,
+                        false))
+                    continue;
+
+                target = candidate;
+                targetFound = true;
+                break;
+            }
+            if (!targetFound)
+                return Failed("No nearby navigable map-click target was found.");
+
+            mapScreen.HandleLeftMouseButtonClick(null, target, target.Face, false);
+
+            return Succeeded($"Issued a real campaign-map click from {current.X:R},{current.Y:R} " +
+                $"to {target.X:R},{target.Y:R}; time={Campaign.Current.TimeControlMode}; " +
+                $"behavior={mainParty.DefaultBehavior}; target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}.");
         }
-        if (!targetFound)
-            return "No nearby navigable map-click target was found.";
-
-        mapScreen.HandleLeftMouseButtonClick(null, target, target.Face, false);
-
-        return
-            $"Issued a real campaign-map click from {current.X:R},{current.Y:R} " +
-            $"to {target.X:R},{target.Y:R}; time={Campaign.Current.TimeControlMode}; " +
-            $"behavior={mainParty.DefaultBehavior}; target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}.";
     }
 
-    [CommandLineArgumentFunction("map_movement_state", "coop.debug.ui")]
-    public static string MapMovementState(List<string> args)
+    public sealed class UiMapMovementStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.map_movement_state";
+        public string Prefix => "coop.debug.ui";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null || Campaign.Current == null)
-            return "Failed: no active campaign or main party.";
+        public string Name => "map_movement_state";
 
-        return
-            $"position={mainParty.Position.X:R},{mainParty.Position.Y:R}|" +
-            $"target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}|" +
-            $"behavior={mainParty.DefaultBehavior}|" +
-            $"settlement={mainParty.CurrentSettlement?.StringId ?? "none"}|" +
-            $"encounter={PlayerEncounter.EncounterSettlement?.StringId ?? "none"}|" +
-            $"time={Campaign.Current.TimeControlMode}";
+        public string Description => "Reports map movement state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null || Campaign.Current == null)
+                return Failed("Failed: no active campaign or main party.");
+
+            return Succeeded($"position={mainParty.Position.X:R},{mainParty.Position.Y:R}|" +
+                $"target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}|" +
+                $"behavior={mainParty.DefaultBehavior}|" +
+                $"settlement={mainParty.CurrentSettlement?.StringId ?? "none"}|" +
+                $"encounter={PlayerEncounter.EncounterSettlement?.StringId ?? "none"}|" +
+                $"time={Campaign.Current.TimeControlMode}");
+        }
     }
 #endif
 
-    [CommandLineArgumentFunction("switch_menu", "coop.debug.ui")]
-    public static string SwitchMenu(List<string> args)
+    public sealed class UiSwitchMenuCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.ui";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.ui.switch_menu <menuId>";
+        public string Name => "switch_menu";
 
-        if (Campaign.Current == null)
-            return "Failed: no active campaign.";
+        public string Description => "Runs the switch menu debug operation.";
 
-        try
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            GameMenu.SwitchToMenu(args[0]);
-        }
-        catch (Exception ex)
+            new ExpectedArgs("menu_id", "The game menu id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return CommandHelpers.FormatException("Switch menu", ex);
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            if (Campaign.Current == null)
+                return Failed("Failed: no active campaign.");
+
+            try
+            {
+                GameMenu.SwitchToMenu(args[0]);
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Switch menu", ex));
+            }
+
+            return Succeeded($"Switched to game menu {args[0]}.");
         }
-
-        return $"Switched to game menu {args[0]}.";
     }
 
-    [CommandLineArgumentFunction("pop_state", "coop.debug.ui")]
-    public static string PopState(List<string> args)
+    public sealed class UiPopStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.pop_state";
+        public string Prefix => "coop.debug.ui";
 
-        TaleWorlds.Core.GameState activeState = Game.Current?.GameStateManager?.ActiveState;
-        if (activeState == null)
-            return "Failed: no active game state.";
+        public string Name => "pop_state";
 
-        if (activeState is MapState)
-            return "Active state is already MapState.";
+        public string Description => "Reports pop state.";
 
-        Game.Current.GameStateManager.PopState();
-        return $"Queued pop for {activeState.GetType().Name}.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            TaleWorlds.Core.GameState activeState = Game.Current?.GameStateManager?.ActiveState;
+            if (activeState == null)
+                return Failed("Failed: no active game state.");
+
+            if (activeState is MapState)
+                return Failed("Active state is already MapState.");
+
+            Game.Current.GameStateManager.PopState();
+            return Succeeded($"Queued pop for {activeState.GetType().Name}.");
+        }
     }
 
-    [CommandLineArgumentFunction("active_state", "coop.debug.ui")]
-    public static string ActiveState(List<string> args)
+    public sealed class UiActiveStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.active_state";
+        public string Prefix => "coop.debug.ui";
 
-        return Game.Current?.GameStateManager?.ActiveState?.GetType().Name ?? "none";
+        public string Name => "active_state";
+
+        public string Description => "Reports active state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            return Succeeded(Game.Current?.GameStateManager?.ActiveState?.GetType().Name ?? "none");
+        }
     }
 
-    [CommandLineArgumentFunction("loading_window_state", "coop.debug.ui")]
-    public static string LoadingWindowState(List<string> args)
+    public sealed class UiLoadingWindowStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.loading_window_state";
+        public string Prefix => "coop.debug.ui";
 
-        return $"Loading window: {(LoadingWindow.IsLoadingWindowActive ? "ACTIVE" : "INACTIVE")}.";
+        public string Name => "loading_window_state";
+
+        public string Description => "Reports loading window state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            return Succeeded($"Loading window: {(LoadingWindow.IsLoadingWindowActive ? "ACTIVE" : "INACTIVE")}.");
+        }
     }
 
-    [CommandLineArgumentFunction("saving_overlay_state", "coop.debug.ui")]
-    public static string SavingOverlayState(List<string> args)
+    public sealed class UiSavingOverlayStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.saving_overlay_state";
+        public string Prefix => "coop.debug.ui";
 
-        var dataSource = MapScreen.Instance?
-            .GetMapView<GauntletMapSaveView>()?
-            ._dataSource;
-        if (dataSource == null)
-            return "Saving overlay: UNAVAILABLE.";
+        public string Name => "saving_overlay_state";
 
-        return $"Saving overlay: {(dataSource.IsActive ? "ACTIVE" : "INACTIVE")}.";
+        public string Description => "Reports saving overlay state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            var dataSource = MapScreen.Instance?
+                .GetMapView<GauntletMapSaveView>()?
+                ._dataSource;
+            if (dataSource == null)
+                return Failed("Saving overlay: UNAVAILABLE.");
+
+            return Succeeded($"Saving overlay: {(dataSource.IsActive ? "ACTIVE" : "INACTIVE")}.");
+        }
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
@@ -1,4 +1,6 @@
-﻿using Common;
+﻿using System;
+using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.MobileParties.Messages.Unstuck;
 using System.Collections.Generic;
@@ -10,23 +12,39 @@ namespace GameInterface.Services.GameDebug.Commands;
 
 public class UnstuckCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     // coop.debug.mobileparty.unstuck
     /// <summary>
     /// Requests a server-authoritative unstuck of the local player party. Client only.
     /// </summary>
-    [CommandLineArgumentFunction("unstuck", "coop")]
-    public static string Unstuck(List<string> args)
+    public sealed class UnstuckCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (Campaign.Current == null) return "No campaign is loaded.";
+        public string Prefix => "coop";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null) return "No main party on this client.";
+        public string Name => "unstuck";
 
-        MessageBroker.Instance.Publish(mainParty, new PlayerUnstuckRequested(mainParty));
+        public string Description => "Runs the unstuck debug operation.";
 
-        return "Unstuck request sent to the server. Captivity, map event, army, siege camp, and " +
-               "settlement exits apply on the server; the local encounter and menu state clear when its reply arrives. " +
-               "Consenting clients may also send their current co-op log for a diagnostic report.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (Campaign.Current == null) return Failed("No campaign is loaded.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null) return Failed("No main party on this client.");
+
+            MessageBroker.Instance.Publish(mainParty, new PlayerUnstuckRequested(mainParty));
+
+            return Succeeded("Unstuck request sent to the server. Captivity, map event, army, siege camp, and " +
+                   "settlement exits apply on the server; the local encounter and menu state clear when its reply arrives. " +
+                   "Consenting clients may also send their current co-op log for a diagnostic report.");
+        }
     }
 }

--- a/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using Serilog;
 using System.Collections.Generic;
@@ -13,38 +14,58 @@ namespace GameInterface.Services.HeroDevelopers.Commands;
 
 internal class HeroDeveloperCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<HeroDeveloperCommands>();
 
     /// <summary>
     /// Add skill xp to a hero with a skill object name.
-    /// Examples: 
+    /// Examples:
     /// coop.debug.herodeveloper.addskillxp RandomPlayer OneHanded 3000
     /// </summary>
-    [CommandLineArgumentFunction("addskillxp", "coop.debug.herodeveloper")]
-    public static string AddSkillXpCommand(List<string> strings)
+    public sealed class HeroDeveloperAddSkillXpCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 3) return "Usage: addskillxp heroName skillName xp";
+        public string Name => "add_skill_xp";
 
-        SkillObject skillObject = GetSkillByName(strings[1]);
-        if (skillObject == null) return "Unable to find SkillObject by provided name.";
+        public string Description => "Runs the add skill xp debug operation.";
 
-        if (!int.TryParse(strings[2], out int xpGain)) return "An integer amount of xp is required.";
-
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+            new ExpectedArgs("skill_name", "The skill object name.", isRequired: true),
+            new ExpectedArgs("xp_amount", "The amount of skill experience.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            SkillObject skillObject = GetSkillByName(strings[1]);
+            if (skillObject == null) return Failed("Unable to find SkillObject by provided name.");
+
+            if (!int.TryParse(strings[2], out int xpGain)) return Failed("An integer amount of xp is required.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                hero.AddSkillXp(skillObject, xpGain);
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    hero.AddSkillXp(skillObject, xpGain);
 
-                stringBuilder.AppendLine($"{strings[0]} was given {xpGain} xp for {skillObject.Name}");
+                    stringBuilder.AppendLine($"{strings[0]} was given {xpGain} xp for {skillObject.Name}");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     /// <summary>
@@ -52,29 +73,42 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addattributepoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addattributepoints", "coop.debug.herodeveloper")]
-    public static string AddAttributePointsCommand(List<string> strings)
+    public sealed class HeroDeveloperAddAttributePointsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 2) return "Usage: addattributepoints heroName numPoints";
+        public string Name => "add_attribute_points";
 
-        if (!int.TryParse(strings[1], out int numPoints)) return "An integer amount of attribute points is required.";
+        public string Description => "Runs the add attribute points debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+            new ExpectedArgs("point_count", "The number of attribute points.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            if (!int.TryParse(strings[1], out int numPoints)) return Failed("An integer amount of attribute points is required.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                // Use same implementation as vanilla command
-                hero.HeroDeveloper.UnspentAttributePoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentAttributePoints + numPoints, 0, 10000);
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    // Use same implementation as vanilla command
+                    hero.HeroDeveloper.UnspentAttributePoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentAttributePoints + numPoints, 0, 10000);
 
-                stringBuilder.AppendLine($"{strings[0]} was given {numPoints} attribute points.");
+                    stringBuilder.AppendLine($"{strings[0]} was given {numPoints} attribute points.");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     /// <summary>
@@ -82,29 +116,42 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addfocuspoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addfocuspoints", "coop.debug.herodeveloper")]
-    public static string AddFocusPointsCommand(List<string> strings)
+    public sealed class HeroDeveloperAddFocusPointsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 2) return "Usage: addfocuspoints heroName numPoints";
+        public string Name => "add_focus_points";
 
-        if (!int.TryParse(strings[1], out int numPoints)) return "An integer amount of focus points is required.";
+        public string Description => "Runs the add focus points debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+            new ExpectedArgs("point_count", "The number of focus points.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            if (!int.TryParse(strings[1], out int numPoints)) return Failed("An integer amount of focus points is required.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                // Use same implementation as vanilla command
-                hero.HeroDeveloper.UnspentFocusPoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentFocusPoints + numPoints, 0, 10000);
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    // Use same implementation as vanilla command
+                    hero.HeroDeveloper.UnspentFocusPoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentFocusPoints + numPoints, 0, 10000);
 
-                stringBuilder.AppendLine($"{strings[0]} was given {numPoints} focus points.");
+                    stringBuilder.AppendLine($"{strings[0]} was given {numPoints} focus points.");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     /// <summary>
@@ -112,26 +159,38 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.resetskills
     /// </summary>
-    [CommandLineArgumentFunction("resetskills", "coop.debug.herodeveloper")]
-    public static string ResetSkillsCommand(List<string> strings)
+    public sealed class HeroDeveloperResetSkillsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 1) return "Usage: resetskills heroName";
+        public string Name => "reset_skills";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Description => "Runs the reset skills debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                hero.HeroDeveloper.ResetCharacterStats();
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    hero.HeroDeveloper.ResetCharacterStats();
 
-                stringBuilder.AppendLine($"{strings[0]}'s skills were reset.");
+                    stringBuilder.AppendLine($"{strings[0]}'s skills were reset.");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     private static SkillObject GetSkillByName(string skillName)

--- a/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
+++ b/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using GameInterface.Services.ObjectManager;
@@ -13,6 +14,12 @@ namespace GameInterface.Services.Inventory.Commands;
 
 internal class InventoryCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<InventoryCommands>();
 
     /// <summary>
@@ -29,204 +36,250 @@ internal class InventoryCommands
     /// <summary>
     /// View item ids in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemids", "coop.debug.inventory")]
-    public static string ViewItemIdsCommand(List<string> strings)
+    public sealed class InventoryItemIdsCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.inventory";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "item_ids";
+
+        public string Description => "Runs the item ids debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                stringBuilder.AppendLine(hero.Name.ToString());
-                foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement._amount);
+                    stringBuilder.AppendLine(hero.Name.ToString());
+                    foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                    {
+                        stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement._amount);
+                    }
                 }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// View item values in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemvalues", "coop.debug.inventory")]
-    public static string ViewItemValuesCommand(List<string> strings)
+    public sealed class InventoryItemValuesCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.inventory";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "item_values";
+
+        public string Description => "Runs the item values debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                stringBuilder.AppendLine(hero.Name.ToString());
-                foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement.EquipmentElement.Item.Value + "(" + rosterElement.EquipmentElement.ItemValue + ")");
+                    stringBuilder.AppendLine(hero.Name.ToString());
+                    foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                    {
+                        stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement.EquipmentElement.Item.Value + "(" + rosterElement.EquipmentElement.ItemValue + ")");
+                    }
                 }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Output equipment ids of battle, civilian and stealth equipment for a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("heroequipment", "coop.debug.inventory")]
-    public static string HeroEquipmentCommand(List<string> strings)
+    public sealed class InventoryHeroEquipmentCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.inventory";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "hero_equipment";
+
+        public string Description => "Runs the hero equipment debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                stringBuilder.AppendLine(hero.Name.ToString());
+                if (hero.Name.ToString() == strings[0])
+                {
+                    stringBuilder.AppendLine(hero.Name.ToString());
 
-                stringBuilder.AppendLine("BattleEquipment");
-                foreach (var equipmentElement in hero.BattleEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                    stringBuilder.AppendLine("BattleEquipment");
+                    foreach (var equipmentElement in hero.BattleEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
 
-                stringBuilder.AppendLine("CivilianEquipment");
-                foreach (var equipmentElement in hero.CivilianEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                    stringBuilder.AppendLine("CivilianEquipment");
+                    foreach (var equipmentElement in hero.CivilianEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
 
-                stringBuilder.AppendLine("StealthEquipment");
-                foreach (var equipmentElement in hero.StealthEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                    stringBuilder.AppendLine("StealthEquipment");
+                    foreach (var equipmentElement in hero.StealthEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Give debug animals to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("giveanimals", "coop.debug.inventory")]
-    public static string GiveAnimalsCommand(List<string> strings)
+    public sealed class InventoryGiveAnimalsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.inventory";
 
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Name => "give_animals";
 
-        if (TryGetObjectManager(out var objectManager) == false)
-        {
-            return "Unable to resolve ObjectManager.";
-        }
+        public string Description => "Runs the give animals debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false)
             {
-                var itemsToAdd = new Dictionary<string, int>()
-                {
-                    { "sheep", 5 },
-                    { "cow", 5 },
-                    { "hog", 5 },
-                    { "goose", 5 },
-                    { "chicken", 5 }
-                };
-
-                foreach (var itemId in itemsToAdd.Keys)
-                {
-                    if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
-                    {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
-                    }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
-                    }
-                }
-
-                stringBuilder.AppendLine(strings[0] + " was given animals.");
+                return Failed("Unable to resolve ObjectManager.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
+            {
+                if (hero.Name.ToString() == strings[0])
+                {
+                    var itemsToAdd = new Dictionary<string, int>()
+                    {
+                        { "sheep", 5 },
+                        { "cow", 5 },
+                        { "hog", 5 },
+                        { "goose", 5 },
+                        { "chicken", 5 }
+                    };
+
+                    foreach (var itemId in itemsToAdd.Keys)
+                    {
+                        if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
+                        }
+                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given animals.");
+                }
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Give war horses to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givewarhorses", "coop.debug.inventory")]
-    public static string GiveWarhorsesCommand(List<string> strings)
+    public sealed class InventoryGiveWarhorsesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.inventory";
 
-        if (strings.Count == 0) return "Hero name argument required.";
-        
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Name => "give_warhorses";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Description => "Runs the give warhorses debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                var itemsToAdd = new Dictionary<string, int>()
+                if (hero.Name.ToString() == strings[0])
                 {
-                    { "t2_empire_horse", 3 },
-                    { "t2_khuzait_horse", 2 }
-                };
+                    var itemsToAdd = new Dictionary<string, int>()
+                    {
+                        { "t2_empire_horse", 3 },
+                        { "t2_khuzait_horse", 2 }
+                    };
 
-                foreach (var itemId in itemsToAdd.Keys)
-                {
-                    if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                    foreach (var itemId in itemsToAdd.Keys)
                     {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
+                        }
                     }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
-                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given war horses.");
                 }
-
-                stringBuilder.AppendLine(strings[0] + " was given war horses.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 }

--- a/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
+++ b/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
@@ -1,4 +1,6 @@
-﻿using Common;
+﻿using System;
+using Common.Commands;
+using Common;
 using GameInterface.CoopSessionData;
 using System.Collections.Generic;
 using System.Text;
@@ -11,125 +13,161 @@ namespace GameInterface.Services.Inventory.TradeSkills.Commands;
 
 internal class TradeSkillCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// View trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_data", "coop.debug.inventory")]
-    public static string ViewPlayerTradeDataCommand(List<string> strings)
+    public sealed class InventoryViewPlayerTradeDataCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.inventory";
+
+        public string Name => "view_player_trade_data";
+
+        public string Description => "Reports view player trade data.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerTradeData in coopSessionProvider.CoopSession.TradePlayerData.PlayerItemsTradeData)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerTradeData.Key == null || playerTradeData.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerTradeData.Key}");
-                foreach (var itemIdTradeData in playerTradeData.Value)
+                foreach (var playerTradeData in coopSessionProvider.CoopSession.TradePlayerData.PlayerItemsTradeData)
                 {
-                    stringBuilder.AppendLine($"{itemIdTradeData.Key} (Total Purchased: {itemIdTradeData.Value.Item2}, Average price: {itemIdTradeData.Value.Item1})");
+                    if (playerTradeData.Key == null || playerTradeData.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerTradeData.Key}");
+                    foreach (var itemIdTradeData in playerTradeData.Value)
+                    {
+                        stringBuilder.AppendLine($"{itemIdTradeData.Key} (Total Purchased: {itemIdTradeData.Value.Item2}, Average price: {itemIdTradeData.Value.Item1})");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var itemTradeData in Campaign.Current.GetCampaignBehavior<TradeSkillCampaignBehavior>().ItemsTradeData)
+            else
             {
-                stringBuilder.AppendLine($"{itemTradeData.Key.StringId} (Total Purchased: {itemTradeData.Value.NumItemsPurchased}, Average price: {itemTradeData.Value.AveragePrice})");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var itemTradeData in Campaign.Current.GetCampaignBehavior<TradeSkillCampaignBehavior>().ItemsTradeData)
+                {
+                    stringBuilder.AppendLine($"{itemTradeData.Key.StringId} (Total Purchased: {itemTradeData.Value.NumItemsPurchased}, Average price: {itemTradeData.Value.AveragePrice})");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve player trade data");
         }
-        return "Failed to retrieve player trade data";
     }
 
     /// <summary>
     /// View trade rumors for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_rumors", "coop.debug.inventory")]
-    public static string ViewPlayerTradeRumorsCommand(List<string> strings)
+    public sealed class InventoryViewPlayerTradeRumorsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.inventory";
+
+        public string Name => "view_player_trade_rumors";
+
+        public string Description => "Reports view player trade rumors.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerTradeRumors in coopSessionProvider.CoopSession.TradePlayerData.PlayerTradeRumors)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerTradeRumors.Key == null || playerTradeRumors.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerTradeRumors.Key}");
-                foreach (var rumorData in playerTradeRumors.Value)
+                foreach (var playerTradeRumors in coopSessionProvider.CoopSession.TradePlayerData.PlayerTradeRumors)
                 {
-                    stringBuilder.AppendLine($"{rumorData.ItemObjectId} at {rumorData.SettlementId} (expiring in {new CampaignTime(rumorData.RumorEndTime).RemainingHoursFromNow} hours) rumored to:");
-                    stringBuilder.AppendLine($"     Buy at: {rumorData.BuyPrice}");
-                    stringBuilder.AppendLine($"     Sell at: {rumorData.SellPrice}");
+                    if (playerTradeRumors.Key == null || playerTradeRumors.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerTradeRumors.Key}");
+                    foreach (var rumorData in playerTradeRumors.Value)
+                    {
+                        stringBuilder.AppendLine($"{rumorData.ItemObjectId} at {rumorData.SettlementId} (expiring in {new CampaignTime(rumorData.RumorEndTime).RemainingHoursFromNow} hours) rumored to:");
+                        stringBuilder.AppendLine($"     Buy at: {rumorData.BuyPrice}");
+                        stringBuilder.AppendLine($"     Sell at: {rumorData.SellPrice}");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var tradeRumor in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._tradeRumors)
+            else
             {
-                stringBuilder.AppendLine($"{tradeRumor.ItemCategory.StringId} at {tradeRumor.Settlement.StringId} (expiring in {tradeRumor.RumorEndTime.RemainingHoursFromNow} hours) rumored to:");
-                stringBuilder.AppendLine($"     Buy at: {tradeRumor.BuyPrice}");
-                stringBuilder.AppendLine($"     Sell at: {tradeRumor.SellPrice}");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var tradeRumor in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._tradeRumors)
+                {
+                    stringBuilder.AppendLine($"{tradeRumor.ItemCategory.StringId} at {tradeRumor.Settlement.StringId} (expiring in {tradeRumor.RumorEndTime.RemainingHoursFromNow} hours) rumored to:");
+                    stringBuilder.AppendLine($"     Buy at: {tradeRumor.BuyPrice}");
+                    stringBuilder.AppendLine($"     Sell at: {tradeRumor.SellPrice}");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve player rumors data");
         }
-        return "Failed to retrieve player rumors data";
     }
 
     /// <summary>
     /// View entered settlements trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_entered_settlements", "coop.debug.inventory")]
-    public static string ViewPlayerEnteredSettlementsCommand(List<string> strings)
+    public sealed class InventoryViewEnteredSettlementsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.inventory";
+
+        public string Name => "view_entered_settlements";
+
+        public string Description => "Reports view entered settlements.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerEnteredSettlement in coopSessionProvider.CoopSession.TradePlayerData.PlayerEnteredSettlements)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerEnteredSettlement.Key == null || playerEnteredSettlement.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerEnteredSettlement.Key}");
-                foreach (var enteredSettlementData in playerEnteredSettlement.Value)
+                foreach (var playerEnteredSettlement in coopSessionProvider.CoopSession.TradePlayerData.PlayerEnteredSettlements)
                 {
-                    stringBuilder.AppendLine($"{enteredSettlementData.Key} {new CampaignTime(enteredSettlementData.Value).ElapsedHoursUntilNow} hours ago.");
+                    if (playerEnteredSettlement.Key == null || playerEnteredSettlement.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerEnteredSettlement.Key}");
+                    foreach (var enteredSettlementData in playerEnteredSettlement.Value)
+                    {
+                        stringBuilder.AppendLine($"{enteredSettlementData.Key} {new CampaignTime(enteredSettlementData.Value).ElapsedHoursUntilNow} hours ago.");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var enteredSettlement in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._enteredSettlements)
+            else
             {
-                stringBuilder.AppendLine($"{enteredSettlement.Key.StringId} {enteredSettlement.Value.ElapsedHoursUntilNow} hours ago.");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var enteredSettlement in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._enteredSettlements)
+                {
+                    stringBuilder.AppendLine($"{enteredSettlement.Key.StringId} {enteredSettlement.Value.ElapsedHoursUntilNow} hours ago.");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve player trade data");
         }
-        return "Failed to retrieve player trade data";
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
+++ b/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using GameInterface.Services.Issues.Generic;
 using GameInterface.Utils.Commands;
 using System;
@@ -12,54 +13,71 @@ namespace GameInterface.Services.Issues.Commands;
 
 public static class IssuesDebugCommand
 {
-    [CommandLineArgumentFunction("give", "coop.debug.issues")]
-    public static string Give(List<string> args)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class IssuesGiveCoopCommand : ICoopCommand
     {
-        if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.give")) return error;
+        public string Prefix => "coop.debug.issues";
 
-        const string usage = "Usage: coop.debug.issues.give <heroId> <questTypeKey> (see coop.debug.issues.list_types)";
+        public string Name => "give";
 
-        if (!CommandHelpers.HasArgCount(args, 2, usage, out error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return error;
+        public string Description => "Runs the give debug operation.";
 
-        var key = args[1];
-        if (!IssueGiveCatalog.TryGet(key, out var entry))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unknown quest type key '{key}'. Use coop.debug.issues.list_types to see all valid keys.";
-        }
+            new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+            new ExpectedArgs("quest_type_key", "The issue type key.", isRequired: true),
+        };
 
-        if (entry.Resolve == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Quest type '{key}' is a known vanilla Issue type but is not wired for give: {entry.NotWiredReason}";
-        }
+            if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.give")) return Failed(error);
 
-        if (hero.Issue != null)
-        {
-            return $"Hero '{hero.Name}' (StringId '{hero.StringId}') already has an active issue " +
-                $"({hero.Issue.GetType().Name}, StringId '{hero.Issue.StringId}'). Complete or clear it first.";
-        }
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return Failed(error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return Failed(error);
 
-        (PotentialIssueData.StartIssueDelegate factory, string resolveError) = entry.Resolve(hero);
-        if (factory == null)
-        {
-            return $"Could not give '{key}' to hero '{hero.Name}': {resolveError}";
-        }
+            var key = args[1];
+            if (!IssueGiveCatalog.TryGet(key, out var entry))
+            {
+                return Failed($"Unknown quest type key '{key}'. Use coop.debug.issues.list_types to see all valid keys.");
+            }
 
-        try
-        {
-            var pid = new PotentialIssueData(factory, entry.IssueType, IssueBase.IssueFrequency.Common);
-            Campaign.Current.IssueManager.CreateNewIssue(in pid, hero);
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException($"coop.debug.issues.give ({key}): CreateNewIssue", ex);
-        }
+            if (entry.Resolve == null)
+            {
+                return Failed($"Quest type '{key}' is a known vanilla Issue type but is not wired for give: {entry.NotWiredReason}");
+            }
 
-        return StartQuestOrRollback(hero, key);
+            if (hero.Issue != null)
+            {
+                return Failed($"Hero '{hero.Name}' (StringId '{hero.StringId}') already has an active issue " +
+                    $"({hero.Issue.GetType().Name}, StringId '{hero.Issue.StringId}'). Complete or clear it first.");
+            }
+
+            (PotentialIssueData.StartIssueDelegate factory, string resolveError) = entry.Resolve(hero);
+            if (factory == null)
+            {
+                return Failed($"Could not give '{key}' to hero '{hero.Name}': {resolveError}");
+            }
+
+            try
+            {
+                var pid = new PotentialIssueData(factory, entry.IssueType, IssueBase.IssueFrequency.Common);
+                Campaign.Current.IssueManager.CreateNewIssue(in pid, hero);
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException($"coop.debug.issues.give ({key}): CreateNewIssue", ex));
+            }
+
+            return StartQuestOrRollback(hero, key);
+        }
     }
 
-    private static string StartQuestOrRollback(Hero hero, string key)
+    private static CoopCommandResult StartQuestOrRollback(Hero hero, string key)
     {
         bool started;
         try
@@ -80,104 +98,121 @@ public static class IssuesDebugCommand
                 }
                 catch (Exception cleanupEx)
                 {
-                    return CommandHelpers.FormatException(
+                    return Failed(CommandHelpers.FormatException(
                         $"coop.debug.issues.give ({key}): StartIssueQuest threw ({ex.GetType().Name}: {ex.Message}), " +
                         $"then the DeactivateIssue rollback ALSO threw - hero '{hero.Name}' (StringId '{hero.StringId}') " +
-                        "may still have a stuck issue attached", cleanupEx);
+                        "may still have a stuck issue attached", cleanupEx));
                 }
             }
 
-            return CommandHelpers.FormatException(
+            return Failed(CommandHelpers.FormatException(
                 $"coop.debug.issues.give ({key}): StartIssueQuest threw during quest construction. The issue has " +
                 $"been rolled back via DeactivateIssue - hero '{hero.Name}' (StringId '{hero.StringId}') has no " +
-                "issue attached and is safe to retry give with any quest type", ex);
+                "issue attached and is safe to retry give with any quest type", ex));
         }
 
         if (!started)
         {
-            return $"Issue '{key}' was created for hero '{hero.Name}' but StartIssueQuest returned false " +
-                "(its IssueStayAliveConditions failed immediately) - the game has already cleaned the issue up.";
+            return Failed($"Issue '{key}' was created for hero '{hero.Name}' but StartIssueQuest returned false " +
+                "(its IssueStayAliveConditions failed immediately) - the game has already cleaned the issue up.");
         }
 
-        return $"Gave quest type '{key}' to hero '{hero.Name}' (StringId '{hero.StringId}'). " +
-            $"Issue StringId: '{hero.Issue?.StringId}'. Quest StringId: '{hero.Issue?.IssueQuest?.StringId ?? "none"}'.";
+        return Succeeded($"Gave quest type '{key}' to hero '{hero.Name}' (StringId '{hero.StringId}'). " +
+            $"Issue StringId: '{hero.Issue?.StringId}'. Quest StringId: '{hero.Issue?.IssueQuest?.StringId ?? "none"}'.");
     }
 
-    [CommandLineArgumentFunction("complete", "coop.debug.issues")]
-    public static string Complete(List<string> args)
+    public sealed class IssuesCompleteCoopCommand : ICoopCommand
     {
-        if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.complete")) return error;
+        public string Prefix => "coop.debug.issues";
 
-        const string usage = "Usage: coop.debug.issues.complete <heroId> [success|cancel|fail|timeout|betrayal]";
+        public string Name => "complete";
 
-        if (args == null || args.Count < 1 || args.Count > 2)
+        public string Description => "Runs the complete debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return usage;
-        }
+            new ExpectedArgs("hero_id", "The registered issue owner hero id.", isRequired: true),
+            new ExpectedArgs("outcome", "success, cancel, fail, timeout, or betrayal.", isRequired: false),
+        };
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return error;
-
-        if (hero.Issue == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Hero '{hero.Name}' (StringId '{hero.StringId}') has no active issue.";
-        }
+            if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.complete")) return Failed(error);
 
-        var quest = hero.Issue.IssueQuest;
-        if (quest == null)
-        {
-            return $"Hero '{hero.Name}' has an active issue ({hero.Issue.GetType().Name}) but no live quest yet. " +
-                "Use coop.debug.issues.give (or the natural accept flow) to start the quest before completing it.";
-        }
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return Failed(error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return Failed(error);
 
-        var outcome = args.Count == 2 ? args[1].Trim().ToLowerInvariant() : "success";
-
-        try
-        {
-            using (new IssueFinalizeAuthorityGuard())
+            if (hero.Issue == null)
             {
-                switch (outcome)
+                return Failed($"Hero '{hero.Name}' (StringId '{hero.StringId}') has no active issue.");
+            }
+
+            var quest = hero.Issue.IssueQuest;
+            if (quest == null)
+            {
+                return Failed($"Hero '{hero.Name}' has an active issue ({hero.Issue.GetType().Name}) but no live quest yet. " +
+                    "Use coop.debug.issues.give (or the natural accept flow) to start the quest before completing it.");
+            }
+
+            var outcome = args.Count == 2 ? args[1].Trim().ToLowerInvariant() : "success";
+
+            try
+            {
+                using (new IssueFinalizeAuthorityGuard())
                 {
-                    case "success":
-                        quest.CompleteQuestWithSuccess();
-                        break;
-                    case "cancel":
-                        quest.CompleteQuestWithCancel();
-                        break;
-                    case "fail":
-                        quest.CompleteQuestWithFail();
-                        break;
-                    case "timeout":
-                        quest.CompleteQuestWithTimeOut();
-                        break;
-                    case "betrayal":
-                        quest.CompleteQuestWithBetrayal();
-                        break;
-                    default:
-                        return $"Unknown outcome '{outcome}'. {usage}";
+                    switch (outcome)
+                    {
+                        case "success":
+                            quest.CompleteQuestWithSuccess();
+                            break;
+                        case "cancel":
+                            quest.CompleteQuestWithCancel();
+                            break;
+                        case "fail":
+                            quest.CompleteQuestWithFail();
+                            break;
+                        case "timeout":
+                            quest.CompleteQuestWithTimeOut();
+                            break;
+                        case "betrayal":
+                            quest.CompleteQuestWithBetrayal();
+                            break;
+                        default:
+                            return Failed($"Unknown outcome '{outcome}'. Expected success, cancel, fail, timeout, or betrayal.");
+                    }
                 }
             }
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException($"coop.debug.issues.complete ({outcome})", ex);
-        }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException($"coop.debug.issues.complete ({outcome})", ex));
+            }
 
-        return $"Completed quest for hero '{hero.Name}' (StringId '{hero.StringId}') with outcome '{outcome}'.";
+            return Succeeded($"Completed quest for hero '{hero.Name}' (StringId '{hero.StringId}') with outcome '{outcome}'.");
+        }
     }
 
-    [CommandLineArgumentFunction("list_types", "coop.debug.issues")]
-    public static string ListTypes(List<string> args)
+    public sealed class IssuesListTypesCoopCommand : ICoopCommand
     {
-        var sb = new StringBuilder();
+        public string Prefix => "coop.debug.issues";
 
-        foreach (var entry in IssueGiveCatalog.Entries.Values.OrderBy(e => e.Key, StringComparer.Ordinal))
+        public string Name => "list_types";
+
+        public string Description => "Reports list types.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            sb.AppendLine(entry.Resolve != null
-                ? $"{entry.Key} [wired]"
-                : $"{entry.Key} [not wired: {entry.NotWiredReason}]");
-        }
+            var sb = new StringBuilder();
 
-        return sb.ToString();
+            foreach (var entry in IssueGiveCatalog.Entries.Values.OrderBy(e => e.Key, StringComparer.Ordinal))
+            {
+                sb.AppendLine(entry.Resolve != null
+                    ? $"{entry.Key} [wired]"
+                    : $"{entry.Key} [not wired: {entry.NotWiredReason}]");
+            }
+
+            return Succeeded(sb.ToString());
+        }
     }
 }

--- a/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
+++ b/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using GameInterface.Services.ObjectManager;
 using System.Collections.Generic;
 using System.Text;
@@ -9,6 +10,12 @@ namespace GameInterface.Services.ItemObjects.Commands
 {
     internal class ItemObjectCommands
     {
+        private static CoopCommandResult Succeeded(string output) =>
+            new CoopCommandResult(true, output);
+
+        private static CoopCommandResult Failed(string output) =>
+            new CoopCommandResult(false, output, "command_failed");
+
         private static bool TryGetObjectManager(out IObjectManager objectManager)
         {
             objectManager = null;
@@ -20,42 +27,51 @@ namespace GameInterface.Services.ItemObjects.Commands
         /// <summary>
         /// View select properties of an item object retrieved by string id
         /// </summary>
-        [CommandLineArgumentFunction("data", "coop.debug.itemobject")]
-        public static string ViewCraftedItemData(List<string> strings)
+        public sealed class ItemObjectDataCoopCommand : ICoopCommand
         {
-            if (strings.Count == 0)
+            public string Prefix => "coop.debug.item_object";
+
+            public string Name => "data";
+
+            public string Description => "Reports data.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Hero name argument required.";
-            }
+                new ExpectedArgs("item_id", "The registered item object id.", isRequired: true),
+            };
 
-            if (TryGetObjectManager(out var objectManager) == false)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
             {
-                return "Unable to resolve ObjectManager.";
+
+                if (TryGetObjectManager(out var objectManager) == false)
+                {
+                    return Failed("Unable to resolve ObjectManager.");
+                }
+
+                string itemId = strings[0];
+
+                StringBuilder stringBuilder = new StringBuilder();
+
+                if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                {
+                    return Failed("Failed to retrieve object for ItemObject id: " + itemId);
+                }
+
+                // Add properties as necessary
+                stringBuilder.AppendLine(itemObject.StringId + ": " + itemObject.Name);
+                stringBuilder.AppendLine("Value: " + itemObject.Value);
+                stringBuilder.AppendLine("Difficulty: " + itemObject.Difficulty);
+                stringBuilder.AppendLine("Tier: " + itemObject.Tier);
+                stringBuilder.AppendLine("Tierf: " + itemObject.Tierf);
+                stringBuilder.AppendLine("Appearance: " + itemObject.Appearance);
+
+                string result = stringBuilder.ToString();
+                if (result.Length > 0)
+                {
+                    return Succeeded(result);
+                }
+                return Failed("Item object not found.");
             }
-
-            string itemId = strings[0];
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
-            {
-                return "Failed to retrieve object for ItemObject id: " + itemId;
-            }
-
-            // Add properties as necessary
-            stringBuilder.AppendLine(itemObject.StringId + ": " + itemObject.Name);
-            stringBuilder.AppendLine("Value: " + itemObject.Value);
-            stringBuilder.AppendLine("Difficulty: " + itemObject.Difficulty);
-            stringBuilder.AppendLine("Tier: " + itemObject.Tier);
-            stringBuilder.AppendLine("Tierf: " + itemObject.Tierf);
-            stringBuilder.AppendLine("Appearance: " + itemObject.Appearance);
-
-            string result = stringBuilder.ToString();
-            if (result.Length > 0)
-            {
-                return result;
-            }
-            return "Item object not found.";
         }
     }
 }

--- a/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
+++ b/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -17,109 +18,152 @@ namespace GameInterface.Services.ItemRosters.Commands
 {
     internal class ItemRosterDebugCommands
     {
-        [CommandLineArgumentFunction("add_random_item", "coop.debug.itemrosters")]
-        public static string AddRandomItem(List<string> args)
+        private static CoopCommandResult Succeeded(string output) =>
+            new CoopCommandResult(true, output);
+
+        private static CoopCommandResult Failed(string output) =>
+            new CoopCommandResult(false, output, "command_failed");
+
+        public sealed class ItemRostersAddRandomItemCoopCommand : ICoopCommand
         {
-            if (args.Count < 1)
+            public string Prefix => "coop.debug.item_rosters";
+
+            public string Name => "add_random_item";
+
+            public string Description => "Runs the add random item debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.itemrosters.add_random_item <party base id> (i.e. town_V1)";
-            }
+                new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+            };
 
-            var settlementId = args[0];
-            var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
-
-            if (settlement == null) return $"Unable to find settlement with id: {settlementId}";
-
-            Random random = new();
-
-            var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
-
-            var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
-
-            settlement.ItemRoster.AddToCounts(new EquipmentElement(randomItem), 1);
-
-            return $"Added {randomItem.Name} to {settlement.Name}'s ItemRoster";
-        }
-
-        [CommandLineArgumentFunction("add_item_burst", "coop.debug.itemrosters")]
-        public static string AddItemBurst(List<string> args)
-        {
-            if (ModInformation.IsClient)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                return "Run this on the server; it is authoritative and replicates to clients.";
-            }
 
-            if (args.Count < 2)
-            {
-                return "Usage: coop.debug.itemrosters.add_item_burst <settlement id> <count> (i.e. town_ES1 20)";
-            }
+                var settlementId = args[0];
+                var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
 
-            var settlementId = args[0];
-            var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
+                if (settlement == null) return Failed($"Unable to find settlement with id: {settlementId}");
 
-            if (settlement == null) return $"Unable to find settlement with id: {settlementId}";
+                Random random = new();
 
-            if (!int.TryParse(args[1], out var count) || count < 1)
-            {
-                return $"Invalid count: '{args[1]}'. Provide a positive integer.";
-            }
+                var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
 
-            var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
+                var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
 
-            if (itemEnumerable.Count == 0) return "No items are loaded.";
-
-            Random random = new();
-
-            var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
-
-            // Add the same item count times in one tick so the coalescer collapses them into a single
-            // update carrying the final count.
-            for (int i = 0; i < count; i++)
-            {
                 settlement.ItemRoster.AddToCounts(new EquipmentElement(randomItem), 1);
-            }
 
-            return $"Added {count}x {randomItem.Name} to {settlement.Name}'s ItemRoster in one tick";
+                return Succeeded($"Added {randomItem.Name} to {settlement.Name}'s ItemRoster");
+            }
         }
 
-        [CommandLineArgumentFunction("info", "coop.debug.itemrosters")]
-        public static string Info(List<string> args)
+        public sealed class ItemRostersAddItemBurstCoopCommand : ICoopCommand
         {
-            if (args.Count < 1)
-            {
-                return "Usage: coop.debug.itemrosters.info <party base id> (i.e. town_V1)";
-            }
+            public string Prefix => "coop.debug.item_rosters";
 
-            var roster = FindItemRoster(args[0], out string owner);
-            
-            if (roster == null)
-            {
-                return string.Format("ID: '{0}' not found", args[0]);
-            }
+            public string Name => "add_item_burst";
 
-            return string.Format("ItemRoster info for '{0}':\n  Items: {1}\n  Count: {2}\n  SHA1: {3:X}\n",
-                owner, roster.Count, roster.Sum((i) => { return i.Amount; }), ItemRosterHash(roster));
+            public string Description => "Runs the add item burst debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+                new ExpectedArgs("count", "The positive number of items to add.", isRequired: true),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+                if (ModInformation.IsClient)
+                {
+                    return Failed("Run this on the server; it is authoritative and replicates to clients.");
+                }
+
+
+                var settlementId = args[0];
+                var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
+
+                if (settlement == null) return Failed($"Unable to find settlement with id: {settlementId}");
+
+                if (!int.TryParse(args[1], out var count) || count < 1)
+                {
+                    return Failed($"Invalid count: '{args[1]}'. Provide a positive integer.");
+                }
+
+                var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
+
+                if (itemEnumerable.Count == 0) return Failed("No items are loaded.");
+
+                Random random = new();
+
+                var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
+
+                // Add the same item count times in one tick so the coalescer collapses them into a single
+                // update carrying the final count.
+                for (int i = 0; i < count; i++)
+                {
+                    settlement.ItemRoster.AddToCounts(new EquipmentElement(randomItem), 1);
+                }
+
+                return Succeeded($"Added {count}x {randomItem.Name} to {settlement.Name}'s ItemRoster in one tick");
+            }
         }
 
-        [CommandLineArgumentFunction("export", "coop.debug.itemrosters")]
-        public static string Export(List<string> args)
+        public sealed class ItemRostersInfoCoopCommand : ICoopCommand
         {
-            if (args.Count < 1)
+            public string Prefix => "coop.debug.item_rosters";
+
+            public string Name => "info";
+
+            public string Description => "Reports info.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.itemrosters.export <party base id> (i.e. town_V1)";
-            }
+                new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+            };
 
-            var roster = FindItemRoster(args[0], out string owner);
-
-            if (roster == null)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                return string.Format("ID: '{0}' not found", args[0]);
+
+                var roster = FindItemRoster(args[0], out string owner);
+
+                if (roster == null)
+                {
+                    return Failed(string.Format("ID: '{0}' not found", args[0]));
+                }
+
+                return Succeeded(string.Format("ItemRoster info for '{0}':\n  Items: {1}\n  Count: {2}\n  SHA1: {3:X}\n",
+                    owner, roster.Count, roster.Sum((i) => { return i.Amount; }), ItemRosterHash(roster)));
             }
+        }
 
-            var name = "!" + (ModInformation.IsServer ? "server-itemroster-export-" : "client-itemroster-export-") + $"{owner}.txt";
-            File.WriteAllText(name, ItemRosterContent(roster));
+        public sealed class ItemRostersExportCoopCommand : ICoopCommand
+        {
+            public string Prefix => "coop.debug.item_rosters";
 
-            return $"Exported '{owner}' into '{name}'.\n Check bannerlord bin directory.";
+            public string Name => "export";
+
+            public string Description => "Runs the export debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+
+                var roster = FindItemRoster(args[0], out string owner);
+
+                if (roster == null)
+                {
+                    return Failed(string.Format("ID: '{0}' not found", args[0]));
+                }
+
+                var name = "!" + (ModInformation.IsServer ? "server-itemroster-export-" : "client-itemroster-export-") + $"{owner}.txt";
+                File.WriteAllText(name, ItemRosterContent(roster));
+
+                return Succeeded($"Exported '{owner}' into '{name}'.\n Check bannerlord bin directory.");
+            }
         }
 
         private static ItemRoster FindItemRoster(string id, out string name)
@@ -127,7 +171,7 @@ namespace GameInterface.Services.ItemRosters.Commands
             if (MBObjectManager.Instance.ContainsObject<Settlement>(id))
             {
                 var obj = MBObjectManager.Instance.GetObject<Settlement>(id);
-                
+
                 name = obj.Town.Name.ToString();
                 return obj.ItemRoster;
             }

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Common.Commands;
+using Common.Logging;
 using GameInterface.Configuration;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Utils.Commands;
@@ -15,7 +16,6 @@ using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.GauntletUI.Mission.Singleplayer;
 using TaleWorlds.MountAndBlade.GauntletUI.Widgets.Scoreboard;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.MapEvents.Commands;
 
@@ -27,232 +27,244 @@ namespace GameInterface.Services.MapEvents.Commands;
 /// </summary>
 internal class BattleTeamKillCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     public static readonly ILogger Logger = LogManager.GetLogger<BattleTeamKillCommands>();
 
     private const string ScoreboardMovieName = "SPScoreboard";
     private const string PartyScoreToggleWidgetId = "PartyScoreToggleWidget";
     private const string PartyDetailsWidgetId = "PartyDetails";
 
-    private const string ClickDeploymentReadyUsage =
-@"Usage:
-  coop.debug.mapevent.click_deployment_ready
-
-Activates the deployment Ready button's native UI callback.";
-
-    [CommandLineArgumentFunction("click_deployment_ready", "coop.debug.mapevent")]
-    public static string ClickDeploymentReady(List<string> args)
+    public sealed class ClickDeploymentReadyCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext("click_deployment_ready", ClickDeploymentReadyUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Prefix => "coop.debug.map_event";
 
-        var mission = Mission.Current;
-        if (mission is null)
-            return "Failed: no active mission.";
+        public string Name => "click_deployment_ready";
 
-        var deploymentController = mission.GetMissionBehavior<DeploymentMissionController>();
-        if (deploymentController == null)
-            return "No active deployment.";
-        if (!deploymentController.TeamSetupOver)
-            return "Failed: deployment team setup is not complete.";
+        public string Description => "Runs the click deployment ready debug operation.";
 
-        var orderUi = mission.GetMissionBehavior<MissionGauntletSingleplayerOrderUIHandler>();
-        if (orderUi == null)
-            return "Failed: no deployment order UI.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        orderUi.OnBeginMission();
-        return "Clicked deployment Ready through the native UI callback.";
-    }
-
-    private const string FinishDeploymentUsage =
-@"Usage:
-  coop.debug.mapevent.finish_deployment
-
-Finishes the current battle deployment through the native deployment handler.";
-
-    [CommandLineArgumentFunction("deployment_state", "coop.debug.mapevent")]
-    public static string DeploymentState(List<string> args)
-    {
-        var ctx = new CommandContext("deployment_state", "Usage: coop.debug.mapevent.deployment_state", args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
-
-        var mission = Mission.Current;
-        if (mission == null)
-            return "Deployment state: mission=False, controller=False, teamSetupOver=False, handler=False.";
-
-        var controller = mission.GetMissionBehavior<DeploymentMissionController>();
-        var handler = mission.GetMissionBehavior<DeploymentHandler>();
-        return $"Deployment state: mission=True, controller={controller != null}, " +
-               $"teamSetupOver={controller?.TeamSetupOver ?? false}, handler={handler != null}.";
-    }
-
-    [CommandLineArgumentFunction("finish_deployment", "coop.debug.mapevent")]
-    public static string FinishDeployment(List<string> args)
-    {
-        var ctx = new CommandContext("finish_deployment", FinishDeploymentUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
-
-        var mission = Mission.Current;
-        if (mission is null)
-            return "Failed: no active mission.";
-
-        var deploymentController = mission.GetMissionBehavior<DeploymentMissionController>();
-        if (deploymentController == null)
-            return "No active deployment.";
-        if (!deploymentController.TeamSetupOver)
-            return "Failed: deployment team setup is not complete.";
-
-        var deploymentHandler = mission.GetMissionBehavior<DeploymentHandler>();
-        if (deploymentHandler == null)
-            return "Failed: no deployment handler.";
-
-        deploymentHandler.FinishDeployment();
-        return "Finished the current deployment.";
-    }
-
-    private const string ToggleScoreboardUsage =
-@"Usage:
-  coop.debug.mapevent.toggle_scoreboard
-
-Holds or releases the native scoreboard input without requiring window focus.";
-
-    [CommandLineArgumentFunction("toggle_scoreboard", "coop.debug.mapevent")]
-    public static string ToggleScoreboard(List<string> args)
-    {
-        var ctx = new CommandContext("toggle_scoreboard", ToggleScoreboardUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
-
-        var mission = Mission.Current;
-        if (mission is null)
-            return "Failed: no active mission.";
-
-        var scoreboard = mission.GetMissionBehavior<MissionGauntletBattleScore>();
-        if (scoreboard?.DataSource == null)
-            return "Failed: no battle scoreboard UI.";
-
-        if (mission.InputManager is ScoreboardInputContext scoreboardInput)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            mission.InputManager = scoreboardInput.Inner;
-            return "Released the native scoreboard input.";
+            var mission = Mission.Current;
+            if (mission is null)
+                return Failed("Failed: no active mission.");
+
+            var deploymentController = mission.GetMissionBehavior<DeploymentMissionController>();
+            if (deploymentController == null)
+                return Failed("No active deployment.");
+            if (!deploymentController.TeamSetupOver)
+                return Failed("Failed: deployment team setup is not complete.");
+
+            var orderUi = mission.GetMissionBehavior<MissionGauntletSingleplayerOrderUIHandler>();
+            if (orderUi == null)
+                return Failed("Failed: no deployment order UI.");
+
+            orderUi.OnBeginMission();
+            return Succeeded("Clicked deployment Ready through the native UI callback.");
         }
-        if (mission.InputManager == null)
-            return "Failed: no mission input context.";
-
-        mission.InputManager = new ScoreboardInputContext(mission.InputManager);
-        return "Holding the native scoreboard input.";
     }
 
-    private const string CollapseScoreboardPartiesUsage =
-@"Usage:
-  coop.debug.mapevent.collapse_scoreboard_parties
-
-Collapses every native scoreboard party roster and returns the scroll position to the top.";
-
-    [CommandLineArgumentFunction("collapse_scoreboard_parties", "coop.debug.mapevent")]
-    public static string CollapseScoreboardParties(List<string> args)
+    public sealed class DeploymentStateCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext("collapse_scoreboard_parties", CollapseScoreboardPartiesUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Prefix => "coop.debug.map_event";
 
-        var scoreboard = Mission.Current?.GetMissionBehavior<MissionGauntletBattleScore>();
-        var dataSource = scoreboard?.DataSource;
-        if (dataSource == null)
-            return "Failed: no battle scoreboard UI.";
+        public string Name => "deployment_state";
 
-        if (!TryGetScoreboardWidgets(scoreboard, out var scrollablePanel, out var partyHeaderCount, out var partyDetails))
-            return "Failed: native scoreboard widgets are not loaded.";
+        public string Description => "Reports deployment state.";
 
-        var expectedPartyCount = dataSource.Attackers.Parties.Count + dataSource.Defenders.Parties.Count;
-        if (partyHeaderCount != expectedPartyCount || partyDetails.Count != expectedPartyCount)
-            return $"Failed: found {partyHeaderCount} native party headers and {partyDetails.Count} party detail panels, " +
-                   $"expected {expectedPartyCount} each.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        var verticalScrollbar = scrollablePanel.VerticalScrollbar;
-
-        foreach (var partyDetail in partyDetails)
-            partyDetail.IsVisible = false;
-
-        scrollablePanel.ResetTweenSpeed();
-        verticalScrollbar.ValueFloat = verticalScrollbar.MinValue;
-        scrollablePanel.SetVerticalScrollTarget(verticalScrollbar.MinValue, 0f);
-        return $"Collapsed native party details: {partyHeaderCount}/{expectedPartyCount}.";
-    }
-
-    private const string ScoreboardStateUsage =
-@"Usage:
-  coop.debug.mapevent.scoreboard_state
-
-Lists the map-event parties and party rows currently loaded by the battle scoreboard.";
-
-    [CommandLineArgumentFunction("scoreboard_state", "coop.debug.mapevent")]
-    public static string ScoreboardState(List<string> args)
-    {
-        var ctx = new CommandContext("scoreboard_state", ScoreboardStateUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
-
-        var mission = Mission.Current;
-        if (mission is null)
-            return "Failed: no active mission.";
-
-        var scoreboard = mission.GetMissionBehavior<MissionGauntletBattleScore>();
-        var dataSource = scoreboard?.DataSource;
-        if (dataSource == null)
-            return "Failed: no battle scoreboard UI.";
-        if (dataSource.Attackers?.Parties == null || dataSource.Defenders?.Parties == null)
-            return "Failed: battle scoreboard parties are not loaded.";
-
-        var mapEvent = MobileParty.MainParty?.MapEvent;
-        if (mapEvent == null)
-            return "Failed: the main party has no current map event.";
-
-        var expectedParties = mapEvent.InvolvedParties
-            .Where(party => party != null)
-            .Distinct()
-            .ToArray();
-        var expectedPlayerParties = expectedParties
-            .Where(party => party.MobileParty?.IsPlayerParty() == true)
-            .ToArray();
-        if (expectedPlayerParties.Length == 0)
-            return "Failed: the current map event has no registered player parties.";
-        var scoreboardParties = dataSource.Attackers.Parties
-            .Concat(dataSource.Defenders.Parties)
-            .Select(party => party.BattleCombatant)
-            .OfType<PartyBase>()
-            .Distinct()
-            .ToArray();
-        var scoreboardPlayerParties = scoreboardParties
-            .Where(party => party.MobileParty?.IsPlayerParty() == true)
-            .ToArray();
-        var missingParties = expectedParties.Except(scoreboardParties).ToArray();
-        var missingPlayerParties = expectedPlayerParties.Except(scoreboardParties).ToArray();
-        var expandedPartyDetails = 0;
-        var scrollTop = false;
-        var nativeWidgetsLoaded = TryGetScoreboardWidgets(
-            scoreboard,
-            out var scrollablePanel,
-            out var partyHeaderCount,
-            out var partyDetails);
-        if (nativeWidgetsLoaded)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            expandedPartyDetails = partyDetails.Count(details => details.IsVisible);
-            var scrollbar = scrollablePanel.VerticalScrollbar;
-            scrollTop = Math.Abs(scrollbar.ValueFloat - scrollbar.MinValue) < 0.01f;
-        }
+            var mission = Mission.Current;
+            if (mission == null)
+                return Succeeded("Deployment state: mission=False, controller=False, teamSetupOver=False, handler=False.");
 
-        return $"Visible: {dataSource.ShowScoreboard}; " +
-               $"Expected parties ({expectedParties.Length}): {FormatPartyNames(expectedParties)}; " +
-               $"Expected player parties ({expectedPlayerParties.Length}): {FormatPartyNames(expectedPlayerParties)}; " +
-               $"Scoreboard parties ({scoreboardParties.Length}): {FormatPartyNames(scoreboardParties)}; " +
-               $"Scoreboard player parties ({scoreboardPlayerParties.Length}): {FormatPartyNames(scoreboardPlayerParties)}; " +
-               $"Missing parties ({missingParties.Length}): {FormatPartyNames(missingParties)}; " +
-               $"Missing player parties ({missingPlayerParties.Length}): {FormatPartyNames(missingPlayerParties)}; " +
-               $"Native widgets loaded: {nativeWidgetsLoaded}; " +
-               $"Party headers ({partyHeaderCount}); Expanded party details ({expandedPartyDetails}); Scroll top: {scrollTop}";
+            var controller = mission.GetMissionBehavior<DeploymentMissionController>();
+            var handler = mission.GetMissionBehavior<DeploymentHandler>();
+            return Succeeded($"Deployment state: mission=True, controller={controller != null}, " +
+                   $"teamSetupOver={controller?.TeamSetupOver ?? false}, handler={handler != null}.");
+        }
+    }
+
+    public sealed class FinishDeploymentCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "finish_deployment";
+
+        public string Description => "Runs the finish deployment debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var mission = Mission.Current;
+            if (mission is null)
+                return Failed("Failed: no active mission.");
+
+            var deploymentController = mission.GetMissionBehavior<DeploymentMissionController>();
+            if (deploymentController == null)
+                return Failed("No active deployment.");
+            if (!deploymentController.TeamSetupOver)
+                return Failed("Failed: deployment team setup is not complete.");
+
+            var deploymentHandler = mission.GetMissionBehavior<DeploymentHandler>();
+            if (deploymentHandler == null)
+                return Failed("Failed: no deployment handler.");
+
+            deploymentHandler.FinishDeployment();
+            return Succeeded("Finished the current deployment.");
+        }
+    }
+
+    public sealed class ToggleScoreboardCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "toggle_scoreboard";
+
+        public string Description => "Runs the toggle scoreboard debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var mission = Mission.Current;
+            if (mission is null)
+                return Failed("Failed: no active mission.");
+
+            var scoreboard = mission.GetMissionBehavior<MissionGauntletBattleScore>();
+            if (scoreboard?.DataSource == null)
+                return Failed("Failed: no battle scoreboard UI.");
+
+            if (mission.InputManager is ScoreboardInputContext scoreboardInput)
+            {
+                mission.InputManager = scoreboardInput.Inner;
+                return Succeeded("Released the native scoreboard input.");
+            }
+            if (mission.InputManager == null)
+                return Failed("Failed: no mission input context.");
+
+            mission.InputManager = new ScoreboardInputContext(mission.InputManager);
+            return Succeeded("Holding the native scoreboard input.");
+        }
+    }
+
+    public sealed class CollapseScoreboardPartiesCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "collapse_scoreboard_parties";
+
+        public string Description => "Runs the collapse scoreboard parties debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var scoreboard = Mission.Current?.GetMissionBehavior<MissionGauntletBattleScore>();
+            var dataSource = scoreboard?.DataSource;
+            if (dataSource == null)
+                return Failed("Failed: no battle scoreboard UI.");
+
+            if (!TryGetScoreboardWidgets(scoreboard, out var scrollablePanel, out var partyHeaderCount, out var partyDetails))
+                return Failed("Failed: native scoreboard widgets are not loaded.");
+
+            var expectedPartyCount = dataSource.Attackers.Parties.Count + dataSource.Defenders.Parties.Count;
+            if (partyHeaderCount != expectedPartyCount || partyDetails.Count != expectedPartyCount)
+                return Failed($"Failed: found {partyHeaderCount} native party headers and {partyDetails.Count} party detail panels, " +
+                       $"expected {expectedPartyCount} each.");
+
+            var verticalScrollbar = scrollablePanel.VerticalScrollbar;
+
+            foreach (var partyDetail in partyDetails)
+                partyDetail.IsVisible = false;
+
+            scrollablePanel.ResetTweenSpeed();
+            verticalScrollbar.ValueFloat = verticalScrollbar.MinValue;
+            scrollablePanel.SetVerticalScrollTarget(verticalScrollbar.MinValue, 0f);
+            return Succeeded($"Collapsed native party details: {partyHeaderCount}/{expectedPartyCount}.");
+        }
+    }
+
+    public sealed class ScoreboardStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "scoreboard_state";
+
+        public string Description => "Reports scoreboard state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var mission = Mission.Current;
+            if (mission is null)
+                return Failed("Failed: no active mission.");
+
+            var scoreboard = mission.GetMissionBehavior<MissionGauntletBattleScore>();
+            var dataSource = scoreboard?.DataSource;
+            if (dataSource == null)
+                return Failed("Failed: no battle scoreboard UI.");
+            if (dataSource.Attackers?.Parties == null || dataSource.Defenders?.Parties == null)
+                return Failed("Failed: battle scoreboard parties are not loaded.");
+
+            var mapEvent = MobileParty.MainParty?.MapEvent;
+            if (mapEvent == null)
+                return Failed("Failed: the main party has no current map event.");
+
+            var expectedParties = mapEvent.InvolvedParties
+                .Where(party => party != null)
+                .Distinct()
+                .ToArray();
+            var expectedPlayerParties = expectedParties
+                .Where(party => party.MobileParty?.IsPlayerParty() == true)
+                .ToArray();
+            if (expectedPlayerParties.Length == 0)
+                return Failed("Failed: the current map event has no registered player parties.");
+            var scoreboardParties = dataSource.Attackers.Parties
+                .Concat(dataSource.Defenders.Parties)
+                .Select(party => party.BattleCombatant)
+                .OfType<PartyBase>()
+                .Distinct()
+                .ToArray();
+            var scoreboardPlayerParties = scoreboardParties
+                .Where(party => party.MobileParty?.IsPlayerParty() == true)
+                .ToArray();
+            var missingParties = expectedParties.Except(scoreboardParties).ToArray();
+            var missingPlayerParties = expectedPlayerParties.Except(scoreboardParties).ToArray();
+            var expandedPartyDetails = 0;
+            var scrollTop = false;
+            var nativeWidgetsLoaded = TryGetScoreboardWidgets(
+                scoreboard,
+                out var scrollablePanel,
+                out var partyHeaderCount,
+                out var partyDetails);
+            if (nativeWidgetsLoaded)
+            {
+                expandedPartyDetails = partyDetails.Count(details => details.IsVisible);
+                var scrollbar = scrollablePanel.VerticalScrollbar;
+                scrollTop = Math.Abs(scrollbar.ValueFloat - scrollbar.MinValue) < 0.01f;
+            }
+
+            return Succeeded($"Visible: {dataSource.ShowScoreboard}; " +
+                   $"Expected parties ({expectedParties.Length}): {FormatPartyNames(expectedParties)}; " +
+                   $"Expected player parties ({expectedPlayerParties.Length}): {FormatPartyNames(expectedPlayerParties)}; " +
+                   $"Scoreboard parties ({scoreboardParties.Length}): {FormatPartyNames(scoreboardParties)}; " +
+                   $"Scoreboard player parties ({scoreboardPlayerParties.Length}): {FormatPartyNames(scoreboardPlayerParties)}; " +
+                   $"Missing parties ({missingParties.Length}): {FormatPartyNames(missingParties)}; " +
+                   $"Missing player parties ({missingPlayerParties.Length}): {FormatPartyNames(missingPlayerParties)}; " +
+                   $"Native widgets loaded: {nativeWidgetsLoaded}; " +
+                   $"Party headers ({partyHeaderCount}); Expanded party details ({expandedPartyDetails}); Scroll top: {scrollTop}");
+        }
     }
 
     private static bool TryGetScoreboardWidgets(
@@ -329,120 +341,119 @@ Lists the map-event parties and party rows currently loaded by the battle scoreb
         public InputKey[] GetClickKeys() => Inner.GetClickKeys();
     }
 
-    private const string LeaveBattleUsage =
-@"Usage:
-  coop.debug.mapevent.leave_battle
-
-Leaves the current battle through the native mission lifecycle.";
-
-    [CommandLineArgumentFunction("leave_battle", "coop.debug.mapevent")]
-    public static string LeaveBattle(List<string> args)
+    public sealed class LeaveBattleCoopCommand : ICoopCommand
     {
-        if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
-            return "The host has disabled cheats on clients.";
+        public string Prefix => "coop.debug.map_event";
 
-        var ctx = new CommandContext("leave_battle", LeaveBattleUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Name => "leave_battle";
 
-        var mission = Mission.Current;
-        if (mission is null)
-            return "Failed: no active mission.";
+        public string Description => "Runs the leave battle debug operation.";
 
-        mission.EndMission();
-        return "Left the current battle mission.";
-    }
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-    private const string KillEnemyUsage =
-@"Usage:
-  coop.debug.mapevent.kill_enemy
-
-Kills one live enemy-team agent in the current battle (battle-authority side).";
-
-    [CommandLineArgumentFunction("kill_enemy", "coop.debug.mapevent")]
-    public static string KillOneEnemy(List<string> args)
-    {
-        if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
-            return "The host has disabled cheats on clients.";
-
-        var ctx = new CommandContext("kill_one_enemy", KillEnemyUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
-
-        if (!TryGetEnemyAgents(out var agents, out var failure))
-            return failure;
-
-        var agent = agents.FirstOrDefault();
-        if (agent is null)
-            return "No live enemy agents to kill.";
-
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            Kill(agent);
+            if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
+                return Failed("The host has disabled cheats on clients.");
+
+            var mission = Mission.Current;
+            if (mission is null)
+                return Failed("Failed: no active mission.");
+
+            mission.EndMission();
+            return Succeeded("Left the current battle mission.");
         }
-        catch (Exception ex)
+    }
+
+    public sealed class KillEnemyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "kill_enemy";
+
+        public string Description => "Runs the kill enemy debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return CommandHelpers.FormatException("Kill enemy", ex);
+            if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
+                return Failed("The host has disabled cheats on clients.");
+
+            if (!TryGetEnemyAgents(out var agents, out var failure))
+                return Failed(failure);
+
+            var agent = agents.FirstOrDefault();
+            if (agent is null)
+                return Failed("No live enemy agents to kill.");
+
+            try
+            {
+                Kill(agent);
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Kill enemy", ex));
+            }
+
+            return Succeeded($"Killed enemy agent: {agent.Name}");
         }
-
-        return $"Killed enemy agent: {agent.Name}";
     }
 
-    private const string KillEnemyTeamUsage =
-@"Usage:
-  coop.debug.mapevent.kill_enemy_team
-
-Kills every live enemy-team agent in the current battle (battle-authority side). Useful for testing a coop battle WIN.";
-
-    [CommandLineArgumentFunction("kill_enemy_team", "coop.debug.mapevent")]
-    public static string KillEnemyTeam(List<string> args)
+    public sealed class KillEnemyTeamCoopCommand : ICoopCommand
     {
-        if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
-            return "The host has disabled cheats on clients.";
+        public string Prefix => "coop.debug.map_event";
 
-        var ctx = new CommandContext("kill_enemy_team", KillEnemyTeamUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Name => "kill_enemy_team";
 
-        if (!TryGetEnemyAgents(out var agents, out var failure))
-            return failure;
+        public string Description => "Runs the kill enemy team debug operation.";
 
-        var killed = KillAll(agents, out var ex);
-        if (ex != null)
-            return CommandHelpers.FormatException("Kill enemy team", ex);
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        return $"Killed {killed} enemy agent(s).";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
+                return Failed("The host has disabled cheats on clients.");
+
+            if (!TryGetEnemyAgents(out var agents, out var failure))
+                return Failed(failure);
+
+            var killed = KillAll(agents, out var ex);
+            if (ex != null)
+                return Failed(CommandHelpers.FormatException("Kill enemy team", ex));
+
+            return Succeeded($"Killed {killed} enemy agent(s).");
+        }
     }
 
-    private const string KillOwnTeamUsage =
-@"Usage:
-  coop.debug.mapevent.kill_own_team
-
-Kills every live agent on the local player team in the current battle (battle-authority side). Useful for testing a
-coop battle LOSS.";
-
-    [CommandLineArgumentFunction("kill_own_team", "coop.debug.mapevent")]
-    public static string KillOwnTeam(List<string> args)
+    public sealed class KillOwnTeamCoopCommand : ICoopCommand
     {
-        if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
-            return "The host has disabled cheats on clients.";
+        public string Prefix => "coop.debug.map_event";
 
-        var ctx = new CommandContext("kill_own_team", KillOwnTeamUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Name => "kill_own_team";
 
-        var mission = Mission.Current;
-        if (mission is null)
-            return "Failed: no active mission.";
-        if (mission.PlayerTeam is null)
-            return "Failed: no player team in this mission.";
+        public string Description => "Runs the kill own team debug operation.";
 
-        var agents = mission.PlayerTeam.ActiveAgents.ToList();
-        var killed = KillAll(agents, out var ex);
-        if (ex != null)
-            return CommandHelpers.FormatException("Kill own team", ex);
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        return $"Killed {killed} agent(s) on the local player team.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
+                return Failed("The host has disabled cheats on clients.");
+
+            var mission = Mission.Current;
+            if (mission is null)
+                return Failed("Failed: no active mission.");
+            if (mission.PlayerTeam is null)
+                return Failed("Failed: no player team in this mission.");
+
+            var agents = mission.PlayerTeam.ActiveAgents.ToList();
+            var killed = KillAll(agents, out var ex);
+            if (ex != null)
+                return Failed(CommandHelpers.FormatException("Kill own team", ex));
+
+            return Succeeded($"Killed {killed} agent(s) on the local player team.");
+        }
     }
 
     /// <summary>Live agents on any team hostile to the player (host) team.</summary>

--- a/source/GameInterface/Services/MapEvents/Commands/KillPlayerAgentCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/KillPlayerAgentCommands.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Common.Logging;
 using GameInterface.Utils.Commands;
 using Serilog;
@@ -5,53 +6,53 @@ using System;
 using System.Collections.Generic;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.MapEvents.Commands;
 
 internal class KillPlayerAgentCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     public static readonly ILogger Logger = LogManager.GetLogger<KillPlayerAgentCommands>();
 
-    private const string KillPlayerAgentUsage =
-@"Usage:
-  coop.debug.mapevent.kms
-
-Kills the main agent (the player) in the current battle mission.
-Useful for testing player captivity without waiting to die.";
-
-    [CommandLineArgumentFunction("kms", "coop.debug.mapevent")]
-    public static string KillPlayerAgent(List<string> args)
+    public sealed class KmsCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "kill_player_agent",
-            KillPlayerAgentUsage,
-            args);
+        public string Prefix => "coop.debug.map_event";
 
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Name => "kms";
 
-        if (Mission.Current is null)
-            return "Failed to kill player agent: no active mission.";
+        public string Description => "Runs the kms debug operation.";
 
-        var agent = Agent.Main;
-        if (agent is null)
-            return "Failed to kill player agent: Agent.Main is null (player has no agent in this mission).";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        if (!agent.IsActive())
-            return "Failed to kill player agent: main agent is not active (already dead or removed).";
-
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var blow = CreateFatalBlow(agent);
-            agent.Die(blow, Agent.KillInfo.Invalid);
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException("Kill player agent", ex);
-        }
+            if (Mission.Current is null)
+                return Failed("Failed to kill player agent: no active mission.");
 
-        return $"Killed player agent: {agent.Name}";
+            var agent = Agent.Main;
+            if (agent is null)
+                return Failed("Failed to kill player agent: Agent.Main is null (player has no agent in this mission).");
+
+            if (!agent.IsActive())
+                return Failed("Failed to kill player agent: main agent is not active (already dead or removed).");
+
+            try
+            {
+                var blow = CreateFatalBlow(agent);
+                agent.Die(blow, Agent.KillInfo.Invalid);
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Kill player agent", ex));
+            }
+
+            return Succeeded($"Killed player agent: {agent.Name}");
+        }
     }
 
     private static Blow CreateFatalBlow(Agent agent)

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using Common.Messaging;
@@ -50,70 +51,97 @@ using TaleWorlds.Localization;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.Source.Missions.Handlers;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Villages.Commands;
 
 public class MapEventDebugCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<MapEventDebugCommands>();
     private static LateJoinModeFixture lateJoinModeFixture;
     private static InquiryData pendingPrisonerPromptInquiry;
 
-    [CommandLineArgumentFunction("prisoner_prompt_state", "coop.debug.mapevent")]
-    public static string PrisonerPromptState(List<string> args)
+    public sealed class PrisonerPromptStateCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient) return "Run this command on a client.";
-        if (args.Count != 0) return "Usage: coop.debug.mapevent.prisoner_prompt_state";
-        return CreatePrisonerPromptStateResult();
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "prisoner_prompt_state";
+
+        public string Description => "Reports prisoner prompt state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Run this command on a client.");
+            return Succeeded(CreatePrisonerPromptStateResult());
+        }
     }
 
-    [CommandLineArgumentFunction("prisoner_prompt", "coop.debug.mapevent")]
-    public static string PrisonerPrompt(List<string> args)
+    public sealed class PrisonerPromptCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient) return "Run this command on a client.";
-        if (args.Count != 1 || (args[0] != "commit" && args[0] != "accept"))
-            return "Usage: coop.debug.mapevent.prisoner_prompt <commit|accept>";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args[0] == "commit")
+        public string Name => "prisoner_prompt";
+
+        public string Description => "Runs the prisoner prompt debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (pendingPrisonerPromptInquiry != null)
-                return "A prisoner warning is already pending acceptance.";
-            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
-                partyState.PartyScreenMode != PartyScreenHelper.PartyScreenMode.Loot)
-                return "The real aftermath Party screen is not active.";
-            if (partyState.PartyScreenLogic?.PrisonerRosters[0]?.TotalManCount <= 0)
-                return "The aftermath screen has no prisoners left behind.";
-            if (!((ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource is { } partyVm))
-                return "The active aftermath Party view model is unavailable.";
+            new ExpectedArgs("action", "The action.", true),
+        };
 
-            InquiryData capturedInquiry = null;
-            Action<InquiryData, bool, bool> captureInquiry = (data, _, _) => capturedInquiry = data;
-            InformationManager.OnShowInquiry += captureInquiry;
-            try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Run this command on a client.");
+            if ((args[0] != "commit" && args[0] != "accept"))
+                return Failed("Invalid command argument value.");
+
+            if (args[0] == "commit")
             {
-                partyVm.ExecuteDone();
-            }
-            finally
-            {
-                InformationManager.OnShowInquiry -= captureInquiry;
+                if (pendingPrisonerPromptInquiry != null)
+                    return Failed("A prisoner warning is already pending acceptance.");
+                if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
+                    partyState.PartyScreenMode != PartyScreenHelper.PartyScreenMode.Loot)
+                    return Failed("The real aftermath Party screen is not active.");
+                if (partyState.PartyScreenLogic?.PrisonerRosters[0]?.TotalManCount <= 0)
+                    return Failed("The aftermath screen has no prisoners left behind.");
+                if (!((ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource is { } partyVm))
+                    return Failed("The active aftermath Party view model is unavailable.");
+
+                InquiryData capturedInquiry = null;
+                Action<InquiryData, bool, bool> captureInquiry = (data, _, _) => capturedInquiry = data;
+                InformationManager.OnShowInquiry += captureInquiry;
+                try
+                {
+                    partyVm.ExecuteDone();
+                }
+                finally
+                {
+                    InformationManager.OnShowInquiry -= captureInquiry;
+                }
+
+                if (capturedInquiry?.AffirmativeAction == null || !InformationManager.IsAnyInquiryActive())
+                    return Failed("The real leave-prisoners warning did not open.");
+
+                pendingPrisonerPromptInquiry = capturedInquiry;
+                return Succeeded(CreatePrisonerPromptStateResult());
             }
 
-            if (capturedInquiry?.AffirmativeAction == null || !InformationManager.IsAnyInquiryActive())
-                return "The real leave-prisoners warning did not open.";
+            var inquiry = pendingPrisonerPromptInquiry;
+            if (inquiry?.AffirmativeAction == null)
+                return Failed("No captured prisoner warning is pending acceptance.");
 
-            pendingPrisonerPromptInquiry = capturedInquiry;
-            return CreatePrisonerPromptStateResult();
+            pendingPrisonerPromptInquiry = null;
+            InformationManager.HideInquiry();
+            inquiry.AffirmativeAction();
+            return Succeeded(CreatePrisonerPromptStateResult());
         }
-
-        var inquiry = pendingPrisonerPromptInquiry;
-        if (inquiry?.AffirmativeAction == null)
-            return "No captured prisoner warning is pending acceptance.";
-
-        pendingPrisonerPromptInquiry = null;
-        InformationManager.HideInquiry();
-        inquiry.AffirmativeAction();
-        return CreatePrisonerPromptStateResult();
     }
 
     private static string CreatePrisonerPromptStateResult()
@@ -256,128 +284,147 @@ public class MapEventDebugCommands
                partyBaseId == id;
     }
 
-    [CommandLineArgumentFunction("start_player_field_battle", "coop.debug.mapevent")]
-    public static string StartPlayerFieldBattle(List<string> args)
+    public sealed class StartPlayerFieldBattleCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.start_player_field_battle <attackerMobilePartyId> <defenderMobilePartyId>";
+        public string Name => "start_player_field_battle";
 
-        if (playerFieldBattleFixture != null)
-            return "A player field-battle fixture is already pending restoration.";
+        public string Description => "Runs the start player field battle debug operation.";
 
-        if (!TryGetObjectManager(out var objectManager))
-            return "Unable to resolve ObjectManager.";
-
-        var attackerError = string.Empty;
-        if ((!objectManager.TryGetObject(args[0], out MobileParty attacker) &&
-             !CommandHelpers.TryGetMobileParty(args[0], out attacker, out attackerError)) ||
-            attacker?.Party == null)
-            return "Unable to resolve attacker party: " + attackerError;
-
-        var defenderError = string.Empty;
-        if ((!objectManager.TryGetObject(args[1], out MobileParty defender) &&
-             !CommandHelpers.TryGetMobileParty(args[1], out defender, out defenderError)) ||
-            defender?.Party == null)
-            return "Unable to resolve defender party: " + defenderError;
-
-        if (attacker == defender)
-            return "Attacker and defender parties must be distinct.";
-
-        if (!attacker.IsActive || !defender.IsActive || attacker.MapEvent != null || defender.MapEvent != null)
-            return "Both player parties must be active and outside a map event.";
-
-        if (attacker.CurrentSettlement != null || defender.CurrentSettlement != null)
-            return "Both player parties must be outside settlements.";
-
-        var attackerFaction = attacker.MapFaction;
-        var defenderFaction = defender.MapFaction;
-        if (attackerFaction == null || defenderFaction == null || attackerFaction == defenderFaction)
-            return "Player parties must belong to distinct map factions.";
-
-        if (!objectManager.TryGetId(attacker, out var attackerMobilePartyId) ||
-            !objectManager.TryGetId(defender, out var defenderMobilePartyId) ||
-            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
-            return "Unable to resolve the registered player-party identities.";
-
-        var attackerPlayer = playerManager.Players.FirstOrDefault(player =>
-            player.MobilePartyId == attackerMobilePartyId);
-        var defenderPlayer = playerManager.Players.FirstOrDefault(player =>
-            player.MobilePartyId == defenderMobilePartyId);
-        if (attackerPlayer == null || defenderPlayer == null ||
-            !playerManager.IsConnected(attackerPlayer) || !playerManager.IsConnected(defenderPlayer))
-            return "Both parties must belong to connected players.";
-
-        if (!objectManager.TryGetId(attacker.Party, out var attackerPartyBaseId) ||
-            !objectManager.TryGetId(defender.Party, out var defenderPartyBaseId))
-            return "Unable to resolve the registered PartyBase ids.";
-
-        if (!ContainerProvider.TryResolve<IPlayerPartyHostileEncounterService>(out var encounterService))
-            return "Unable to resolve the player hostile-encounter service.";
-
-        var fixture = new PlayerFieldBattleFixture
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            AttackerParty = attacker,
-            DefenderParty = defender,
-            AttackerFaction = attackerFaction,
-            DefenderFaction = defenderFaction,
-            WasAtWar = AreFactionsAtWar(attackerFaction, defenderFaction),
+            new ExpectedArgs("attacker_mobile_party_id", "The attacker mobile party id.", true),
+            new ExpectedArgs("defender_mobile_party_id", "The defender mobile party id.", true),
         };
-        playerFieldBattleFixture = fixture;
 
-        var sessionId = "live-test-" + Guid.NewGuid().ToString("N");
-        if (!encounterService.TryStartHostileEncounter(
-                sessionId,
-                attackerPartyBaseId,
-                defenderPartyBaseId,
-                responderSurrenders: false))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var partiallyCreatedMapEvent = attacker.MapEvent;
-            if (partiallyCreatedMapEvent != null &&
-                partiallyCreatedMapEvent == defender.MapEvent &&
-                !partiallyCreatedMapEvent.IsFinalized)
-                partiallyCreatedMapEvent.FinalizeEvent();
+            if (!ModInformation.IsServer)
+                return Failed("Run this command on the server.");
 
-            var peaceRestored = RestoreFixtureWarState(fixture);
-            playerFieldBattleFixture = null;
-            return $"Failed to start the player field-battle fixture. PeaceRestored: {peaceRestored}";
+
+            if (playerFieldBattleFixture != null)
+                return Failed("A player field-battle fixture is already pending restoration.");
+
+            if (!TryGetObjectManager(out var objectManager))
+                return Failed("Unable to resolve ObjectManager.");
+
+            var attackerError = string.Empty;
+            if ((!objectManager.TryGetObject(args[0], out MobileParty attacker) &&
+                 !CommandHelpers.TryGetMobileParty(args[0], out attacker, out attackerError)) ||
+                attacker?.Party == null)
+                return Failed("Unable to resolve attacker party: " + attackerError);
+
+            var defenderError = string.Empty;
+            if ((!objectManager.TryGetObject(args[1], out MobileParty defender) &&
+                 !CommandHelpers.TryGetMobileParty(args[1], out defender, out defenderError)) ||
+                defender?.Party == null)
+                return Failed("Unable to resolve defender party: " + defenderError);
+
+            if (attacker == defender)
+                return Failed("Attacker and defender parties must be distinct.");
+
+            if (!attacker.IsActive || !defender.IsActive || attacker.MapEvent != null || defender.MapEvent != null)
+                return Failed("Both player parties must be active and outside a map event.");
+
+            if (attacker.CurrentSettlement != null || defender.CurrentSettlement != null)
+                return Failed("Both player parties must be outside settlements.");
+
+            var attackerFaction = attacker.MapFaction;
+            var defenderFaction = defender.MapFaction;
+            if (attackerFaction == null || defenderFaction == null || attackerFaction == defenderFaction)
+                return Failed("Player parties must belong to distinct map factions.");
+
+            if (!objectManager.TryGetId(attacker, out var attackerMobilePartyId) ||
+                !objectManager.TryGetId(defender, out var defenderMobilePartyId) ||
+                !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+                return Failed("Unable to resolve the registered player-party identities.");
+
+            var attackerPlayer = playerManager.Players.FirstOrDefault(player =>
+                player.MobilePartyId == attackerMobilePartyId);
+            var defenderPlayer = playerManager.Players.FirstOrDefault(player =>
+                player.MobilePartyId == defenderMobilePartyId);
+            if (attackerPlayer == null || defenderPlayer == null ||
+                !playerManager.IsConnected(attackerPlayer) || !playerManager.IsConnected(defenderPlayer))
+                return Failed("Both parties must belong to connected players.");
+
+            if (!objectManager.TryGetId(attacker.Party, out var attackerPartyBaseId) ||
+                !objectManager.TryGetId(defender.Party, out var defenderPartyBaseId))
+                return Failed("Unable to resolve the registered PartyBase ids.");
+
+            if (!ContainerProvider.TryResolve<IPlayerPartyHostileEncounterService>(out var encounterService))
+                return Failed("Unable to resolve the player hostile-encounter service.");
+
+            var fixture = new PlayerFieldBattleFixture
+            {
+                AttackerParty = attacker,
+                DefenderParty = defender,
+                AttackerFaction = attackerFaction,
+                DefenderFaction = defenderFaction,
+                WasAtWar = AreFactionsAtWar(attackerFaction, defenderFaction),
+            };
+            playerFieldBattleFixture = fixture;
+
+            var sessionId = "live-test-" + Guid.NewGuid().ToString("N");
+            if (!encounterService.TryStartHostileEncounter(
+                    sessionId,
+                    attackerPartyBaseId,
+                    defenderPartyBaseId,
+                    responderSurrenders: false))
+            {
+                var partiallyCreatedMapEvent = attacker.MapEvent;
+                if (partiallyCreatedMapEvent != null &&
+                    partiallyCreatedMapEvent == defender.MapEvent &&
+                    !partiallyCreatedMapEvent.IsFinalized)
+                    partiallyCreatedMapEvent.FinalizeEvent();
+
+                var peaceRestored = RestoreFixtureWarState(fixture);
+                playerFieldBattleFixture = null;
+                return Failed($"Failed to start the player field-battle fixture. PeaceRestored: {peaceRestored}");
+            }
+
+            var mapEvent = attacker.MapEvent;
+            var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out var resolvedMapEventId)
+                ? resolvedMapEventId
+                : "<unresolved>";
+
+            return Succeeded("Player field-battle fixture started.\n" +
+                $"MapEventId: {mapEventId}\n" +
+                $"AttackerPartyId: {args[0]}\n" +
+                $"DefenderPartyId: {args[1]}\n" +
+                $"OriginalWarState: {fixture.WasAtWar}");
         }
-
-        var mapEvent = attacker.MapEvent;
-        var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out var resolvedMapEventId)
-            ? resolvedMapEventId
-            : "<unresolved>";
-
-        return
-            "Player field-battle fixture started.\n" +
-            $"MapEventId: {mapEventId}\n" +
-            $"AttackerPartyId: {args[0]}\n" +
-            $"DefenderPartyId: {args[1]}\n" +
-            $"OriginalWarState: {fixture.WasAtWar}";
     }
 
-    [CommandLineArgumentFunction("restore_player_field_battle", "coop.debug.mapevent")]
-    public static string RestorePlayerFieldBattle(List<string> args)
+    public sealed class RestorePlayerFieldBattleCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.restore_player_field_battle";
+        public string Name => "restore_player_field_battle";
 
-        var fixture = playerFieldBattleFixture;
-        if (fixture == null)
-            return "No player field-battle fixture is pending restoration.";
+        public string Description => "Restores or clears restore player field battle.";
 
-        if (fixture.AttackerParty.MapEvent != null || fixture.DefenderParty.MapEvent != null)
-            return "Cannot restore the player field-battle fixture while its map event is active.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        var peaceRestored = RestoreFixtureWarState(fixture);
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+                return Failed("Run this command on the server.");
 
-        playerFieldBattleFixture = null;
-        return $"Player field-battle fixture restored. PeaceRestored: {peaceRestored}";
+
+            var fixture = playerFieldBattleFixture;
+            if (fixture == null)
+                return Failed("No player field-battle fixture is pending restoration.");
+
+            if (fixture.AttackerParty.MapEvent != null || fixture.DefenderParty.MapEvent != null)
+                return Failed("Cannot restore the player field-battle fixture while its map event is active.");
+
+            var peaceRestored = RestoreFixtureWarState(fixture);
+
+            playerFieldBattleFixture = null;
+            return Succeeded($"Player field-battle fixture restored. PeaceRestored: {peaceRestored}");
+        }
     }
 
     private static bool RestoreFixtureWarState(PlayerFieldBattleFixture fixture)
@@ -389,98 +436,126 @@ public class MapEventDebugCommands
         return true;
     }
 
-    [CommandLineArgumentFunction("request_player_field_battle", "coop.debug.mapevent")]
-    public static string RequestPlayerFieldBattle(List<string> args)
+    public sealed class RequestPlayerFieldBattleCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient)
-            return "Run this command on the attacking client.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.request_player_field_battle <defenderMobilePartyId>";
+        public string Name => "request_player_field_battle";
 
-        var attacker = MobileParty.MainParty;
-        if (attacker?.Party == null || !attacker.IsActive || attacker.MapEvent != null)
-            return "The local player must lead an active party outside a map event.";
+        public string Description => "Runs the request player field battle debug operation.";
 
-        if (!TryGetObjectManager(out var objectManager))
-            return "Unable to resolve ObjectManager.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("defender_mobile_party_id", "The defender mobile party id.", true),
+        };
 
-        var defenderError = string.Empty;
-        if ((!objectManager.TryGetObject(args[0], out MobileParty defender) &&
-             !CommandHelpers.TryGetMobileParty(args[0], out defender, out defenderError)) ||
-            defender?.Party == null)
-            return "Unable to resolve defender party: " + defenderError;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient)
+                return Failed("Run this command on the attacking client.");
 
-        if (defender == attacker || !defender.IsActive || defender.MapEvent != null)
-            return "The defender must be a distinct active party outside a map event.";
 
-        if (attacker.CurrentSettlement != null || defender.CurrentSettlement != null)
-            return "Both player parties must be outside settlements.";
+            var attacker = MobileParty.MainParty;
+            if (attacker?.Party == null || !attacker.IsActive || attacker.MapEvent != null)
+                return Failed("The local player must lead an active party outside a map event.");
 
-        if (attacker.MapFaction == null || defender.MapFaction == null ||
-            attacker.MapFaction == defender.MapFaction)
-            return "Player parties must belong to distinct map factions.";
+            if (!TryGetObjectManager(out var objectManager))
+                return Failed("Unable to resolve ObjectManager.");
 
-        if (!objectManager.TryGetId(defender, out var defenderMobilePartyId) ||
-            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.Players.Any(player => player.MobilePartyId == defenderMobilePartyId))
-            return "The defender must belong to a registered player.";
+            var defenderError = string.Empty;
+            if ((!objectManager.TryGetObject(args[0], out MobileParty defender) &&
+                 !CommandHelpers.TryGetMobileParty(args[0], out defender, out defenderError)) ||
+                defender?.Party == null)
+                return Failed("Unable to resolve defender party: " + defenderError);
 
-        if (!objectManager.TryGetId(attacker.Party, out var attackerPartyId) ||
-            !objectManager.TryGetId(defender.Party, out var defenderPartyId))
-            return "Unable to resolve the registered PartyBase ids.";
+            if (defender == attacker || !defender.IsActive || defender.MapEvent != null)
+                return Failed("The defender must be a distinct active party outside a map event.");
 
-        if (!ContainerProvider.TryResolve<INetwork>(out var network))
-            return "Unable to resolve the client network.";
+            if (attacker.CurrentSettlement != null || defender.CurrentSettlement != null)
+                return Failed("Both player parties must be outside settlements.");
 
-        network.SendAll(new NetworkRequestConversation(
-            defenderPartyId,
-            attackerPartyId,
-            forcePlayerOutFromSettlement: false,
-            ConversationRestartSource.PlayerEncounter,
-            armyTalkEncounter: false));
+            if (attacker.MapFaction == null || defender.MapFaction == null ||
+                attacker.MapFaction == defender.MapFaction)
+                return Failed("Player parties must belong to distinct map factions.");
 
-        return
-            "Player field-battle interaction requested through the production conversation path.\n" +
-            $"AttackerPartyId: {attacker.StringId}\n" +
-            $"DefenderPartyId: {defender.StringId}";
+            if (!objectManager.TryGetId(defender, out var defenderMobilePartyId) ||
+                !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.Players.Any(player => player.MobilePartyId == defenderMobilePartyId))
+                return Failed("The defender must belong to a registered player.");
+
+            if (!objectManager.TryGetId(attacker.Party, out var attackerPartyId) ||
+                !objectManager.TryGetId(defender.Party, out var defenderPartyId))
+                return Failed("Unable to resolve the registered PartyBase ids.");
+
+            if (!ContainerProvider.TryResolve<INetwork>(out var network))
+                return Failed("Unable to resolve the client network.");
+
+            network.SendAll(new NetworkRequestConversation(
+                defenderPartyId,
+                attackerPartyId,
+                forcePlayerOutFromSettlement: false,
+                ConversationRestartSource.PlayerEncounter,
+                armyTalkEncounter: false));
+
+            return Succeeded("Player field-battle interaction requested through the production conversation path.\n" +
+                $"AttackerPartyId: {attacker.StringId}\n" +
+                $"DefenderPartyId: {defender.StringId}");
+        }
     }
 
-    [CommandLineArgumentFunction("player_interaction_state", "coop.debug.mapevent")]
-    public static string PlayerInteractionState(List<string> args)
+    public sealed class PlayerInteractionStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.player_interaction_state";
+        public string Prefix => "coop.debug.map_event";
 
-        return
-            $"Active: {PlayerPartyInteractionDialogState.HasActiveState}\n" +
-            $"SessionId: {PlayerPartyInteractionDialogState.SessionId ?? "none"}\n" +
-            $"PartyId: {PlayerPartyInteractionDialogState.PartyId ?? "none"}\n" +
-            $"OtherPartyId: {PlayerPartyInteractionDialogState.OtherPartyId ?? "none"}\n" +
-            $"Phase: {PlayerPartyInteractionDialogState.Phase}\n" +
-            $"Proposal: {PlayerPartyInteractionDialogState.Proposal}";
+        public string Name => "player_interaction_state";
+
+        public string Description => "Reports player interaction state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return Succeeded($"Active: {PlayerPartyInteractionDialogState.HasActiveState}\n" +
+                $"SessionId: {PlayerPartyInteractionDialogState.SessionId ?? "none"}\n" +
+                $"PartyId: {PlayerPartyInteractionDialogState.PartyId ?? "none"}\n" +
+                $"OtherPartyId: {PlayerPartyInteractionDialogState.OtherPartyId ?? "none"}\n" +
+                $"Phase: {PlayerPartyInteractionDialogState.Phase}\n" +
+                $"Proposal: {PlayerPartyInteractionDialogState.Proposal}");
+        }
     }
 
-    [CommandLineArgumentFunction("submit_player_interaction", "coop.debug.mapevent")]
-    public static string SubmitPlayerInteraction(List<string> args)
+    public sealed class SubmitPlayerInteractionCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient)
-            return "Run this command on a player client.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1 ||
-            !Enum.TryParse(args[0], ignoreCase: true, out PlayerPartyInteractionOption option) ||
-            option == PlayerPartyInteractionOption.None)
-            return "Usage: coop.debug.mapevent.submit_player_interaction <option>";
+        public string Name => "submit_player_interaction";
 
-        if (!PlayerPartyInteractionDialogState.HasActiveState)
-            return "No player-party interaction is active.";
+        public string Description => "Runs the submit player interaction debug operation.";
 
-        if (!PlayerPartyInteractionDialogState.IsOptionEnabled(option))
-            return $"Player-party interaction option '{option}' is not enabled.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("option", "The option.", true),
+        };
 
-        var sessionId = PlayerPartyInteractionDialogState.SessionId;
-        PlayerPartyInteractionDialogState.Submit(option);
-        return $"Submitted player-party interaction option '{option}' for session '{sessionId}'.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient)
+                return Failed("Run this command on a player client.");
+
+            if (!Enum.TryParse(args[0], ignoreCase: true, out PlayerPartyInteractionOption option) ||
+                option == PlayerPartyInteractionOption.None)
+                return Failed("Invalid command argument value.");
+
+            if (!PlayerPartyInteractionDialogState.HasActiveState)
+                return Failed("No player-party interaction is active.");
+
+            if (!PlayerPartyInteractionDialogState.IsOptionEnabled(option))
+                return Failed($"Player-party interaction option '{option}' is not enabled.");
+
+            var sessionId = PlayerPartyInteractionDialogState.SessionId;
+            PlayerPartyInteractionDialogState.Submit(option);
+            return Succeeded($"Submitted player-party interaction option '{option}' for session '{sessionId}'.");
+        }
     }
 
     private static bool AreFactionsAtWar(IFaction first, IFaction second)
@@ -498,70 +573,87 @@ public class MapEventDebugCommands
     /// <summary>
     /// Starts the current battle through the normal client/server mission-start gate.
     /// </summary>
-    [CommandLineArgumentFunction("start_attack_mission", "coop.debug.mapevent")]
-    public static string StartAttackMission(List<string> args)
+    public sealed class StartAttackMissionCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "start_attack_mission";
+
+        public string Description => "Runs the start attack mission debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return StartAttackMissionCore(args);
+        }
+    }
+
+    private static CoopCommandResult StartAttackMissionCore(ICoopCommandArgs args)
     {
         if (ModInformation.IsServer)
         {
-            return "Run this command on a client";
+            return Failed("Run this command on a client");
         }
 
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.mapevent.start_attack_mission";
-        }
 
         var mainParty = MobileParty.MainParty;
         var mapEvent = mainParty?.MapEvent;
         if (mapEvent == null)
         {
-            return "The main party has no replicated map event";
+            return Failed("The main party has no replicated map event");
         }
 
         if (!TryGetObjectManager(out var objectManager)
             || !objectManager.TryGetId(mapEvent, out var mapEventId)
             || !objectManager.TryGetId(mainParty, out var partyId))
         {
-            return "Unable to resolve the current battle ids";
+            return Failed("Unable to resolve the current battle ids");
         }
 
         var coordinator = BattleStartCoordinator.Instance;
         if (coordinator == null)
         {
-            return "Battle start coordinator is unavailable";
+            return Failed("Battle start coordinator is unavailable");
         }
 
-        return coordinator.RequestBlocking(BattleStartMode.Mission, mapEventId, partyId)
-            ? $"Starting attack mission for {mapEventId}"
-            : $"Server rejected attack mission for {mapEventId}";
+        bool requested = coordinator.RequestBlocking(BattleStartMode.Mission, mapEventId, partyId);
+        return requested
+            ? Succeeded($"Starting attack mission for {mapEventId}")
+            : Failed($"Server rejected attack mission for {mapEventId}");
+
+
     }
 
     // coop.debug.mapevent.start_looter
     /// <summary>
     /// Starts combat with looter
     /// </summary>
-    [CommandLineArgumentFunction("start_looter", "coop.debug.mapevent")]
-    public static string StartRandomLooterMapEvent(List<string> args)
+    public sealed class StartLooterCoopCommand : ICoopCommand
     {
-        //if (args.Count != 2)
-        //{
-        //    return "Usage: coop.debug.besiegercamp.set_number_of_troops_killed_on_side <besiegerCampId> <value> ";
-        //}
+        public string Prefix => "coop.debug.map_event";
 
-        if (TryGetObjectManager(out var objectManager) == false)
+        public string Name => "start_looter";
+
+        public string Description => "Runs the start looter debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+            if (!TryGetObjectManager(out var objectManager))
+                return Failed("Unable to resolve ObjectManager");
+
+            if (!objectManager.TryGetObject("sea_raiders_1", out PartyBase partyBase))
+            {
+                return Failed($"BesiegerCamp with ID: sea_raiders_1 not found");
+            }
+
+            EncounterManager.StartPartyEncounter(MobileParty.MainParty.Party, partyBase);
+
+
+            return Succeeded($"MapEvent Started");
         }
-
-        if (!objectManager.TryGetObject("sea_raiders_1", out PartyBase partyBase))
-        {
-            return $"BesiegerCamp with ID: sea_raiders_1 not found";
-        }
-
-        EncounterManager.StartPartyEncounter(MobileParty.MainParty.Party, partyBase);
-
-
-        return $"MapEvent Started";
     }
 
     // coop.debug.mapevent.start_nearest_looter
@@ -571,377 +663,443 @@ public class MapEventDebugCommands
     /// (uses the player's main party). Bring a much larger party than the bandits so they offer to
     /// surrender or join.
     /// </summary>
-    [CommandLineArgumentFunction("start_nearest_looter", "coop.debug.mapevent")]
-    public static string StartNearestLooterMapEvent(List<string> args)
+    public sealed class StartNearestLooterCoopCommand : ICoopCommand
     {
-        if (!TryGetObjectManager(out var objectManager))
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "start_nearest_looter";
+
+        public string Description => "Runs the start nearest looter debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+            if (!TryGetObjectManager(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null)
+            {
+                return Failed("No main party — run this on a client with a player party.");
+            }
+
+            var mainPos = mainParty.Position.ToVec2();
+            var nearest = MobileParty.All
+                .Where(p => p.IsActive && p.IsBandit && p != mainParty
+                            && p.MapEvent == null && p.CurrentSettlement == null && p.MemberRoster.TotalManCount > 0)
+                .OrderBy(p => p.Position.ToVec2().DistanceSquared(mainPos))
+                .FirstOrDefault();
+
+            if (nearest == null)
+            {
+                return Failed("No active bandit/looter party found on the map.");
+            }
+
+            EncounterManager.StartPartyEncounter(mainParty.Party, nearest.Party);
+
+            var partyId = objectManager.TryGetId(nearest, out string registryId) ? registryId : nearest.StringId;
+
+            return Succeeded($"Started encounter with {nearest.Name} (StringId {nearest.StringId}, registry id {partyId}), " +
+                   $"{nearest.MemberRoster.TotalManCount} troops, {nearest.Position.ToVec2().Distance(mainPos):0.0} away.");
         }
-
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null)
-        {
-            return "No main party — run this on a client with a player party.";
-        }
-
-        var mainPos = mainParty.Position.ToVec2();
-        var nearest = MobileParty.All
-            .Where(p => p.IsActive && p.IsBandit && p != mainParty
-                        && p.MapEvent == null && p.CurrentSettlement == null && p.MemberRoster.TotalManCount > 0)
-            .OrderBy(p => p.Position.ToVec2().DistanceSquared(mainPos))
-            .FirstOrDefault();
-
-        if (nearest == null)
-        {
-            return "No active bandit/looter party found on the map.";
-        }
-
-        EncounterManager.StartPartyEncounter(mainParty.Party, nearest.Party);
-
-        var partyId = objectManager.TryGetId(nearest, out string registryId) ? registryId : nearest.StringId;
-
-        return $"Started encounter with {nearest.Name} (StringId {nearest.StringId}, registry id {partyId}), " +
-               $"{nearest.MemberRoster.TotalManCount} troops, {nearest.Position.ToVec2().Distance(mainPos):0.0} away.";
     }
 
     // coop.debug.mapevent.start_nearest_bandit_attack PlayerOne [excludedPartyId]
     /// <summary>
     /// Starts a server-authoritative bandit attack encounter against a connected player.
     /// </summary>
-    [CommandLineArgumentFunction("start_nearest_bandit_attack", "coop.debug.mapevent")]
-    public static string StartNearestBanditAttack(List<string> args)
+    public sealed class StartNearestBanditAttackCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "Run this command on the server.";
-        }
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count < 1 || args.Count > 2)
-        {
-            return "Usage: coop.debug.mapevent.start_nearest_bandit_attack <controllerId> [excludedPartyId]";
-        }
+        public string Name => "start_nearest_bandit_attack";
 
-        if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
-        {
-            return error;
-        }
+        public string Description => "Runs the start nearest bandit attack debug operation.";
 
-        const int maximumFixtureTroops = 8;
-        var remainingFixtureTroops = maximumFixtureTroops;
-        var removedTroops = 0;
-        for (var index = playerParty.MemberRoster.Count - 1; index >= 0; index--)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            var element = playerParty.MemberRoster.GetElementCopyAtIndex(index);
-            if (element.Character.IsHero)
-                continue;
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("excluded_party_id", "The excluded party id.", false),
+        };
 
-            var kept = Math.Min(element.Number, remainingFixtureTroops);
-            var removed = element.Number - kept;
-            if (removed > 0)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
             {
-                playerParty.MemberRoster.AddToCountsAtIndex(
-                    index,
-                    -removed,
-                    -Math.Min(element.WoundedNumber, removed),
-                    removeDepleted: false);
-                removedTroops += removed;
+                return Failed("Run this command on the server.");
             }
-            remainingFixtureTroops -= kept;
+
+
+            if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
+            {
+                return Failed(error);
+            }
+
+            const int maximumFixtureTroops = 8;
+            var remainingFixtureTroops = maximumFixtureTroops;
+            var removedTroops = 0;
+            for (var index = playerParty.MemberRoster.Count - 1; index >= 0; index--)
+            {
+                var element = playerParty.MemberRoster.GetElementCopyAtIndex(index);
+                if (element.Character.IsHero)
+                    continue;
+
+                var kept = Math.Min(element.Number, remainingFixtureTroops);
+                var removed = element.Number - kept;
+                if (removed > 0)
+                {
+                    playerParty.MemberRoster.AddToCountsAtIndex(
+                        index,
+                        -removed,
+                        -Math.Min(element.WoundedNumber, removed),
+                        removeDepleted: false);
+                    removedTroops += removed;
+                }
+                remainingFixtureTroops -= kept;
+            }
+            playerParty.MemberRoster.RemoveZeroCounts();
+
+            if (playerParty.CurrentSettlement != null)
+            {
+                LeaveSettlementAction.ApplyForParty(playerParty);
+            }
+
+            var excludedPartyId = args.Count == 2 ? args[1] : null;
+            var playerPosition = playerParty.Position.ToVec2();
+            var banditParty = MobileParty.All
+                .Where(p => p.IsActive && p.IsBandit && p != playerParty
+                            && p.MapEvent == null && p.CurrentSettlement == null && p.MemberRoster.TotalManCount > 0
+                            && !MatchesPartyId(objectManager, p, excludedPartyId))
+                .OrderBy(p => p.Position.ToVec2().DistanceSquared(playerPosition))
+                .FirstOrDefault();
+
+            if (banditParty == null)
+            {
+                return Failed("No active bandit/looter party found on the map.");
+            }
+
+            StartBattleAction.Apply(banditParty.Party, playerParty.Party);
+
+            var partyId = objectManager.TryGetId(banditParty, out string registryId)
+                ? registryId
+                : banditParty.StringId;
+            var partyBaseId = objectManager.TryGetId(banditParty.Party, out string partyBaseRegistryId)
+                ? partyBaseRegistryId
+                : "<unregistered>";
+
+            return Succeeded($"Started attack by {banditParty.Name} (StringId {banditParty.StringId}, " +
+                   $"registry id {partyId}, PartyBase id {partyBaseId}) " +
+                   $"against player {args[0]} after removing {removedTroops} excess fixture troops.");
         }
-        playerParty.MemberRoster.RemoveZeroCounts();
-
-        if (playerParty.CurrentSettlement != null)
-        {
-            LeaveSettlementAction.ApplyForParty(playerParty);
-        }
-
-        var excludedPartyId = args.Count == 2 ? args[1] : null;
-        var playerPosition = playerParty.Position.ToVec2();
-        var banditParty = MobileParty.All
-            .Where(p => p.IsActive && p.IsBandit && p != playerParty
-                        && p.MapEvent == null && p.CurrentSettlement == null && p.MemberRoster.TotalManCount > 0
-                        && !MatchesPartyId(objectManager, p, excludedPartyId))
-            .OrderBy(p => p.Position.ToVec2().DistanceSquared(playerPosition))
-            .FirstOrDefault();
-
-        if (banditParty == null)
-        {
-            return "No active bandit/looter party found on the map.";
-        }
-
-        StartBattleAction.Apply(banditParty.Party, playerParty.Party);
-
-        var partyId = objectManager.TryGetId(banditParty, out string registryId)
-            ? registryId
-            : banditParty.StringId;
-        var partyBaseId = objectManager.TryGetId(banditParty.Party, out string partyBaseRegistryId)
-            ? partyBaseRegistryId
-            : "<unregistered>";
-
-        return $"Started attack by {banditParty.Name} (StringId {banditParty.StringId}, " +
-               $"registry id {partyId}, PartyBase id {partyBaseId}) " +
-               $"against player {args[0]} after removing {removedTroops} excess fixture troops.";
     }
 
     // coop.debug.mapevent.bandit_attack_fixture_prepare PlayerOne mountain_bandits_24
     /// <summary>Prepares a reversible exact-bandit attack fixture for evidence capture.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_prepare", "coop.debug.mapevent")]
-    public static string PrepareBanditAttackFixture(List<string> args)
+    public sealed class BanditAttackFixturePrepareCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_prepare <controllerId> <banditPartyId>";
+        public string Name => "bandit_attack_fixture_prepare";
 
-        if (banditAttackFixture != null)
-            return "A bandit attack fixture is already active.";
+        public string Description => "Runs the bandit attack fixture prepare debug operation.";
 
-        if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
-            return error;
-
-        if ((!objectManager.TryGetObject(args[1], out MobileParty banditParty) &&
-             !CommandHelpers.TryGetMobileParty(args[1], out banditParty, out error)) ||
-            banditParty?.Party == null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unable to resolve bandit party {args[1]}: {error}";
-        }
-
-        if (!banditParty.IsBandit || banditParty.MapEvent != null)
-        {
-            return $"Bandit party {args[1]} must be a bandit outside a map event.";
-        }
-
-        if (playerParty.Army?.LeaderParty == playerParty && playerParty.AttachedParties.Count > 0)
-            return $"Player {args[0]} must not lead an army with attached parties.";
-
-        if (banditParty.CurrentSettlement?.SettlementComponent is Hideout &&
-            banditParty.CurrentSettlement.Parties.Count <= 1)
-        {
-            return $"Bandit party {args[1]} must not be the last party in its hideout.";
-        }
-
-        if (!objectManager.TryGetId(playerParty, out string playerPartyId) ||
-            !objectManager.TryGetId(playerParty.Party, out string playerPartyBaseId) ||
-            !objectManager.TryGetId(banditParty, out string banditPartyId) ||
-            !objectManager.TryGetId(banditParty.Party, out string banditPartyBaseId))
-        {
-            return "The player and bandit parties must have registered MobileParty and PartyBase ids.";
-        }
-
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
-            !behaviorSnapshot.TryCreate(playerParty, out PartyBehaviorUpdateData playerBehavior) ||
-            !behaviorSnapshot.TryCreate(banditParty, out PartyBehaviorUpdateData banditBehavior))
-        {
-            return "Unable to capture the original party behavior.";
-        }
-
-        CharacterObject fixtureTroop = null;
-        if (banditParty.MemberRoster.TotalManCount <= 0)
-        {
-            fixtureTroop = MobileParty.All
-                .Where(party => party != banditParty && party.IsActive && party.IsBandit &&
-                                party.MemberRoster.TotalManCount > 0)
-                .SelectMany(party => party.MemberRoster.GetTroopRoster())
-                .Where(element => !element.Character.IsHero && element.Number > 0)
-                .OrderByDescending(element => element.Number)
-                .Select(element => element.Character)
-                .FirstOrDefault();
-            if (fixtureTroop == null)
-                return "No active bandit party has a regular troop for the fixture.";
-        }
-
-        var fixture = new BanditAttackFixture
-        {
-            ControllerId = args[0],
-            PlayerParty = playerParty,
-            BanditParty = banditParty,
-            PlayerSettlement = playerParty.CurrentSettlement,
-            BanditSettlement = banditParty.CurrentSettlement,
-            BanditWasActive = banditParty.IsActive,
-            BanditMemberRoster = banditParty.MemberRoster.GetTroopRoster().ToArray(),
-            PlayerBehavior = playerBehavior,
-            BanditBehavior = banditBehavior,
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("bandit_party_id", "The bandit party id.", true),
         };
-        banditAttackFixture = fixture;
 
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (playerParty.CurrentSettlement != null)
-                LeaveSettlementAction.ApplyForParty(playerParty);
-            if (banditParty.CurrentSettlement != null)
-                LeaveSettlementAction.ApplyForParty(banditParty);
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-            if (fixtureTroop != null)
-                banditParty.MemberRoster.AddToCounts(fixtureTroop, 1);
-            banditParty.IsActive = true;
-            banditParty.Position = new CampaignVec2(
-                new Vec2(playerParty.Position.X - 0.4f, playerParty.Position.Y),
-                isOnLand: true);
-            banditParty.SetMoveModeHold();
-            banditParty.ResetNavigationToHold();
 
-            MessageBroker.Instance.Publish(
-                typeof(MapEventDebugCommands),
-                new PartyBehaviorChangeAttempted(
-                    banditParty,
-                    forcePosition: true,
-                    isCurrentlyAtSea: false,
-                    resetMovementToHold: true));
+            if (banditAttackFixture != null)
+                return Failed("A bandit attack fixture is already active.");
 
-            return $"Bandit attack fixture prepared: controller={args[0]}, playerParty={playerPartyId}, " +
-                   $"playerPartyBase={playerPartyBaseId}, banditParty={banditPartyId}, " +
-                   $"banditPartyBase={banditPartyBaseId}, banditStringId={banditParty.StringId}, " +
-                   $"originalSettlement={fixture.PlayerSettlement?.StringId ?? "none"}, " +
-                   $"originalBanditSettlement={fixture.BanditSettlement?.StringId ?? "none"}, " +
-                   $"originalBanditActive={fixture.BanditWasActive}, " +
-                   $"originalBanditTroops={fixture.BanditMemberRoster.Sum(element => element.Number)}.";
-        }
-        catch (Exception e)
-        {
-            Logger.Error(e, "Failed to prepare bandit attack fixture");
-            if (TryRestoreBanditAttackFixture(fixture, out var restoreError))
-                banditAttackFixture = null;
-            else
-                return $"Fixture preparation failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.";
+            if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
+                return Failed(error);
 
-            return $"Fixture preparation failed: {e.Message}";
+            if ((!objectManager.TryGetObject(args[1], out MobileParty banditParty) &&
+                 !CommandHelpers.TryGetMobileParty(args[1], out banditParty, out error)) ||
+                banditParty?.Party == null)
+            {
+                return Failed($"Unable to resolve bandit party {args[1]}: {error}");
+            }
+
+            if (!banditParty.IsBandit || banditParty.MapEvent != null)
+            {
+                return Failed($"Bandit party {args[1]} must be a bandit outside a map event.");
+            }
+
+            if (playerParty.Army?.LeaderParty == playerParty && playerParty.AttachedParties.Count > 0)
+                return Failed($"Player {args[0]} must not lead an army with attached parties.");
+
+            if (banditParty.CurrentSettlement?.SettlementComponent is Hideout &&
+                banditParty.CurrentSettlement.Parties.Count <= 1)
+            {
+                return Failed($"Bandit party {args[1]} must not be the last party in its hideout.");
+            }
+
+            if (!objectManager.TryGetId(playerParty, out string playerPartyId) ||
+                !objectManager.TryGetId(playerParty.Party, out string playerPartyBaseId) ||
+                !objectManager.TryGetId(banditParty, out string banditPartyId) ||
+                !objectManager.TryGetId(banditParty.Party, out string banditPartyBaseId))
+            {
+                return Failed("The player and bandit parties must have registered MobileParty and PartyBase ids.");
+            }
+
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
+                !behaviorSnapshot.TryCreate(playerParty, out PartyBehaviorUpdateData playerBehavior) ||
+                !behaviorSnapshot.TryCreate(banditParty, out PartyBehaviorUpdateData banditBehavior))
+            {
+                return Failed("Unable to capture the original party behavior.");
+            }
+
+            CharacterObject fixtureTroop = null;
+            if (banditParty.MemberRoster.TotalManCount <= 0)
+            {
+                fixtureTroop = MobileParty.All
+                    .Where(party => party != banditParty && party.IsActive && party.IsBandit &&
+                                    party.MemberRoster.TotalManCount > 0)
+                    .SelectMany(party => party.MemberRoster.GetTroopRoster())
+                    .Where(element => !element.Character.IsHero && element.Number > 0)
+                    .OrderByDescending(element => element.Number)
+                    .Select(element => element.Character)
+                    .FirstOrDefault();
+                if (fixtureTroop == null)
+                    return Failed("No active bandit party has a regular troop for the fixture.");
+            }
+
+            var fixture = new BanditAttackFixture
+            {
+                ControllerId = args[0],
+                PlayerParty = playerParty,
+                BanditParty = banditParty,
+                PlayerSettlement = playerParty.CurrentSettlement,
+                BanditSettlement = banditParty.CurrentSettlement,
+                BanditWasActive = banditParty.IsActive,
+                BanditMemberRoster = banditParty.MemberRoster.GetTroopRoster().ToArray(),
+                PlayerBehavior = playerBehavior,
+                BanditBehavior = banditBehavior,
+            };
+            banditAttackFixture = fixture;
+
+            try
+            {
+                if (playerParty.CurrentSettlement != null)
+                    LeaveSettlementAction.ApplyForParty(playerParty);
+                if (banditParty.CurrentSettlement != null)
+                    LeaveSettlementAction.ApplyForParty(banditParty);
+
+                if (fixtureTroop != null)
+                    banditParty.MemberRoster.AddToCounts(fixtureTroop, 1);
+                banditParty.IsActive = true;
+                banditParty.Position = new CampaignVec2(
+                    new Vec2(playerParty.Position.X - 0.4f, playerParty.Position.Y),
+                    isOnLand: true);
+                banditParty.SetMoveModeHold();
+                banditParty.ResetNavigationToHold();
+
+                MessageBroker.Instance.Publish(
+                    typeof(MapEventDebugCommands),
+                    new PartyBehaviorChangeAttempted(
+                        banditParty,
+                        forcePosition: true,
+                        isCurrentlyAtSea: false,
+                        resetMovementToHold: true));
+
+                return Succeeded($"Bandit attack fixture prepared: controller={args[0]}, playerParty={playerPartyId}, " +
+                       $"playerPartyBase={playerPartyBaseId}, banditParty={banditPartyId}, " +
+                       $"banditPartyBase={banditPartyBaseId}, banditStringId={banditParty.StringId}, " +
+                       $"originalSettlement={fixture.PlayerSettlement?.StringId ?? "none"}, " +
+                       $"originalBanditSettlement={fixture.BanditSettlement?.StringId ?? "none"}, " +
+                       $"originalBanditActive={fixture.BanditWasActive}, " +
+                       $"originalBanditTroops={fixture.BanditMemberRoster.Sum(element => element.Number)}.");
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to prepare bandit attack fixture");
+                if (TryRestoreBanditAttackFixture(fixture, out var restoreError))
+                    banditAttackFixture = null;
+                else
+                    return Failed($"Fixture preparation failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.");
+
+                return Failed($"Fixture preparation failed: {e.Message}");
+            }
         }
     }
 
     // coop.debug.mapevent.bandit_attack_fixture_start PlayerOne mountain_bandits_24
     /// <summary>Starts the prepared server-authoritative attack by the exact bandit party.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_start", "coop.debug.mapevent")]
-    public static string StartBanditAttackFixture(List<string> args)
+    public sealed class BanditAttackFixtureStartCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_start <controllerId> <banditPartyId>";
+        public string Name => "bandit_attack_fixture_start";
 
-        if (!TryGetObjectManager(out var objectManager))
-            return "Unable to resolve ObjectManager";
+        public string Description => "Runs the bandit attack fixture start debug operation.";
 
-        var fixture = banditAttackFixture;
-        if (fixture == null || fixture.ControllerId != args[0] ||
-            !MatchesPartyId(objectManager, fixture.BanditParty, args[1]))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Prepare the bandit attack fixture for {args[0]} and {args[1]} first.";
-        }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("bandit_party_id", "The bandit party id.", true),
+        };
 
-        if (fixture.MapEvent != null)
-            return "The bandit attack fixture was already started.";
-
-        var playerParty = fixture.PlayerParty;
-        var banditParty = fixture.BanditParty;
-        if (!banditParty.IsActive || banditParty.MemberRoster.TotalManCount <= 0 ||
-            playerParty.CurrentSettlement != null || banditParty.CurrentSettlement != null ||
-            playerParty.MapEvent != null || banditParty.MapEvent != null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "The prepared bandit attack fixture is no longer ready.";
-        }
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-        if (!objectManager.TryGetId(playerParty, out string playerPartyId) ||
-            !objectManager.TryGetId(playerParty.Party, out string playerPartyBaseId) ||
-            !objectManager.TryGetId(banditParty, out string banditPartyId) ||
-            !objectManager.TryGetId(banditParty.Party, out string banditPartyBaseId))
-        {
-            return "The player and bandit parties must have registered MobileParty and PartyBase ids.";
-        }
 
-        try
-        {
-            StartBattleAction.Apply(banditParty.Party, playerParty.Party);
-            fixture.MapEvent = playerParty.MapEvent;
-            if (fixture.MapEvent == null || banditParty.MapEvent != fixture.MapEvent)
-                throw new InvalidOperationException("The bandit attack did not create a shared map event.");
+            if (!TryGetObjectManager(out var objectManager))
+                return Failed("Unable to resolve ObjectManager");
 
-            fixture.InvolvedParties = fixture.MapEvent.InvolvedParties.ToArray();
+            var fixture = banditAttackFixture;
+            if (fixture == null || fixture.ControllerId != args[0] ||
+                !MatchesPartyId(objectManager, fixture.BanditParty, args[1]))
+            {
+                return Failed($"Prepare the bandit attack fixture for {args[0]} and {args[1]} first.");
+            }
 
-            objectManager.TryGetId(fixture.MapEvent, out string mapEventId);
-            return $"Bandit attack fixture started: controller={args[0]}, playerParty={playerPartyId}, " +
-                   $"playerPartyBase={playerPartyBaseId}, banditParty={banditPartyId}, " +
-                   $"banditPartyBase={banditPartyBaseId}, banditStringId={banditParty.StringId}, " +
-                   $"mapEvent={mapEventId ?? "unregistered"}.";
-        }
-        catch (Exception e)
-        {
-            Logger.Error(e, "Failed to start bandit attack fixture");
-            fixture.MapEvent ??= playerParty.MapEvent ?? banditParty.MapEvent;
-            fixture.InvolvedParties ??= fixture.MapEvent?.InvolvedParties.ToArray();
-            if (TryRestoreBanditAttackFixture(fixture, out var restoreError))
-                banditAttackFixture = null;
-            else
-                return $"Fixture setup failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.";
+            if (fixture.MapEvent != null)
+                return Failed("The bandit attack fixture was already started.");
 
-            return $"Fixture setup failed: {e.Message}";
+            var playerParty = fixture.PlayerParty;
+            var banditParty = fixture.BanditParty;
+            if (!banditParty.IsActive || banditParty.MemberRoster.TotalManCount <= 0 ||
+                playerParty.CurrentSettlement != null || banditParty.CurrentSettlement != null ||
+                playerParty.MapEvent != null || banditParty.MapEvent != null)
+            {
+                return Failed("The prepared bandit attack fixture is no longer ready.");
+            }
+
+            if (!objectManager.TryGetId(playerParty, out string playerPartyId) ||
+                !objectManager.TryGetId(playerParty.Party, out string playerPartyBaseId) ||
+                !objectManager.TryGetId(banditParty, out string banditPartyId) ||
+                !objectManager.TryGetId(banditParty.Party, out string banditPartyBaseId))
+            {
+                return Failed("The player and bandit parties must have registered MobileParty and PartyBase ids.");
+            }
+
+            try
+            {
+                StartBattleAction.Apply(banditParty.Party, playerParty.Party);
+                fixture.MapEvent = playerParty.MapEvent;
+                if (fixture.MapEvent == null || banditParty.MapEvent != fixture.MapEvent)
+                    throw new InvalidOperationException("The bandit attack did not create a shared map event.");
+
+                fixture.InvolvedParties = fixture.MapEvent.InvolvedParties.ToArray();
+
+                objectManager.TryGetId(fixture.MapEvent, out string mapEventId);
+                return Succeeded($"Bandit attack fixture started: controller={args[0]}, playerParty={playerPartyId}, " +
+                       $"playerPartyBase={playerPartyBaseId}, banditParty={banditPartyId}, " +
+                       $"banditPartyBase={banditPartyBaseId}, banditStringId={banditParty.StringId}, " +
+                       $"mapEvent={mapEventId ?? "unregistered"}.");
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to start bandit attack fixture");
+                fixture.MapEvent ??= playerParty.MapEvent ?? banditParty.MapEvent;
+                fixture.InvolvedParties ??= fixture.MapEvent?.InvolvedParties.ToArray();
+                if (TryRestoreBanditAttackFixture(fixture, out var restoreError))
+                    banditAttackFixture = null;
+                else
+                    return Failed($"Fixture setup failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.");
+
+                return Failed($"Fixture setup failed: {e.Message}");
+            }
         }
     }
 
     // coop.debug.mapevent.bandit_attack_fixture_state PlayerOne mountain_bandits_24
     /// <summary>Reports the exact bandit attack state on the server or a client.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_state", "coop.debug.mapevent")]
-    public static string GetBanditAttackFixtureState(List<string> args)
+    public sealed class BanditAttackFixtureStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_state <controllerId> <banditPartyId>";
+        public string Prefix => "coop.debug.map_event";
 
-        if (!TryGetPlayerParty(
-                args[0],
-                requireReady: false,
-                out var objectManager,
-                out var playerParty,
-                out var error,
-                allowActiveMapEvent: true))
+        public string Name => "bandit_attack_fixture_state";
+
+        public string Description => "Reports bandit attack fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return error;
-        }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("bandit_party_id", "The bandit party id.", true),
+        };
 
-        if ((!objectManager.TryGetObject(args[1], out MobileParty banditParty) &&
-             !CommandHelpers.TryGetMobileParty(args[1], out banditParty, out error)) ||
-            banditParty == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Unable to resolve bandit party {args[1]}: {error}";
+            if (!TryGetPlayerParty(
+                    args[0],
+                    requireReady: false,
+                    out var objectManager,
+                    out var playerParty,
+                    out var error,
+                    allowActiveMapEvent: true))
+            {
+                return Failed(error);
+            }
+
+            if ((!objectManager.TryGetObject(args[1], out MobileParty banditParty) &&
+                 !CommandHelpers.TryGetMobileParty(args[1], out banditParty, out error)) ||
+                banditParty == null)
+            {
+                return Failed($"Unable to resolve bandit party {args[1]}: {error}");
+            }
+
+            objectManager.TryGetId(playerParty, out string playerPartyId);
+            objectManager.TryGetId(banditParty, out string banditPartyId);
+            objectManager.TryGetId(playerParty.MapEvent, out string playerMapEventId);
+            objectManager.TryGetId(banditParty.MapEvent, out string banditMapEventId);
+
+            return Succeeded($"Bandit attack fixture state: controller={args[0]}, local={playerParty == MobileParty.MainParty}, " +
+                   $"playerParty={playerPartyId ?? "unregistered"}, banditParty={banditPartyId ?? "unregistered"}, " +
+                   $"banditStringId={banditParty.StringId}, playerMapEvent={playerMapEventId ?? "none"}, " +
+                   $"banditMapEvent={banditMapEventId ?? "none"}, " +
+                   $"sharedMapEvent={playerParty.MapEvent != null && playerParty.MapEvent == banditParty.MapEvent}, " +
+                   $"playerSettlement={playerParty.CurrentSettlement?.StringId ?? "none"}, " +
+                   $"banditSettlement={banditParty.CurrentSettlement?.StringId ?? "none"}, " +
+                   $"banditActive={banditParty.IsActive}, banditTroops={banditParty.MemberRoster.TotalManCount}, " +
+                   $"menu={Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "none"}.");
         }
-
-        objectManager.TryGetId(playerParty, out string playerPartyId);
-        objectManager.TryGetId(banditParty, out string banditPartyId);
-        objectManager.TryGetId(playerParty.MapEvent, out string playerMapEventId);
-        objectManager.TryGetId(banditParty.MapEvent, out string banditMapEventId);
-
-        return $"Bandit attack fixture state: controller={args[0]}, local={playerParty == MobileParty.MainParty}, " +
-               $"playerParty={playerPartyId ?? "unregistered"}, banditParty={banditPartyId ?? "unregistered"}, " +
-               $"banditStringId={banditParty.StringId}, playerMapEvent={playerMapEventId ?? "none"}, " +
-               $"banditMapEvent={banditMapEventId ?? "none"}, " +
-               $"sharedMapEvent={playerParty.MapEvent != null && playerParty.MapEvent == banditParty.MapEvent}, " +
-               $"playerSettlement={playerParty.CurrentSettlement?.StringId ?? "none"}, " +
-               $"banditSettlement={banditParty.CurrentSettlement?.StringId ?? "none"}, " +
-               $"banditActive={banditParty.IsActive}, banditTroops={banditParty.MemberRoster.TotalManCount}, " +
-               $"menu={Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "none"}.";
     }
 
     // coop.debug.mapevent.bandit_attack_fixture_restore PlayerOne
     /// <summary>Finalizes the bandit attack and restores both parties' original behavior.</summary>
-    [CommandLineArgumentFunction("bandit_attack_fixture_restore", "coop.debug.mapevent")]
-    public static string RestoreBanditAttackFixture(List<string> args)
+    public sealed class BanditAttackFixtureRestoreCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.bandit_attack_fixture_restore <controllerId>";
+        public string Name => "bandit_attack_fixture_restore";
 
-        if (banditAttackFixture == null || banditAttackFixture.ControllerId != args[0])
-            return $"No active bandit attack fixture exists for {args[0]}.";
+        public string Description => "Restores or clears bandit attack fixture restore.";
 
-        var fixture = banditAttackFixture;
-        if (!TryRestoreBanditAttackFixture(fixture, out var error))
-            return $"Fixture restore failed: {error}. Retry the restore command.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        banditAttackFixture = null;
-        return $"Bandit attack fixture restored: controller={args[0]}, banditStringId={fixture.BanditParty.StringId}.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+
+            if (banditAttackFixture == null || banditAttackFixture.ControllerId != args[0])
+                return Failed($"No active bandit attack fixture exists for {args[0]}.");
+
+            var fixture = banditAttackFixture;
+            if (!TryRestoreBanditAttackFixture(fixture, out var error))
+                return Failed($"Fixture restore failed: {error}. Retry the restore command.");
+
+            banditAttackFixture = null;
+            return Succeeded($"Bandit attack fixture restored: controller={args[0]}, banditStringId={fixture.BanditParty.StringId}.");
+        }
     }
 
     private static bool TryRestoreBanditAttackFixture(BanditAttackFixture fixture, out string error)
@@ -996,566 +1154,670 @@ public class MapEventDebugCommands
         }
     }
 
-    [CommandLineArgumentFunction("finish_non_battle_encounter", "coop.debug.mapevent")]
-    public static string FinishNonBattleEncounter(List<string> args)
+    public sealed class FinishNonBattleEncounterCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.finish_non_battle_encounter";
+        public string Name => "finish_non_battle_encounter";
 
-        if (PlayerEncounter.Current == null)
-            return "No player encounter is active.";
-        if (PlayerEncounter.Battle != null || MobileParty.MainParty?.MapEvent != null)
-            return "Refusing to finish a battle encounter.";
+        public string Description => "Runs the finish non battle encounter debug operation.";
 
-        PlayerEncounter.Finish();
-        return "Finished the current non-battle encounter.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            if (PlayerEncounter.Current == null)
+                return Failed("No player encounter is active.");
+            if (PlayerEncounter.Battle != null || MobileParty.MainParty?.MapEvent != null)
+                return Failed("Refusing to finish a battle encounter.");
+
+            PlayerEncounter.Finish();
+            return Succeeded("Finished the current non-battle encounter.");
+        }
     }
 
-    [CommandLineArgumentFunction("join_existing", "coop.debug.mapevent")]
-    public static string JoinExistingBattle(List<string> args)
+    public sealed class JoinExistingCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 2 ||
-            !Enum.TryParse(args[1], true, out BattleSideEnum side) ||
-            (side != BattleSideEnum.Attacker && side != BattleSideEnum.Defender))
+        public string Name => "join_existing";
+
+        public string Description => "Runs the join existing debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.mapevent.join_existing <mapEventId> <Attacker|Defender>";
-        }
+            new ExpectedArgs("map_event_id", "The map event id.", true),
+            new ExpectedArgs("side", "The battle side.", true),
+        };
 
-        if (!TryGetObjectManager(out var objectManager))
-            return "Unable to resolve ObjectManager";
-        if (!objectManager.TryGetObjectWithLogging<MapEvent>(args[0], out var mapEvent))
-            return $"Unable to resolve map event {args[0]}.";
-        if (mapEvent.IsFinalized || mapEvent.BattleState != BattleState.None)
-            return $"Map event {args[0]} is already concluded.";
-
-        var encounter = PlayerEncounter.Current;
-        if (encounter != null && PlayerEncounter.Battle != mapEvent)
-            return "A player encounter for another map event is already active.";
-
-        if (encounter?.IsJoinedBattle == true)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (encounter.PlayerSide != side)
-                return $"The active encounter already joined the {encounter.PlayerSide} side.";
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
 
-            return $"Started the {side} join encounter for map event {args[0]}.";
+            if (!Enum.TryParse(args[1], true, out BattleSideEnum side) ||
+                (side != BattleSideEnum.Attacker && side != BattleSideEnum.Defender))
+            {
+                return Failed("Invalid command argument value.");
+            }
+
+            if (!TryGetObjectManager(out var objectManager))
+                return Failed("Unable to resolve ObjectManager");
+            if (!objectManager.TryGetObjectWithLogging<MapEvent>(args[0], out var mapEvent))
+                return Failed($"Unable to resolve map event {args[0]}.");
+            if (mapEvent.IsFinalized || mapEvent.BattleState != BattleState.None)
+                return Failed($"Map event {args[0]} is already concluded.");
+
+            var encounter = PlayerEncounter.Current;
+            if (encounter != null && PlayerEncounter.Battle != mapEvent)
+                return Failed("A player encounter for another map event is already active.");
+
+            if (encounter?.IsJoinedBattle == true)
+            {
+                if (encounter.PlayerSide != side)
+                    return Failed($"The active encounter already joined the {encounter.PlayerSide} side.");
+
+                return Succeeded($"Started the {side} join encounter for map event {args[0]}.");
+            }
+
+            var opposingParty = mapEvent.GetLeaderParty(
+                side == BattleSideEnum.Attacker ? BattleSideEnum.Defender : BattleSideEnum.Attacker);
+            if (opposingParty == null)
+                return Failed($"Map event {args[0]} has no opposing leader party.");
+
+            if (encounter == null)
+            {
+                PlayerEncounter.Start();
+                if (side == BattleSideEnum.Attacker)
+                    PlayerEncounter.Current.SetupFields(MobileParty.MainParty.Party, opposingParty);
+                else
+                    PlayerEncounter.Current.SetupFields(opposingParty, MobileParty.MainParty.Party);
+            }
+
+            PlayerEncounter.JoinBattle(side);
+
+            return Succeeded($"Started the {side} join encounter for map event {args[0]}.");
         }
-
-        var opposingParty = mapEvent.GetLeaderParty(
-            side == BattleSideEnum.Attacker ? BattleSideEnum.Defender : BattleSideEnum.Attacker);
-        if (opposingParty == null)
-            return $"Map event {args[0]} has no opposing leader party.";
-
-        if (encounter == null)
-        {
-            PlayerEncounter.Start();
-            if (side == BattleSideEnum.Attacker)
-                PlayerEncounter.Current.SetupFields(MobileParty.MainParty.Party, opposingParty);
-            else
-                PlayerEncounter.Current.SetupFields(opposingParty, MobileParty.MainParty.Party);
-        }
-
-        PlayerEncounter.JoinBattle(side);
-
-        return $"Started the {side} join encounter for map event {args[0]}.";
     }
 
     // coop.debug.mapevent.battle_reward_fixture_prepare testclient testclient2
     /// <summary>Closes the unfinished idle player encounter loaded by the #2308 live-test save.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_prepare", "coop.debug.mapevent")]
-    public static string PrepareBattleRewardFixture(List<string> args)
+    public sealed class BattleRewardFixturePrepareCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_prepare <initiatorControllerId> <lateJoinerControllerId>";
+        public string Name => "battle_reward_fixture_prepare";
 
-        if (args[0] == args[1])
-            return "The initiator and late joiner must be different players.";
+        public string Description => "Runs the battle reward fixture prepare debug operation.";
 
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.TryGetPlayer(args[0], out var initiatorPlayer) ||
-            !playerManager.TryGetPlayer(args[1], out var lateJoinerPlayer) ||
-            !playerManager.IsConnected(initiatorPlayer) ||
-            !playerManager.IsConnected(lateJoinerPlayer))
-            return "Both fixture players must be connected.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("initiator_controller_id", "The initiator controller id.", true),
+            new ExpectedArgs("late_joiner_controller_id", "The late joiner controller id.", true),
+        };
 
-        if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var initiatorParty, out var error))
-            return error;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-        if (!TryGetPlayerParty(args[1], requireReady: false, out _, out var lateJoinerParty, out error))
-            return error;
 
-        var mapEvent = initiatorParty.MapEvent;
-        if (mapEvent == null && lateJoinerParty.MapEvent == null)
-            return "Battle reward fixture preflight is already clean.";
+            if (args[0] == args[1])
+                return Failed("The initiator and late joiner must be different players.");
 
-        if (mapEvent == null || lateJoinerParty.MapEvent != mapEvent)
-            return "The fixture players must share the same saved map event.";
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.TryGetPlayer(args[0], out var initiatorPlayer) ||
+                !playerManager.TryGetPlayer(args[1], out var lateJoinerPlayer) ||
+                !playerManager.IsConnected(initiatorPlayer) ||
+                !playerManager.IsConnected(lateJoinerPlayer))
+                return Failed("Both fixture players must be connected.");
 
-        if (mapEvent.IsFinalized)
-            return "The saved map event is already finalized.";
+            if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var initiatorParty, out var error))
+                return Failed(error);
 
-        if (mapEvent.BattleState != BattleState.None)
-            return $"Refusing to finalize saved map event with battle state {mapEvent.BattleState}.";
+            if (!TryGetPlayerParty(args[1], requireReady: false, out _, out var lateJoinerParty, out error))
+                return Failed(error);
 
-        if (mapEvent.MapEventSettlement != null || mapEvent.BattleObserver != null)
-            return "Refusing to finalize a settlement or active simulation map event.";
+            var mapEvent = initiatorParty.MapEvent;
+            if (mapEvent == null && lateJoinerParty.MapEvent == null)
+                return Failed("Battle reward fixture preflight is already clean.");
 
-        var mapEventId = objectManager.TryGetId(mapEvent, out string resolvedMapEventId)
-            ? resolvedMapEventId
-            : "<unregistered>";
-        mapEvent.FinalizeEvent();
+            if (mapEvent == null || lateJoinerParty.MapEvent != mapEvent)
+                return Failed("The fixture players must share the same saved map event.");
 
-        if (!mapEvent.IsFinalized || initiatorParty.MapEvent != null || lateJoinerParty.MapEvent != null)
-            return $"Saved map event {mapEventId} did not finalize cleanly.";
+            if (mapEvent.IsFinalized)
+                return Failed("The saved map event is already finalized.");
 
-        return $"Battle reward fixture preflight prepared: finalized={mapEventId}, battleState=None.";
+            if (mapEvent.BattleState != BattleState.None)
+                return Failed($"Refusing to finalize saved map event with battle state {mapEvent.BattleState}.");
+
+            if (mapEvent.MapEventSettlement != null || mapEvent.BattleObserver != null)
+                return Failed("Refusing to finalize a settlement or active simulation map event.");
+
+            var mapEventId = objectManager.TryGetId(mapEvent, out string resolvedMapEventId)
+                ? resolvedMapEventId
+                : "<unregistered>";
+            mapEvent.FinalizeEvent();
+
+            if (!mapEvent.IsFinalized || initiatorParty.MapEvent != null || lateJoinerParty.MapEvent != null)
+                return Failed($"Saved map event {mapEventId} did not finalize cleanly.");
+
+            return Succeeded($"Battle reward fixture preflight prepared: finalized={mapEventId}, battleState=None.");
+        }
     }
 
     // coop.debug.mapevent.battle_reward_fixture_start testclient testclient2 army
     /// <summary>Creates the two-player late-join field battle from #2308.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_start", "coop.debug.mapevent")]
-    public static string StartBattleRewardFixture(List<string> args)
+    public sealed class BattleRewardFixtureStartCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        var createArmy = args.Count == 3 && string.Equals(args[2], "army", StringComparison.OrdinalIgnoreCase);
-        if (args.Count != 2 && !createArmy)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_start <initiatorControllerId> <lateJoinerControllerId> [army]";
+        public string Name => "battle_reward_fixture_start";
 
-        if (args[0] == args[1])
-            return "The initiator and late joiner must be different players.";
+        public string Description => "Runs the battle reward fixture start debug operation.";
 
-        if (battleRewardFixture != null)
-            return "A battle reward fixture is already active.";
-
-        if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var initiatorParty, out var error))
-            return error;
-
-        if (!TryGetPlayerParty(args[1], requireReady: true, out _, out var lateJoinerParty, out error))
-            return error;
-
-        if (VillageHostileFactionStanceHelper.HasWarStance(initiatorParty.MapFaction, lateJoinerParty.MapFaction))
-            return "The fixture players must be allied.";
-
-        if (createArmy && (initiatorParty.Army != null || lateJoinerParty.Army != null))
-            return "Both fixture players must be outside an army before starting army mode.";
-
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
-            return "Unable to resolve the mobile-party behavior snapshot service.";
-
-        if (!TryCreateBattleRewardPlayerSnapshot(
-                args[0],
-                objectManager,
-                initiatorParty,
-                behaviorSnapshot,
-                out var initiator,
-                out error))
-            return error;
-
-        if (!TryCreateBattleRewardPlayerSnapshot(
-                args[1],
-                objectManager,
-                lateJoinerParty,
-                behaviorSnapshot,
-                out var lateJoiner,
-                out error))
-            return error;
-
-        var danustica = Settlement.All.FirstOrDefault(settlement => settlement.StringId == "town_ES1");
-        if (danustica == null)
-            return "Danustica (town_ES1) was not found.";
-
-        var referenceBandit = MobileParty.All.FirstOrDefault(party =>
-            party.IsActive &&
-            party.IsBandit &&
-            party.ActualClan != null &&
-            party.PartyComponent is BanditPartyComponent &&
-            party.MemberRoster.TotalManCount > 0);
-        if (referenceBandit == null)
-            return "No active bandit party is available as a fixture template.";
-
-        var banditTroop = referenceBandit.MemberRoster.GetTroopRoster()
-            .Where(element => !element.Character.IsHero)
-            .OrderByDescending(element => element.Number)
-            .Select(element => element.Character)
-            .FirstOrDefault();
-        if (banditTroop == null)
-            return "The bandit fixture template has no regular troop.";
-
-        var fixture = new BattleRewardFixture
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            Initiator = initiator,
-            LateJoiner = lateJoiner,
-            BanditTroop = banditTroop,
+            new ExpectedArgs("initiator_controller_id", "The initiator controller id.", true),
+            new ExpectedArgs("late_joiner_controller_id", "The late joiner controller id.", true),
+            new ExpectedArgs("army", "The army.", false),
         };
-        battleRewardFixture = fixture;
 
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var fixturePosition = new CampaignVec2(
-                new Vec2(danustica.GatePosition.X - 1.5f, danustica.GatePosition.Y),
-                isOnLand: true);
-            fixture.FixturePosition = fixturePosition;
-            PrepareBattleRewardPlayer(initiator, totalTroops: 60, fixturePosition);
-            PrepareBattleRewardPlayer(
-                lateJoiner,
-                totalTroops: 20,
-                new CampaignVec2(new Vec2(fixturePosition.X - 0.2f, fixturePosition.Y), isOnLand: true));
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-            if (createArmy)
+            bool createArmy = args.Count == 3;
+            if (createArmy && !string.Equals(args[2], "army", StringComparison.OrdinalIgnoreCase))
+                return Failed("army must be the literal value 'army' when supplied.");
+
+            if (args[0] == args[1])
+                return Failed("The initiator and late joiner must be different players.");
+
+            if (battleRewardFixture != null)
+                return Failed("A battle reward fixture is already active.");
+
+            if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var initiatorParty, out var error))
+                return Failed(error);
+
+            if (!TryGetPlayerParty(args[1], requireReady: true, out _, out var lateJoinerParty, out error))
+                return Failed(error);
+
+            if (VillageHostileFactionStanceHelper.HasWarStance(initiatorParty.MapFaction, lateJoinerParty.MapFaction))
+                return Failed("The fixture players must be allied.");
+
+            if (createArmy && (initiatorParty.Army != null || lateJoinerParty.Army != null))
+                return Failed("Both fixture players must be outside an army before starting army mode.");
+
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
+                return Failed("Unable to resolve the mobile-party behavior snapshot service.");
+
+            if (!TryCreateBattleRewardPlayerSnapshot(
+                    args[0],
+                    objectManager,
+                    initiatorParty,
+                    behaviorSnapshot,
+                    out var initiator,
+                    out error))
+                return Failed(error);
+
+            if (!TryCreateBattleRewardPlayerSnapshot(
+                    args[1],
+                    objectManager,
+                    lateJoinerParty,
+                    behaviorSnapshot,
+                    out var lateJoiner,
+                    out error))
+                return Failed(error);
+
+            var danustica = Settlement.All.FirstOrDefault(settlement => settlement.StringId == "town_ES1");
+            if (danustica == null)
+                return Failed("Danustica (town_ES1) was not found.");
+
+            var referenceBandit = MobileParty.All.FirstOrDefault(party =>
+                party.IsActive &&
+                party.IsBandit &&
+                party.ActualClan != null &&
+                party.PartyComponent is BanditPartyComponent &&
+                party.MemberRoster.TotalManCount > 0);
+            if (referenceBandit == null)
+                return Failed("No active bandit party is available as a fixture template.");
+
+            var banditTroop = referenceBandit.MemberRoster.GetTroopRoster()
+                .Where(element => !element.Character.IsHero)
+                .OrderByDescending(element => element.Number)
+                .Select(element => element.Character)
+                .FirstOrDefault();
+            if (banditTroop == null)
+                return Failed("The bandit fixture template has no regular troop.");
+
+            var fixture = new BattleRewardFixture
             {
-                var clan = initiator.Hero.Clan;
-                if (clan == null)
-                    throw new InvalidOperationException($"Player {initiator.ControllerId} must belong to a clan for army mode.");
+                Initiator = initiator,
+                LateJoiner = lateJoiner,
+                BanditTroop = banditTroop,
+            };
+            battleRewardFixture = fixture;
 
-                var kingdom = clan.Kingdom;
-                if (kingdom == null)
+            try
+            {
+                var fixturePosition = new CampaignVec2(
+                    new Vec2(danustica.GatePosition.X - 1.5f, danustica.GatePosition.Y),
+                    isOnLand: true);
+                fixture.FixturePosition = fixturePosition;
+                PrepareBattleRewardPlayer(initiator, totalTroops: 60, fixturePosition);
+                PrepareBattleRewardPlayer(
+                    lateJoiner,
+                    totalTroops: 20,
+                    new CampaignVec2(new Vec2(fixturePosition.X - 0.2f, fixturePosition.Y), isOnLand: true));
+
+                if (createArmy)
                 {
-                    kingdom = danustica.MapFaction as Kingdom ?? danustica.OwnerClan?.Kingdom;
-                    if (kingdom == null)
-                        throw new InvalidOperationException("Danustica does not belong to a kingdom for army mode.");
-                    if (!ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState))
-                        throw new InvalidOperationException("Unable to resolve the kingdom membership state service.");
+                    var clan = initiator.Hero.Clan;
+                    if (clan == null)
+                        throw new InvalidOperationException($"Player {initiator.ControllerId} must belong to a clan for army mode.");
 
-                    fixture.InitiatorKingdomChanged = true;
-                    kingdomMembershipState.MoveClanToKingdom(
-                        null,
-                        kingdom,
-                        clan,
-                        publishCollectionChanges: true,
-                        republishExistingCollections: true);
-                    if (clan.Kingdom != kingdom)
-                        throw new InvalidOperationException("The initiator clan was not added to the fixture kingdom.");
+                    var kingdom = clan.Kingdom;
+                    if (kingdom == null)
+                    {
+                        kingdom = danustica.MapFaction as Kingdom ?? danustica.OwnerClan?.Kingdom;
+                        if (kingdom == null)
+                            throw new InvalidOperationException("Danustica does not belong to a kingdom for army mode.");
+                        if (!ContainerProvider.TryResolve<IKingdomMembershipState>(out var kingdomMembershipState))
+                            throw new InvalidOperationException("Unable to resolve the kingdom membership state service.");
+
+                        fixture.InitiatorKingdomChanged = true;
+                        kingdomMembershipState.MoveClanToKingdom(
+                            null,
+                            kingdom,
+                            clan,
+                            publishCollectionChanges: true,
+                            republishExistingCollections: true);
+                        if (clan.Kingdom != kingdom)
+                            throw new InvalidOperationException("The initiator clan was not added to the fixture kingdom.");
+                    }
+
+                    if (initiator.Party.LeaderHero != initiator.Hero)
+                        throw new InvalidOperationException("The fixture initiator must lead its party before creating an army.");
+
+                    fixture.Army = new Army(kingdom, initiator.Party, Army.ArmyTypes.Raider);
+                    fixture.Army.Gather(danustica);
+                    CampaignEventDispatcher.Instance.OnArmyCreated(fixture.Army);
+                    if (fixture.Army == null || fixture.Army.LeaderParty != initiator.Party)
+                        throw new InvalidOperationException("The fixture army was not created with the initiator as its leader.");
+
+                    lateJoiner.Party.Army = fixture.Army;
+                    if (lateJoiner.Party.Army != fixture.Army)
+                        throw new InvalidOperationException("The late joiner was not added to the fixture army.");
                 }
 
-                if (initiator.Party.LeaderHero != initiator.Hero)
-                    throw new InvalidOperationException("The fixture initiator must lead its party before creating an army.");
+                var banditComponent = (BanditPartyComponent)referenceBandit.PartyComponent;
+                fixture.BanditParty = BanditPartyComponent.CreateBanditParty(
+                    $"debug_2308_reward_bandits_{Guid.NewGuid():N}",
+                    referenceBandit.ActualClan,
+                    banditComponent.Hideout,
+                    isBossParty: false,
+                    pt: null,
+                    new CampaignVec2(new Vec2(fixturePosition.X - 0.4f, fixturePosition.Y), isOnLand: true));
+                fixture.BanditParty.MemberRoster.AddToCounts(banditTroop, 30);
+                fixture.BanditParty.PrisonRoster.AddToCounts(banditTroop, 120);
+                fixture.BanditParty.ItemRoster.AddToCounts(DefaultItems.Grain, 600);
+                fixture.BanditParty.SetMoveModeHold();
 
-                fixture.Army = new Army(kingdom, initiator.Party, Army.ArmyTypes.Raider);
-                fixture.Army.Gather(danustica);
-                CampaignEventDispatcher.Instance.OnArmyCreated(fixture.Army);
-                if (fixture.Army == null || fixture.Army.LeaderParty != initiator.Party)
-                    throw new InvalidOperationException("The fixture army was not created with the initiator as its leader.");
+                fixture.MapEvent = MapEventBattleFactory.CreateMapEvent(
+                    fixture.BanditParty.Party,
+                    initiator.Party.Party,
+                    default);
+                if (fixture.MapEvent == null)
+                    throw new InvalidOperationException("The fixture battle did not create a map event.");
 
-                lateJoiner.Party.Army = fixture.Army;
-                if (lateJoiner.Party.Army != fixture.Army)
-                    throw new InvalidOperationException("The late joiner was not added to the fixture army.");
+                fixture.InitiatorMapEventParty = fixture.MapEvent.DefenderSide.Parties
+                    .FirstOrDefault(party => party.Party == initiator.Party.Party);
+                if (fixture.InitiatorMapEventParty == null)
+                    throw new InvalidOperationException("The initiating party was not added to the fixture battle.");
+
+                if (!ContainerProvider.TryResolve<INetwork>(out var network) ||
+                    !objectManager.TryGetId(fixture.BanditParty.Party, out string banditPartyId) ||
+                    !objectManager.TryGetId(initiator.Party.Party, out string initiatorPartyId) ||
+                    !objectManager.TryGetId(fixture.MapEvent, out string mapEventId))
+                {
+                    throw new InvalidOperationException("Unable to resolve the fixture's network ids.");
+                }
+
+                var armyId = "none";
+                if (fixture.Army != null && !objectManager.TryGetId(fixture.Army, out armyId))
+                    throw new InvalidOperationException("Unable to resolve the fixture army's network id.");
+
+                network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
+                    $"debug-2308-initiator-{Guid.NewGuid():N}",
+                    banditPartyId,
+                    initiatorPartyId,
+                    mapEventId));
+
+                return Succeeded($"Battle reward fixture started: mapEvent={mapEventId}, initiator={args[0]}, " +
+                       $"initiatorTroops={initiator.Party.MemberRoster.TotalManCount}, lateJoiner={args[1]}, " +
+                       $"lateJoinerTroops={lateJoiner.Party.MemberRoster.TotalManCount}, " +
+                       $"bandit={fixture.BanditParty.StringId}, banditTroops={fixture.BanditParty.MemberRoster.TotalManCount}, " +
+                       $"army={armyId}, armyMember={lateJoiner.Party.Army == fixture.Army && fixture.Army != null}, " +
+                       $"position={fixturePosition.X:R}|{fixturePosition.Y:R}.");
             }
-
-            var banditComponent = (BanditPartyComponent)referenceBandit.PartyComponent;
-            fixture.BanditParty = BanditPartyComponent.CreateBanditParty(
-                $"debug_2308_reward_bandits_{Guid.NewGuid():N}",
-                referenceBandit.ActualClan,
-                banditComponent.Hideout,
-                isBossParty: false,
-                pt: null,
-                new CampaignVec2(new Vec2(fixturePosition.X - 0.4f, fixturePosition.Y), isOnLand: true));
-            fixture.BanditParty.MemberRoster.AddToCounts(banditTroop, 30);
-            fixture.BanditParty.PrisonRoster.AddToCounts(banditTroop, 120);
-            fixture.BanditParty.ItemRoster.AddToCounts(DefaultItems.Grain, 600);
-            fixture.BanditParty.SetMoveModeHold();
-
-            fixture.MapEvent = MapEventBattleFactory.CreateMapEvent(
-                fixture.BanditParty.Party,
-                initiator.Party.Party,
-                default);
-            if (fixture.MapEvent == null)
-                throw new InvalidOperationException("The fixture battle did not create a map event.");
-
-            fixture.InitiatorMapEventParty = fixture.MapEvent.DefenderSide.Parties
-                .FirstOrDefault(party => party.Party == initiator.Party.Party);
-            if (fixture.InitiatorMapEventParty == null)
-                throw new InvalidOperationException("The initiating party was not added to the fixture battle.");
-
-            if (!ContainerProvider.TryResolve<INetwork>(out var network) ||
-                !objectManager.TryGetId(fixture.BanditParty.Party, out string banditPartyId) ||
-                !objectManager.TryGetId(initiator.Party.Party, out string initiatorPartyId) ||
-                !objectManager.TryGetId(fixture.MapEvent, out string mapEventId))
+            catch (Exception e)
             {
-                throw new InvalidOperationException("Unable to resolve the fixture's network ids.");
+                Logger.Error(e, "Failed to create battle reward fixture");
+                if (createArmy && fixture.Army == null)
+                    fixture.Army = fixture.Initiator.Party.Army;
+                if (TryRestoreBattleRewardFixture(fixture, out var restoreError))
+                    battleRewardFixture = null;
+                else
+                    return Failed($"Fixture setup failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.");
+
+                return Failed($"Fixture setup failed: {e.Message}");
             }
-
-            var armyId = "none";
-            if (fixture.Army != null && !objectManager.TryGetId(fixture.Army, out armyId))
-                throw new InvalidOperationException("Unable to resolve the fixture army's network id.");
-
-            network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
-                $"debug-2308-initiator-{Guid.NewGuid():N}",
-                banditPartyId,
-                initiatorPartyId,
-                mapEventId));
-
-            return $"Battle reward fixture started: mapEvent={mapEventId}, initiator={args[0]}, " +
-                   $"initiatorTroops={initiator.Party.MemberRoster.TotalManCount}, lateJoiner={args[1]}, " +
-                   $"lateJoinerTroops={lateJoiner.Party.MemberRoster.TotalManCount}, " +
-                   $"bandit={fixture.BanditParty.StringId}, banditTroops={fixture.BanditParty.MemberRoster.TotalManCount}, " +
-                   $"army={armyId}, armyMember={lateJoiner.Party.Army == fixture.Army && fixture.Army != null}, " +
-                   $"position={fixturePosition.X:R}|{fixturePosition.Y:R}.";
-        }
-        catch (Exception e)
-        {
-            Logger.Error(e, "Failed to create battle reward fixture");
-            if (createArmy && fixture.Army == null)
-                fixture.Army = fixture.Initiator.Party.Army;
-            if (TryRestoreBattleRewardFixture(fixture, out var restoreError))
-                battleRewardFixture = null;
-            else
-                return $"Fixture setup failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.";
-
-            return $"Fixture setup failed: {e.Message}";
         }
     }
 
-    [CommandLineArgumentFunction("battle_reward_fixture_reinforce", "coop.debug.mapevent")]
-    public static string ReinforceBattleRewardFixture(List<string> args)
+    public sealed class BattleRewardFixtureReinforceCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_reinforce";
+        public string Name => "battle_reward_fixture_reinforce";
 
-        var fixture = battleRewardFixture;
-        if (fixture == null)
-            return "No battle reward fixture is active.";
-        if (fixture.MapEvent.IsFinalized)
-            return "The fixture battle is already finalized.";
-        if (fixture.ReinforcementAdded)
-            return "The fixture reinforcement was already added.";
+        public string Description => "Runs the battle reward fixture reinforce debug operation.";
 
-        var banditSide = fixture.BanditParty?.Party?.MapEventSide;
-        var banditComponent = fixture.BanditParty?.PartyComponent as BanditPartyComponent;
-        if (banditSide == null || banditComponent == null || fixture.BanditTroop == null)
-            return "The fixture bandit side is no longer available.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        fixture.ReinforcementParty = BanditPartyComponent.CreateBanditParty(
-            $"debug_2423_reward_reinforcement_{Guid.NewGuid():N}",
-            fixture.BanditParty.ActualClan,
-            banditComponent.Hideout,
-            isBossParty: false,
-            pt: null,
-            new CampaignVec2(
-                new Vec2(fixture.FixturePosition.X - 0.6f, fixture.FixturePosition.Y),
-                isOnLand: true));
-        fixture.ReinforcementParty.MemberRoster.AddToCounts(fixture.BanditTroop, 12);
-        fixture.ReinforcementParty.SetMoveModeHold();
-        fixture.ReinforcementParty.Party.MapEventSide = banditSide;
-        fixture.ReinforcementAdded = true;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-        return $"Battle reward fixture reinforced: party={fixture.ReinforcementParty.StringId}, " +
-               $"troops={fixture.ReinforcementParty.MemberRoster.TotalManCount}, " +
-               $"enemyParties={banditSide.Parties.Count}.";
+
+            var fixture = battleRewardFixture;
+            if (fixture == null)
+                return Failed("No battle reward fixture is active.");
+            if (fixture.MapEvent.IsFinalized)
+                return Failed("The fixture battle is already finalized.");
+            if (fixture.ReinforcementAdded)
+                return Failed("The fixture reinforcement was already added.");
+
+            var banditSide = fixture.BanditParty?.Party?.MapEventSide;
+            var banditComponent = fixture.BanditParty?.PartyComponent as BanditPartyComponent;
+            if (banditSide == null || banditComponent == null || fixture.BanditTroop == null)
+                return Failed("The fixture bandit side is no longer available.");
+
+            fixture.ReinforcementParty = BanditPartyComponent.CreateBanditParty(
+                $"debug_2423_reward_reinforcement_{Guid.NewGuid():N}",
+                fixture.BanditParty.ActualClan,
+                banditComponent.Hideout,
+                isBossParty: false,
+                pt: null,
+                new CampaignVec2(
+                    new Vec2(fixture.FixturePosition.X - 0.6f, fixture.FixturePosition.Y),
+                    isOnLand: true));
+            fixture.ReinforcementParty.MemberRoster.AddToCounts(fixture.BanditTroop, 12);
+            fixture.ReinforcementParty.SetMoveModeHold();
+            fixture.ReinforcementParty.Party.MapEventSide = banditSide;
+            fixture.ReinforcementAdded = true;
+
+            return Succeeded($"Battle reward fixture reinforced: party={fixture.ReinforcementParty.StringId}, " +
+                   $"troops={fixture.ReinforcementParty.MemberRoster.TotalManCount}, " +
+                   $"enemyParties={banditSide.Parties.Count}.");
+        }
     }
 
     // coop.debug.mapevent.battle_reward_fixture_join
     /// <summary>Adds the second player to the active #2308 battle and opens its encounter.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_join", "coop.debug.mapevent")]
-    public static string JoinBattleRewardFixture(List<string> args)
+    public sealed class BattleRewardFixtureJoinCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_join";
+        public string Name => "battle_reward_fixture_join";
 
-        var fixture = battleRewardFixture;
-        if (fixture == null)
-            return "No battle reward fixture is active.";
+        public string Description => "Runs the battle reward fixture join debug operation.";
 
-        if (fixture.LateJoinerAdded)
-            return $"Late joiner {fixture.LateJoiner.ControllerId} is already in the fixture battle.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        if (fixture.MapEvent.IsFinalized)
-            return "The fixture battle is already finalized.";
-
-        var joiningParty = fixture.LateJoiner.Party.Party;
-        if (joiningParty.MapEventSide != null)
-            return $"Late joiner {fixture.LateJoiner.ControllerId} is already in a map event.";
-
-        var joiningSide = fixture.Initiator.Party.Party.MapEventSide;
-        if (joiningSide == null)
-            return "The initiating party is no longer in the fixture battle.";
-
-        joiningParty.MapEventSide = joiningSide;
-        fixture.LateJoinerMapEventParty = joiningSide.Parties
-            .FirstOrDefault(party => party.Party == joiningParty);
-        if (fixture.LateJoinerMapEventParty == null)
-            return "The late joiner was not added to the fixture battle.";
-
-        if (!TryGetObjectManager(out var objectManager) ||
-            !ContainerProvider.TryResolve<INetwork>(out var network) ||
-            !objectManager.TryGetId(fixture.BanditParty.Party, out string banditPartyId) ||
-            !objectManager.TryGetId(joiningParty, out string joiningPartyId) ||
-            !objectManager.TryGetId(fixture.MapEvent, out string mapEventId))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve the late join encounter ids.";
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+
+            var fixture = battleRewardFixture;
+            if (fixture == null)
+                return Failed("No battle reward fixture is active.");
+
+            if (fixture.LateJoinerAdded)
+                return Failed($"Late joiner {fixture.LateJoiner.ControllerId} is already in the fixture battle.");
+
+            if (fixture.MapEvent.IsFinalized)
+                return Failed("The fixture battle is already finalized.");
+
+            var joiningParty = fixture.LateJoiner.Party.Party;
+            if (joiningParty.MapEventSide != null)
+                return Failed($"Late joiner {fixture.LateJoiner.ControllerId} is already in a map event.");
+
+            var joiningSide = fixture.Initiator.Party.Party.MapEventSide;
+            if (joiningSide == null)
+                return Failed("The initiating party is no longer in the fixture battle.");
+
+            joiningParty.MapEventSide = joiningSide;
+            fixture.LateJoinerMapEventParty = joiningSide.Parties
+                .FirstOrDefault(party => party.Party == joiningParty);
+            if (fixture.LateJoinerMapEventParty == null)
+                return Failed("The late joiner was not added to the fixture battle.");
+
+            if (!TryGetObjectManager(out var objectManager) ||
+                !ContainerProvider.TryResolve<INetwork>(out var network) ||
+                !objectManager.TryGetId(fixture.BanditParty.Party, out string banditPartyId) ||
+                !objectManager.TryGetId(joiningParty, out string joiningPartyId) ||
+                !objectManager.TryGetId(fixture.MapEvent, out string mapEventId))
+            {
+                return Failed("Unable to resolve the late join encounter ids.");
+            }
+
+            fixture.LateJoinerAdded = true;
+            network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
+                $"debug-2308-late-join-{Guid.NewGuid():N}",
+                banditPartyId,
+                joiningPartyId,
+                mapEventId));
+
+            return Succeeded($"Battle reward fixture late join opened: mapEvent={mapEventId}, " +
+                   $"controller={fixture.LateJoiner.ControllerId}, party={fixture.LateJoiner.Party.StringId}.");
         }
-
-        fixture.LateJoinerAdded = true;
-        network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
-            $"debug-2308-late-join-{Guid.NewGuid():N}",
-            banditPartyId,
-            joiningPartyId,
-            mapEventId));
-
-        return $"Battle reward fixture late join opened: mapEvent={mapEventId}, " +
-               $"controller={fixture.LateJoiner.ControllerId}, party={fixture.LateJoiner.Party.StringId}.";
     }
 
-    [CommandLineArgumentFunction("battle_reward_fixture_begin_rout", "coop.debug.mapevent")]
-    public static string BeginBattleRewardFixtureRout(List<string> args)
+    public sealed class BattleRewardFixtureBeginRoutCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_begin_rout";
+        public string Name => "battle_reward_fixture_begin_rout";
 
-        var fixture = battleRewardFixture;
-        if (fixture == null)
-            return "No battle reward fixture is active.";
-        if (fixture.MapEvent.IsFinalized)
-            return "The fixture battle is already finalized.";
-        if (!fixture.LateJoinerAdded)
-            return "Add the late joiner before routing the fixture enemies.";
-        if (!fixture.ReinforcementAdded)
-            return "Add the fixture reinforcement before routing enemies.";
-        if (fixture.PartialRoutIssued)
-            return "The fixture partial rout was already issued.";
-        if (!TryGetObjectManager(out var objectManager) ||
-            !objectManager.TryGetId(fixture.MapEvent, out string mapEventId) ||
-            !ContainerProvider.TryResolve<INetwork>(out var network))
+        public string Description => "Runs the battle reward fixture begin rout debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve the fixture battle network state.";
-        }
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-        fixture.PartialRoutIssued = true;
-        network.SendAll(new NetworkRouteBattleEnemies(mapEventId, enemiesToLeaveFighting: 20));
-        return $"Ordered fixture enemies to retreat while leaving up to 20 fighting: mapEvent={mapEventId}.";
+
+            var fixture = battleRewardFixture;
+            if (fixture == null)
+                return Failed("No battle reward fixture is active.");
+            if (fixture.MapEvent.IsFinalized)
+                return Failed("The fixture battle is already finalized.");
+            if (!fixture.LateJoinerAdded)
+                return Failed("Add the late joiner before routing the fixture enemies.");
+            if (!fixture.ReinforcementAdded)
+                return Failed("Add the fixture reinforcement before routing enemies.");
+            if (fixture.PartialRoutIssued)
+                return Failed("The fixture partial rout was already issued.");
+            if (!TryGetObjectManager(out var objectManager) ||
+                !objectManager.TryGetId(fixture.MapEvent, out string mapEventId) ||
+                !ContainerProvider.TryResolve<INetwork>(out var network))
+            {
+                return Failed("Unable to resolve the fixture battle network state.");
+            }
+
+            fixture.PartialRoutIssued = true;
+            network.SendAll(new NetworkRouteBattleEnemies(mapEventId, enemiesToLeaveFighting: 20));
+            return Succeeded($"Ordered fixture enemies to retreat while leaving up to 20 fighting: mapEvent={mapEventId}.");
+        }
     }
 
-    [CommandLineArgumentFunction("battle_reward_fixture_route_enemies", "coop.debug.mapevent")]
-    public static string RouteBattleRewardFixtureEnemies(List<string> args)
+    public sealed class BattleRewardFixtureRouteEnemiesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_route_enemies";
+        public string Name => "battle_reward_fixture_route_enemies";
 
-        var fixture = battleRewardFixture;
-        if (fixture == null)
-            return "No battle reward fixture is active.";
-        if (fixture.MapEvent.IsFinalized)
-            return "The fixture battle is already finalized.";
-        if (!fixture.PartialRoutIssued)
-            return "Begin the fixture rout before routing the final enemy.";
-        if (fixture.EnemiesRouted)
-            return "The fixture enemies were already ordered to retreat.";
-        if (!TryGetObjectManager(out var objectManager) ||
-            !objectManager.TryGetId(fixture.MapEvent, out string mapEventId) ||
-            !ContainerProvider.TryResolve<INetwork>(out var network))
+        public string Description => "Runs the battle reward fixture route enemies debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve the fixture battle network state.";
-        }
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-        fixture.EnemiesRouted = true;
-        network.SendAll(new NetworkRouteBattleEnemies(mapEventId, enemiesToLeaveFighting: 0));
-        return $"Ordered the battle authority to route fixture enemies: mapEvent={mapEventId}.";
+
+            var fixture = battleRewardFixture;
+            if (fixture == null)
+                return Failed("No battle reward fixture is active.");
+            if (fixture.MapEvent.IsFinalized)
+                return Failed("The fixture battle is already finalized.");
+            if (!fixture.PartialRoutIssued)
+                return Failed("Begin the fixture rout before routing the final enemy.");
+            if (fixture.EnemiesRouted)
+                return Failed("The fixture enemies were already ordered to retreat.");
+            if (!TryGetObjectManager(out var objectManager) ||
+                !objectManager.TryGetId(fixture.MapEvent, out string mapEventId) ||
+                !ContainerProvider.TryResolve<INetwork>(out var network))
+            {
+                return Failed("Unable to resolve the fixture battle network state.");
+            }
+
+            fixture.EnemiesRouted = true;
+            network.SendAll(new NetworkRouteBattleEnemies(mapEventId, enemiesToLeaveFighting: 0));
+            return Succeeded($"Ordered the battle authority to route fixture enemies: mapEvent={mapEventId}.");
+        }
     }
 
     // coop.debug.mapevent.battle_reward_fixture_state
     /// <summary>Reports contributions and roster reward deltas for the active #2308 fixture.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_state", "coop.debug.mapevent")]
-    public static string GetBattleRewardFixtureState(List<string> args)
+    public sealed class BattleRewardFixtureStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_state";
+        public string Name => "battle_reward_fixture_state";
 
-        var fixture = battleRewardFixture;
-        if (fixture == null)
-            return "No battle reward fixture is active.";
+        public string Description => "Reports battle reward fixture state.";
 
-        TryGetObjectManager(out var objectManager);
-        string mapEventId = null;
-        objectManager?.TryGetId(fixture.MapEvent, out mapEventId);
-        string armyId = null;
-        if (fixture.Army != null)
-            objectManager?.TryGetId(fixture.Army, out armyId);
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        return $"Battle reward fixture state: mapEvent={mapEventId ?? "unregistered"}, " +
-               $"finalized={fixture.MapEvent.IsFinalized}, lateJoinerAdded={fixture.LateJoinerAdded}, " +
-               $"reinforcementAdded={fixture.ReinforcementAdded}, partialRoutIssued={fixture.PartialRoutIssued}, " +
-               $"enemiesRouted={fixture.EnemiesRouted}, army={armyId ?? "none"}, " +
-               $"armyLeader={fixture.Army?.LeaderParty?.StringId ?? "none"}, " +
-               $"lateJoinerArmyMember={fixture.Army != null && fixture.LateJoiner.Party.Army == fixture.Army}, " +
-               FormatBattleRewardPlayerState("initiator", fixture.Initiator, fixture.InitiatorMapEventParty) + ", " +
-               FormatBattleRewardPlayerState("lateJoiner", fixture.LateJoiner, fixture.LateJoinerMapEventParty) + ".";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+
+            var fixture = battleRewardFixture;
+            if (fixture == null)
+                return Failed("No battle reward fixture is active.");
+
+            TryGetObjectManager(out var objectManager);
+            string mapEventId = null;
+            objectManager?.TryGetId(fixture.MapEvent, out mapEventId);
+            string armyId = null;
+            if (fixture.Army != null)
+                objectManager?.TryGetId(fixture.Army, out armyId);
+
+            return Succeeded($"Battle reward fixture state: mapEvent={mapEventId ?? "unregistered"}, " +
+                   $"finalized={fixture.MapEvent.IsFinalized}, lateJoinerAdded={fixture.LateJoinerAdded}, " +
+                   $"reinforcementAdded={fixture.ReinforcementAdded}, partialRoutIssued={fixture.PartialRoutIssued}, " +
+                   $"enemiesRouted={fixture.EnemiesRouted}, army={armyId ?? "none"}, " +
+                   $"armyLeader={fixture.Army?.LeaderParty?.StringId ?? "none"}, " +
+                   $"lateJoinerArmyMember={fixture.Army != null && fixture.LateJoiner.Party.Army == fixture.Army}, " +
+                   FormatBattleRewardPlayerState("initiator", fixture.Initiator, fixture.InitiatorMapEventParty) + ", " +
+                   FormatBattleRewardPlayerState("lateJoiner", fixture.LateJoiner, fixture.LateJoinerMapEventParty) + ".");
+        }
     }
 
     // coop.debug.mapevent.battle_reward_client_state
     /// <summary>Reports the local player's staged or already-applied native battle rewards.</summary>
-    [CommandLineArgumentFunction("battle_reward_client_state", "coop.debug.mapevent")]
-    public static string GetBattleRewardClientState(List<string> args)
+    public sealed class BattleRewardClientStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_client_state";
+        public string Name => "battle_reward_client_state";
 
-        var encounter = PlayerEncounter.Current;
-        var mainParty = PartyBase.MainParty;
-        var mainMobileParty = mainParty?.MobileParty;
-        var army = mainMobileParty?.Army;
-        string armyId = null;
-        if (army != null && ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-            objectManager.TryGetId(army, out armyId);
-        return $"Battle reward client state: encounter={encounter != null}, " +
-               $"encounterState={(encounter == null ? "none" : encounter.EncounterState.ToString())}, " +
-               $"activeState={GameStateManager.Current?.ActiveState?.GetType().Name ?? "none"}, " +
-               $"pendingItems={encounter?.RosterToReceiveLootItems.Sum(element => element.Amount) ?? 0}, " +
-               $"pendingMembers={encounter?.RosterToReceiveLootMembers.TotalManCount ?? 0}, " +
-               $"pendingPrisoners={encounter?.RosterToReceiveLootPrisoners.TotalManCount ?? 0}, " +
-               $"partyItems={mainParty?.ItemRoster.Sum(element => element.Amount) ?? 0}, " +
-               $"partyPrisoners={mainParty?.PrisonRoster.TotalManCount ?? 0}, " +
-               $"army={armyId ?? "none"}, armyLeader={army?.LeaderParty?.StringId ?? "none"}, " +
-               $"isArmyLeader={army != null && army.LeaderParty == mainMobileParty}.";
+        public string Description => "Reports battle reward client state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            var encounter = PlayerEncounter.Current;
+            var mainParty = PartyBase.MainParty;
+            var mainMobileParty = mainParty?.MobileParty;
+            var army = mainMobileParty?.Army;
+            string armyId = null;
+            if (army != null && ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+                objectManager.TryGetId(army, out armyId);
+            return Succeeded($"Battle reward client state: encounter={encounter != null}, " +
+                   $"encounterState={(encounter == null ? "none" : encounter.EncounterState.ToString())}, " +
+                   $"activeState={GameStateManager.Current?.ActiveState?.GetType().Name ?? "none"}, " +
+                   $"pendingItems={encounter?.RosterToReceiveLootItems.Sum(element => element.Amount) ?? 0}, " +
+                   $"pendingMembers={encounter?.RosterToReceiveLootMembers.TotalManCount ?? 0}, " +
+                   $"pendingPrisoners={encounter?.RosterToReceiveLootPrisoners.TotalManCount ?? 0}, " +
+                   $"partyItems={mainParty?.ItemRoster.Sum(element => element.Amount) ?? 0}, " +
+                   $"partyPrisoners={mainParty?.PrisonRoster.TotalManCount ?? 0}, " +
+                   $"army={armyId ?? "none"}, armyLeader={army?.LeaderParty?.StringId ?? "none"}, " +
+                   $"isArmyLeader={army != null && army.LeaderParty == mainMobileParty}.");
+        }
     }
 
     // coop.debug.mapevent.battle_reward_fixture_restore
     /// <summary>Finalizes the #2308 battle, removes its bandits, and restores both players.</summary>
-    [CommandLineArgumentFunction("battle_reward_fixture_restore", "coop.debug.mapevent")]
-    public static string RestoreBattleRewardFixture(List<string> args)
+    public sealed class BattleRewardFixtureRestoreCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.battle_reward_fixture_restore";
+        public string Name => "battle_reward_fixture_restore";
 
-        var fixture = battleRewardFixture;
-        if (fixture == null)
-            return "No battle reward fixture is active.";
+        public string Description => "Restores or clears battle reward fixture restore.";
 
-        if (!TryRestoreBattleRewardFixture(fixture, out var error))
-            return $"Fixture restore failed: {error}. Retry the restore command.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        battleRewardFixture = null;
-        return $"Battle reward fixture restored: initiator={fixture.Initiator.ControllerId}, " +
-               $"lateJoiner={fixture.LateJoiner.ControllerId}.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+
+            var fixture = battleRewardFixture;
+            if (fixture == null)
+                return Failed("No battle reward fixture is active.");
+
+            if (!TryRestoreBattleRewardFixture(fixture, out var error))
+                return Failed($"Fixture restore failed: {error}. Retry the restore command.");
+
+            battleRewardFixture = null;
+            return Succeeded($"Battle reward fixture restored: initiator={fixture.Initiator.ControllerId}, " +
+                   $"lateJoiner={fixture.LateJoiner.ControllerId}.");
+        }
     }
 
     private static bool TryCreateBattleRewardPlayerSnapshot(
@@ -1765,182 +2027,214 @@ public class MapEventDebugCommands
 
     // coop.debug.mapevent.wounded_allied_fixture_start PlayerOne
     /// <summary>Creates the wounded, troop-less player plus healthy allied force field encounter from #2097.</summary>
-    [CommandLineArgumentFunction("wounded_allied_fixture_start", "coop.debug.mapevent")]
-    public static string StartWoundedAlliedFixture(List<string> args)
+    public sealed class WoundedAlliedFixtureStartCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.wounded_allied_fixture_start <controllerId>";
+        public string Name => "wounded_allied_fixture_start";
 
-        if (woundedAlliedFixture != null)
-            return $"Fixture already active for {woundedAlliedFixture.ControllerId}.";
+        public string Description => "Runs the wounded allied fixture start debug operation.";
 
-        if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
-            return error;
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.TryGetPlayer(args[0], out var player) ||
-            !objectManager.TryGetObjectWithLogging<Hero>(player.HeroId, out var playerHero))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unable to resolve player hero for {args[0]}.";
-        }
-
-        if (!ContainerProvider.TryResolve<INetwork>(out var network))
-            return "Unable to resolve network.";
-
-        if (playerParty.PartyMoveMode != MoveModeType.Hold)
-            return $"Player party {playerParty.StringId} must be holding before the fixture starts.";
-
-        var playerPosition = playerParty.Position.ToVec2();
-        var banditParty = MobileParty.All
-            .Where(p => p.IsActive && p.IsBandit && p.MapEvent == null && p.CurrentSettlement == null &&
-                        p.MemberRoster.TotalHealthyCount > 0)
-            .OrderBy(p => p.Position.ToVec2().DistanceSquared(playerPosition))
-            .FirstOrDefault();
-        if (banditParty == null)
-            return "No active healthy bandit party is available.";
-
-        var alliedParty = MobileParty.All
-            .Where(p => p.IsActive && !p.IsBandit && !p.IsPlayerParty() && p != playerParty &&
-                        p.MapEvent == null && p.CurrentSettlement == null && p.MemberRoster.TotalHealthyCount > 0 &&
-                        p.MapFaction != null &&
-                        !VillageHostileFactionStanceHelper.HasWarStance(playerParty.MapFaction, p.MapFaction) &&
-                        VillageHostileFactionStanceHelper.HasWarStance(banditParty.MapFaction, p.MapFaction))
-            .OrderBy(p => p.Position.ToVec2().DistanceSquared(playerPosition))
-            .FirstOrDefault();
-        if (alliedParty == null)
-            return "No active healthy AI party is available for the allied side.";
-
-        var fixture = new WoundedAlliedFixture
-        {
-            ControllerId = args[0],
-            PlayerHero = playerHero,
-            PlayerParty = playerParty,
-            OriginalHitPoints = playerHero.HitPoints,
-            OriginalRecentEventsMorale = playerParty.RecentEventsMorale,
-            OriginalRoster = playerParty.MemberRoster.GetTroopRoster().ToArray(),
-            OriginalPosition = playerParty.Position,
+            new ExpectedArgs("controller_id", "The controller id.", true),
         };
 
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            playerHero.HitPoints = 1;
-            RemoveHealthyPlayerTroops(fixture);
-            playerParty.RecentEventsMorale = -1000f;
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-            fixture.MapEvent = MapEventBattleFactory.CreateMapEvent(
-                banditParty.Party,
-                playerParty.Party,
-                default);
-            if (fixture.MapEvent == null)
-                throw new InvalidOperationException("The bandit encounter did not create a map event.");
 
-            alliedParty.Party.MapEventSide = playerParty.Party.MapEventSide;
-            fixture.InvolvedParties = fixture.MapEvent.InvolvedParties.ToArray();
+            if (woundedAlliedFixture != null)
+                return Failed($"Fixture already active for {woundedAlliedFixture.ControllerId}.");
 
-            if (!objectManager.TryGetId(banditParty.Party, out string banditPartyId) ||
-                !objectManager.TryGetId(playerParty.Party, out string playerPartyId) ||
-                !objectManager.TryGetId(fixture.MapEvent, out string fixtureMapEventId))
+            if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
+                return Failed(error);
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.TryGetPlayer(args[0], out var player) ||
+                !objectManager.TryGetObjectWithLogging<Hero>(player.HeroId, out var playerHero))
             {
-                throw new InvalidOperationException("Unable to resolve the fixture's network ids.");
+                return Failed($"Unable to resolve player hero for {args[0]}.");
             }
 
-            network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
-                $"debug-2097-{Guid.NewGuid():N}",
-                banditPartyId,
-                playerPartyId,
-                fixtureMapEventId));
-            woundedAlliedFixture = fixture;
-        }
-        catch (Exception e)
-        {
-            Logger.Error(e, "Failed to create wounded allied force fixture");
-            woundedAlliedFixture = fixture;
-            if (TryRestoreWoundedAlliedFixture(fixture, out var restoreError))
-                woundedAlliedFixture = null;
-            else
-                return $"Fixture setup failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.";
+            if (!ContainerProvider.TryResolve<INetwork>(out var network))
+                return Failed("Unable to resolve network.");
 
-            return $"Fixture setup failed: {e.Message}";
-        }
+            if (playerParty.PartyMoveMode != MoveModeType.Hold)
+                return Failed($"Player party {playerParty.StringId} must be holding before the fixture starts.");
 
-        objectManager.TryGetId(fixture.MapEvent, out string mapEventId);
-        return $"Wounded allied fixture started: controller={args[0]}, mapEvent={mapEventId}, " +
-               $"playerHealthy={playerParty.Party.NumberOfHealthyMembers}, alliedParty={alliedParty.StringId}, " +
-               $"alliedHealthy={alliedParty.Party.NumberOfHealthyMembers}, banditParty={banditParty.StringId}.";
+            var playerPosition = playerParty.Position.ToVec2();
+            var banditParty = MobileParty.All
+                .Where(p => p.IsActive && p.IsBandit && p.MapEvent == null && p.CurrentSettlement == null &&
+                            p.MemberRoster.TotalHealthyCount > 0)
+                .OrderBy(p => p.Position.ToVec2().DistanceSquared(playerPosition))
+                .FirstOrDefault();
+            if (banditParty == null)
+                return Failed("No active healthy bandit party is available.");
+
+            var alliedParty = MobileParty.All
+                .Where(p => p.IsActive && !p.IsBandit && !p.IsPlayerParty() && p != playerParty &&
+                            p.MapEvent == null && p.CurrentSettlement == null && p.MemberRoster.TotalHealthyCount > 0 &&
+                            p.MapFaction != null &&
+                            !VillageHostileFactionStanceHelper.HasWarStance(playerParty.MapFaction, p.MapFaction) &&
+                            VillageHostileFactionStanceHelper.HasWarStance(banditParty.MapFaction, p.MapFaction))
+                .OrderBy(p => p.Position.ToVec2().DistanceSquared(playerPosition))
+                .FirstOrDefault();
+            if (alliedParty == null)
+                return Failed("No active healthy AI party is available for the allied side.");
+
+            var fixture = new WoundedAlliedFixture
+            {
+                ControllerId = args[0],
+                PlayerHero = playerHero,
+                PlayerParty = playerParty,
+                OriginalHitPoints = playerHero.HitPoints,
+                OriginalRecentEventsMorale = playerParty.RecentEventsMorale,
+                OriginalRoster = playerParty.MemberRoster.GetTroopRoster().ToArray(),
+                OriginalPosition = playerParty.Position,
+            };
+
+            try
+            {
+                playerHero.HitPoints = 1;
+                RemoveHealthyPlayerTroops(fixture);
+                playerParty.RecentEventsMorale = -1000f;
+
+                fixture.MapEvent = MapEventBattleFactory.CreateMapEvent(
+                    banditParty.Party,
+                    playerParty.Party,
+                    default);
+                if (fixture.MapEvent == null)
+                    throw new InvalidOperationException("The bandit encounter did not create a map event.");
+
+                alliedParty.Party.MapEventSide = playerParty.Party.MapEventSide;
+                fixture.InvolvedParties = fixture.MapEvent.InvolvedParties.ToArray();
+
+                if (!objectManager.TryGetId(banditParty.Party, out string banditPartyId) ||
+                    !objectManager.TryGetId(playerParty.Party, out string playerPartyId) ||
+                    !objectManager.TryGetId(fixture.MapEvent, out string fixtureMapEventId))
+                {
+                    throw new InvalidOperationException("Unable to resolve the fixture's network ids.");
+                }
+
+                network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
+                    $"debug-2097-{Guid.NewGuid():N}",
+                    banditPartyId,
+                    playerPartyId,
+                    fixtureMapEventId));
+                woundedAlliedFixture = fixture;
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to create wounded allied force fixture");
+                woundedAlliedFixture = fixture;
+                if (TryRestoreWoundedAlliedFixture(fixture, out var restoreError))
+                    woundedAlliedFixture = null;
+                else
+                    return Failed($"Fixture setup failed: {e.Message}. Cleanup failed: {restoreError}. Run the restore command.");
+
+                return Failed($"Fixture setup failed: {e.Message}");
+            }
+
+            objectManager.TryGetId(fixture.MapEvent, out string mapEventId);
+            return Succeeded($"Wounded allied fixture started: controller={args[0]}, mapEvent={mapEventId}, " +
+                   $"playerHealthy={playerParty.Party.NumberOfHealthyMembers}, alliedParty={alliedParty.StringId}, " +
+                   $"alliedHealthy={alliedParty.Party.NumberOfHealthyMembers}, banditParty={banditParty.StringId}.");
+        }
     }
 
     // coop.debug.mapevent.wounded_allied_fixture_state PlayerOne
     /// <summary>Reports the #2097 fixture state and the local patched order-attack option when applicable.</summary>
-    [CommandLineArgumentFunction("wounded_allied_fixture_state", "coop.debug.mapevent")]
-    public static string GetWoundedAlliedFixtureState(List<string> args)
+    public sealed class WoundedAlliedFixtureStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.wounded_allied_fixture_state <controllerId>";
+        public string Prefix => "coop.debug.map_event";
 
-        if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
-            return error;
+        public string Name => "wounded_allied_fixture_state";
 
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.TryGetPlayer(args[0], out var player) ||
-            !objectManager.TryGetObjectWithLogging<Hero>(player.HeroId, out var playerHero))
+        public string Description => "Reports wounded allied fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unable to resolve player hero for {args[0]}.";
-        }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        var mapEvent = playerParty.MapEvent;
-        var side = playerParty.Party.MapEventSide;
-        var alliedHealthy = side?.Parties
-            .Where(p => p.Party != playerParty.Party)
-            .Sum(p => p.Party.NumberOfHealthyMembers) ?? 0;
-
-        var option = "not-local";
-        if (ModInformation.IsClient && playerParty == MobileParty.MainParty && PlayerEncounter.Current != null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var callbackArgs = new MenuCallbackArgs((MenuContext)null, null);
-            var shown = new EncounterGameMenuBehavior()
-                .game_menu_encounter_order_attack_on_condition(callbackArgs);
-            var renderedOption = Campaign.Current?.CurrentMenuContext?.GameMenu?.MenuOptions
-                .FirstOrDefault(menuOption => menuOption.IdString == "str_order_attack");
-            option = $"conditionShown={shown},conditionEnabled={callbackArgs.IsEnabled}," +
-                     $"leaveType={callbackArgs.optionLeaveType},renderedRegistered={renderedOption != null}," +
-                     $"renderedEnabled={renderedOption?.IsEnabled ?? false}";
-        }
+            if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
+                return Failed(error);
 
-        objectManager.TryGetId(mapEvent, out string mapEventId);
-        return $"Wounded allied fixture state: controller={args[0]}, local={playerParty == MobileParty.MainParty}, " +
-               $"hitPoints={playerHero.HitPoints}, wounded={playerHero.IsWounded}, " +
-               $"roster={playerParty.MemberRoster.TotalManCount}, playerHealthy={playerParty.Party.NumberOfHealthyMembers}, " +
-               $"morale={playerParty.Morale:0.##}, recentEventsMorale={playerParty.RecentEventsMorale:0.##}, " +
-               $"position={playerParty.Position.X:R}|{playerParty.Position.Y:R}, moveMode={playerParty.PartyMoveMode}, " +
-               $"alliedHealthy={alliedHealthy}, mapEvent={mapEventId ?? "none"}, " +
-               $"menu={Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "none"}, option={option}.";
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.TryGetPlayer(args[0], out var player) ||
+                !objectManager.TryGetObjectWithLogging<Hero>(player.HeroId, out var playerHero))
+            {
+                return Failed($"Unable to resolve player hero for {args[0]}.");
+            }
+
+            var mapEvent = playerParty.MapEvent;
+            var side = playerParty.Party.MapEventSide;
+            var alliedHealthy = side?.Parties
+                .Where(p => p.Party != playerParty.Party)
+                .Sum(p => p.Party.NumberOfHealthyMembers) ?? 0;
+
+            var option = "not-local";
+            if (ModInformation.IsClient && playerParty == MobileParty.MainParty && PlayerEncounter.Current != null)
+            {
+                var callbackArgs = new MenuCallbackArgs((MenuContext)null, null);
+                var shown = new EncounterGameMenuBehavior()
+                    .game_menu_encounter_order_attack_on_condition(callbackArgs);
+                var renderedOption = Campaign.Current?.CurrentMenuContext?.GameMenu?.MenuOptions
+                    .FirstOrDefault(menuOption => menuOption.IdString == "str_order_attack");
+                option = $"conditionShown={shown},conditionEnabled={callbackArgs.IsEnabled}," +
+                         $"leaveType={callbackArgs.optionLeaveType},renderedRegistered={renderedOption != null}," +
+                         $"renderedEnabled={renderedOption?.IsEnabled ?? false}";
+            }
+
+            objectManager.TryGetId(mapEvent, out string mapEventId);
+            return Succeeded($"Wounded allied fixture state: controller={args[0]}, local={playerParty == MobileParty.MainParty}, " +
+                   $"hitPoints={playerHero.HitPoints}, wounded={playerHero.IsWounded}, " +
+                   $"roster={playerParty.MemberRoster.TotalManCount}, playerHealthy={playerParty.Party.NumberOfHealthyMembers}, " +
+                   $"morale={playerParty.Morale:0.##}, recentEventsMorale={playerParty.RecentEventsMorale:0.##}, " +
+                   $"position={playerParty.Position.X:R}|{playerParty.Position.Y:R}, moveMode={playerParty.PartyMoveMode}, " +
+                   $"alliedHealthy={alliedHealthy}, mapEvent={mapEventId ?? "none"}, " +
+                   $"menu={Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "none"}, option={option}.");
+        }
     }
 
     // coop.debug.mapevent.wounded_allied_fixture_restore PlayerOne
     /// <summary>Finalizes the #2097 fixture and restores the player's original hero, morale, and roster state.</summary>
-    [CommandLineArgumentFunction("wounded_allied_fixture_restore", "coop.debug.mapevent")]
-    public static string RestoreWoundedAlliedFixture(List<string> args)
+    public sealed class WoundedAlliedFixtureRestoreCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.wounded_allied_fixture_restore <controllerId>";
+        public string Name => "wounded_allied_fixture_restore";
 
-        if (woundedAlliedFixture == null || woundedAlliedFixture.ControllerId != args[0])
-            return $"No active fixture exists for {args[0]}.";
+        public string Description => "Restores or clears wounded allied fixture restore.";
 
-        var fixture = woundedAlliedFixture;
-        if (!TryRestoreWoundedAlliedFixture(fixture, out var error))
-            return $"Fixture restore failed: {error}. Retry the restore command.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        woundedAlliedFixture = null;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
 
-        return $"Wounded allied fixture restored: controller={args[0]}, hitPoints={fixture.PlayerHero.HitPoints}, " +
-               $"roster={fixture.PlayerParty.MemberRoster.TotalManCount}.";
+
+            if (woundedAlliedFixture == null || woundedAlliedFixture.ControllerId != args[0])
+                return Failed($"No active fixture exists for {args[0]}.");
+
+            var fixture = woundedAlliedFixture;
+            if (!TryRestoreWoundedAlliedFixture(fixture, out var error))
+                return Failed($"Fixture restore failed: {error}. Retry the restore command.");
+
+            woundedAlliedFixture = null;
+
+            return Succeeded($"Wounded allied fixture restored: controller={args[0]}, hitPoints={fixture.PlayerHero.HitPoints}, " +
+                   $"roster={fixture.PlayerParty.MemberRoster.TotalManCount}.");
+        }
     }
 
     private static void RemoveHealthyPlayerTroops(WoundedAlliedFixture fixture)
@@ -2049,137 +2343,182 @@ public class MapEventDebugCommands
         }
     }
 
-    [CommandLineArgumentFunction("leave_settlement", "coop.debug.mapevent")]
-    public static string LeaveSettlement(List<string> args)
+    public sealed class LeaveSettlementCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.leave_settlement <controllerId>";
+        public string Name => "leave_settlement";
 
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
-            return "Unable to resolve PlayerManager";
+        public string Description => "Runs the leave settlement debug operation.";
 
-        if (!playerManager.TryGetPlayer(args[0], out var player))
-            return $"No registered player has controller id {args[0]}.";
-
-        if (!playerManager.IsConnected(player))
-            return $"Player {args[0]} is not connected.";
-
-        if (!TryGetObjectManager(out var objectManager) ||
-            !objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
-            return $"Unable to resolve player party {player.MobilePartyId}.";
-
-        var settlement = playerParty.CurrentSettlement;
-        if (settlement == null)
-            return $"Player {args[0]} is already outside a settlement.";
-
-        LeaveSettlementAction.ApplyForParty(playerParty);
-        return $"Moved player {args[0]} out of {settlement.Name}.";
-    }
-
-    [CommandLineArgumentFunction("finish_current_encounter", "coop.debug.mapevent")]
-    public static string FinishCurrentEncounter(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.finish_current_encounter";
-
-        if (PlayerEncounter.Current == null)
-            return "No active encounter.";
-
-        PlayerEncounter.Finish();
-        return "Finished the current local encounter.";
-    }
-
-    [CommandLineArgumentFunction("enter_current_battle", "coop.debug.mapevent")]
-    public static string EnterCurrentBattle(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.enter_current_battle";
-
-        if (PlayerEncounter.Current == null)
-            return "No active encounter.";
-
-        if (PlayerEncounter.Battle == null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (PlayerEncounter.StartBattle() == null)
-                return "Unable to start the current battle.";
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-            GameMenu.SwitchToMenu("encounter");
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+                return Failed("Unable to resolve PlayerManager");
+
+            if (!playerManager.TryGetPlayer(args[0], out var player))
+                return Failed($"No registered player has controller id {args[0]}.");
+
+            if (!playerManager.IsConnected(player))
+                return Failed($"Player {args[0]} is not connected.");
+
+            if (!TryGetObjectManager(out var objectManager) ||
+                !objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
+                return Failed($"Unable to resolve player party {player.MobilePartyId}.");
+
+            var settlement = playerParty.CurrentSettlement;
+            if (settlement == null)
+                return Failed($"Player {args[0]} is already outside a settlement.");
+
+            LeaveSettlementAction.ApplyForParty(playerParty);
+            return Succeeded($"Moved player {args[0]} out of {settlement.Name}.");
         }
+    }
 
-        var startResult = StartAttackMission(args);
-        if (!startResult.StartsWith("Starting attack mission for ", StringComparison.Ordinal))
-            return startResult;
+    public sealed class FinishCurrentEncounterCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
 
-        return "Requested entry into the current battle.";
+        public string Name => "finish_current_encounter";
+
+        public string Description => "Runs the finish current encounter debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            if (PlayerEncounter.Current == null)
+                return Failed("No active encounter.");
+
+            PlayerEncounter.Finish();
+            return Succeeded("Finished the current local encounter.");
+        }
+    }
+
+    public sealed class EnterCurrentBattleCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "enter_current_battle";
+
+        public string Description => "Runs the enter current battle debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            if (PlayerEncounter.Current == null)
+                return Failed("No active encounter.");
+
+            if (PlayerEncounter.Battle == null)
+            {
+                if (PlayerEncounter.StartBattle() == null)
+                    return Failed("Unable to start the current battle.");
+
+                GameMenu.SwitchToMenu("encounter");
+            }
+
+            CoopCommandResult startResult = StartAttackMissionCore(args);
+            if (!startResult.Succeeded)
+                return startResult;
+
+            return Succeeded("Requested entry into the current battle.");
+        }
     }
 
     // coop.debug.mapevent.finish_player_encounter PlayerOne
     /// <summary>
     /// Closes the connected player's encounter through the existing authoritative leave path.
     /// </summary>
-    [CommandLineArgumentFunction("finish_player_encounter", "coop.debug.mapevent")]
-    public static string FinishPlayerEncounter(List<string> args)
+    public sealed class FinishPlayerEncounterCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "Run this command on the server.";
-        }
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.mapevent.finish_player_encounter <controllerId>";
-        }
+        public string Name => "finish_player_encounter";
 
-        if (!TryGetPlayerParty(
-                args[0],
-                requireReady: true,
-                out var objectManager,
-                out var playerParty,
-                out var error,
-                allowActiveMapEvent: true))
-        {
-            return error;
-        }
+        public string Description => "Runs the finish player encounter debug operation.";
 
-        if (!objectManager.TryGetIdWithLogging(playerParty.Party, out var partyBaseId))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unable to resolve PartyBase for player {args[0]}.";
-        }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        MessageBroker.Instance.Publish(
-            playerParty.Party,
-            new PlayerLeaveBattleAttempted(playerParty.Party));
-        return $"Requested encounter finish for player {args[0]} (PartyBase id {partyBaseId}).";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+            {
+                return Failed("Run this command on the server.");
+            }
+
+
+            if (!TryGetPlayerParty(
+                    args[0],
+                    requireReady: true,
+                    out var objectManager,
+                    out var playerParty,
+                    out var error,
+                    allowActiveMapEvent: true))
+            {
+                return Failed(error);
+            }
+
+            if (!objectManager.TryGetIdWithLogging(playerParty.Party, out var partyBaseId))
+            {
+                return Failed($"Unable to resolve PartyBase for player {args[0]}.");
+            }
+
+            MessageBroker.Instance.Publish(
+                playerParty.Party,
+                new PlayerLeaveBattleAttempted(playerParty.Party));
+            return Succeeded($"Requested encounter finish for player {args[0]} (PartyBase id {partyBaseId}).");
+        }
     }
 
     // coop.debug.mapevent.conversation_hold_state <partyBaseId>
     /// <summary>
     /// Reports whether the server currently holds an AI PartyBase for a conversation.
     /// </summary>
-    [CommandLineArgumentFunction("conversation_hold_state", "coop.debug.mapevent")]
-    public static string ConversationHoldState(List<string> args)
+    public sealed class ConversationHoldStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "Run this command on the server.";
-        }
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.mapevent.conversation_hold_state <partyBaseId>";
-        }
+        public string Name => "conversation_hold_state";
 
-        var held = ConversationPartyTracker.Instance?.TryGetEngagement(args[0], out _) == true;
-        return $"Conversation hold for PartyBase id {args[0]}: {(held ? "held" : "released")}.";
+        public string Description => "Reports conversation hold state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_base_id", "The party base id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+            {
+                return Failed("Run this command on the server.");
+            }
+
+
+            var held = ConversationPartyTracker.Instance?.TryGetEngagement(args[0], out _) == true;
+            return Succeeded($"Conversation hold for PartyBase id {args[0]}: {(held ? "held" : "released")}.");
+        }
     }
 
     // coop.debug.mapevent.late_join_mode_fixture PlayerOne PlayerTwo
@@ -2187,286 +2526,328 @@ public class MapEventDebugCommands
     /// Creates a server-authoritative battle, claims mission mode before the second player joins, then routes the
     /// second player's join through the real request handler.
     /// </summary>
-    [CommandLineArgumentFunction("late_join_mode_fixture", "coop.debug.mapevent")]
-    public static string StartLateJoinModeFixture(List<string> args)
+    public sealed class LateJoinModeFixtureCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "late_join_mode_fixture";
+
+        public string Description => "Runs the late join mode fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Run this command on the server.";
-        }
-
-        if (args.Count != 2)
-        {
-            return "Usage: coop.debug.mapevent.late_join_mode_fixture <firstControllerId> <joiningControllerId>";
-        }
-
-        if (lateJoinModeFixture != null)
-        {
-            return $"A late-join mode fixture is already active for map event {lateJoinModeFixture.MapEventId}.";
-        }
-
-        if (args[0] == args[1])
-        {
-            return "The fixture requires two different connected players.";
-        }
-
-        if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var firstParty, out var error))
-        {
-            return error;
-        }
-
-        if (!TryGetPlayerParty(args[1], requireReady: true, out _, out var joiningParty, out error))
-        {
-            return error;
-        }
-
-        if (firstParty.CurrentSettlement != null || joiningParty.CurrentSettlement != null)
-        {
-            return "Both players must be on the campaign map, outside settlements.";
-        }
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.TryGetPeer(args[0], out var firstPeer) ||
-            !playerManager.TryGetPeer(args[1], out _))
-        {
-            return "Unable to resolve both connected player peers.";
-        }
-
-        if (!ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
-            !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
-        {
-            return "Unable to resolve the late-join mode fixture services.";
-        }
-
-        if (!behaviorSnapshot.TryCreate(firstParty, out var firstPlayerBehavior) ||
-            !behaviorSnapshot.TryCreate(joiningParty, out var joiningPlayerBehavior))
-        {
-            return "Unable to capture both players' original movement state.";
-        }
-
-        var firstFaction = firstParty.MapFaction?.MapFaction ?? firstParty.MapFaction;
-        var joiningFaction = joiningParty.MapFaction?.MapFaction ?? joiningParty.MapFaction;
-        var firstPosition = firstParty.Position.ToVec2();
-        var opponentParty = MobileParty.All
-            .Where(p => p.IsActive && p.IsBandit && p.MapEvent == null && p.CurrentSettlement == null &&
-                        p.MemberRoster.TotalHealthyCount > 0 && p.MapFaction != null &&
-                        VillageHostileFactionStanceHelper.HasWarStance(firstFaction, p.MapFaction) &&
-                        VillageHostileFactionStanceHelper.HasWarStance(joiningFaction, p.MapFaction))
-            .OrderBy(p => p.Position.ToVec2().DistanceSquared(firstPosition))
-            .FirstOrDefault();
-
-        if (opponentParty == null)
-        {
-            return "No active healthy bandit party hostile to both players was found.";
-        }
-
-        if (!behaviorSnapshot.TryCreate(opponentParty, out var opponentBehavior))
-        {
-            return $"Unable to capture the opponent movement state for {opponentParty.Name}.";
-        }
-
-        if (!objectManager.TryGetId(firstParty.Party, out string firstPartyId) ||
-            !objectManager.TryGetId(firstParty, out string firstMobilePartyId) ||
-            !objectManager.TryGetId(joiningParty.Party, out string joiningPartyId) ||
-            !objectManager.TryGetId(joiningParty, out string joiningMobilePartyId) ||
-            !objectManager.TryGetId(opponentParty, out string opponentMobilePartyId))
-        {
-            return "Unable to resolve fixture party ids.";
-        }
-
-        var mapEvent = MapEventBattleFactory.CreateMapEvent(firstParty.Party, opponentParty.Party, default);
-        if (mapEvent == null || !objectManager.TryGetId(mapEvent, out string mapEventId))
-        {
-            if (mapEvent != null && !mapEvent.IsFinalized)
-                mapEvent.FinalizeEvent();
-
-            RestorePartyBehavior(firstParty, firstPlayerBehavior, behaviorSnapshot);
-            RestorePartyBehavior(joiningParty, joiningPlayerBehavior, behaviorSnapshot);
-            RestorePartyBehavior(opponentParty, opponentBehavior, behaviorSnapshot);
-            return "Unable to create or resolve the fixture map event.";
-        }
-
-        lateJoinModeFixture = new LateJoinModeFixture
-        {
-            MapEventId = mapEventId,
-            FirstControllerId = args[0],
-            FirstPlayerPartyId = firstPartyId,
-            FirstPlayerMobilePartyId = firstMobilePartyId,
-            FirstPlayerBehavior = firstPlayerBehavior,
-            JoiningControllerId = args[1],
-            JoiningPlayerPartyId = joiningPartyId,
-            JoiningPlayerMobilePartyId = joiningMobilePartyId,
-            JoiningPlayerBehavior = joiningPlayerBehavior,
-            OpponentMobilePartyId = opponentMobilePartyId,
-            OpponentBehavior = opponentBehavior,
+            new ExpectedArgs("first_controller_id", "The first controller id.", true),
+            new ExpectedArgs("joining_controller_id", "The joining controller id.", true),
         };
 
-        var hasFieldBattleOpponent = mapEvent.EventType == MapEvent.BattleTypes.FieldBattle &&
-                                     mapEvent.MapEventSettlement == null &&
-                                     mapEvent.DefenderSide?.Parties.Any(
-                                         p => p.Party == opponentParty.Party) == true;
-        if (!hasFieldBattleOpponent)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            CleanupLateJoinModeFixture(messageBroker, behaviorSnapshot, objectManager);
-            return $"Late-join fixture {mapEventId} did not create the required field battle.";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Run this command on the server.");
+            }
+
+
+            if (lateJoinModeFixture != null)
+            {
+                return Failed($"A late-join mode fixture is already active for map event {lateJoinModeFixture.MapEventId}.");
+            }
+
+            if (args[0] == args[1])
+            {
+                return Failed("The fixture requires two different connected players.");
+            }
+
+            if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var firstParty, out var error))
+            {
+                return Failed(error);
+            }
+
+            if (!TryGetPlayerParty(args[1], requireReady: true, out _, out var joiningParty, out error))
+            {
+                return Failed(error);
+            }
+
+            if (firstParty.CurrentSettlement != null || joiningParty.CurrentSettlement != null)
+            {
+                return Failed("Both players must be on the campaign map, outside settlements.");
+            }
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.TryGetPeer(args[0], out var firstPeer) ||
+                !playerManager.TryGetPeer(args[1], out _))
+            {
+                return Failed("Unable to resolve both connected player peers.");
+            }
+
+            if (!ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
+                !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
+            {
+                return Failed("Unable to resolve the late-join mode fixture services.");
+            }
+
+            if (!behaviorSnapshot.TryCreate(firstParty, out var firstPlayerBehavior) ||
+                !behaviorSnapshot.TryCreate(joiningParty, out var joiningPlayerBehavior))
+            {
+                return Failed("Unable to capture both players' original movement state.");
+            }
+
+            var firstFaction = firstParty.MapFaction?.MapFaction ?? firstParty.MapFaction;
+            var joiningFaction = joiningParty.MapFaction?.MapFaction ?? joiningParty.MapFaction;
+            var firstPosition = firstParty.Position.ToVec2();
+            var opponentParty = MobileParty.All
+                .Where(p => p.IsActive && p.IsBandit && p.MapEvent == null && p.CurrentSettlement == null &&
+                            p.MemberRoster.TotalHealthyCount > 0 && p.MapFaction != null &&
+                            VillageHostileFactionStanceHelper.HasWarStance(firstFaction, p.MapFaction) &&
+                            VillageHostileFactionStanceHelper.HasWarStance(joiningFaction, p.MapFaction))
+                .OrderBy(p => p.Position.ToVec2().DistanceSquared(firstPosition))
+                .FirstOrDefault();
+
+            if (opponentParty == null)
+            {
+                return Failed("No active healthy bandit party hostile to both players was found.");
+            }
+
+            if (!behaviorSnapshot.TryCreate(opponentParty, out var opponentBehavior))
+            {
+                return Failed($"Unable to capture the opponent movement state for {opponentParty.Name}.");
+            }
+
+            if (!objectManager.TryGetId(firstParty.Party, out string firstPartyId) ||
+                !objectManager.TryGetId(firstParty, out string firstMobilePartyId) ||
+                !objectManager.TryGetId(joiningParty.Party, out string joiningPartyId) ||
+                !objectManager.TryGetId(joiningParty, out string joiningMobilePartyId) ||
+                !objectManager.TryGetId(opponentParty, out string opponentMobilePartyId))
+            {
+                return Failed("Unable to resolve fixture party ids.");
+            }
+
+            var mapEvent = MapEventBattleFactory.CreateMapEvent(firstParty.Party, opponentParty.Party, default);
+            if (mapEvent == null || !objectManager.TryGetId(mapEvent, out string mapEventId))
+            {
+                if (mapEvent != null && !mapEvent.IsFinalized)
+                    mapEvent.FinalizeEvent();
+
+                RestorePartyBehavior(firstParty, firstPlayerBehavior, behaviorSnapshot);
+                RestorePartyBehavior(joiningParty, joiningPlayerBehavior, behaviorSnapshot);
+                RestorePartyBehavior(opponentParty, opponentBehavior, behaviorSnapshot);
+                return Failed("Unable to create or resolve the fixture map event.");
+            }
+
+            lateJoinModeFixture = new LateJoinModeFixture
+            {
+                MapEventId = mapEventId,
+                FirstControllerId = args[0],
+                FirstPlayerPartyId = firstPartyId,
+                FirstPlayerMobilePartyId = firstMobilePartyId,
+                FirstPlayerBehavior = firstPlayerBehavior,
+                JoiningControllerId = args[1],
+                JoiningPlayerPartyId = joiningPartyId,
+                JoiningPlayerMobilePartyId = joiningMobilePartyId,
+                JoiningPlayerBehavior = joiningPlayerBehavior,
+                OpponentMobilePartyId = opponentMobilePartyId,
+                OpponentBehavior = opponentBehavior,
+            };
+
+            var hasFieldBattleOpponent = mapEvent.EventType == MapEvent.BattleTypes.FieldBattle &&
+                                         mapEvent.MapEventSettlement == null &&
+                                         mapEvent.DefenderSide?.Parties.Any(
+                                             p => p.Party == opponentParty.Party) == true;
+            if (!hasFieldBattleOpponent)
+            {
+                CleanupLateJoinModeFixture(messageBroker, behaviorSnapshot, objectManager);
+                return Failed($"Late-join fixture {mapEventId} did not create the required field battle.");
+            }
+
+            // Route the first player's Attack through the real server handler. The resulting mission-start and mode
+            // broadcasts reach PlayerTwo before its party belongs to the event, reproducing the missed-claim timing.
+            messageBroker.Publish(firstPeer, new NetworkBattleStartRequest(
+                Guid.NewGuid().ToString(),
+                (int)BattleStartMode.Mission,
+                mapEventId,
+                firstMobilePartyId));
+
+            return Succeeded($"Late-join field-battle fixture created and first mission requested: mapEvent={mapEventId}, " +
+                   $"eventType={mapEvent.EventType}, opponent={opponentParty.Name} ({opponentParty.StringId}), " +
+                   $"firstPlayer={args[0]}, joiningPlayer={args[1]}, firstSide=Attacker.");
         }
-
-        // Route the first player's Attack through the real server handler. The resulting mission-start and mode
-        // broadcasts reach PlayerTwo before its party belongs to the event, reproducing the missed-claim timing.
-        messageBroker.Publish(firstPeer, new NetworkBattleStartRequest(
-            Guid.NewGuid().ToString(),
-            (int)BattleStartMode.Mission,
-            mapEventId,
-            firstMobilePartyId));
-
-        return $"Late-join field-battle fixture created and first mission requested: mapEvent={mapEventId}, " +
-               $"eventType={mapEvent.EventType}, opponent={opponentParty.Name} ({opponentParty.StringId}), " +
-               $"firstPlayer={args[0]}, joiningPlayer={args[1]}, firstSide=Attacker.";
     }
 
     // coop.debug.mapevent.late_join_mode_join
     /// <summary>Routes the waiting player's attacker-side join after the first player has entered the mission.</summary>
-    [CommandLineArgumentFunction("late_join_mode_join", "coop.debug.mapevent")]
-    public static string JoinLateJoinModeFixture(List<string> args)
+    public sealed class LateJoinModeJoinCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_join";
+        public string Prefix => "coop.debug.map_event";
 
-        var fixture = lateJoinModeFixture;
-        if (fixture == null)
-            return "No late-join mode fixture is active.";
-        if (fixture.JoiningPartyJoined)
-            return $"Player {fixture.JoiningControllerId} already joined fixture map event {fixture.MapEventId}.";
+        public string Name => "late_join_mode_join";
 
-        if (!TryGetObjectManager(out var objectManager) ||
-            !ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
-            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !ContainerProvider.TryResolve<IMissionMembershipRegistry>(out var missionMembership) ||
-            !playerManager.TryGetPeer(fixture.JoiningControllerId, out var joiningPeer))
+        public string Description => "Runs the late join mode join debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve the late-join fixture services.";
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+            var fixture = lateJoinModeFixture;
+            if (fixture == null)
+                return Failed("No late-join mode fixture is active.");
+            if (fixture.JoiningPartyJoined)
+                return Failed($"Player {fixture.JoiningControllerId} already joined fixture map event {fixture.MapEventId}.");
+
+            if (!TryGetObjectManager(out var objectManager) ||
+                !ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
+                !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !ContainerProvider.TryResolve<IMissionMembershipRegistry>(out var missionMembership) ||
+                !playerManager.TryGetPeer(fixture.JoiningControllerId, out var joiningPeer))
+            {
+                return Failed("Unable to resolve the late-join fixture services.");
+            }
+
+            if (!missionMembership.IsControllerInMission(fixture.FirstControllerId))
+                return Failed($"Player {fixture.FirstControllerId} has not entered the field battle mission.");
+            if (missionMembership.IsControllerInMission(fixture.JoiningControllerId))
+                return Failed($"Player {fixture.JoiningControllerId} is already in a mission.");
+            if (!ServerBattleModeArbiter.TryGetMode(fixture.MapEventId, out var mode) ||
+                mode != BattleStartMode.Mission)
+            {
+                return Failed($"Fixture map event {fixture.MapEventId} is not claimed for Mission mode.");
+            }
+            if (!objectManager.TryGetObjectWithLogging<MapEvent>(fixture.MapEventId, out var mapEvent) ||
+                !objectManager.TryGetObjectWithLogging<PartyBase>(fixture.JoiningPlayerPartyId, out var joiningParty))
+            {
+                return Failed("Unable to resolve the fixture map event or joining party.");
+            }
+
+            messageBroker.Publish(joiningPeer, new NetworkRequestJoinBattle(
+                Guid.NewGuid().ToString(),
+                fixture.MapEventId,
+                fixture.JoiningPlayerPartyId,
+                BattleSideEnum.Attacker));
+
+            if (joiningParty.MapEvent != mapEvent)
+                return Failed($"Player {fixture.JoiningControllerId} did not join fixture map event {fixture.MapEventId}.");
+
+            fixture.JoiningPartyJoined = true;
+            return Succeeded($"Late join accepted: mapEvent={fixture.MapEventId}, joiningPlayer={fixture.JoiningControllerId}, " +
+                   "side=Attacker, replayedMode=Mission, firstPlayerInMission=True, joiningPlayerInMission=False.");
         }
-
-        if (!missionMembership.IsControllerInMission(fixture.FirstControllerId))
-            return $"Player {fixture.FirstControllerId} has not entered the field battle mission.";
-        if (missionMembership.IsControllerInMission(fixture.JoiningControllerId))
-            return $"Player {fixture.JoiningControllerId} is already in a mission.";
-        if (!ServerBattleModeArbiter.TryGetMode(fixture.MapEventId, out var mode) ||
-            mode != BattleStartMode.Mission)
-        {
-            return $"Fixture map event {fixture.MapEventId} is not claimed for Mission mode.";
-        }
-        if (!objectManager.TryGetObjectWithLogging<MapEvent>(fixture.MapEventId, out var mapEvent) ||
-            !objectManager.TryGetObjectWithLogging<PartyBase>(fixture.JoiningPlayerPartyId, out var joiningParty))
-        {
-            return "Unable to resolve the fixture map event or joining party.";
-        }
-
-        messageBroker.Publish(joiningPeer, new NetworkRequestJoinBattle(
-            Guid.NewGuid().ToString(),
-            fixture.MapEventId,
-            fixture.JoiningPlayerPartyId,
-            BattleSideEnum.Attacker));
-
-        if (joiningParty.MapEvent != mapEvent)
-            return $"Player {fixture.JoiningControllerId} did not join fixture map event {fixture.MapEventId}.";
-
-        fixture.JoiningPartyJoined = true;
-        return $"Late join accepted: mapEvent={fixture.MapEventId}, joiningPlayer={fixture.JoiningControllerId}, " +
-               "side=Attacker, replayedMode=Mission, firstPlayerInMission=True, joiningPlayerInMission=False.";
     }
 
     // coop.debug.mapevent.late_join_mode_enter
     /// <summary>Routes the late joiner's Attack request through the real mission-start handler.</summary>
-    [CommandLineArgumentFunction("late_join_mode_enter", "coop.debug.mapevent")]
-    public static string EnterLateJoinModeFixtureMission(List<string> args)
+    public sealed class LateJoinModeEnterCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_enter";
+        public string Prefix => "coop.debug.map_event";
 
-        var fixture = lateJoinModeFixture;
-        if (fixture == null)
-            return "No late-join mode fixture is active.";
-        if (!fixture.JoiningPartyJoined)
-            return $"Player {fixture.JoiningControllerId} has not joined fixture map event {fixture.MapEventId}.";
+        public string Name => "late_join_mode_enter";
 
-        if (!ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
-            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !ContainerProvider.TryResolve<IMissionMembershipRegistry>(out var missionMembership) ||
-            !playerManager.TryGetPeer(fixture.JoiningControllerId, out var joiningPeer))
+        public string Description => "Runs the late join mode enter debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve the late-join mission-entry services.";
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+            var fixture = lateJoinModeFixture;
+            if (fixture == null)
+                return Failed("No late-join mode fixture is active.");
+            if (!fixture.JoiningPartyJoined)
+                return Failed($"Player {fixture.JoiningControllerId} has not joined fixture map event {fixture.MapEventId}.");
+
+            if (!ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
+                !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !ContainerProvider.TryResolve<IMissionMembershipRegistry>(out var missionMembership) ||
+                !playerManager.TryGetPeer(fixture.JoiningControllerId, out var joiningPeer))
+            {
+                return Failed("Unable to resolve the late-join mission-entry services.");
+            }
+
+            if (!missionMembership.IsControllerInMission(fixture.FirstControllerId))
+                return Failed($"Player {fixture.FirstControllerId} is no longer in the field battle mission.");
+            if (missionMembership.IsControllerInMission(fixture.JoiningControllerId))
+                return Failed($"Player {fixture.JoiningControllerId} already entered the field battle mission.");
+
+            messageBroker.Publish(joiningPeer, new NetworkBattleStartRequest(
+                Guid.NewGuid().ToString(),
+                (int)BattleStartMode.Mission,
+                fixture.MapEventId,
+                fixture.JoiningPlayerMobilePartyId));
+
+            return Succeeded($"Late joiner mission requested: mapEvent={fixture.MapEventId}, " +
+                   $"joiningPlayer={fixture.JoiningControllerId}, mode=Mission.");
         }
-
-        if (!missionMembership.IsControllerInMission(fixture.FirstControllerId))
-            return $"Player {fixture.FirstControllerId} is no longer in the field battle mission.";
-        if (missionMembership.IsControllerInMission(fixture.JoiningControllerId))
-            return $"Player {fixture.JoiningControllerId} already entered the field battle mission.";
-
-        messageBroker.Publish(joiningPeer, new NetworkBattleStartRequest(
-            Guid.NewGuid().ToString(),
-            (int)BattleStartMode.Mission,
-            fixture.MapEventId,
-            fixture.JoiningPlayerMobilePartyId));
-
-        return $"Late joiner mission requested: mapEvent={fixture.MapEventId}, " +
-               $"joiningPlayer={fixture.JoiningControllerId}, mode=Mission.";
     }
 
 #if DEBUG
     // coop.debug.mapevent.late_join_mode_begin_field_battle
     /// <summary>Finishes the local deployment phase so live evidence shows the active field battle.</summary>
-    [CommandLineArgumentFunction("late_join_mode_begin_field_battle", "coop.debug.mapevent")]
-    public static string BeginLateJoinModeFixtureFieldBattle(List<string> args)
+    public sealed class LateJoinModeBeginFieldBattleCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_begin_field_battle";
+        public string Prefix => "coop.debug.map_event";
 
-        var mission = Mission.Current;
-        if (mission == null)
-            return "No mission is active.";
+        public string Name => "late_join_mode_begin_field_battle";
 
-        var deploymentController = mission.GetMissionBehavior<DeploymentMissionController>();
-        if (deploymentController?.TeamSetupOver != true)
-            return "Local deployment is not ready.";
+        public string Description => "Runs the late join mode begin field battle debug operation.";
 
-        var deploymentHandler = mission.GetMissionBehavior<DeploymentHandler>();
-        if (deploymentHandler == null)
-            return "The field battle is already active.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        mission.DisableDying = true;
-        deploymentHandler.FinishDeployment();
-        if (!ProtectLateJoinModeFixturePlayer(mission))
-            return "Local deployment finished, but the local player agent was not assigned.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
 
-        return "Local deployment finished; the field battle is active and the local player is protected.";
+            var mission = Mission.Current;
+            if (mission == null)
+                return Failed("No mission is active.");
+
+            var deploymentController = mission.GetMissionBehavior<DeploymentMissionController>();
+            if (deploymentController?.TeamSetupOver != true)
+                return Failed("Local deployment is not ready.");
+
+            var deploymentHandler = mission.GetMissionBehavior<DeploymentHandler>();
+            if (deploymentHandler == null)
+                return Failed("The field battle is already active.");
+
+            mission.DisableDying = true;
+            deploymentHandler.FinishDeployment();
+            if (!ProtectLateJoinModeFixturePlayer(mission))
+                return Failed("Local deployment finished, but the local player agent was not assigned.");
+
+            return Succeeded("Local deployment finished; the field battle is active and the local player is protected.");
+        }
     }
 
     // coop.debug.mapevent.late_join_mode_disable_dying
     /// <summary>Prevents the live-test battle from resolving before both client views are captured.</summary>
-    [CommandLineArgumentFunction("late_join_mode_disable_dying", "coop.debug.mapevent")]
-    public static string DisableLateJoinModeFixtureDying(List<string> args)
+    public sealed class LateJoinModeDisableDyingCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_disable_dying";
+        public string Prefix => "coop.debug.map_event";
 
-        var mission = Mission.Current;
-        if (mission == null)
-            return "No mission is active.";
+        public string Name => "late_join_mode_disable_dying";
 
-        mission.DisableDying = true;
-        var playerProtected = ProtectLateJoinModeFixturePlayer(mission);
-        return playerProtected
-            ? "Dying disabled for the local fixture mission; the local player is protected."
-            : "Dying disabled for the local fixture mission; the local player is not assigned yet.";
+        public string Description => "Runs the late join mode disable dying debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+            var mission = Mission.Current;
+            if (mission == null)
+                return Failed("No mission is active.");
+
+            mission.DisableDying = true;
+            var playerProtected = ProtectLateJoinModeFixturePlayer(mission);
+            return Failed(playerProtected
+                ? "Dying disabled for the local fixture mission; the local player is protected."
+                : "Dying disabled for the local fixture mission; the local player is not assigned yet.");
+        }
     }
 
     private static bool ProtectLateJoinModeFixturePlayer(Mission mission)
@@ -2482,23 +2863,36 @@ public class MapEventDebugCommands
 
     // coop.debug.mapevent.late_join_mode_exit_missions
     /// <summary>Asks every fixture mission member to return to campaign before authoritative cleanup.</summary>
-    [CommandLineArgumentFunction("late_join_mode_exit_missions", "coop.debug.mapevent")]
-    public static string ExitLateJoinModeFixtureMissions(List<string> args)
+    public sealed class LateJoinModeExitMissionsCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "late_join_mode_exit_missions";
+
+        public string Description => "Runs the late join mode exit missions debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return ExitLateJoinModeFixtureMissionsCore(args);
+        }
+    }
+
+    private static CoopCommandResult ExitLateJoinModeFixtureMissionsCore(ICoopCommandArgs args)
     {
         if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_exit_missions";
+            return Failed("Run this command on the server.");
 
         var fixture = lateJoinModeFixture;
         if (fixture == null)
-            return "No late-join mode fixture is active.";
+            return Failed("No late-join mode fixture is active.");
 
         if (!ContainerProvider.TryResolve<INetwork>(out var network) ||
             !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
             !ContainerProvider.TryResolve<IMissionMembershipRegistry>(out var missionMembership))
         {
-            return "Unable to resolve the late-join mission-exit services.";
+            return Failed("Unable to resolve the late-join mission-exit services.");
         }
 
         var requested = 0;
@@ -2512,109 +2906,143 @@ public class MapEventDebugCommands
             requested++;
         }
 
-        return $"Late-join fixture mission exit requested for {requested} player(s).";
+        return Succeeded($"Late-join fixture mission exit requested for {requested} player(s).");
+
+
     }
 
     /// <summary>Returns both fixture clients to campaign and restores the server-side battle state.</summary>
-    [CommandLineArgumentFunction("late_join_mode_restore", "coop.debug.mapevent")]
-    public static string RestoreLateJoinModeFixture(List<string> args)
+    public sealed class LateJoinModeRestoreCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.late_join_mode_restore";
+        public string Prefix => "coop.debug.map_event";
 
-        string exitResult = ExitLateJoinModeFixtureMissions(args);
-        if (lateJoinModeFixture == null)
-            return exitResult;
+        public string Name => "late_join_mode_restore";
 
-        string cleanupResult = CleanupLateJoinModeFixture(args);
-        return $"{exitResult} {cleanupResult}";
+        public string Description => "Restores or clears late join mode restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+
+            CoopCommandResult exitResult = ExitLateJoinModeFixtureMissionsCore(args);
+            if (!exitResult.Succeeded || lateJoinModeFixture == null)
+                return exitResult;
+
+            CoopCommandResult cleanupResult = CleanupLateJoinModeFixtureCore(args);
+            if (!cleanupResult.Succeeded)
+                return cleanupResult;
+
+            return Succeeded($"{exitResult.Output} {cleanupResult.Output}");
+        }
     }
 #endif
 
     // coop.debug.mapevent.late_join_mode_state PlayerTwo
     /// <summary>Reports a player's map-event membership and known authoritative battle mode.</summary>
-    [CommandLineArgumentFunction("late_join_mode_state", "coop.debug.mapevent")]
-    public static string GetLateJoinModeState(List<string> args)
+    public sealed class LateJoinModeStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "late_join_mode_state";
+
+        public string Description => "Reports late join mode state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.mapevent.late_join_mode_state <controllerId>";
-        }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return error;
+            if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
+            {
+                return Failed(error);
+            }
+
+            var mapEvent = playerParty.MapEvent;
+            var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out string resolvedId)
+                ? resolvedId
+                : "none";
+            var eventType = mapEvent?.EventType.ToString() ?? "none";
+            var settlement = mapEvent?.MapEventSettlement;
+            var settlementName = settlement != null ? $"{settlement.Name} ({settlement.StringId})" : "none";
+            var opponentParties = mapEvent?.DefenderSide?.Parties.Count ?? 0;
+            var side = playerParty.MapEventSide?.MissionSide.ToString() ?? "none";
+            var mode = "Unclaimed";
+            if (mapEventId != "none")
+            {
+                if (ModInformation.IsServer && ServerBattleModeArbiter.TryGetMode(mapEventId, out var serverMode))
+                    mode = serverMode.ToString();
+                else if (BattleModeRegistry.IsMission(mapEventId))
+                    mode = BattleStartMode.Mission.ToString();
+                else if (BattleModeRegistry.IsSimulation(mapEventId))
+                    mode = BattleStartMode.Simulation.ToString();
+            }
+
+            var missionActive = ModInformation.IsServer
+                ? ContainerProvider.TryResolve<IMissionMembershipRegistry>(out var missionMembership) &&
+                  missionMembership.IsControllerInMission(args[0])
+                : MissionState.Current != null || Mission.Current != null;
+            var missionAgents = ModInformation.IsClient && Mission.Current != null
+                ? Mission.Current.Agents.Count
+                : 0;
+            var deploymentActive = ModInformation.IsClient &&
+                                   Mission.Current?.HasMissionBehavior<DeploymentHandler>() == true;
+
+            return Succeeded($"Late-join mode state: controller={args[0]}, mapEvent={mapEventId}, eventType={eventType}, " +
+                   $"settlement={settlementName}, opponentParties={opponentParties}, side={side}, mode={mode}, " +
+                   $"missionActive={missionActive}, missionAgents={missionAgents}, deploymentActive={deploymentActive}.");
         }
-
-        var mapEvent = playerParty.MapEvent;
-        var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out string resolvedId)
-            ? resolvedId
-            : "none";
-        var eventType = mapEvent?.EventType.ToString() ?? "none";
-        var settlement = mapEvent?.MapEventSettlement;
-        var settlementName = settlement != null ? $"{settlement.Name} ({settlement.StringId})" : "none";
-        var opponentParties = mapEvent?.DefenderSide?.Parties.Count ?? 0;
-        var side = playerParty.MapEventSide?.MissionSide.ToString() ?? "none";
-        var mode = "Unclaimed";
-        if (mapEventId != "none")
-        {
-            if (ModInformation.IsServer && ServerBattleModeArbiter.TryGetMode(mapEventId, out var serverMode))
-                mode = serverMode.ToString();
-            else if (BattleModeRegistry.IsMission(mapEventId))
-                mode = BattleStartMode.Mission.ToString();
-            else if (BattleModeRegistry.IsSimulation(mapEventId))
-                mode = BattleStartMode.Simulation.ToString();
-        }
-
-        var missionActive = ModInformation.IsServer
-            ? ContainerProvider.TryResolve<IMissionMembershipRegistry>(out var missionMembership) &&
-              missionMembership.IsControllerInMission(args[0])
-            : MissionState.Current != null || Mission.Current != null;
-        var missionAgents = ModInformation.IsClient && Mission.Current != null
-            ? Mission.Current.Agents.Count
-            : 0;
-        var deploymentActive = ModInformation.IsClient &&
-                               Mission.Current?.HasMissionBehavior<DeploymentHandler>() == true;
-
-        return $"Late-join mode state: controller={args[0]}, mapEvent={mapEventId}, eventType={eventType}, " +
-               $"settlement={settlementName}, opponentParties={opponentParties}, side={side}, mode={mode}, " +
-               $"missionActive={missionActive}, missionAgents={missionAgents}, deploymentActive={deploymentActive}.";
     }
 
     // coop.debug.mapevent.late_join_mode_cleanup
     /// <summary>Removes the fixture field battle and restores each party's movement state.</summary>
-    [CommandLineArgumentFunction("late_join_mode_cleanup", "coop.debug.mapevent")]
-    public static string CleanupLateJoinModeFixture(List<string> args)
+    public sealed class LateJoinModeCleanupCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "late_join_mode_cleanup";
+
+        public string Description => "Runs the late join mode cleanup debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return CleanupLateJoinModeFixtureCore(args);
+        }
+    }
+
+    private static CoopCommandResult CleanupLateJoinModeFixtureCore(ICoopCommandArgs args)
     {
         if (ModInformation.IsClient)
         {
-            return "Run this command on the server.";
+            return Failed("Run this command on the server.");
         }
 
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.mapevent.late_join_mode_cleanup";
-        }
 
         if (lateJoinModeFixture == null)
         {
-            return "No late-join mode fixture is active.";
+            return Failed("No late-join mode fixture is active.");
         }
 
         if (!TryGetObjectManager(out var objectManager) ||
             !ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker) ||
             !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
         {
-            return "Unable to resolve the late-join mode cleanup services.";
+            return Failed("Unable to resolve the late-join mode cleanup services.");
         }
 
         var mapEventId = lateJoinModeFixture.MapEventId;
         var restored = CleanupLateJoinModeFixture(messageBroker, behaviorSnapshot, objectManager);
-        return restored
+        return Succeeded(restored
             ? $"Late-join field-battle fixture {mapEventId} cleaned up and party movement restored."
-            : $"Late-join field-battle fixture {mapEventId} cleaned up, but its original state could not be fully restored.";
+            : $"Late-join field-battle fixture {mapEventId} cleaned up, but its original state could not be fully restored.");
+
+
     }
 
     private static bool CleanupLateJoinModeFixture(
@@ -2676,110 +3104,140 @@ public class MapEventDebugCommands
     /// <summary>
     /// Finds a neutral AI party that can be used without changing its original movement state.
     /// </summary>
-    [CommandLineArgumentFunction("peace_pursuit_fixture", "coop.debug.mapevent")]
-    public static string GetPeacePursuitFixture(List<string> args)
+    public sealed class PeacePursuitFixtureCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "Run this command on the server.";
-        }
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.mapevent.peace_pursuit_fixture <controllerId>";
-        }
+        public string Name => "peace_pursuit_fixture";
 
-        if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
-        {
-            return error;
-        }
+        public string Description => "Runs the peace pursuit fixture debug operation.";
 
-        var neutralParty = FindPeacePursuitFixture(playerParty);
-        if (neutralParty == null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "No active neutral AI party already holding on the map.";
-        }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        return FormatPeacePursuitState("Peace pursuit fixture", objectManager, neutralParty, playerParty);
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+            {
+                return Failed("Run this command on the server.");
+            }
+
+
+            if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
+            {
+                return Failed(error);
+            }
+
+            var neutralParty = FindPeacePursuitFixture(playerParty);
+            if (neutralParty == null)
+            {
+                return Failed("No active neutral AI party already holding on the map.");
+            }
+
+            return Succeeded(FormatPeacePursuitState("Peace pursuit fixture", objectManager, neutralParty, playerParty));
+        }
     }
 
     // coop.debug.mapevent.peace_pursuit_state PlayerOne mobileParty_1
     /// <summary>
     /// Reports the pursuit-test party state on the current machine.
     /// </summary>
-    [CommandLineArgumentFunction("peace_pursuit_state", "coop.debug.mapevent")]
-    public static string GetPeacePursuitState(List<string> args)
+    public sealed class PeacePursuitStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
-        {
-            return "Usage: coop.debug.mapevent.peace_pursuit_state <controllerId> <partyStringId>";
-        }
+        public string Prefix => "coop.debug.map_event";
 
-        if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
-        {
-            return error;
-        }
+        public string Name => "peace_pursuit_state";
 
-        var neutralParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[1]);
-        if (neutralParty == null)
-        {
-            return $"Party {args[1]} was not found.";
-        }
+        public string Description => "Reports peace pursuit state.";
 
-        return FormatPeacePursuitState("Peace pursuit state", objectManager, neutralParty, playerParty);
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("party_string_id", "The party string id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryGetPlayerParty(args[0], requireReady: false, out var objectManager, out var playerParty, out var error))
+            {
+                return Failed(error);
+            }
+
+            var neutralParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[1]);
+            if (neutralParty == null)
+            {
+                return Failed($"Party {args[1]} was not found.");
+            }
+
+            return Succeeded(FormatPeacePursuitState("Peace pursuit state", objectManager, neutralParty, playerParty));
+        }
     }
 
     // coop.debug.mapevent.test_peace_stops_pursuit PlayerOne mobileParty_1
     /// <summary>
     /// Makes a selected neutral AI party pursue a connected player, then makes peace.
     /// </summary>
-    [CommandLineArgumentFunction("test_peace_stops_pursuit", "coop.debug.mapevent")]
-    public static string TestPeaceStopsPursuit(List<string> args)
+    public sealed class TestPeaceStopsPursuitCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "test_peace_stops_pursuit";
+
+        public string Description => "Runs the test peace stops pursuit debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Run this command on the server.";
-        }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("party_string_id", "The party string id.", true),
+        };
 
-        if (args.Count != 2)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.mapevent.test_peace_stops_pursuit <controllerId> <partyStringId>";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Run this command on the server.");
+            }
+
+
+            if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
+            {
+                return Failed(error);
+            }
+
+            var neutralParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[1]);
+            if (neutralParty == null)
+            {
+                return Failed($"Party {args[1]} was not found.");
+            }
+
+            if (!IsPeacePursuitFixture(neutralParty, playerParty))
+            {
+                return Failed($"Party {args[1]} is not a neutral AI party already holding on the map.");
+            }
+
+            DeclareWarAction.ApplyByDefault(neutralParty.MapFaction, playerParty.MapFaction);
+            if (!FactionManager.IsAtWarAgainstFaction(neutralParty.MapFaction, playerParty.MapFaction))
+            {
+                return Failed($"Unable to establish war between {neutralParty.MapFaction.Name} and {playerParty.MapFaction.Name}.");
+            }
+
+            neutralParty.SetMoveGoAroundParty(playerParty, MobileParty.NavigationType.Default);
+            MakePeaceAction.Apply(neutralParty.MapFaction, playerParty.MapFaction);
+
+            var stopped = neutralParty.DefaultBehavior == AiBehavior.Hold &&
+                          neutralParty.PartyMoveMode == MoveModeType.Hold &&
+                          neutralParty.TargetParty == null &&
+                          !FactionManager.IsAtWarAgainstFaction(neutralParty.MapFaction, playerParty.MapFaction);
+
+            string output = FormatPeacePursuitState(
+                $"Peace pursuit test {(stopped ? "passed" : "failed")}",
+                objectManager,
+                neutralParty,
+                playerParty);
+            return stopped ? Succeeded(output) : Failed(output);
         }
-
-        if (!TryGetPlayerParty(args[0], requireReady: true, out var objectManager, out var playerParty, out var error))
-        {
-            return error;
-        }
-
-        var neutralParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[1]);
-        if (neutralParty == null)
-        {
-            return $"Party {args[1]} was not found.";
-        }
-
-        if (!IsPeacePursuitFixture(neutralParty, playerParty))
-        {
-            return $"Party {args[1]} is not a neutral AI party already holding on the map.";
-        }
-
-        DeclareWarAction.ApplyByDefault(neutralParty.MapFaction, playerParty.MapFaction);
-        if (!FactionManager.IsAtWarAgainstFaction(neutralParty.MapFaction, playerParty.MapFaction))
-        {
-            return $"Unable to establish war between {neutralParty.MapFaction.Name} and {playerParty.MapFaction.Name}.";
-        }
-
-        neutralParty.SetMoveGoAroundParty(playerParty, MobileParty.NavigationType.Default);
-        MakePeaceAction.Apply(neutralParty.MapFaction, playerParty.MapFaction);
-
-        var stopped = neutralParty.DefaultBehavior == AiBehavior.Hold &&
-                      neutralParty.PartyMoveMode == MoveModeType.Hold &&
-                      neutralParty.TargetParty == null &&
-                      !FactionManager.IsAtWarAgainstFaction(neutralParty.MapFaction, playerParty.MapFaction);
-
-        return FormatPeacePursuitState($"Peace pursuit test {(stopped ? "passed" : "failed")}",
-            objectManager,
-            neutralParty,
-            playerParty);
     }
 
     private static bool TryGetPlayerParty(
@@ -2883,168 +3341,198 @@ public class MapEventDebugCommands
     /// <summary>
     /// Kills a random troop from the enemy side of the current map event.
     /// </summary>
-    [CommandLineArgumentFunction("kill_random_troop", "coop.debug.mapevent")]
-    public static string KillRandomTroop(List<string> args)
+    public sealed class KillRandomTroopCoopCommand : ICoopCommand
     {
-        var mapEvent = MobileParty.MainParty.MapEvent;
-        if (mapEvent is null)
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "kill_random_troop";
+
+        public string Description => "Runs the kill random troop debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Main party is not in a map event";
+            var mapEvent = MobileParty.MainParty.MapEvent;
+            if (mapEvent is null)
+            {
+                return Failed("Main party is not in a map event");
+            }
+
+            var mainPartySide = MobileParty.MainParty.MapEventSide;
+            if (mainPartySide is null)
+            {
+                return Failed("Main party has no map event side");
+            }
+
+            var enemySide = mapEvent._sides
+                .SingleOrDefault(side => side != mainPartySide);
+
+            if (enemySide is null)
+            {
+                return Failed("Failed to get enemy map event side");
+            }
+
+            var party = enemySide.Parties[MBRandom.RandomInt(enemySide.Parties.Count)];
+            if (party is null)
+            {
+                return Failed("Enemy side has no parties");
+            }
+
+            var troops = party.Troops;
+            if (troops is null || troops.Count() == 0)
+            {
+                return Failed("Enemy party has no troops");
+            }
+
+            var entries = troops._elementDictionary.ToArray();
+
+            if (entries.Length == 0)
+            {
+                return Failed("Enemy party has no troops");
+            }
+
+            var randomEntry = entries[MBRandom.RandomInt(entries.Length)];
+
+            UniqueTroopDescriptor descriptor = randomEntry.Key;
+            FlattenedTroopRosterElement troopElement = randomEntry.Value;
+
+            try
+            {
+                enemySide.OnTroopKilled(descriptor);
+            }
+            catch (Exception ex)
+            {
+                return Failed($"Failed to kill random troop: {ex.Message}");
+            }
+
+            return Succeeded($"Killed random troop: {troopElement.Troop?.Name}");
         }
-
-        var mainPartySide = MobileParty.MainParty.MapEventSide;
-        if (mainPartySide is null)
-        {
-            return "Main party has no map event side";
-        }
-
-        var enemySide = mapEvent._sides
-            .SingleOrDefault(side => side != mainPartySide);
-
-        if (enemySide is null)
-        {
-            return "Failed to get enemy map event side";
-        }
-
-        var party = enemySide.Parties[MBRandom.RandomInt(enemySide.Parties.Count)];
-        if (party is null)
-        {
-            return "Enemy side has no parties";
-        }
-
-        var troops = party.Troops;
-        if (troops is null || troops.Count() == 0)
-        {
-            return "Enemy party has no troops";
-        }
-
-        var entries = troops._elementDictionary.ToArray();
-
-        if (entries.Length == 0)
-        {
-            return "Enemy party has no troops";
-        }
-
-        var randomEntry = entries[MBRandom.RandomInt(entries.Length)];
-
-        UniqueTroopDescriptor descriptor = randomEntry.Key;
-        FlattenedTroopRosterElement troopElement = randomEntry.Value;
-
-        try
-        {
-            enemySide.OnTroopKilled(descriptor);
-        }
-        catch (Exception ex)
-        {
-            return $"Failed to kill random troop: {ex.Message}";
-        }
-
-        return $"Killed random troop: {troopElement.Troop?.Name}";
     }
 
     /// <summary>
     /// Kills all but one troop from the enemy side of the current map event.
     /// </summary>
-    [CommandLineArgumentFunction("kill_all_but_one", "coop.debug.mapevent")]
-    public static string KillAllButOneTroop(List<string> args)
+    public sealed class KillAllButOneCoopCommand : ICoopCommand
     {
-        var mapEvent = MobileParty.MainParty.MapEvent;
-        if (mapEvent is null)
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "kill_all_but_one";
+
+        public string Description => "Runs the kill all but one debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Main party is not in a map event";
-        }
-
-        var mainPartySide = MobileParty.MainParty.MapEventSide;
-        if (mainPartySide is null)
-        {
-            return "Main party has no map event side";
-        }
-
-        var enemySide = mapEvent._sides
-            .SingleOrDefault(side => side != mainPartySide);
-
-        if (enemySide is null)
-        {
-            return "Failed to get enemy map event side";
-        }
-
-        if (enemySide.Parties is null || enemySide.Parties.Count == 0)
-        {
-            return "Enemy side has no parties";
-        }
-
-        var allTroops = new List<(MapEventParty Party, UniqueTroopDescriptor Descriptor, FlattenedTroopRosterElement Element)>();
-
-        foreach (var party in enemySide.Parties)
-        {
-            if (party?.Troops?._elementDictionary is null)
-                continue;
-
-            foreach (var entry in party.Troops._elementDictionary)
+            var mapEvent = MobileParty.MainParty.MapEvent;
+            if (mapEvent is null)
             {
-                var descriptor = entry.Key;
-                var element = entry.Value;
-
-                allTroops.Add((party, descriptor, element));
+                return Failed("Main party is not in a map event");
             }
-        }
 
-        if (allTroops.Count == 0)
-        {
-            return "Enemy side has no troops";
-        }
-
-        if (allTroops.Count == 1)
-        {
-            return $"Enemy side already has only one troop: {allTroops[0].Element.Troop?.Name}";
-        }
-
-        var survivorIndex = MBRandom.RandomInt(allTroops.Count);
-        var survivor = allTroops[survivorIndex];
-
-        var killedCount = 0;
-
-        for (var i = 0; i < allTroops.Count; i++)
-        {
-            if (i == survivorIndex)
-                continue;
-
-            try
+            var mainPartySide = MobileParty.MainParty.MapEventSide;
+            if (mainPartySide is null)
             {
-                enemySide.OnTroopKilled(allTroops[i].Descriptor);
-                killedCount++;
+                return Failed("Main party has no map event side");
             }
-            catch (Exception ex)
+
+            var enemySide = mapEvent._sides
+                .SingleOrDefault(side => side != mainPartySide);
+
+            if (enemySide is null)
             {
-
+                return Failed("Failed to get enemy map event side");
             }
-        }
 
-        return $"Killed {killedCount} troops. Survivor: {survivor.Element.Troop?.Name}";
+            if (enemySide.Parties is null || enemySide.Parties.Count == 0)
+            {
+                return Failed("Enemy side has no parties");
+            }
+
+            var allTroops = new List<(MapEventParty Party, UniqueTroopDescriptor Descriptor, FlattenedTroopRosterElement Element)>();
+
+            foreach (var party in enemySide.Parties)
+            {
+                if (party?.Troops?._elementDictionary is null)
+                    continue;
+
+                foreach (var entry in party.Troops._elementDictionary)
+                {
+                    var descriptor = entry.Key;
+                    var element = entry.Value;
+
+                    allTroops.Add((party, descriptor, element));
+                }
+            }
+
+            if (allTroops.Count == 0)
+            {
+                return Failed("Enemy side has no troops");
+            }
+
+            if (allTroops.Count == 1)
+            {
+                return Failed($"Enemy side already has only one troop: {allTroops[0].Element.Troop?.Name}");
+            }
+
+            var survivorIndex = MBRandom.RandomInt(allTroops.Count);
+            var survivor = allTroops[survivorIndex];
+
+            var killedCount = 0;
+
+            for (var i = 0; i < allTroops.Count; i++)
+            {
+                if (i == survivorIndex)
+                    continue;
+
+                try
+                {
+                    enemySide.OnTroopKilled(allTroops[i].Descriptor);
+                    killedCount++;
+                }
+                catch (Exception ex)
+                {
+
+                }
+            }
+
+            return Succeeded($"Killed {killedCount} troops. Survivor: {survivor.Element.Troop?.Name}");
+        }
     }
 
     /// <summary>
     /// Lists the fields and properties of the current PlayerEncounter.
     /// </summary>
-    [CommandLineArgumentFunction("list_player_encounter", "coop.debug.mapevent")]
-    public static string ListPlayerEncounter(List<string> args)
+    public sealed class ListPlayerEncounterCoopCommand : ICoopCommand
     {
-        var playerEncounter = PlayerEncounter.Current;
-        if (playerEncounter == null)
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "list_player_encounter";
+
+        public string Description => "Reports player encounter.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "No current PlayerEncounter";
+            var playerEncounter = PlayerEncounter.Current;
+            if (playerEncounter == null)
+            {
+                return Failed("No current PlayerEncounter");
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine("PlayerEncounter:");
+            AppendObjectDetails(sb, playerEncounter, "\t", "PlayerEncounter Details");
+
+            var result = sb.ToString();
+
+            Logger.Debug("{PlayerEncounter}", result);
+
+            return Succeeded(result);
         }
-
-        var sb = new StringBuilder();
-
-        sb.AppendLine("PlayerEncounter:");
-        AppendObjectDetails(sb, playerEncounter, "\t", "PlayerEncounter Details");
-
-        var result = sb.ToString();
-
-        Logger.Debug("{PlayerEncounter}", result);
-
-        return result;
     }
 
     /// <summary>
@@ -3053,133 +3541,173 @@ public class MapEventDebugCommands
     /// e.g. PlayerEncounter.Current still PRESENT, or MainParty.MapEvent lingering on an already-finalized event.
     /// Unlike <c>list_player_encounter</c> (full reflection dump) this is short enough to diff across clients.
     /// </summary>
-    [CommandLineArgumentFunction("encounter_state", "coop.debug.mapevent")]
-    public static string EncounterState(List<string> args)
+    public sealed class EncounterStateCoopCommand : ICoopCommand
     {
-        TryGetObjectManager(out var objectManager);
+        public string Prefix => "coop.debug.map_event";
 
-        var sb = new StringBuilder();
+        public string Name => "encounter_state";
 
-        var encounter = PlayerEncounter.Current;
-        sb.AppendLine($"PlayerEncounter.Current: {(encounter == null ? "<null> (torn down)" : "PRESENT")}");
-        if (encounter != null)
+        public string Description => "Reports encounter state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            sb.AppendLine($"\tBattle:           {FormatMapEvent(PlayerEncounter.Battle, objectManager)}");
-            sb.AppendLine($"\t_mapEvent:        {FormatMapEvent(encounter._mapEvent, objectManager)}");
-            sb.AppendLine($"\tEncounteredParty: {FormatPartyBaseWithId(PlayerEncounter.EncounteredParty, objectManager)}");
-            sb.AppendLine($"\t_attackerParty:   {FormatPartyBaseWithId(encounter._attackerParty, objectManager)}");
-            sb.AppendLine($"\t_defenderParty:   {FormatPartyBaseWithId(encounter._defenderParty, objectManager)}");
+            TryGetObjectManager(out var objectManager);
+
+            var sb = new StringBuilder();
+
+            var encounter = PlayerEncounter.Current;
+            sb.AppendLine($"PlayerEncounter.Current: {(encounter == null ? "<null> (torn down)" : "PRESENT")}");
+            if (encounter != null)
+            {
+                sb.AppendLine($"\tBattle:           {FormatMapEvent(PlayerEncounter.Battle, objectManager)}");
+                sb.AppendLine($"\t_mapEvent:        {FormatMapEvent(encounter._mapEvent, objectManager)}");
+                sb.AppendLine($"\tEncounteredParty: {FormatPartyBaseWithId(PlayerEncounter.EncounteredParty, objectManager)}");
+                sb.AppendLine($"\t_attackerParty:   {FormatPartyBaseWithId(encounter._attackerParty, objectManager)}");
+                sb.AppendLine($"\t_defenderParty:   {FormatPartyBaseWithId(encounter._defenderParty, objectManager)}");
+            }
+
+            var mainParty = MobileParty.MainParty;
+            sb.AppendLine($"MainParty.MapEvent:      {FormatMapEvent(mainParty?.MapEvent, objectManager)}");
+
+            var side = mainParty?.Party?.MapEventSide;
+            if (side == null)
+                sb.AppendLine("MainParty.MapEventSide:  <null>");
+            else
+                sb.AppendLine($"MainParty.MapEventSide:  leader={FormatPartyBaseWithId(side.LeaderParty, objectManager)} mainPartyIsLeader={side.LeaderParty == mainParty?.Party}");
+
+            sb.AppendLine($"CurrentMenu:             {Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "<none>"}");
+            sb.AppendLine($"CurrentBattleSimulation: {(PlayerEncounter.CurrentBattleSimulation == null ? "<null>" : "PRESENT")}");
+            sb.AppendLine($"MissionState.Current:    {(MissionState.Current == null ? "<null>" : "PRESENT")}");
+
+            var result = sb.ToString();
+            Logger.Debug("{EncounterState}", result);
+            return Succeeded(result);
         }
-
-        var mainParty = MobileParty.MainParty;
-        sb.AppendLine($"MainParty.MapEvent:      {FormatMapEvent(mainParty?.MapEvent, objectManager)}");
-
-        var side = mainParty?.Party?.MapEventSide;
-        if (side == null)
-            sb.AppendLine("MainParty.MapEventSide:  <null>");
-        else
-            sb.AppendLine($"MainParty.MapEventSide:  leader={FormatPartyBaseWithId(side.LeaderParty, objectManager)} mainPartyIsLeader={side.LeaderParty == mainParty?.Party}");
-
-        sb.AppendLine($"CurrentMenu:             {Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId ?? "<none>"}");
-        sb.AppendLine($"CurrentBattleSimulation: {(PlayerEncounter.CurrentBattleSimulation == null ? "<null>" : "PRESENT")}");
-        sb.AppendLine($"MissionState.Current:    {(MissionState.Current == null ? "<null>" : "PRESENT")}");
-
-        var result = sb.ToString();
-        Logger.Debug("{EncounterState}", result);
-        return result;
     }
 
     /// <summary>Shows, closes, or reports the live retreat confirmation for automated battle-exit testing.</summary>
-    [CommandLineArgumentFunction("retreat_confirmation", "coop.debug.mapevent")]
-    public static string RetreatConfirmation(List<string> args)
+    public sealed class RetreatConfirmationCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client in a battle mission.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.retreat_confirmation <show|accept|cancel|state>";
+        public string Name => "retreat_confirmation";
 
-        var handler = Mission.Current?.GetMissionBehavior<BasicMissionHandler>();
-        if (handler == null)
-            return "No active battle retreat handler.";
+        public string Description => "Runs the retreat confirmation debug operation.";
 
-        switch (args[0].ToLowerInvariant())
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "show":
-                if (handler.IsWarningWidgetOpened)
-                    return "Retreat confirmation already open: true";
+            new ExpectedArgs("action", "The action.", true),
+        };
 
-                handler.CreateWarningWidgetForResult(BattleEndLogic.ExitResult.NeedsPlayerConfirmation);
-                return $"Retreat confirmation open: {handler.IsWarningWidgetOpened}";
-            case "accept":
-                if (!handler.IsWarningWidgetOpened)
-                    return "Retreat confirmation is not open.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client in a battle mission.");
 
-                InformationManager.HideInquiry();
-                handler.OnEventAcceptSelectionWidget();
-                return "Retreat confirmation accepted.";
-            case "cancel":
-                if (!handler.IsWarningWidgetOpened)
-                    return "Retreat confirmation is not open.";
 
-                InformationManager.HideInquiry();
-                handler.OnEventCancelSelectionWidget();
-                return $"Retreat confirmation open: {handler.IsWarningWidgetOpened}";
-            case "state":
-                return $"Retreat confirmation open: {handler.IsWarningWidgetOpened}";
-            default:
-                return "Usage: coop.debug.mapevent.retreat_confirmation <show|accept|cancel|state>";
+            var handler = Mission.Current?.GetMissionBehavior<BasicMissionHandler>();
+            if (handler == null)
+                return Failed("No active battle retreat handler.");
+
+            switch (args[0].ToLowerInvariant())
+            {
+                case "show":
+                    if (handler.IsWarningWidgetOpened)
+                        return Failed("Retreat confirmation already open: true");
+
+                    handler.CreateWarningWidgetForResult(BattleEndLogic.ExitResult.NeedsPlayerConfirmation);
+                    return Succeeded($"Retreat confirmation open: {handler.IsWarningWidgetOpened}");
+                case "accept":
+                    if (!handler.IsWarningWidgetOpened)
+                        return Failed("Retreat confirmation is not open.");
+
+                    InformationManager.HideInquiry();
+                    handler.OnEventAcceptSelectionWidget();
+                    return Succeeded("Retreat confirmation accepted.");
+                case "cancel":
+                    if (!handler.IsWarningWidgetOpened)
+                        return Failed("Retreat confirmation is not open.");
+
+                    InformationManager.HideInquiry();
+                    handler.OnEventCancelSelectionWidget();
+                    return Succeeded($"Retreat confirmation open: {handler.IsWarningWidgetOpened}");
+                case "state":
+                    return Succeeded($"Retreat confirmation open: {handler.IsWarningWidgetOpened}");
+                default:
+                    return Failed("Invalid command argument value.");
+            }
         }
     }
 
     /// <summary>Closes the current encounter conversation so vanilla can advance to battle choices.</summary>
-    [CommandLineArgumentFunction("complete_encounter_meeting", "coop.debug.mapevent")]
-    public static string CompleteEncounterMeeting(List<string> args)
+    public sealed class CompleteEncounterMeetingCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client at the encounter meeting.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.complete_encounter_meeting";
+        public string Name => "complete_encounter_meeting";
 
-        if (Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId != "encounter_meeting")
-            return "The encounter meeting is not active.";
+        public string Description => "Runs the complete encounter meeting debug operation.";
 
-        var conversationManager = Campaign.Current.ConversationManager;
-        if (!conversationManager.IsConversationInProgress)
-            return "The encounter conversation is not active.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        conversationManager.EndConversation();
-        return "Encounter meeting completed.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client at the encounter meeting.");
+
+
+            if (Campaign.Current?.CurrentMenuContext?.GameMenu?.StringId != "encounter_meeting")
+                return Failed("The encounter meeting is not active.");
+
+            var conversationManager = Campaign.Current.ConversationManager;
+            if (!conversationManager.IsConversationInProgress)
+                return Failed("The encounter conversation is not active.");
+
+            conversationManager.EndConversation();
+            return Succeeded("Encounter meeting completed.");
+        }
     }
 
     /// <summary>Runs the encounter menu's mission or simulation consequence for automated battle testing.</summary>
-    [CommandLineArgumentFunction("choose_battle_mode", "coop.debug.mapevent")]
-    public static string ChooseBattleMode(List<string> args)
+    public sealed class ChooseBattleModeCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client at the encounter menu.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.mapevent.choose_battle_mode <mission|simulation>";
+        public string Name => "choose_battle_mode";
 
-        if (PlayerEncounter.Current == null)
-            return "No active player encounter.";
+        public string Description => "Runs the choose battle mode debug operation.";
 
-        var behavior = Campaign.Current?.GetCampaignBehavior<EncounterGameMenuBehavior>();
-        if (behavior == null)
-            return "Encounter menu behavior is unavailable.";
-
-        switch (args[0].ToLowerInvariant())
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "mission":
-                behavior.game_menu_encounter_attack_on_consequence(null);
-                return "Mission battle requested.";
-            case "simulation":
-                behavior.game_menu_encounter_order_attack_on_consequence(null);
-                return "Battle simulation requested.";
-            default:
-                return "Usage: coop.debug.mapevent.choose_battle_mode <mission|simulation>";
+            new ExpectedArgs("mode", "The battle mode.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client at the encounter menu.");
+
+
+            if (PlayerEncounter.Current == null)
+                return Failed("No active player encounter.");
+
+            var behavior = Campaign.Current?.GetCampaignBehavior<EncounterGameMenuBehavior>();
+            if (behavior == null)
+                return Failed("Encounter menu behavior is unavailable.");
+
+            switch (args[0].ToLowerInvariant())
+            {
+                case "mission":
+                    behavior.game_menu_encounter_attack_on_consequence(null);
+                    return Succeeded("Mission battle requested.");
+                case "simulation":
+                    behavior.game_menu_encounter_order_attack_on_consequence(null);
+                    return Succeeded("Battle simulation requested.");
+                default:
+                    return Failed("Invalid command argument value.");
+            }
         }
     }
 
@@ -3194,31 +3722,41 @@ public class MapEventDebugCommands
         return $"id={id} finalized={mapEvent.IsFinalized} state={mapEvent.BattleState} winner={mapEvent.WinningSide}";
     }
 
-    [CommandLineArgumentFunction("get_events", "coop.debug.mapevent")]
-    public static string GetEvents(List<string> args)
+    public sealed class GetEventsCoopCommand : ICoopCommand
     {
-        var sb = new StringBuilder();
+        public string Prefix => "coop.debug.map_event";
 
-        if(!TryGetObjectManager(out var objectManager))
-        {
-            return "Failed to get object manager";
-        }
+        public string Name => "get_events";
 
-        foreach(var mapEvent in Campaign.Current.MapEventManager.MapEvents)
+        public string Description => "Reports events.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (objectManager.TryGetIdWithLogging(mapEvent, out var id))
+            var sb = new StringBuilder();
+
+            if(!TryGetObjectManager(out var objectManager))
             {
-                sb.AppendLine($"Map event id: {id}");
+                return Failed("Failed to get object manager");
             }
 
-            var partyNames = mapEvent.AttackerSide.Parties?
-                .Select(party => party?.Party?.Name?.ToString() ?? "<null>")
-                .ToArray() ?? Array.Empty<string>();
-            sb.AppendLine($"\tAttacker: {string.Join(",", FormatSideNames(mapEvent.AttackerSide))}");
-            sb.AppendLine($"\tDefender: {string.Join(",", FormatSideNames(mapEvent.DefenderSide))}");
-        }
+            foreach(var mapEvent in Campaign.Current.MapEventManager.MapEvents)
+            {
+                if (objectManager.TryGetIdWithLogging(mapEvent, out var id))
+                {
+                    sb.AppendLine($"Map event id: {id}");
+                }
 
-        return sb.ToString();
+                var partyNames = mapEvent.AttackerSide.Parties?
+                    .Select(party => party?.Party?.Name?.ToString() ?? "<null>")
+                    .ToArray() ?? Array.Empty<string>();
+                sb.AppendLine($"\tAttacker: {string.Join(",", FormatSideNames(mapEvent.AttackerSide))}");
+                sb.AppendLine($"\tDefender: {string.Join(",", FormatSideNames(mapEvent.DefenderSide))}");
+            }
+
+            return Succeeded(sb.ToString());
+        }
     }
 
     private static string[] FormatSideNames(MapEventSide side)
@@ -3231,39 +3769,47 @@ public class MapEventDebugCommands
             .ToArray() ?? Array.Empty<string>();
     }
 
-    [CommandLineArgumentFunction("get_event", "coop.debug.mapevent")]
-    public static string GetEvent(List<string> args)
+    public sealed class GetEventCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "get_event";
+
+        public string Description => "Reports event.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.mapevent.get_event <mapEventId>";
-        }
+            new ExpectedArgs("map_event_id", "The map event id.", true),
+        };
 
-        if (!TryGetObjectManager(out var objectManager))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Failed to get object manager";
+            if (!TryGetObjectManager(out var objectManager))
+            {
+                return Failed("Failed to get object manager");
+            }
+
+            var mapEventId = args[0];
+
+            if (!objectManager.TryGetObjectWithLogging<MapEvent>(mapEventId, out var mapEvent))
+            {
+                return Failed($"Failed to find MapEvent with id: {mapEventId}");
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"Map event id: {mapEventId}");
+            sb.AppendLine();
+
+            AppendMapEventSummary(sb, mapEvent);
+            sb.AppendLine();
+
+            var result = sb.ToString();
+
+            Logger.Debug("{MapEvent}", result);
+
+            return Succeeded(result);
         }
-
-        var mapEventId = args[0];
-
-        if (!objectManager.TryGetObjectWithLogging<MapEvent>(mapEventId, out var mapEvent))
-        {
-            return $"Failed to find MapEvent with id: {mapEventId}";
-        }
-
-        var sb = new StringBuilder();
-
-        sb.AppendLine($"Map event id: {mapEventId}");
-        sb.AppendLine();
-
-        AppendMapEventSummary(sb, mapEvent);
-        sb.AppendLine();
-
-        var result = sb.ToString();
-
-        Logger.Debug("{MapEvent}", result);
-
-        return result;
     }
 
     private static void AppendMapEventSummary(StringBuilder sb, MapEvent mapEvent)

--- a/source/GameInterface/Services/MapEvents/Commands/PostBattleFreezeFixtureCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/PostBattleFreezeFixtureCommands.cs
@@ -1,4 +1,5 @@
 ﻿#if DEBUG
+using Common.Commands;
 using Autofac;
 using Common;
 using Common.Messaging;
@@ -28,12 +29,17 @@ using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.Localization;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.MapEvents.Commands;
 
 internal class PostBattleFreezeFixtureCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private const string TubilisCastleId = "castle_A1";
     private const int FirstPlayerTroops = 179;
     private const int SecondPlayerTroops = 202;
@@ -41,248 +47,292 @@ internal class PostBattleFreezeFixtureCommands
 
     private static PostBattleFreezeFixture fixture;
 
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_start", "coop.debug.mapevent")]
-    public static string StartFixture(List<string> args)
+    public sealed class PostBattleFreezeFixtureStartCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 2)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_start <firstControllerId> <secondControllerId>";
-        if (fixture != null)
-            return "The post-battle freeze fixture is already active.";
+        public string Prefix => "coop.debug.map_event";
 
-        if (!TryResolveServices(
-                out var objectManager,
-                out var playerManager,
-                out var behaviorSnapshot,
-                out var timeControl,
-                out var error))
-            return error;
+        public string Name => "post_battle_freeze_fixture_start";
 
-        if (!TryGetReadyPlayerParty(playerManager, objectManager, args[0], out var firstPlayer, out error) ||
-            !TryGetReadyPlayerParty(playerManager, objectManager, args[1], out var secondPlayer, out error))
-            return error;
-        if (firstPlayer == secondPlayer)
-            return "The fixture requires two different player parties.";
+        public string Description => "Runs the post battle freeze fixture start debug operation.";
 
-        var tubilisCastle = Settlement.Find(TubilisCastleId);
-        if (tubilisCastle == null)
-            return $"Settlement {TubilisCastleId} was not found.";
-
-        var aiLordParty = MobileParty.All
-            .Where(p => p.IsActive &&
-                        p != firstPlayer &&
-                        p != secondPlayer &&
-                        p.LeaderHero?.IsLord == true &&
-                        !p.IsPlayerParty() &&
-                        p.MapEvent == null &&
-                        p.CurrentSettlement == null &&
-                        p.MemberRoster.TotalManCount > 0 &&
-                        p.MapFaction != null &&
-                        firstPlayer.MapFaction != null &&
-                        FactionManager.IsAtWarAgainstFaction(p.MapFaction, firstPlayer.MapFaction))
-            .OrderBy(p => p.Position.ToVec2().DistanceSquared(tubilisCastle.Position.ToVec2()))
-            .FirstOrDefault();
-        if (aiLordParty == null)
-            return "No active AI lord party at war with the first player is available.";
-
-        var troop = FindFixtureTroop(firstPlayer, secondPlayer, aiLordParty);
-        if (troop == null)
-            return "No regular troop template is available for the fixture.";
-
-        var firstPlayerSnapshot = CaptureParty(firstPlayer, behaviorSnapshot);
-        var secondPlayerSnapshot = CaptureParty(secondPlayer, behaviorSnapshot);
-        var aiLordSnapshot = CaptureParty(aiLordParty, behaviorSnapshot);
-        var partySnapshots = new[]
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            firstPlayerSnapshot,
-            secondPlayerSnapshot,
-            aiLordSnapshot,
+            new ExpectedArgs("first_controller_id", "The first controller id.", true),
+            new ExpectedArgs("second_controller_id", "The second controller id.", true),
         };
-        var heroSnapshots = partySnapshots
-            .SelectMany(party => party.MemberRoster.Concat(party.PrisonRoster))
-            .Where(element => element.Character.IsHero)
-            .Select(element => element.Character.HeroObject)
-            .Concat(partySnapshots.Select(party => party.LeaderHero))
-            .Where(hero => hero != null)
-            .Distinct()
-            .Select(CaptureHero)
-            .ToArray();
-        var battleHeroes = firstPlayerSnapshot.MemberRoster
-            .Concat(secondPlayerSnapshot.MemberRoster)
-            .Where(element => element.Character.IsHero)
-            .Select(element => element.Character.HeroObject)
-            .Concat(new[]
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+            if (fixture != null)
+                return Failed("The post-battle freeze fixture is already active.");
+
+            if (!TryResolveServices(
+                    out var objectManager,
+                    out var playerManager,
+                    out var behaviorSnapshot,
+                    out var timeControl,
+                    out var error))
+                return Failed(error);
+
+            if (!TryGetReadyPlayerParty(playerManager, objectManager, args[0], out var firstPlayer, out error) ||
+                !TryGetReadyPlayerParty(playerManager, objectManager, args[1], out var secondPlayer, out error))
+                return Failed(error);
+            if (firstPlayer == secondPlayer)
+                return Failed("The fixture requires two different player parties.");
+
+            var tubilisCastle = Settlement.Find(TubilisCastleId);
+            if (tubilisCastle == null)
+                return Failed($"Settlement {TubilisCastleId} was not found.");
+
+            var aiLordParty = MobileParty.All
+                .Where(p => p.IsActive &&
+                            p != firstPlayer &&
+                            p != secondPlayer &&
+                            p.LeaderHero?.IsLord == true &&
+                            !p.IsPlayerParty() &&
+                            p.MapEvent == null &&
+                            p.CurrentSettlement == null &&
+                            p.MemberRoster.TotalManCount > 0 &&
+                            p.MapFaction != null &&
+                            firstPlayer.MapFaction != null &&
+                            FactionManager.IsAtWarAgainstFaction(p.MapFaction, firstPlayer.MapFaction))
+                .OrderBy(p => p.Position.ToVec2().DistanceSquared(tubilisCastle.Position.ToVec2()))
+                .FirstOrDefault();
+            if (aiLordParty == null)
+                return Failed("No active AI lord party at war with the first player is available.");
+
+            var troop = FindFixtureTroop(firstPlayer, secondPlayer, aiLordParty);
+            if (troop == null)
+                return Failed("No regular troop template is available for the fixture.");
+
+            var firstPlayerSnapshot = CaptureParty(firstPlayer, behaviorSnapshot);
+            var secondPlayerSnapshot = CaptureParty(secondPlayer, behaviorSnapshot);
+            var aiLordSnapshot = CaptureParty(aiLordParty, behaviorSnapshot);
+            var partySnapshots = new[]
             {
-                firstPlayerSnapshot.LeaderHero,
-                secondPlayerSnapshot.LeaderHero,
+                firstPlayerSnapshot,
+                secondPlayerSnapshot,
+                aiLordSnapshot,
+            };
+            var heroSnapshots = partySnapshots
+                .SelectMany(party => party.MemberRoster.Concat(party.PrisonRoster))
+                .Where(element => element.Character.IsHero)
+                .Select(element => element.Character.HeroObject)
+                .Concat(partySnapshots.Select(party => party.LeaderHero))
+                .Where(hero => hero != null)
+                .Distinct()
+                .Select(CaptureHero)
+                .ToArray();
+            var battleHeroes = firstPlayerSnapshot.MemberRoster
+                .Concat(secondPlayerSnapshot.MemberRoster)
+                .Where(element => element.Character.IsHero)
+                .Select(element => element.Character.HeroObject)
+                .Concat(new[]
+                {
+                    firstPlayerSnapshot.LeaderHero,
+                    secondPlayerSnapshot.LeaderHero,
+                    aiLordParty.LeaderHero,
+                })
+                .Where(hero => hero != null)
+                .Distinct()
+                .ToArray();
+            var clanSnapshots = heroSnapshots
+                .Select(snapshot => snapshot.Hero.Clan)
+                .Where(clan => clan != null)
+                .Distinct()
+                .Select(CaptureClan)
+                .ToArray();
+
+            var pendingFixture = new PostBattleFreezeFixture(
+                args[0],
+                args[1],
+                tubilisCastle,
+                firstPlayerSnapshot,
+                secondPlayerSnapshot,
+                aiLordSnapshot,
                 aiLordParty.LeaderHero,
-            })
-            .Where(hero => hero != null)
-            .Distinct()
-            .ToArray();
-        var clanSnapshots = heroSnapshots
-            .Select(snapshot => snapshot.Hero.Clan)
-            .Where(clan => clan != null)
-            .Distinct()
-            .Select(CaptureClan)
-            .ToArray();
+                battleHeroes,
+                heroSnapshots,
+                clanSnapshots,
+                timeControl.GetTimeControl());
 
-        var pendingFixture = new PostBattleFreezeFixture(
-            args[0],
-            args[1],
-            tubilisCastle,
-            firstPlayerSnapshot,
-            secondPlayerSnapshot,
-            aiLordSnapshot,
-            aiLordParty.LeaderHero,
-            battleHeroes,
-            heroSnapshots,
-            clanSnapshots,
-            timeControl.GetTimeControl());
-
-        fixture = pendingFixture;
-        try
-        {
-            var battlePosition = new CampaignVec2(
-                new Vec2(tubilisCastle.Position.X, tubilisCastle.Position.Y - 1.5f),
-                true);
-
-            pendingFixture.AiParty = CreateDisposableAiLordParty(
-                battlePosition,
-                pendingFixture.AiLeader,
-                aiLordParty.ActualClan);
-
-            aiLordParty.RemovePartyLeader();
-            aiLordParty.MemberRoster.AddToCounts(pendingFixture.AiLeader.CharacterObject, -1);
-            pendingFixture.AiParty.MemberRoster.AddToCounts(pendingFixture.AiLeader.CharacterObject, 1);
-
-            PrepareParty(firstPlayer, battlePosition, FirstPlayerTroops, troop);
-            PrepareParty(secondPlayer, battlePosition, SecondPlayerTroops, troop);
-            PrepareParty(pendingFixture.AiParty, battlePosition, AiLordTroops, troop);
-
-            pendingFixture.MapEvent = MapEventBattleFactory.CreateMapEvent(
-                pendingFixture.AiParty.Party,
-                firstPlayer.Party,
-                default);
-            if (pendingFixture.MapEvent == null)
-                throw new InvalidOperationException("The fixture could not create a field battle.");
-
-            secondPlayer.Party.MapEventSide = firstPlayer.Party.MapEventSide;
-
-            return FormatState("Post-battle freeze fixture started", pendingFixture, timeControl);
-        }
-        catch (Exception setupException)
-        {
+            fixture = pendingFixture;
             try
             {
+                var battlePosition = new CampaignVec2(
+                    new Vec2(tubilisCastle.Position.X, tubilisCastle.Position.Y - 1.5f),
+                    true);
+
+                pendingFixture.AiParty = CreateDisposableAiLordParty(
+                    battlePosition,
+                    pendingFixture.AiLeader,
+                    aiLordParty.ActualClan);
+
+                aiLordParty.RemovePartyLeader();
+                aiLordParty.MemberRoster.AddToCounts(pendingFixture.AiLeader.CharacterObject, -1);
+                pendingFixture.AiParty.MemberRoster.AddToCounts(pendingFixture.AiLeader.CharacterObject, 1);
+
+                PrepareParty(firstPlayer, battlePosition, FirstPlayerTroops, troop);
+                PrepareParty(secondPlayer, battlePosition, SecondPlayerTroops, troop);
+                PrepareParty(pendingFixture.AiParty, battlePosition, AiLordTroops, troop);
+
+                pendingFixture.MapEvent = MapEventBattleFactory.CreateMapEvent(
+                    pendingFixture.AiParty.Party,
+                    firstPlayer.Party,
+                    default);
+                if (pendingFixture.MapEvent == null)
+                    throw new InvalidOperationException("The fixture could not create a field battle.");
+
+                secondPlayer.Party.MapEventSide = firstPlayer.Party.MapEventSide;
+
+                return Succeeded(FormatState("Post-battle freeze fixture started", pendingFixture, timeControl));
+            }
+            catch (Exception setupException)
+            {
+                try
+                {
+                    RestoreFixture(pendingFixture, behaviorSnapshot, timeControl);
+                    fixture = null;
+                }
+                catch (Exception restoreException)
+                {
+                    return Failed($"Fixture setup failed: {setupException.Message}. " +
+                           $"Rollback failed: {restoreException.Message}. Run the restore command.");
+                }
+
+                return Failed($"Fixture setup failed: {setupException.Message}. The baseline was restored.");
+            }
+        }
+    }
+
+    public sealed class PostBattleFreezeFixtureOpenCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "post_battle_freeze_fixture_open";
+
+        public string Description => "Runs the post battle freeze fixture open debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+            if (fixture == null)
+                return Failed("The post-battle freeze fixture is not active.");
+            if (fixture.EncountersOpened)
+                return Failed("The post-battle freeze fixture encounters are already open.");
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
+                !ContainerProvider.TryResolve<INetwork>(out var network))
+                return Failed("Unable to resolve the encounter services.");
+
+            if (!objectManager.TryGetId(fixture.AiParty.Party, out string aiPartyId) ||
+                !objectManager.TryGetId(fixture.FirstPlayer.Party.Party, out string firstPlayerPartyId) ||
+                !objectManager.TryGetId(fixture.SecondPlayer.Party.Party, out string secondPlayerPartyId) ||
+                !objectManager.TryGetId(fixture.MapEvent, out string mapEventId))
+                return Failed("The fixture could not resolve the battle's network ids.");
+
+            network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
+                $"debug-2218-first-{Guid.NewGuid():N}",
+                aiPartyId,
+                firstPlayerPartyId,
+                mapEventId));
+            network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
+                $"debug-2218-second-{Guid.NewGuid():N}",
+                aiPartyId,
+                secondPlayerPartyId,
+                mapEventId));
+            fixture.EncountersOpened = true;
+            return Succeeded($"Opened the post-battle freeze fixture encounter for " +
+                   $"{fixture.FirstControllerId} and {fixture.SecondControllerId}.");
+        }
+    }
+
+    public sealed class PostBattleFreezeFixtureStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "post_battle_freeze_fixture_state";
+
+        public string Description => "Reports post battle freeze fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server. Use the existing client observation commands on each client.");
+            if (fixture == null)
+                return Failed("The post-battle freeze fixture is not active.");
+            if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControl))
+                return Failed("Unable to resolve time control.");
+
+            return Succeeded(FormatState("Post-battle freeze fixture state", fixture, timeControl));
+        }
+    }
+
+    public sealed class PostBattleFreezeFixtureUnpauseCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "post_battle_freeze_fixture_unpause";
+
+        public string Description => "Runs the post battle freeze fixture unpause debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+            if (fixture == null)
+                return Failed("The post-battle freeze fixture is not active.");
+            if (fixture.FirstPlayer.Party.MapEvent != null || fixture.SecondPlayer.Party.MapEvent != null)
+                return Failed("Both player parties must leave the battle before the unpause probe.");
+            if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControl))
+                return Failed("Unable to resolve time control.");
+
+            fixture.ProbeStartedAt = CampaignTime.Now;
+            timeControl.ServerSetTimeControl(TimeControlEnum.Play_1x);
+            return Succeeded($"Post-battle unpause requested at {fixture.ProbeStartedAt.NumTicks} ticks. " +
+                   "Submit coop.debug.mobileparty.move_offset 0.5 0 on both clients, then check fixture state.");
+        }
+    }
+
+    public sealed class PostBattleFreezeFixtureRestoreCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.map_event";
+
+        public string Name => "post_battle_freeze_fixture_restore";
+
+        public string Description => "Restores or clears post battle freeze fixture restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+            if (fixture == null)
+                return Failed("The post-battle freeze fixture is not active.");
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
+                !ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControl))
+                return Failed("Unable to resolve fixture restore services.");
+
+            try
+            {
+                var pendingFixture = fixture;
                 RestoreFixture(pendingFixture, behaviorSnapshot, timeControl);
                 fixture = null;
+                return Succeeded("Post-battle freeze fixture restored.");
             }
-            catch (Exception restoreException)
+            catch (Exception e)
             {
-                return $"Fixture setup failed: {setupException.Message}. " +
-                       $"Rollback failed: {restoreException.Message}. Run the restore command.";
+                return Failed($"Fixture restore failed: {e.Message}. Retry the restore command.");
             }
-
-            return $"Fixture setup failed: {setupException.Message}. The baseline was restored.";
-        }
-    }
-
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_open", "coop.debug.mapevent")]
-    public static string OpenFixtureEncounters(List<string> args)
-    {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_open";
-        if (fixture == null)
-            return "The post-battle freeze fixture is not active.";
-        if (fixture.EncountersOpened)
-            return "The post-battle freeze fixture encounters are already open.";
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
-            !ContainerProvider.TryResolve<INetwork>(out var network))
-            return "Unable to resolve the encounter services.";
-
-        if (!objectManager.TryGetId(fixture.AiParty.Party, out string aiPartyId) ||
-            !objectManager.TryGetId(fixture.FirstPlayer.Party.Party, out string firstPlayerPartyId) ||
-            !objectManager.TryGetId(fixture.SecondPlayer.Party.Party, out string secondPlayerPartyId) ||
-            !objectManager.TryGetId(fixture.MapEvent, out string mapEventId))
-            return "The fixture could not resolve the battle's network ids.";
-
-        network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
-            $"debug-2218-first-{Guid.NewGuid():N}",
-            aiPartyId,
-            firstPlayerPartyId,
-            mapEventId));
-        network.SendAll(new NetworkPlayerPartyHostileEncounterStarted(
-            $"debug-2218-second-{Guid.NewGuid():N}",
-            aiPartyId,
-            secondPlayerPartyId,
-            mapEventId));
-        fixture.EncountersOpened = true;
-        return $"Opened the post-battle freeze fixture encounter for " +
-               $"{fixture.FirstControllerId} and {fixture.SecondControllerId}.";
-    }
-
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_state", "coop.debug.mapevent")]
-    public static string GetFixtureState(List<string> args)
-    {
-        if (ModInformation.IsClient)
-            return "Run this command on the server. Use the existing client observation commands on each client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_state";
-        if (fixture == null)
-            return "The post-battle freeze fixture is not active.";
-        if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControl))
-            return "Unable to resolve time control.";
-
-        return FormatState("Post-battle freeze fixture state", fixture, timeControl);
-    }
-
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_unpause", "coop.debug.mapevent")]
-    public static string UnpauseFixture(List<string> args)
-    {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_unpause";
-        if (fixture == null)
-            return "The post-battle freeze fixture is not active.";
-        if (fixture.FirstPlayer.Party.MapEvent != null || fixture.SecondPlayer.Party.MapEvent != null)
-            return "Both player parties must leave the battle before the unpause probe.";
-        if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControl))
-            return "Unable to resolve time control.";
-
-        fixture.ProbeStartedAt = CampaignTime.Now;
-        timeControl.ServerSetTimeControl(TimeControlEnum.Play_1x);
-        return $"Post-battle unpause requested at {fixture.ProbeStartedAt.NumTicks} ticks. " +
-               "Submit coop.debug.mobileparty.move_offset 0.5 0 on both clients, then check fixture state.";
-    }
-
-    [CommandLineArgumentFunction("post_battle_freeze_fixture_restore", "coop.debug.mapevent")]
-    public static string RestoreFixture(List<string> args)
-    {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mapevent.post_battle_freeze_fixture_restore";
-        if (fixture == null)
-            return "The post-battle freeze fixture is not active.";
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
-            !ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControl))
-            return "Unable to resolve fixture restore services.";
-
-        try
-        {
-            var pendingFixture = fixture;
-            RestoreFixture(pendingFixture, behaviorSnapshot, timeControl);
-            fixture = null;
-            return "Post-battle freeze fixture restored.";
-        }
-        catch (Exception e)
-        {
-            return $"Fixture restore failed: {e.Message}. Retry the restore command.";
         }
     }
 

--- a/source/GameInterface/Services/Party/Commands/GarrisonTroopXpFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/GarrisonTroopXpFixtureCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using Common.Messaging;
 using GameInterface.Services.MobileParties.Messages.Behavior;
@@ -19,7 +20,6 @@ using TaleWorlds.CampaignSystem.Settlements.Buildings;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
@@ -28,6 +28,12 @@ namespace GameInterface.Services.Party.Commands;
 /// </summary>
 internal static class GarrisonTroopXpFixtureCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private const string SettlementId = "town_ES1";
     private const string CharacterId = "imperial_infantryman";
     private const int FixtureTroopCount = 1;
@@ -37,438 +43,548 @@ internal static class GarrisonTroopXpFixtureCommands
     private static GarrisonFixture restoredFixture;
     private static string pendingNoopRestorationControllerId;
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_capture", "coop.debug.mobileparty")]
-    public static string Capture(List<string> args)
+    public sealed class GarrisonXpFixtureCaptureCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_capture <controllerId>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 1) return usage;
-        if (fixture != null || restoredFixture != null || pendingNoopRestorationControllerId != null)
-            return "A garrison XP fixture lifecycle is already active.";
-        if (pendingCapture != null)
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "garrison_xp_fixture_capture";
+
+        public string Description => "Runs the garrison xp fixture capture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (pendingCapture.ControllerId != args[0] || !IsCaptureCurrent(pendingCapture))
-                return "A different or stale garrison XP fixture capture is active.";
-            return FormatCapture(pendingCapture);
-        }
-        if (!TryResolve(args[0], out var objectManager, out var playerManager, out var player,
-            out var playerHero, out var playerClan, out var playerParty, out var settlement,
-            out var garrison, out var character, out var error))
-            return "Failed to capture garrison XP fixture: " + error;
-        if (!playerManager.TryGetPeer(player.ControllerId, out _))
-            return $"Player '{player.ControllerId}' is not connected.";
-        if (playerParty.MapEvent != null || playerParty.BesiegerCamp != null ||
-            playerParty.IsTransitionInProgress)
-            return "Failed to capture garrison XP fixture: the player party is in a map event, siege, or navigation transition.";
-        if (playerParty.Army != null || playerParty.AttachedTo != null ||
-            playerParty.AttachedParties?.Count > 0)
-            return "Failed to capture garrison XP fixture: the player party is attached to an army or has attached parties.";
-        if (settlement.Party.MapEvent != null || settlement.SiegeEvent != null)
-            return "Failed to capture garrison XP fixture: Danustica is in an active map event or siege.";
-        if (settlement.OwnerClan?.Leader == null)
-            return "Failed to capture garrison XP fixture: Danustica has no restorable owner.";
-        if (character.UpgradeTargets.Length == 0)
-            return $"Failed to capture garrison XP fixture: {CharacterId} has no upgrade target.";
-        if (!objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId) ||
-            !objectManager.TryGetIdWithLogging(garrison, out var garrisonPartyId))
-            return "Failed to capture garrison XP fixture: a required party is not registered.";
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        var garrisonState = ReadRosterState(garrison.MemberRoster, character);
-        var playerState = ReadRosterState(playerParty.MemberRoster, character);
-        int upgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
-        if (upgradeXp <= 0)
-            return $"Failed to capture garrison XP fixture: {CharacterId} has invalid upgrade XP {upgradeXp}.";
-
-        pendingCapture = new GarrisonFixture(
-            player.ControllerId,
-            playerPartyId,
-            garrisonPartyId,
-            playerHero,
-            playerClan,
-            playerParty,
-            settlement,
-            garrison,
-            character,
-            settlement.OwnerClan.Leader,
-            settlement.Town.Governor,
-            settlement.Town.BuildingsInProgress.ToArray(),
-            settlement.Town.BoostBuildingProcess,
-            settlement.Town.IsOwnerUnassigned,
-            playerParty.CurrentSettlement,
-            playerParty.LastVisitedSettlement,
-            playerParty.Position,
-            playerParty.Bearing,
-            garrisonState,
-            playerState,
-            upgradeXp);
-        return FormatCapture(pendingCapture);
-    }
-
-    [CommandLineArgumentFunction("garrison_xp_fixture_setup", "coop.debug.mobileparty")]
-    public static string Setup(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_setup " +
-            "<controllerId> <playerPartyId> <garrisonPartyId> <originalOwnerHeroId> <originalSettlementId|none> " +
-            "<originalPositionX> <originalPositionY> <originalPositionIsOnLand> " +
-            "<garrisonExists> <garrisonCount> <garrisonWounded> <garrisonXp> " +
-            "<playerExists> <playerCount> <playerWounded> <playerXp> <upgradeXp>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 17 ||
-            !float.TryParse(args[5], System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var originalPositionX) ||
-            !float.TryParse(args[6], System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var originalPositionY) ||
-            !bool.TryParse(args[7], out var originalPositionIsOnLand) ||
-            !bool.TryParse(args[8], out var expectedGarrisonExists) ||
-            !int.TryParse(args[9], out var expectedGarrisonCount) ||
-            !int.TryParse(args[10], out var expectedGarrisonWounded) ||
-            !int.TryParse(args[11], out var expectedGarrisonXp) ||
-            !bool.TryParse(args[12], out var expectedPlayerExists) ||
-            !int.TryParse(args[13], out var expectedPlayerCount) ||
-            !int.TryParse(args[14], out var expectedPlayerWounded) ||
-            !int.TryParse(args[15], out var expectedPlayerXp) ||
-            !int.TryParse(args[16], out var expectedUpgradeXp))
-            return usage;
-        if (fixture != null || restoredFixture != null)
-            return "A garrison XP fixture lifecycle is already active.";
-
-        pendingNoopRestorationControllerId = args[0];
-        if (!TryResolve(args[0], out var objectManager, out var playerManager, out var player,
-            out var playerHero, out var playerClan, out var playerParty, out var settlement,
-            out var garrison, out var character, out var error))
-            return "Failed to set up garrison XP fixture: " + error;
-        if (!playerManager.TryGetPeer(player.ControllerId, out _))
-            return $"Player '{player.ControllerId}' is not connected.";
-        if (!objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId) ||
-            !objectManager.TryGetIdWithLogging(garrison, out var garrisonPartyId))
-            return "Failed to set up garrison XP fixture: a required party is not registered.";
-
-        var capturedFixture = pendingCapture;
-        var originalOwner = Hero.FindFirst(hero => hero.StringId == args[3]);
-        var expectedGarrisonState = new RosterState(
-            expectedGarrisonExists, expectedGarrisonCount, expectedGarrisonWounded, expectedGarrisonXp);
-        var expectedPlayerState = new RosterState(
-            expectedPlayerExists, expectedPlayerCount, expectedPlayerWounded, expectedPlayerXp);
-        int currentUpgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
-        if (capturedFixture == null || capturedFixture.ControllerId != args[0] ||
-            playerPartyId != args[1] || garrisonPartyId != args[2] || originalOwner == null ||
-            settlement.OwnerClan?.Leader != originalOwner ||
-            (playerParty.CurrentSettlement?.StringId ?? "none") != args[4] ||
-            playerParty.Position.X != originalPositionX || playerParty.Position.Y != originalPositionY ||
-            playerParty.Position.IsOnLand != originalPositionIsOnLand ||
-            !ReadRosterState(garrison.MemberRoster, character).Equals(expectedGarrisonState) ||
-            !ReadRosterState(playerParty.MemberRoster, character).Equals(expectedPlayerState) ||
-            currentUpgradeXp != expectedUpgradeXp || !IsCaptureCurrent(capturedFixture))
-            return "Failed to set up garrison XP fixture: the captured fixture state changed.";
-
-        fixture = capturedFixture;
-        pendingCapture = null;
-
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (settlement.OwnerClan != playerClan)
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (fixture != null || restoredFixture != null || pendingNoopRestorationControllerId != null)
+                return Failed("A garrison XP fixture lifecycle is already active.");
+            if (pendingCapture != null)
             {
-                // Only the ownership field is needed for the XP relevance precondition. Running
-                // the ownership action would fire unrelated, irreversible campaign side effects.
-                settlement.Town.OwnerClan = playerClan;
-                settlement.Town.IsOwnerUnassigned = false;
+                if (pendingCapture.ControllerId != args[0] || !IsCaptureCurrent(pendingCapture))
+                    return Failed("A different or stale garrison XP fixture capture is active.");
+                return Succeeded(FormatCapture(pendingCapture));
             }
+            if (!TryResolve(args[0], out var objectManager, out var playerManager, out var player,
+                out var playerHero, out var playerClan, out var playerParty, out var settlement,
+                out var garrison, out var character, out var error))
+                return Failed("Failed to capture garrison XP fixture: " + error);
+            if (!playerManager.TryGetPeer(player.ControllerId, out _))
+                return Failed($"Player '{player.ControllerId}' is not connected.");
+            if (playerParty.MapEvent != null || playerParty.BesiegerCamp != null ||
+                playerParty.IsTransitionInProgress)
+                return Failed("Failed to capture garrison XP fixture: the player party is in a map event, siege, or navigation transition.");
+            if (playerParty.Army != null || playerParty.AttachedTo != null ||
+                playerParty.AttachedParties?.Count > 0)
+                return Failed("Failed to capture garrison XP fixture: the player party is attached to an army or has attached parties.");
+            if (settlement.Party.MapEvent != null || settlement.SiegeEvent != null)
+                return Failed("Failed to capture garrison XP fixture: Danustica is in an active map event or siege.");
+            if (settlement.OwnerClan?.Leader == null)
+                return Failed("Failed to capture garrison XP fixture: Danustica has no restorable owner.");
+            if (character.UpgradeTargets.Length == 0)
+                return Failed($"Failed to capture garrison XP fixture: {CharacterId} has no upgrade target.");
+            if (!objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId) ||
+                !objectManager.TryGetIdWithLogging(garrison, out var garrisonPartyId))
+                return Failed("Failed to capture garrison XP fixture: a required party is not registered.");
 
-            if (playerParty.CurrentSettlement != settlement)
-                playerParty.CurrentSettlement = settlement;
+            var garrisonState = ReadRosterState(garrison.MemberRoster, character);
+            var playerState = ReadRosterState(playerParty.MemberRoster, character);
+            int upgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
+            if (upgradeXp <= 0)
+                return Failed($"Failed to capture garrison XP fixture: {CharacterId} has invalid upgrade XP {upgradeXp}.");
 
-            SetRosterState(
-                garrison.MemberRoster,
-                character,
-                new RosterState(true, FixtureTroopCount, 0, expectedUpgradeXp));
-            pendingNoopRestorationControllerId = null;
-
-            return JsonResult(new
-            {
-                controllerId = player.ControllerId,
+            pendingCapture = new GarrisonFixture(
+                player.ControllerId,
                 playerPartyId,
                 garrisonPartyId,
-                settlementId = SettlementId,
-                settlementName = settlement.Name.ToString(),
-                characterId = CharacterId,
-                characterName = character.Name.ToString(),
-                upgradeTargetId = character.UpgradeTargets[0].StringId,
-                upgradeXp = expectedUpgradeXp,
-                garrisonCount = FixtureTroopCount,
-                garrisonXp = expectedUpgradeXp,
-                playerCount = expectedPlayerState.Number,
-                playerXp = expectedPlayerState.Xp,
-                totalXp = expectedPlayerState.Xp + expectedUpgradeXp,
-                playerOwnsSettlement = settlement.OwnerClan == playerClan,
-                playerAtSettlement = playerParty.CurrentSettlement == settlement
-            });
-        }
-        catch (Exception exception)
-        {
-            // Keep the partially staged fixture active so the contract's finally path restores
-            // and verifies it instead of treating a failed setup as a no-op.
-            pendingNoopRestorationControllerId = null;
-            return "Failed to set up garrison XP fixture: " + exception.Message;
+                playerHero,
+                playerClan,
+                playerParty,
+                settlement,
+                garrison,
+                character,
+                settlement.OwnerClan.Leader,
+                settlement.Town.Governor,
+                settlement.Town.BuildingsInProgress.ToArray(),
+                settlement.Town.BoostBuildingProcess,
+                settlement.Town.IsOwnerUnassigned,
+                playerParty.CurrentSettlement,
+                playerParty.LastVisitedSettlement,
+                playerParty.Position,
+                playerParty.Bearing,
+                garrisonState,
+                playerState,
+                upgradeXp);
+            return Succeeded(FormatCapture(pendingCapture));
         }
     }
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_state", "coop.debug.mobileparty")]
-    public static string State(List<string> args)
+    public sealed class GarrisonXpFixtureSetupCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_state " +
-            "<playerPartyId> <garrisonPartyId> <characterId>";
-        if (args.Count != 3) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty playerParty))
-            return $"Player party '{args[0]}' was not found.";
-        if (!objectManager.TryGetObject(args[1], out MobileParty garrison))
-            return $"Garrison party '{args[1]}' was not found.";
-        if (!objectManager.TryGetObject(args[2], out CharacterObject character))
-            return $"Character '{args[2]}' was not found.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var settlement = Settlement.Find(SettlementId);
-        var garrisonState = ReadRosterState(garrison.MemberRoster, character);
-        var playerState = ReadRosterState(playerParty.MemberRoster, character);
-        int upgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
-        return JsonResult(new
+        public string Name => "garrison_xp_fixture_setup";
+
+        public string Description => "Runs the garrison xp fixture setup debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            role = ModInformation.IsServer ? "server" : "client",
-            playerPartyId = args[0],
-            garrisonPartyId = args[1],
-            settlementId = SettlementId,
-            settlementName = settlement?.Name.ToString(),
-            characterId = args[2],
-            characterName = character.Name.ToString(),
-            playerOwnsSettlement = settlement?.OwnerClan != null &&
-                ReferenceEquals(settlement.OwnerClan, playerParty.ActualClan),
-            playerAtSettlement = playerParty.CurrentSettlement == settlement,
-            bearingX = playerParty.Bearing.X,
-            bearingY = playerParty.Bearing.Y,
-            garrisonCount = garrisonState.Number,
-            garrisonWounded = garrisonState.Wounded,
-            garrisonXp = garrisonState.Xp,
-            garrisonUpgradeReady = garrisonState.Number > 0 && garrisonState.Xp >= upgradeXp,
-            playerCount = playerState.Number,
-            playerWounded = playerState.Wounded,
-            playerXp = playerState.Xp,
-            playerUpgradeReady = playerState.Number > 0 && playerState.Xp >= upgradeXp,
-            upgradeXp,
-            totalXp = garrisonState.Xp + playerState.Xp
-        });
-    }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("player_party_id", "The player party id.", true),
+            new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+            new ExpectedArgs("original_owner_hero_id", "The original owner hero id.", true),
+            new ExpectedArgs("original_settlement_id", "The original settlement id.", true),
+            new ExpectedArgs("original_position_x", "The original position x.", true),
+            new ExpectedArgs("original_position_y", "The original position y.", true),
+            new ExpectedArgs("original_position_is_on_land", "The original position is on land.", true),
+            new ExpectedArgs("garrison_exists", "The garrison exists.", true),
+            new ExpectedArgs("garrison_count", "The garrison count.", true),
+            new ExpectedArgs("garrison_wounded", "The garrison wounded.", true),
+            new ExpectedArgs("garrison_xp", "The garrison xp.", true),
+            new ExpectedArgs("player_exists", "The player exists.", true),
+            new ExpectedArgs("player_count", "The player count.", true),
+            new ExpectedArgs("player_wounded", "The player wounded.", true),
+            new ExpectedArgs("player_xp", "The player xp.", true),
+            new ExpectedArgs("upgrade_xp", "The upgrade xp.", true),
+        };
 
-    [CommandLineArgumentFunction("open_garrison_xp_fixture", "coop.debug.mobileparty")]
-    public static string OpenGarrison(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.open_garrison_xp_fixture <garrisonPartyId>";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 1) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty garrison))
-            return $"Garrison party '{args[0]}' was not found.";
-        var settlement = Settlement.Find(SettlementId);
-        if (settlement == null || garrison != settlement.Town?.GarrisonParty)
-            return "The target is not Danustica's garrison.";
-        if (Hero.MainHero?.CurrentSettlement != settlement)
-            return "The local player is not in Danustica.";
-        if (settlement.OwnerClan != Hero.MainHero.Clan)
-            return "Danustica does not belong to the local player's clan.";
-
-        PartyScreenHelper.OpenScreenAsManageTroops(garrison);
-        return "GARRISON_XP_FIXTURE_SCREEN_OPENED";
-    }
-
-    [CommandLineArgumentFunction("garrison_xp_fixture_screen_state", "coop.debug.mobileparty")]
-    public static string ScreenState(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_screen_state " +
-            "<garrisonPartyId> <characterId> <baseline|staged|committed>";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 3 ||
-            (args[2] != "baseline" && args[2] != "staged" && args[2] != "committed"))
-            return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty garrison))
-            return $"Garrison party '{args[0]}' was not found.";
-        if (!objectManager.TryGetObject(args[1], out CharacterObject character))
-            return $"Character '{args[1]}' was not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
-            partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != garrison)
-            return "Danustica's Manage Garrison screen is not active.";
-
-        var logic = partyState.PartyScreenLogic;
-        var leftState = ReadRosterState(logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left], character);
-        var rightState = ReadRosterState(logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right], character);
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        var leftRow = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        var rightRow = partyVm?.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        int upgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
-        bool expectedStateReady;
-        if (args[2] == "baseline")
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            expectedStateReady = partyVm != null && !logic.IsThereAnyChanges() &&
-                leftState.Number == FixtureTroopCount && leftState.Xp == upgradeXp &&
-                leftRow?.Troop.Number == FixtureTroopCount && leftRow.Troop.Xp == upgradeXp;
-        }
-        else if (args[2] == "staged")
-        {
-            expectedStateReady = partyVm != null && logic.IsThereAnyChanges() &&
-                leftState.Number == 0 && leftRow == null &&
-                rightState.Number > 0 && rightRow?.Troop.Number == rightState.Number &&
-                rightRow.Troop.Xp == rightState.Xp && rightRow.NumOfReadyToUpgradeTroops > 0;
-        }
-        else
-        {
-            expectedStateReady = partyVm != null && !logic.IsThereAnyChanges() &&
-                leftState.Number == 0 && leftRow == null &&
-                rightState.Number > 0 && rightRow?.Troop.Number == rightState.Number &&
-                rightRow.Troop.Xp == rightState.Xp && rightRow.NumOfReadyToUpgradeTroops > 0;
-        }
-        return JsonResult(new
-        {
-            ready = expectedStateReady,
-            expectedState = args[2],
-            settlementId = SettlementId,
-            settlementName = Settlement.Find(SettlementId)?.Name.ToString(),
-            pending = logic.IsThereAnyChanges(),
-            leftCount = leftState.Number,
-            leftXp = leftState.Xp,
-            leftReady = leftRow?.NumOfReadyToUpgradeTroops ?? 0,
-            rightCount = rightState.Number,
-            rightXp = rightState.Xp,
-            rightReady = rightRow?.NumOfReadyToUpgradeTroops ?? 0,
-            upgradeXp
-        });
-    }
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (!float.TryParse(args[5], System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var originalPositionX) ||
+                !float.TryParse(args[6], System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var originalPositionY) ||
+                !bool.TryParse(args[7], out var originalPositionIsOnLand) ||
+                !bool.TryParse(args[8], out var expectedGarrisonExists) ||
+                !int.TryParse(args[9], out var expectedGarrisonCount) ||
+                !int.TryParse(args[10], out var expectedGarrisonWounded) ||
+                !int.TryParse(args[11], out var expectedGarrisonXp) ||
+                !bool.TryParse(args[12], out var expectedPlayerExists) ||
+                !int.TryParse(args[13], out var expectedPlayerCount) ||
+                !int.TryParse(args[14], out var expectedPlayerWounded) ||
+                !int.TryParse(args[15], out var expectedPlayerXp) ||
+                !int.TryParse(args[16], out var expectedUpgradeXp))
+                return Failed("Invalid command argument value.");
+            if (fixture != null || restoredFixture != null)
+                return Failed("A garrison XP fixture lifecycle is already active.");
 
-    [CommandLineArgumentFunction("stage_garrison_xp_withdrawal", "coop.debug.mobileparty")]
-    public static string StageWithdrawal(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.stage_garrison_xp_withdrawal " +
-            "<garrisonPartyId> <characterId>";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 2) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty garrison))
-            return $"Garrison party '{args[0]}' was not found.";
-        if (!objectManager.TryGetObject(args[1], out CharacterObject character))
-            return $"Character '{args[1]}' was not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
-            partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != garrison)
-            return "Danustica's Manage Garrison screen is not active.";
+            pendingNoopRestorationControllerId = args[0];
+            if (!TryResolve(args[0], out var objectManager, out var playerManager, out var player,
+                out var playerHero, out var playerClan, out var playerParty, out var settlement,
+                out var garrison, out var character, out var error))
+                return Failed("Failed to set up garrison XP fixture: " + error);
+            if (!playerManager.TryGetPeer(player.ControllerId, out _))
+                return Failed($"Player '{player.ControllerId}' is not connected.");
+            if (!objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId) ||
+                !objectManager.TryGetIdWithLogging(garrison, out var garrisonPartyId))
+                return Failed("Failed to set up garrison XP fixture: a required party is not registered.");
 
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        var row = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        if (row == null) return $"Character '{args[1]}' is not rendered in Danustica's garrison.";
+            var capturedFixture = pendingCapture;
+            var originalOwner = Hero.FindFirst(hero => hero.StringId == args[3]);
+            var expectedGarrisonState = new RosterState(
+                expectedGarrisonExists, expectedGarrisonCount, expectedGarrisonWounded, expectedGarrisonXp);
+            var expectedPlayerState = new RosterState(
+                expectedPlayerExists, expectedPlayerCount, expectedPlayerWounded, expectedPlayerXp);
+            int currentUpgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
+            if (capturedFixture == null || capturedFixture.ControllerId != args[0] ||
+                playerPartyId != args[1] || garrisonPartyId != args[2] || originalOwner == null ||
+                settlement.OwnerClan?.Leader != originalOwner ||
+                (playerParty.CurrentSettlement?.StringId ?? "none") != args[4] ||
+                playerParty.Position.X != originalPositionX || playerParty.Position.Y != originalPositionY ||
+                playerParty.Position.IsOnLand != originalPositionIsOnLand ||
+                !ReadRosterState(garrison.MemberRoster, character).Equals(expectedGarrisonState) ||
+                !ReadRosterState(playerParty.MemberRoster, character).Equals(expectedPlayerState) ||
+                currentUpgradeXp != expectedUpgradeXp || !IsCaptureCurrent(capturedFixture))
+                return Failed("Failed to set up garrison XP fixture: the captured fixture state changed.");
 
-        partyVm.OnTransferTroop(row, -1, FixtureTroopCount, row.Side);
-        partyVm.ExecuteRemoveZeroCounts();
-        return partyState.PartyScreenLogic.IsThereAnyChanges()
-            ? "GARRISON_XP_WITHDRAWAL_STAGED"
-            : "GARRISON_XP_WITHDRAWAL_REJECTED";
-    }
-
-    [CommandLineArgumentFunction("commit_garrison_xp_withdrawal", "coop.debug.mobileparty")]
-    public static string CommitWithdrawal(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.commit_garrison_xp_withdrawal";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 0) return usage;
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
-            !partyState.PartyScreenLogic.IsThereAnyChanges())
-            return "No staged garrison withdrawal is active.";
-        if (!((ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource is { } partyVm))
-            return "No active Party screen view model.";
-
-        partyVm.CloseScreenInternal();
-        return Game.Current.GameStateManager.ActiveState is PartyState
-            ? "GARRISON_XP_WITHDRAWAL_NOT_COMMITTED"
-            : "GARRISON_XP_WITHDRAWAL_COMMITTED";
-    }
-
-    [CommandLineArgumentFunction("garrison_xp_fixture_restore", "coop.debug.mobileparty")]
-    public static string Restore(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_restore <controllerId>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 1) return usage;
-        if (fixture == null && pendingCapture?.ControllerId == args[0])
-        {
+            fixture = capturedFixture;
             pendingCapture = null;
-            pendingNoopRestorationControllerId = null;
-            restoredFixture = GarrisonFixture.Noop(args[0]);
-            return JsonResult(new { restored = true, noFixtureCreated = true });
-        }
-        if (fixture == null && pendingNoopRestorationControllerId == args[0])
-        {
-            pendingNoopRestorationControllerId = null;
-            restoredFixture = GarrisonFixture.Noop(args[0]);
-            return JsonResult(new { restored = true, noFixtureCreated = true });
-        }
-        if (fixture == null) return "No garrison XP fixture is active.";
-        if (fixture.ControllerId != args[0])
-            return $"The active fixture belongs to '{fixture.ControllerId}'.";
 
-        var currentFixture = fixture;
-        RestoreFixture(currentFixture);
-        bool restored = IsRestored(currentFixture);
-        if (restored)
-        {
-            fixture = null;
-            restoredFixture = currentFixture;
-        }
+            try
+            {
+                if (settlement.OwnerClan != playerClan)
+                {
+                    // Only the ownership field is needed for the XP relevance precondition. Running
+                    // the ownership action would fire unrelated, irreversible campaign side effects.
+                    settlement.Town.OwnerClan = playerClan;
+                    settlement.Town.IsOwnerUnassigned = false;
+                }
 
-        return JsonResult(new
-        {
-            restored,
-            controllerId = currentFixture.ControllerId,
-            playerPartyId = currentFixture.PlayerPartyId,
-            garrisonPartyId = currentFixture.GarrisonPartyId,
-            settlementId = SettlementId,
-            characterId = CharacterId,
-            playerCount = ReadRosterState(currentFixture.PlayerParty.MemberRoster, currentFixture.Character).Number,
-            playerXp = ReadRosterState(currentFixture.PlayerParty.MemberRoster, currentFixture.Character).Xp,
-            garrisonCount = ReadRosterState(currentFixture.Garrison.MemberRoster, currentFixture.Character).Number,
-            garrisonXp = ReadRosterState(currentFixture.Garrison.MemberRoster, currentFixture.Character).Xp,
-            ownerHeroId = currentFixture.Settlement.OwnerClan?.Leader?.StringId,
-            playerSettlementId = currentFixture.PlayerParty.CurrentSettlement?.StringId
-        });
+                if (playerParty.CurrentSettlement != settlement)
+                    playerParty.CurrentSettlement = settlement;
+
+                SetRosterState(
+                    garrison.MemberRoster,
+                    character,
+                    new RosterState(true, FixtureTroopCount, 0, expectedUpgradeXp));
+                pendingNoopRestorationControllerId = null;
+
+                return Succeeded(JsonResult(new
+                {
+                    controllerId = player.ControllerId,
+                    playerPartyId,
+                    garrisonPartyId,
+                    settlementId = SettlementId,
+                    settlementName = settlement.Name.ToString(),
+                    characterId = CharacterId,
+                    characterName = character.Name.ToString(),
+                    upgradeTargetId = character.UpgradeTargets[0].StringId,
+                    upgradeXp = expectedUpgradeXp,
+                    garrisonCount = FixtureTroopCount,
+                    garrisonXp = expectedUpgradeXp,
+                    playerCount = expectedPlayerState.Number,
+                    playerXp = expectedPlayerState.Xp,
+                    totalXp = expectedPlayerState.Xp + expectedUpgradeXp,
+                    playerOwnsSettlement = settlement.OwnerClan == playerClan,
+                    playerAtSettlement = playerParty.CurrentSettlement == settlement
+                }));
+            }
+            catch (Exception exception)
+            {
+                // Keep the partially staged fixture active so the contract's finally path restores
+                // and verifies it instead of treating a failed setup as a no-op.
+                pendingNoopRestorationControllerId = null;
+                return Failed("Failed to set up garrison XP fixture: " + exception.Message);
+            }
+        }
     }
 
-    [CommandLineArgumentFunction("garrison_xp_fixture_verify_restore", "coop.debug.mobileparty")]
-    public static string VerifyRestore(List<string> args)
+    public sealed class GarrisonXpFixtureStateCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.mobileparty.garrison_xp_fixture_verify_restore <controllerId>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 1) return usage;
-        if (restoredFixture == null || restoredFixture.ControllerId != args[0])
-            return $"No restored garrison XP fixture is awaiting verification for '{args[0]}'.";
-        if (restoredFixture.NoFixtureCreated)
-        {
-            restoredFixture = null;
-            return JsonResult(new { restored = true, noFixtureCreated = true });
-        }
+        public string Prefix => "coop.debug.mobile_party";
 
-        var completedFixture = restoredFixture;
-        bool restored = IsRestored(completedFixture);
-        if (restored) restoredFixture = null;
-        return JsonResult(new
+        public string Name => "garrison_xp_fixture_state";
+
+        public string Description => "Reports garrison xp fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            restored,
-            controllerId = completedFixture.ControllerId,
-            settlementId = SettlementId,
-            characterId = CharacterId,
-            ownerHeroId = completedFixture.Settlement.OwnerClan?.Leader?.StringId,
-            expectedOwnerHeroId = completedFixture.OriginalOwner.StringId,
-            playerSettlementId = completedFixture.PlayerParty.CurrentSettlement?.StringId,
-            expectedPlayerSettlementId = completedFixture.OriginalPlayerSettlement?.StringId,
-            playerRosterRestored = ReadRosterState(
-                completedFixture.PlayerParty.MemberRoster, completedFixture.Character)
-                .Equals(completedFixture.OriginalPlayerState),
-            garrisonRosterRestored = ReadRosterState(
-                completedFixture.Garrison.MemberRoster, completedFixture.Character)
-                .Equals(completedFixture.OriginalGarrisonState)
-        });
+            new ExpectedArgs("player_party_id", "The player party id.", true),
+            new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty playerParty))
+                return Failed($"Player party '{args[0]}' was not found.");
+            if (!objectManager.TryGetObject(args[1], out MobileParty garrison))
+                return Failed($"Garrison party '{args[1]}' was not found.");
+            if (!objectManager.TryGetObject(args[2], out CharacterObject character))
+                return Failed($"Character '{args[2]}' was not found.");
+
+            var settlement = Settlement.Find(SettlementId);
+            var garrisonState = ReadRosterState(garrison.MemberRoster, character);
+            var playerState = ReadRosterState(playerParty.MemberRoster, character);
+            int upgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
+            return Succeeded(JsonResult(new
+            {
+                role = ModInformation.IsServer ? "server" : "client",
+                playerPartyId = args[0],
+                garrisonPartyId = args[1],
+                settlementId = SettlementId,
+                settlementName = settlement?.Name.ToString(),
+                characterId = args[2],
+                characterName = character.Name.ToString(),
+                playerOwnsSettlement = settlement?.OwnerClan != null &&
+                    ReferenceEquals(settlement.OwnerClan, playerParty.ActualClan),
+                playerAtSettlement = playerParty.CurrentSettlement == settlement,
+                bearingX = playerParty.Bearing.X,
+                bearingY = playerParty.Bearing.Y,
+                garrisonCount = garrisonState.Number,
+                garrisonWounded = garrisonState.Wounded,
+                garrisonXp = garrisonState.Xp,
+                garrisonUpgradeReady = garrisonState.Number > 0 && garrisonState.Xp >= upgradeXp,
+                playerCount = playerState.Number,
+                playerWounded = playerState.Wounded,
+                playerXp = playerState.Xp,
+                playerUpgradeReady = playerState.Number > 0 && playerState.Xp >= upgradeXp,
+                upgradeXp,
+                totalXp = garrisonState.Xp + playerState.Xp
+            }));
+        }
+    }
+
+    public sealed class OpenGarrisonXpFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "open_garrison_xp_fixture";
+
+        public string Description => "Runs the open garrison xp fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty garrison))
+                return Failed($"Garrison party '{args[0]}' was not found.");
+            var settlement = Settlement.Find(SettlementId);
+            if (settlement == null || garrison != settlement.Town?.GarrisonParty)
+                return Failed("The target is not Danustica's garrison.");
+            if (Hero.MainHero?.CurrentSettlement != settlement)
+                return Failed("The local player is not in Danustica.");
+            if (settlement.OwnerClan != Hero.MainHero.Clan)
+                return Failed("Danustica does not belong to the local player's clan.");
+
+            PartyScreenHelper.OpenScreenAsManageTroops(garrison);
+            return Succeeded("GARRISON_XP_FIXTURE_SCREEN_OPENED");
+        }
+    }
+
+    public sealed class GarrisonXpFixtureScreenStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "garrison_xp_fixture_screen_state";
+
+        public string Description => "Reports garrison xp fixture screen state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+            new ExpectedArgs("expected_state", "The expected screen state.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if ((args[2] != "baseline" && args[2] != "staged" && args[2] != "committed"))
+                return Failed("Invalid command argument value.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty garrison))
+                return Failed($"Garrison party '{args[0]}' was not found.");
+            if (!objectManager.TryGetObject(args[1], out CharacterObject character))
+                return Failed($"Character '{args[1]}' was not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
+                partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != garrison)
+                return Failed("Danustica's Manage Garrison screen is not active.");
+
+            var logic = partyState.PartyScreenLogic;
+            var leftState = ReadRosterState(logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left], character);
+            var rightState = ReadRosterState(logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right], character);
+            var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+            var leftRow = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            var rightRow = partyVm?.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            int upgradeXp = character.GetUpgradeXpCost(garrison.Party, 0);
+            bool expectedStateReady;
+            if (args[2] == "baseline")
+            {
+                expectedStateReady = partyVm != null && !logic.IsThereAnyChanges() &&
+                    leftState.Number == FixtureTroopCount && leftState.Xp == upgradeXp &&
+                    leftRow?.Troop.Number == FixtureTroopCount && leftRow.Troop.Xp == upgradeXp;
+            }
+            else if (args[2] == "staged")
+            {
+                expectedStateReady = partyVm != null && logic.IsThereAnyChanges() &&
+                    leftState.Number == 0 && leftRow == null &&
+                    rightState.Number > 0 && rightRow?.Troop.Number == rightState.Number &&
+                    rightRow.Troop.Xp == rightState.Xp && rightRow.NumOfReadyToUpgradeTroops > 0;
+            }
+            else
+            {
+                expectedStateReady = partyVm != null && !logic.IsThereAnyChanges() &&
+                    leftState.Number == 0 && leftRow == null &&
+                    rightState.Number > 0 && rightRow?.Troop.Number == rightState.Number &&
+                    rightRow.Troop.Xp == rightState.Xp && rightRow.NumOfReadyToUpgradeTroops > 0;
+            }
+            return Succeeded(JsonResult(new
+            {
+                ready = expectedStateReady,
+                expectedState = args[2],
+                settlementId = SettlementId,
+                settlementName = Settlement.Find(SettlementId)?.Name.ToString(),
+                pending = logic.IsThereAnyChanges(),
+                leftCount = leftState.Number,
+                leftXp = leftState.Xp,
+                leftReady = leftRow?.NumOfReadyToUpgradeTroops ?? 0,
+                rightCount = rightState.Number,
+                rightXp = rightState.Xp,
+                rightReady = rightRow?.NumOfReadyToUpgradeTroops ?? 0,
+                upgradeXp
+            }));
+        }
+    }
+
+    public sealed class StageGarrisonXpWithdrawalCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "stage_garrison_xp_withdrawal";
+
+        public string Description => "Runs the stage garrison xp withdrawal debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty garrison))
+                return Failed($"Garrison party '{args[0]}' was not found.");
+            if (!objectManager.TryGetObject(args[1], out CharacterObject character))
+                return Failed($"Character '{args[1]}' was not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
+                partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != garrison)
+                return Failed("Danustica's Manage Garrison screen is not active.");
+
+            var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+            var row = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            if (row == null) return Failed($"Character '{args[1]}' is not rendered in Danustica's garrison.");
+
+            partyVm.OnTransferTroop(row, -1, FixtureTroopCount, row.Side);
+            partyVm.ExecuteRemoveZeroCounts();
+            return Failed(partyState.PartyScreenLogic.IsThereAnyChanges()
+                ? "GARRISON_XP_WITHDRAWAL_STAGED"
+                : "GARRISON_XP_WITHDRAWAL_REJECTED");
+        }
+    }
+
+    public sealed class CommitGarrisonXpWithdrawalCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "commit_garrison_xp_withdrawal";
+
+        public string Description => "Runs the commit garrison xp withdrawal debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
+                !partyState.PartyScreenLogic.IsThereAnyChanges())
+                return Failed("No staged garrison withdrawal is active.");
+            if (!((ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource is { } partyVm))
+                return Failed("No active Party screen view model.");
+
+            partyVm.CloseScreenInternal();
+            return Succeeded(Game.Current.GameStateManager.ActiveState is PartyState
+                ? "GARRISON_XP_WITHDRAWAL_NOT_COMMITTED"
+                : "GARRISON_XP_WITHDRAWAL_COMMITTED");
+        }
+    }
+
+    public sealed class GarrisonXpFixtureRestoreCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "garrison_xp_fixture_restore";
+
+        public string Description => "Restores or clears garrison xp fixture restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (fixture == null && pendingCapture?.ControllerId == args[0])
+            {
+                pendingCapture = null;
+                pendingNoopRestorationControllerId = null;
+                restoredFixture = GarrisonFixture.Noop(args[0]);
+                return Succeeded(JsonResult(new { restored = true, noFixtureCreated = true }));
+            }
+            if (fixture == null && pendingNoopRestorationControllerId == args[0])
+            {
+                pendingNoopRestorationControllerId = null;
+                restoredFixture = GarrisonFixture.Noop(args[0]);
+                return Succeeded(JsonResult(new { restored = true, noFixtureCreated = true }));
+            }
+            if (fixture == null) return Failed("No garrison XP fixture is active.");
+            if (fixture.ControllerId != args[0])
+                return Failed($"The active fixture belongs to '{fixture.ControllerId}'.");
+
+            var currentFixture = fixture;
+            RestoreFixture(currentFixture);
+            bool restored = IsRestored(currentFixture);
+            if (restored)
+            {
+                fixture = null;
+                restoredFixture = currentFixture;
+            }
+
+            return Succeeded(JsonResult(new
+            {
+                restored,
+                controllerId = currentFixture.ControllerId,
+                playerPartyId = currentFixture.PlayerPartyId,
+                garrisonPartyId = currentFixture.GarrisonPartyId,
+                settlementId = SettlementId,
+                characterId = CharacterId,
+                playerCount = ReadRosterState(currentFixture.PlayerParty.MemberRoster, currentFixture.Character).Number,
+                playerXp = ReadRosterState(currentFixture.PlayerParty.MemberRoster, currentFixture.Character).Xp,
+                garrisonCount = ReadRosterState(currentFixture.Garrison.MemberRoster, currentFixture.Character).Number,
+                garrisonXp = ReadRosterState(currentFixture.Garrison.MemberRoster, currentFixture.Character).Xp,
+                ownerHeroId = currentFixture.Settlement.OwnerClan?.Leader?.StringId,
+                playerSettlementId = currentFixture.PlayerParty.CurrentSettlement?.StringId
+            }));
+        }
+    }
+
+    public sealed class GarrisonXpFixtureVerifyRestoreCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "garrison_xp_fixture_verify_restore";
+
+        public string Description => "Restores or clears garrison xp fixture verify restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (restoredFixture == null || restoredFixture.ControllerId != args[0])
+                return Failed($"No restored garrison XP fixture is awaiting verification for '{args[0]}'.");
+            if (restoredFixture.NoFixtureCreated)
+            {
+                restoredFixture = null;
+                return Succeeded(JsonResult(new { restored = true, noFixtureCreated = true }));
+            }
+
+            var completedFixture = restoredFixture;
+            bool restored = IsRestored(completedFixture);
+            if (restored) restoredFixture = null;
+            return Succeeded(JsonResult(new
+            {
+                restored,
+                controllerId = completedFixture.ControllerId,
+                settlementId = SettlementId,
+                characterId = CharacterId,
+                ownerHeroId = completedFixture.Settlement.OwnerClan?.Leader?.StringId,
+                expectedOwnerHeroId = completedFixture.OriginalOwner.StringId,
+                playerSettlementId = completedFixture.PlayerParty.CurrentSettlement?.StringId,
+                expectedPlayerSettlementId = completedFixture.OriginalPlayerSettlement?.StringId,
+                playerRosterRestored = ReadRosterState(
+                    completedFixture.PlayerParty.MemberRoster, completedFixture.Character)
+                    .Equals(completedFixture.OriginalPlayerState),
+                garrisonRosterRestored = ReadRosterState(
+                    completedFixture.Garrison.MemberRoster, completedFixture.Character)
+                    .Equals(completedFixture.OriginalGarrisonState)
+            }));
+        }
     }
 
     private static void RestoreFixture(GarrisonFixture currentFixture)

--- a/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
@@ -1,4 +1,5 @@
 ﻿#if DEBUG
+using Common.Commands;
 using Autofac;
 using Common;
 using Common.Messaging;
@@ -15,12 +16,17 @@ using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Roster;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
 internal static class LargeBattleRosterFixtureCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private const string FixtureTroopId = "imperial_recruit";
     private static LargeBattleRosterFixture fixture;
 
@@ -45,116 +51,155 @@ internal static class LargeBattleRosterFixtureCommands
         public PartyBehaviorUpdateData Behavior;
     }
 
-    [CommandLineArgumentFunction("large_battle_roster_begin", "coop.debug.mobileparty")]
-    public static string Begin(List<string> args)
+    public sealed class LargeBattleRosterBeginCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer)
-            return "Run this command on the server.";
-        if (args.Count != 3
-            || !int.TryParse(args[2], out int addedPerParty)
-            || addedPerParty < 1
-            || addedPerParty > 500)
-        {
-            return "Usage: coop.debug.mobileparty.large_battle_roster_begin " +
-                   "<firstPartyOrControllerId> <secondPartyOrControllerId> <troopsPerParty:1-500>";
-        }
-        if (fixture != null)
-            return "A large-battle roster fixture is already pending restoration.";
-        if (!TryGetObjectManager(out IObjectManager objectManager))
-            return "Unable to resolve ObjectManager.";
-        if (!TryResolveParty(
-                objectManager,
-                args[0],
-                out MobileParty firstParty,
-                out string firstError))
-        {
-            return firstError;
-        }
-        if (!TryResolveParty(
-                objectManager,
-                args[1],
-                out MobileParty secondParty,
-                out string secondError))
-        {
-            return secondError;
-        }
-        if (firstParty == secondParty)
-            return "The fixture requires two distinct parties.";
-        if (!objectManager.TryGetObject(
-                FixtureTroopId,
-                out CharacterObject fixtureTroop))
-        {
-            return $"Unable to resolve fixture troop {FixtureTroopId}.";
-        }
+        public string Prefix => "coop.debug.mobile_party";
 
-        var activeFixture = new LargeBattleRosterFixture
+        public string Name => "large_battle_roster_begin";
+
+        public string Description => "Runs the large battle roster begin debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            Campaign = Campaign.Current,
-            FirstParty = Capture(firstParty),
-            SecondParty = Capture(secondParty),
+            new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+            new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+            new ExpectedArgs("troops_per_party", "The troops per party.", true),
         };
-        fixture = activeFixture;
 
-        firstParty.MemberRoster.AddToCounts(
-            fixtureTroop,
-            addedPerParty);
-        secondParty.MemberRoster.AddToCounts(
-            fixtureTroop,
-            addedPerParty);
-
-        return
-            $"LARGE_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} addedPerParty={addedPerParty}\n" +
-            FormatState("active", firstParty, secondParty, null, null);
-    }
-
-    [CommandLineArgumentFunction("exact_battle_roster_begin", "coop.debug.mobileparty")]
-    public static string BeginExact(List<string> args)
-    {
-        if (!ModInformation.IsServer)
-            return "Run this command on the server.";
-        if (args.Count != 3
-            || !int.TryParse(args[2], out int healthyPerParty)
-            || (healthyPerParty != 5 && healthyPerParty != 900))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.mobileparty.exact_battle_roster_begin " +
-                   "<firstPartyOrControllerId> <secondPartyOrControllerId> <healthyPerParty:5|900>";
-        }
+            if (!ModInformation.IsServer)
+                return Failed("Run this command on the server.");
+            if (!int.TryParse(args[2], out int addedPerParty)
+                || addedPerParty < 1
+                || addedPerParty > 500)
+            {
+                return Failed("Invalid command argument value.");
+            }
+            if (fixture != null)
+                return Failed("A large-battle roster fixture is already pending restoration.");
+            if (!TryGetObjectManager(out IObjectManager objectManager))
+                return Failed("Unable to resolve ObjectManager.");
+            if (!TryResolveParty(
+                    objectManager,
+                    args[0],
+                    out MobileParty firstParty,
+                    out string firstError))
+            {
+                return Failed(firstError);
+            }
+            if (!TryResolveParty(
+                    objectManager,
+                    args[1],
+                    out MobileParty secondParty,
+                    out string secondError))
+            {
+                return Failed(secondError);
+            }
+            if (firstParty == secondParty)
+                return Failed("The fixture requires two distinct parties.");
+            if (!objectManager.TryGetObject(
+                    FixtureTroopId,
+                    out CharacterObject fixtureTroop))
+            {
+                return Failed($"Unable to resolve fixture troop {FixtureTroopId}.");
+            }
 
-        return BeginExact(args[0], args[1], healthyPerParty, healthyPerParty);
+            var activeFixture = new LargeBattleRosterFixture
+            {
+                Campaign = Campaign.Current,
+                FirstParty = Capture(firstParty),
+                SecondParty = Capture(secondParty),
+            };
+            fixture = activeFixture;
+
+            firstParty.MemberRoster.AddToCounts(
+                fixtureTroop,
+                addedPerParty);
+            secondParty.MemberRoster.AddToCounts(
+                fixtureTroop,
+                addedPerParty);
+
+            return Succeeded($"LARGE_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} addedPerParty={addedPerParty}\n" +
+                FormatState("active", firstParty, secondParty, null, null));
+        }
     }
 
-    [CommandLineArgumentFunction("battle_size_roster_begin", "coop.debug.mobileparty")]
-    public static string BeginBattleSize(List<string> args)
+    public sealed class ExactBattleRosterBeginCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer)
-            return "Run this command on the server.";
-        if (args.Count != 4
-            || !int.TryParse(args[2], out int firstHealthyCount)
-            || !int.TryParse(args[3], out int secondHealthyCount)
-            || firstHealthyCount < 1
-            || firstHealthyCount > 1000
-            || secondHealthyCount < 1
-            || secondHealthyCount > 1000)
-        {
-            return "Usage: coop.debug.mobileparty.battle_size_roster_begin " +
-                   "<firstPartyOrControllerId> <secondPartyOrControllerId> <firstHealthy:1-1000> <secondHealthy:1-1000>";
-        }
+        public string Prefix => "coop.debug.mobile_party";
 
-        return BeginExact(args[0], args[1], firstHealthyCount, secondHealthyCount);
+        public string Name => "exact_battle_roster_begin";
+
+        public string Description => "Runs the exact battle roster begin debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+            new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+            new ExpectedArgs("healthy_per_party", "The healthy per party.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+                return Failed("Run this command on the server.");
+            if (!int.TryParse(args[2], out int healthyPerParty)
+                || (healthyPerParty != 5 && healthyPerParty != 900))
+            {
+                return Failed("Invalid command argument value.");
+            }
+
+            return BeginExact(args[0], args[1], healthyPerParty, healthyPerParty);
+        }
     }
 
-    private static string BeginExact(
+    public sealed class BattleSizeRosterBeginCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "battle_size_roster_begin";
+
+        public string Description => "Runs the battle size roster begin debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+            new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+            new ExpectedArgs("first_healthy", "The first healthy.", true),
+            new ExpectedArgs("second_healthy", "The second healthy.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+                return Failed("Run this command on the server.");
+            if (!int.TryParse(args[2], out int firstHealthyCount)
+                || !int.TryParse(args[3], out int secondHealthyCount)
+                || firstHealthyCount < 1
+                || firstHealthyCount > 1000
+                || secondHealthyCount < 1
+                || secondHealthyCount > 1000)
+            {
+                return Failed("Invalid command argument value.");
+            }
+
+            return BeginExact(args[0], args[1], firstHealthyCount, secondHealthyCount);
+        }
+    }
+
+    private static CoopCommandResult BeginExact(
         string firstPartyId,
         string secondPartyId,
         int firstHealthyCount,
         int secondHealthyCount)
     {
         if (fixture != null)
-            return "A large-battle roster fixture is already pending restoration.";
+            return Failed("A large-battle roster fixture is already pending restoration.");
         if (!TryGetObjectManager(out IObjectManager objectManager) ||
             !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
         {
-            return "Unable to resolve the exact battle fixture services.";
+            return Failed("Unable to resolve the exact battle fixture services.");
         }
         if (!TryResolveParty(
                 objectManager,
@@ -162,7 +207,7 @@ internal static class LargeBattleRosterFixtureCommands
                 out MobileParty firstParty,
                 out string firstError))
         {
-            return firstError;
+            return Failed(firstError);
         }
         if (!TryResolveParty(
                 objectManager,
@@ -170,22 +215,22 @@ internal static class LargeBattleRosterFixtureCommands
                 out MobileParty secondParty,
                 out string secondError))
         {
-            return secondError;
+            return Failed(secondError);
         }
         if (firstParty == secondParty)
-            return "The fixture requires two distinct parties.";
+            return Failed("The fixture requires two distinct parties.");
         if (!CanStageExactBattleParty(firstParty) || !CanStageExactBattleParty(secondParty))
-            return "Both parties must be active on the campaign map, outside settlements and map events.";
+            return Failed("Both parties must be active on the campaign map, outside settlements and map events.");
         if (!objectManager.TryGetObjectWithLogging(
                 FixtureTroopId,
                 out CharacterObject fixtureTroop))
         {
-            return $"Unable to resolve fixture troop {FixtureTroopId}.";
+            return Failed($"Unable to resolve fixture troop {FixtureTroopId}.");
         }
         if (!behaviorSnapshot.TryCreate(firstParty, out var firstBehavior) ||
             !behaviorSnapshot.TryCreate(secondParty, out var secondBehavior))
         {
-            return "Unable to capture both parties' original movement state.";
+            return Failed("Unable to capture both parties' original movement state.");
         }
 
         PartySnapshot firstSnapshot = Capture(firstParty, firstBehavior);
@@ -196,7 +241,7 @@ internal static class LargeBattleRosterFixtureCommands
                 out int firstTroops,
                 out firstError))
         {
-            return firstError;
+            return Failed(firstError);
         }
         if (!TryGetFixtureTroopCount(
                 secondSnapshot,
@@ -204,7 +249,7 @@ internal static class LargeBattleRosterFixtureCommands
                 out int secondTroops,
                 out secondError))
         {
-            return secondError;
+            return Failed(secondError);
         }
 
         var activeFixture = new LargeBattleRosterFixture
@@ -234,40 +279,51 @@ internal static class LargeBattleRosterFixtureCommands
                 secondBehaviorRestored;
             if (restored) fixture = null;
 
-            return
-                $"Unable to stage the exact battle roster fixture: {ex.GetType().Name}: {ex.Message}\n" +
-                $"restored={restored}";
+            return Failed($"Unable to stage the exact battle roster fixture: {ex.GetType().Name}: {ex.Message}\n" +
+                $"restored={restored}");
         }
 
         string started = firstHealthyCount == secondHealthyCount
             ? $"EXACT_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} healthyPerParty={firstHealthyCount}"
             : $"EXACT_BATTLE_ROSTER_FIXTURE_STARTED troop={FixtureTroopId} " +
               $"firstHealthy={firstHealthyCount} secondHealthy={secondHealthyCount}";
-        return started + "\n" +
-               FormatState("active", firstParty, secondParty, firstHealthyCount, secondHealthyCount);
+        return Succeeded(started + "\n" +
+               FormatState("active", firstParty, secondParty, firstHealthyCount, secondHealthyCount));
     }
 
-    [CommandLineArgumentFunction("large_battle_roster_status", "coop.debug.mobileparty")]
-    public static string Status(List<string> args) =>
-        Status(args, "coop.debug.mobileparty.large_battle_roster_status");
+    public sealed class LargeBattleRosterStatusCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
 
-    private static string Status(List<string> args, string commandName)
+        public string Name => "large_battle_roster_status";
+
+        public string Description => "Reports large battle roster status.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+            new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return Status(args);
+        }
+    }
+
+    private static CoopCommandResult Status(IReadOnlyList<string> args)
     {
         if (!ModInformation.IsServer)
-            return "Run this command on the server.";
-        if (args.Count != 2)
-        {
-            return $"Usage: {commandName} <firstPartyOrControllerId> <secondPartyOrControllerId>";
-        }
+            return Failed("Run this command on the server.");
         if (!TryGetObjectManager(out IObjectManager objectManager))
-            return "Unable to resolve ObjectManager.";
+            return Failed("Unable to resolve ObjectManager.");
         if (!TryResolveParty(
                 objectManager,
                 args[0],
                 out MobileParty firstParty,
                 out string firstError))
         {
-            return firstError;
+            return Failed(firstError);
         }
         if (!TryResolveParty(
                 objectManager,
@@ -275,49 +331,75 @@ internal static class LargeBattleRosterFixtureCommands
                 out MobileParty secondParty,
                 out string secondError))
         {
-            return secondError;
+            return Failed(secondError);
         }
 
-        return FormatState(
+        return Succeeded(FormatState(
             fixture == null ? "none" : "active",
             firstParty,
             secondParty,
             fixture?.FirstExactHealthyCount,
-            fixture?.SecondExactHealthyCount);
+            fixture?.SecondExactHealthyCount));
     }
 
-    [CommandLineArgumentFunction("exact_battle_roster_status", "coop.debug.mobileparty")]
-    public static string ExactStatus(List<string> args) =>
-        Status(args, "coop.debug.mobileparty.exact_battle_roster_status");
+    public sealed class ExactBattleRosterStatusCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
 
-    [CommandLineArgumentFunction("large_battle_roster_restore", "coop.debug.mobileparty")]
-    public static string Restore(List<string> args) =>
-        Restore(args, "coop.debug.mobileparty.large_battle_roster_restore");
+        public string Name => "exact_battle_roster_status";
 
-    private static string Restore(List<string> args, string commandName)
+        public string Description => "Reports exact battle roster status.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
+            new ExpectedArgs("second_party_or_controller_id", "The second party or controller id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return Status(args);
+        }
+    }
+
+    public sealed class LargeBattleRosterRestoreCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "large_battle_roster_restore";
+
+        public string Description => "Restores or clears large battle roster restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return Restore(args);
+        }
+    }
+
+    private static CoopCommandResult Restore(IReadOnlyList<string> args)
     {
         if (!ModInformation.IsServer)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return $"Usage: {commandName}";
+            return Failed("Run this command on the server.");
         if (fixture == null)
-            return "No large-battle roster fixture is pending restoration.";
+            return Failed("No large-battle roster fixture is pending restoration.");
 
         LargeBattleRosterFixture activeFixture = fixture;
         if (activeFixture.Campaign != Campaign.Current)
         {
             fixture = null;
-            return "The fixture belongs to a previous campaign and was discarded.";
+            return Succeeded("The fixture belongs to a previous campaign and was discarded.");
         }
         if (!TryGetObjectManager(out IObjectManager objectManager))
-            return "Unable to resolve ObjectManager.";
+            return Failed("Unable to resolve ObjectManager.");
         if (!TryResolveSnapshotParty(
                 objectManager,
                 activeFixture.FirstParty,
                 out string firstError))
         {
             fixture = null;
-            return firstError;
+            return Failed(firstError);
         }
         if (!TryResolveSnapshotParty(
                 objectManager,
@@ -325,7 +407,7 @@ internal static class LargeBattleRosterFixtureCommands
                 out string secondError))
         {
             fixture = null;
-            return secondError;
+            return Failed(secondError);
         }
 
         bool firstRestoredDeadHero = Restore(activeFixture.FirstParty);
@@ -343,31 +425,42 @@ internal static class LargeBattleRosterFixtureCommands
             || !IsPartyStateRestored(activeFixture.SecondParty)
             || !behaviorRestored)
         {
-            return "Large-battle fixture restoration did not restore the original rosters, heroes, leaders, and movement behavior.\n" +
+            return Failed("Large-battle fixture restoration did not restore the original rosters, heroes, leaders, and movement behavior.\n" +
                    warning +
                    FormatState(
                        "restore-failed",
                        activeFixture.FirstParty.Party,
                        activeFixture.SecondParty.Party,
                        activeFixture.FirstExactHealthyCount,
-                       activeFixture.SecondExactHealthyCount);
+                       activeFixture.SecondExactHealthyCount));
         }
 
         fixture = null;
-        return
-            "LARGE_BATTLE_ROSTER_FIXTURE_RESTORED\n" +
+        return Succeeded("LARGE_BATTLE_ROSTER_FIXTURE_RESTORED\n" +
             warning +
             FormatState(
                 "none",
                 activeFixture.FirstParty.Party,
                 activeFixture.SecondParty.Party,
                 null,
-                null);
+                null));
     }
 
-    [CommandLineArgumentFunction("exact_battle_roster_restore", "coop.debug.mobileparty")]
-    public static string RestoreExact(List<string> args) =>
-        Restore(args, "coop.debug.mobileparty.exact_battle_roster_restore");
+    public sealed class ExactBattleRosterRestoreCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "exact_battle_roster_restore";
+
+        public string Description => "Restores or clears exact battle roster restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return Restore(args);
+        }
+    }
 
     private static bool TryGetObjectManager(
         out IObjectManager objectManager)

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System;
+using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using Common.Messaging;
@@ -23,12 +25,17 @@ using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
 using TaleWorlds.ObjectSystem;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
 internal class PartyCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<PartyCommands>();
 
     /// <summary>
@@ -73,90 +80,141 @@ internal class PartyCommands
     /// then pass that to imprison_companion / snapshot_prison to target your exact party when several share the
     /// "RandomPlayer" name.
     /// </summary>
-    [CommandLineArgumentFunction("whoami", "coop.debug.mobileparty")]
-    public static string WhoAmICommand(List<string> strings)
+    public sealed class WhoAmICoopCommand : ICoopCommand
     {
-        if(!ModInformation.IsClient) return "Command can only be run on a client.";
-        
-        var me = Hero.MainHero;
-        if (me == null) return "No main hero on this instance";
+        public string Prefix => "coop.debug.mobile_party";
 
-        return me.PartyBelongedTo != null
-            ? "You are " + me.Name + " | hero id: " + me.StringId + " | party id: " + me.PartyBelongedTo.StringId
-            : "You are " + me.Name + " | hero id: " + me.StringId + " | NO PARTY";
+        public string Name => "who_am_i";
+
+        public string Description => "Runs the whoami debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if(!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+
+            var me = Hero.MainHero;
+            if (me == null) return Failed("No main hero on this instance");
+
+            return Succeeded(me.PartyBelongedTo != null
+                ? "You are " + me.Name + " | hero id: " + me.StringId + " | party id: " + me.PartyBelongedTo.StringId
+                : "You are " + me.Name + " | hero id: " + me.StringId + " | NO PARTY");
+        }
     }
 
     /// <summary>
     /// Reports an exact party position and movement mode for cross-client live-test comparisons.
     /// </summary>
-    [CommandLineArgumentFunction("position", "coop.debug.mobileparty")]
-    public static string PositionCommand(List<string> strings)
+    public sealed class PositionCoopCommand : ICoopCommand
     {
-        if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.position <partyId>";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out MobileParty party))
-            return $"Party with id {strings[0]} not found";
+        public string Name => "position";
 
-        CampaignVec2 position = party.Position;
-        var partyId = objectManager.TryGetId(party, out string resolvedPartyId)
-            ? resolvedPartyId
-            : strings[0];
-        return
-            $"id={partyId}|party={party.StringId}|" +
-            $"x={position.X.ToString("R", CultureInfo.InvariantCulture)}|" +
-            $"y={position.Y.ToString("R", CultureInfo.InvariantCulture)}|" +
-            $"isOnLand={position.IsOnLand}|" +
-            $"settlement={party.CurrentSettlement?.StringId ?? "none"}|" +
-            $"moveMode={party.PartyMoveMode}";
+        public string Description => "Runs the position debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The party id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty party))
+                return Failed($"Party with id {args[0]} not found");
+
+            CampaignVec2 position = party.Position;
+            var partyId = objectManager.TryGetId(party, out string resolvedPartyId)
+                ? resolvedPartyId
+                : args[0];
+            return Succeeded($"id={partyId}|party={party.StringId}|" +
+                $"x={position.X.ToString("R", CultureInfo.InvariantCulture)}|" +
+                $"y={position.Y.ToString("R", CultureInfo.InvariantCulture)}|" +
+                $"isOnLand={position.IsOnLand}|" +
+                $"settlement={party.CurrentSettlement?.StringId ?? "none"}|" +
+                $"moveMode={party.PartyMoveMode}");
+        }
     }
 
     /// <summary>
     /// Issues a local player-party point movement order so automated live tests can verify that a restored
     /// party accepts client control and sends the normal behavior update to the server.
     /// </summary>
-    [CommandLineArgumentFunction("move_offset", "coop.debug.mobileparty")]
-    public static string MoveOffsetCommand(List<string> strings)
+    public sealed class MoveOffsetCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (strings.Count != 2 ||
-            !float.TryParse(strings[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetX) ||
-            !float.TryParse(strings[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetY))
-            return "Usage: coop.debug.mobileparty.move_offset <offsetX> <offsetY>";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var party = Hero.MainHero?.PartyBelongedTo;
-        if (party == null) return "The local player hero has no party.";
+        public string Name => "move_offset";
 
-        var current = party.Position;
-        var target = new CampaignVec2(
-            new TaleWorlds.Library.Vec2(current.X + offsetX, current.Y + offsetY),
-            current.IsOnLand);
-        party.SetNavigationModePoint(target);
-        MessageBroker.Instance.Publish(typeof(PartyCommands), new PartyBehaviorChangeAttempted(party));
+        public string Description => "Runs the move offset debug operation.";
 
-        return
-            $"Movement order submitted for {party.StringId}.\n" +
-            $"From: {current.X:R},{current.Y:R}\n" +
-            $"Target: {target.X:R},{target.Y:R}";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("offset_x", "The offset x.", true),
+            new ExpectedArgs("offset_y", "The offset y.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (!float.TryParse(args[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetX) ||
+                !float.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetY))
+                return Failed("Invalid command argument value.");
+
+            var party = Hero.MainHero?.PartyBelongedTo;
+            if (party == null) return Failed("The local player hero has no party.");
+
+            var current = party.Position;
+            var target = new CampaignVec2(
+                new TaleWorlds.Library.Vec2(current.X + offsetX, current.Y + offsetY),
+                current.IsOnLand);
+            party.SetNavigationModePoint(target);
+            MessageBroker.Instance.Publish(typeof(PartyCommands), new PartyBehaviorChangeAttempted(party));
+
+            return Succeeded($"Movement order submitted for {party.StringId}.\n" +
+                $"From: {current.X:R},{current.Y:R}\n" +
+                $"Target: {target.X:R},{target.Y:R}");
+        }
     }
 
     /// <summary>
     /// Restores a party to an exact campaign-map position and hold state after an automated live test.
     /// </summary>
-    [CommandLineArgumentFunction("restore_position", "coop.debug.mobileparty")]
-    public static string RestorePositionCommand(List<string> strings)
+    public sealed class RestorePositionCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
-        if (strings.Count != 4 ||
-            !float.TryParse(strings[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionX) ||
-            !float.TryParse(strings[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionY) ||
-            !bool.TryParse(strings[3], out var isOnLand))
-            return "Usage: coop.debug.mobileparty.restore_position <partyId> <x> <y> <isOnLand>";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out MobileParty party))
-            return $"Party with id {strings[0]} not found";
+        public string Name => "restore_position";
+
+        public string Description => "Restores a party to a campaign-map position and hold state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+        new ExpectedArgs("party_id", "The registered mobile-party id."),
+        new ExpectedArgs("x", "The campaign-map x coordinate."),
+        new ExpectedArgs("y", "The campaign-map y coordinate."),
+        new ExpectedArgs("is_on_land", "Whether the restored position is on land."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return RestorePartyPosition(args);
+        }
+    }
+
+    internal static CoopCommandResult RestorePartyPosition(IReadOnlyList<string> args)
+    {
+        if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+        if (!float.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionX) ||
+            !float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var positionY) ||
+            !bool.TryParse(args[3], out var isOnLand))
+            return Failed("Invalid command argument value.");
+
+        if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+        if (!objectManager.TryGetObject(args[0], out MobileParty party))
+            return Failed($"Party with id {args[0]} not found");
 
         party.Position = new CampaignVec2(new TaleWorlds.Library.Vec2(positionX, positionY), isOnLand);
         party.SetMoveModeHold();
@@ -169,82 +227,105 @@ internal class PartyCommands
                 isCurrentlyAtSea: party.IsCurrentlyAtSea,
                 resetMovementToHold: true));
 
-        return $"Restored {party.StringId} to {party.Position.X:R},{party.Position.Y:R} in Hold mode.";
+        return Succeeded($"Restored {party.StringId} to {party.Position.X:R},{party.Position.Y:R} in Hold mode.");
     }
 
-    [CommandLineArgumentFunction("move_to_settlement", "coop.debug.mobileparty")]
-    public static string MoveToSettlementCommand(List<string> strings)
+    public sealed class MoveToSettlementCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer)
-            return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (strings.Count != 2)
-            return "Usage: coop.debug.mobileparty.move_to_settlement <partyId> <settlementId>";
+        public string Name => "move_to_settlement";
 
-        if (!TryGetObjectManager(out var objectManager))
-            return "Unable to resolve ObjectManager.";
+        public string Description => "Runs the move to settlement debug operation.";
 
-        if (!objectManager.TryGetObject(strings[0], out MobileParty party))
-            return $"Party with id {strings[0]} not found";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The party id.", true),
+            new ExpectedArgs("settlement_id", "The settlement id.", true),
+        };
 
-        if (!party.IsPlayerParty())
-            return $"Party {party.StringId} is not a player party.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+                return Failed("Command can only be run on the server.");
 
-        var settlement = Settlement.Find(strings[1]);
-        if (settlement == null)
-            return $"Settlement with id {strings[1]} not found";
 
-        if (!party.IsActive)
-            return $"Party {party.StringId} is not active.";
+            if (!TryGetObjectManager(out var objectManager))
+                return Failed("Unable to resolve ObjectManager.");
 
-        if (party.CurrentSettlement != null)
-            return $"Party {party.StringId} is already in {party.CurrentSettlement.StringId}.";
+            if (!objectManager.TryGetObject(args[0], out MobileParty party))
+                return Failed($"Party with id {args[0]} not found");
 
-        var navigationType = party.IsCurrentlyAtSea
-            ? MobileParty.NavigationType.Naval
-            : MobileParty.NavigationType.Default;
-        party.SetMoveGoToSettlement(settlement, navigationType, isTargetingThePort: false);
+            if (!party.IsPlayerParty())
+                return Failed($"Party {party.StringId} is not a player party.");
 
-        return $"Ordered {party.StringId} to {settlement.StringId}.";
+            var settlement = Settlement.Find(args[1]);
+            if (settlement == null)
+                return Failed($"Settlement with id {args[1]} not found");
+
+            if (!party.IsActive)
+                return Failed($"Party {party.StringId} is not active.");
+
+            if (party.CurrentSettlement != null)
+                return Failed($"Party {party.StringId} is already in {party.CurrentSettlement.StringId}.");
+
+            var navigationType = party.IsCurrentlyAtSea
+                ? MobileParty.NavigationType.Naval
+                : MobileParty.NavigationType.Default;
+            party.SetMoveGoToSettlement(settlement, navigationType, isTargetingThePort: false);
+
+            return Succeeded($"Ordered {party.StringId} to {settlement.StringId}.");
+        }
     }
 
     /// <summary>
     /// View character ids in a hero's party by full name or hero id.
     /// </summary>
-    [CommandLineArgumentFunction("characterids", "coop.debug.mobileparty")]
-    public static string ViewItemIdsCommand(List<string> strings)
+    public sealed class CharacterIdsCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0) return "Hero name argument required.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var nameOrId = string.Join(" ", strings);
-        var mainHero = Hero.MainHero;
-        var heroById = mainHero != null &&
-                       mainHero.StringId == nameOrId &&
-                       mainHero.PartyBelongedTo != null
-            ? mainHero
-            : Hero.AllAliveHeroes.FirstOrDefault(
-                hero => hero != null && hero.StringId == nameOrId && hero.PartyBelongedTo != null);
-        var heroes = heroById == null
-            ? FindHeroesWithParty(nameOrId)
-            : new List<Hero> { heroById };
-        if (heroes.Count == 0)
-            return "No hero named or identified by \"" + nameOrId + "\" with a party found.";
+        public string Name => "character_ids";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in heroes)
+        public string Description => "Runs the characterids debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            var party = hero.PartyBelongedTo;
-            if (party == null) continue;
+            new ExpectedArgs("hero_name_or_id", "The hero name or id.", true),
+        };
 
-            stringBuilder.AppendLine("##" + (hero.Name?.ToString() ?? "<unnamed>") + "  (hero id: " + hero.StringId + ")");
-            stringBuilder.AppendLine("Member roster:");
-            AppendRoster(stringBuilder, party.MemberRoster);
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var nameOrId = string.Join(" ", args);
+            var mainHero = Hero.MainHero;
+            var heroById = mainHero != null &&
+                           mainHero.StringId == nameOrId &&
+                           mainHero.PartyBelongedTo != null
+                ? mainHero
+                : Hero.AllAliveHeroes.FirstOrDefault(
+                    hero => hero != null && hero.StringId == nameOrId && hero.PartyBelongedTo != null);
+            var heroes = heroById == null
+                ? FindHeroesWithParty(nameOrId)
+                : new List<Hero> { heroById };
+            if (heroes.Count == 0)
+                return Failed("No hero named or identified by \"" + nameOrId + "\" with a party found.");
 
-            stringBuilder.AppendLine("Prisoner roster:");
-            AppendRoster(stringBuilder, party.PrisonRoster);
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in heroes)
+            {
+                var party = hero.PartyBelongedTo;
+                if (party == null) continue;
+
+                stringBuilder.AppendLine("##" + (hero.Name?.ToString() ?? "<unnamed>") + "  (hero id: " + hero.StringId + ")");
+                stringBuilder.AppendLine("Member roster:");
+                AppendRoster(stringBuilder, party.MemberRoster);
+
+                stringBuilder.AppendLine("Prisoner roster:");
+                AppendRoster(stringBuilder, party.PrisonRoster);
+            }
+
+            return Succeeded(stringBuilder.ToString());
         }
-
-        return stringBuilder.ToString();
     }
 
     private static void AppendRoster(StringBuilder stringBuilder, TroopRoster roster)
@@ -266,89 +347,120 @@ internal class PartyCommands
     /// <summary>
     /// Sets one member-roster troop's wounded count for live synchronization tests.
     /// </summary>
-    [CommandLineArgumentFunction("set_troop_wounded", "coop.debug.mobileparty")]
-    public static string SetTroopWoundedCommand(List<string> strings)
+    public sealed class SetTroopWoundedCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (strings.Count != 3)
-            return "Usage: coop.debug.mobileparty.set_troop_wounded <party id> <character id> <wounded count>";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (!int.TryParse(strings[2], out var woundedCount))
-            return "Please enter an integer for wounded count.";
+        public string Name => "set_troop_wounded";
 
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out MobileParty party))
-            return $"Party with id {strings[0]} not found.";
-        if (!objectManager.TryGetObject(strings[1], out CharacterObject character))
-            return $"Character with id {strings[1]} not found.";
+        public string Description => "Runs the set troop wounded debug operation.";
 
-        var roster = party.MemberRoster;
-        var index = roster.FindIndexOfTroop(character);
-        if (index < 0)
-            return $"{strings[1]} is not in {party.Name}'s member roster.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+            new ExpectedArgs("wounded_count", "The wounded count.", true),
+        };
 
-        var element = roster.GetElementCopyAtIndex(index);
-        if (woundedCount < 0 || woundedCount > element.Number)
-            return $"Wounded count must be between 0 and {element.Number}.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
 
-        roster.SetElementWoundedNumber(index, woundedCount);
-        return $"Set {strings[1]} oldWounded={element.WoundedNumber} newWounded={woundedCount}.";
+            if (!int.TryParse(args[2], out var woundedCount))
+                return Failed("Please enter an integer for wounded count.");
+
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty party))
+                return Failed($"Party with id {args[0]} not found.");
+            if (!objectManager.TryGetObject(args[1], out CharacterObject character))
+                return Failed($"Character with id {args[1]} not found.");
+
+            var roster = party.MemberRoster;
+            var index = roster.FindIndexOfTroop(character);
+            if (index < 0)
+                return Failed($"{args[1]} is not in {party.Name}'s member roster.");
+
+            var element = roster.GetElementCopyAtIndex(index);
+            if (woundedCount < 0 || woundedCount > element.Number)
+                return Failed($"Wounded count must be between 0 and {element.Number}.");
+
+            roster.SetElementWoundedNumber(index, woundedCount);
+            return Succeeded($"Set {args[1]} oldWounded={element.WoundedNumber} newWounded={woundedCount}.");
+        }
     }
 
     /// <summary>
     /// Sets one member-roster troop's exact state and reports the state it replaced.
     /// </summary>
-    [CommandLineArgumentFunction("set_troop_state", "coop.debug.mobileparty")]
-    public static string SetTroopStateCommand(List<string> strings)
+    public sealed class SetTroopStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
-        string validationError = ValidateTroopStateArgs(
-            strings,
-            out var shouldExist,
-            out var number,
-            out var woundedCount,
-            out var xp);
-        if (validationError != null) return validationError;
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out MobileParty party))
-            return $"Party with id {strings[0]} not found.";
-        if (!objectManager.TryGetObject(strings[1], out CharacterObject character))
-            return $"Character with id {strings[1]} not found.";
-        if (character.IsHero) return "Hero roster elements are not supported by this command.";
+        public string Name => "set_troop_state";
 
-        var roster = party.MemberRoster;
-        int index = roster.FindIndexOfTroop(character);
-        bool oldExists = index >= 0;
-        var oldState = oldExists ? roster.GetElementCopyAtIndex(index) : default;
-        int oldNumber = oldExists ? oldState.Number : 0;
-        int oldWounded = oldExists ? oldState.WoundedNumber : 0;
-        int oldXp = oldExists ? oldState.Xp : 0;
+        public string Description => "Reports set troop state.";
 
-        if (index < 0 && shouldExist)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            roster.AddToCounts(character, System.Math.Max(number, 1), removeDepleted: false);
-            index = roster.FindIndexOfTroop(character);
-        }
+            new ExpectedArgs("party_id", "The party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+            new ExpectedArgs("exists", "The exists.", true),
+            new ExpectedArgs("number", "The number.", true),
+            new ExpectedArgs("wounded_count", "The wounded count.", true),
+            new ExpectedArgs("xp", "The xp.", true),
+        };
 
-        if (index >= 0)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            int currentWounded = roster.GetElementWoundedNumber(index);
-            if (currentWounded > number) roster.SetElementWoundedNumber(index, number);
-            roster.SetElementNumber(index, number);
-            roster.SetElementWoundedNumber(index, woundedCount);
-            roster.SetElementXp(index, xp);
-            if (!shouldExist) roster.RemoveZeroCounts();
-            roster.InitializeCachedData();
-        }
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+            string validationError = ValidateTroopStateArgs(
+                args,
+                out var shouldExist,
+                out var number,
+                out var woundedCount,
+                out var xp);
+            if (validationError != null) return Failed(validationError);
 
-        return $"TROOP_STATE_SET party={strings[0]} character={strings[1]} " +
-               $"oldExists={oldExists} oldNumber={oldNumber} oldWounded={oldWounded} oldXp={oldXp} " +
-               $"newExists={shouldExist} newNumber={number} newWounded={woundedCount} newXp={xp}";
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty party))
+                return Failed($"Party with id {args[0]} not found.");
+            if (!objectManager.TryGetObject(args[1], out CharacterObject character))
+                return Failed($"Character with id {args[1]} not found.");
+            if (character.IsHero) return Failed("Hero roster elements are not supported by this command.");
+
+            var roster = party.MemberRoster;
+            int index = roster.FindIndexOfTroop(character);
+            bool oldExists = index >= 0;
+            var oldState = oldExists ? roster.GetElementCopyAtIndex(index) : default;
+            int oldNumber = oldExists ? oldState.Number : 0;
+            int oldWounded = oldExists ? oldState.WoundedNumber : 0;
+            int oldXp = oldExists ? oldState.Xp : 0;
+
+            if (index < 0 && shouldExist)
+            {
+                roster.AddToCounts(character, System.Math.Max(number, 1), removeDepleted: false);
+                index = roster.FindIndexOfTroop(character);
+            }
+
+            if (index >= 0)
+            {
+                int currentWounded = roster.GetElementWoundedNumber(index);
+                if (currentWounded > number) roster.SetElementWoundedNumber(index, number);
+                roster.SetElementNumber(index, number);
+                roster.SetElementWoundedNumber(index, woundedCount);
+                roster.SetElementXp(index, xp);
+                if (!shouldExist) roster.RemoveZeroCounts();
+                roster.InitializeCachedData();
+            }
+
+            return Succeeded($"TROOP_STATE_SET party={args[0]} character={args[1]} " +
+                   $"oldExists={oldExists} oldNumber={oldNumber} oldWounded={oldWounded} oldXp={oldXp} " +
+                   $"newExists={shouldExist} newNumber={number} newWounded={woundedCount} newXp={xp}");
+        }
     }
 
     private static string ValidateTroopStateArgs(
-        List<string> strings,
+        IReadOnlyList<string> strings,
         out bool shouldExist,
         out int number,
         out int woundedCount,
@@ -359,7 +471,7 @@ internal class PartyCommands
         woundedCount = 0;
         xp = 0;
         if (strings.Count != 6)
-            return "Usage: coop.debug.mobileparty.set_troop_state <party id> <character id> <exists> <number> <wounded count> <xp>";
+            return "Invalid troop state values.";
 
         if (!bool.TryParse(strings[2], out shouldExist) ||
             !int.TryParse(strings[3], out number) ||
@@ -376,136 +488,181 @@ internal class PartyCommands
     /// <summary>
     /// Selects a real right-member row so live tests can observe its inline upgrade choices.
     /// </summary>
-    [CommandLineArgumentFunction("select_party_screen_troop", "coop.debug.mobileparty")]
-    public static string SelectPartyScreenTroopCommand(List<string> strings)
+    public sealed class SelectPartyScreenTroopCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer) return "Command can only be run on a client.";
-        if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.select_party_screen_troop <character id>";
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
-            return $"Character with id {strings[0]} not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState))
-            return "No active party screen.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        if (partyVm == null) return "No active Party screen view model.";
+        public string Name => "select_party_screen_troop";
 
-        var row = partyVm.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        if (row == null) return $"{strings[0]} is not in the right member roster.";
+        public string Description => "Runs the select party screen troop debug operation.";
 
-        if (!row.IsSelected) partyVm.ExecuteSelectCharacterTuple(row);
-        return $"PARTY_SCREEN_TROOP_SELECTED character={strings[0]} selected={row.IsSelected} " +
-               $"upgradeTargets={row.Upgrades.Count} ready={row.NumOfReadyToUpgradeTroops} " +
-               $"upgradeable={row.NumOfUpgradeableTroops}";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("character_id", "The character id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out CharacterObject character))
+                return Failed($"Character with id {args[0]} not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState))
+                return Failed("No active party screen.");
+
+            var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+            if (partyVm == null) return Failed("No active Party screen view model.");
+
+            var row = partyVm.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            if (row == null) return Failed($"{args[0]} is not in the right member roster.");
+
+            if (!row.IsSelected) partyVm.ExecuteSelectCharacterTuple(row);
+            return Succeeded($"PARTY_SCREEN_TROOP_SELECTED character={args[0]} selected={row.IsSelected} " +
+                   $"upgradeTargets={row.Upgrades.Count} ready={row.NumOfReadyToUpgradeTroops} " +
+                   $"upgradeable={row.NumOfUpgradeableTroops}");
+        }
     }
 
     /// <summary>
     /// Applies the same upgrade command created by the Party-screen row.
     /// </summary>
-    [CommandLineArgumentFunction("upgrade_party_screen_troop", "coop.debug.mobileparty")]
-    public static string UpgradePartyScreenTroopCommand(List<string> strings)
+    public sealed class UpgradePartyScreenTroopCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer) return "Command can only be run on a client.";
-        if (strings.Count < 1 || strings.Count > 2)
-            return "Usage: coop.debug.mobileparty.upgrade_party_screen_troop <character id> [upgrade target index]";
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
-            return $"Character with id {strings[0]} not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState))
-            return "No active party screen.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        int upgradeTarget = 0;
-        if (strings.Count == 2 && (!int.TryParse(strings[1], out upgradeTarget) || upgradeTarget < 0))
-            return "Upgrade target index must be a non-negative integer.";
-        if (upgradeTarget >= character.UpgradeTargets.Length)
-            return $"{strings[0]} has {character.UpgradeTargets.Length} upgrade targets.";
+        public string Name => "upgrade_party_screen_troop";
 
-        var logic = partyState.PartyScreenLogic;
-        int rosterIndex = logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right]
-            .FindIndexOfTroop(character);
-        if (rosterIndex < 0) return $"{strings[0]} is not in the right member roster.";
+        public string Description => "Runs the upgrade party screen troop debug operation.";
 
-        var troop = logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right]
-            .GetElementCopyAtIndex(rosterIndex);
-        int insertionIndex = logic.GetIndexToInsertTroop(
-            PartyScreenLogic.PartyRosterSide.Right,
-            PartyScreenLogic.TroopType.Member,
-            troop);
-        var command = new PartyScreenLogic.PartyCommand();
-        command.FillForUpgradeTroop(
-            PartyScreenLogic.PartyRosterSide.Right,
-            PartyScreenLogic.TroopType.Member,
-            character,
-            1,
-            upgradeTarget,
-            insertionIndex);
-        if (!logic.ValidateCommand(command))
-            return $"PARTY_SCREEN_UPGRADE_REJECTED character={strings[0]} target={upgradeTarget}";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("character_id", "The character id.", true),
+            new ExpectedArgs("upgrade_target_index", "The upgrade target index.", false),
+        };
 
-        logic.AddCommand(command);
-        return $"PARTY_SCREEN_UPGRADE_STAGED character={strings[0]} " +
-            $"target={character.UpgradeTargets[upgradeTarget].StringId} pending={logic.IsThereAnyChanges()}";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out CharacterObject character))
+                return Failed($"Character with id {args[0]} not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState))
+                return Failed("No active party screen.");
+
+            int upgradeTarget = 0;
+            if (args.Count == 2 && (!int.TryParse(args[1], out upgradeTarget) || upgradeTarget < 0))
+                return Failed("Upgrade target index must be a non-negative integer.");
+            if (upgradeTarget >= character.UpgradeTargets.Length)
+                return Succeeded($"{args[0]} has {character.UpgradeTargets.Length} upgrade targets.");
+
+            var logic = partyState.PartyScreenLogic;
+            int rosterIndex = logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right]
+                .FindIndexOfTroop(character);
+            if (rosterIndex < 0) return Failed($"{args[0]} is not in the right member roster.");
+
+            var troop = logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right]
+                .GetElementCopyAtIndex(rosterIndex);
+            int insertionIndex = logic.GetIndexToInsertTroop(
+                PartyScreenLogic.PartyRosterSide.Right,
+                PartyScreenLogic.TroopType.Member,
+                troop);
+            var command = new PartyScreenLogic.PartyCommand();
+            command.FillForUpgradeTroop(
+                PartyScreenLogic.PartyRosterSide.Right,
+                PartyScreenLogic.TroopType.Member,
+                character,
+                1,
+                upgradeTarget,
+                insertionIndex);
+            if (!logic.ValidateCommand(command))
+                return Failed($"PARTY_SCREEN_UPGRADE_REJECTED character={args[0]} target={upgradeTarget}");
+
+            logic.AddCommand(command);
+            return Succeeded($"PARTY_SCREEN_UPGRADE_STAGED character={args[0]} " +
+                $"target={character.UpgradeTargets[upgradeTarget].StringId} pending={logic.IsThereAnyChanges()}");
+        }
     }
 
     /// <summary>
     /// Creates a real pending Party-screen transfer for live synchronization tests.
     /// </summary>
-    [CommandLineArgumentFunction("stage_party_screen_transfer", "coop.debug.mobileparty")]
-    public static string StagePartyScreenTransferCommand(List<string> strings)
+    public sealed class StagePartyScreenTransferCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer) return "Command can only be run on a client.";
-        if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.stage_party_screen_transfer <character id>";
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
-            return $"Character with id {strings[0]} not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState))
-            return "No active party screen.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var logic = partyState.PartyScreenLogic;
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        if (partyVm == null) return "No active Party screen view model.";
+        public string Name => "stage_party_screen_transfer";
 
-        var row = partyVm.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        if (row == null) return $"{strings[0]} is not in the right member roster.";
+        public string Description => "Runs the stage party screen transfer debug operation.";
 
-        partyVm.OnTransferTroop(row, -1, 1, row.Side);
-        partyVm.ExecuteRemoveZeroCounts();
-        return $"PARTY_SCREEN_EDIT_STAGED pending={logic.IsThereAnyChanges()}";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("character_id", "The character id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out CharacterObject character))
+                return Failed($"Character with id {args[0]} not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState))
+                return Failed("No active party screen.");
+
+            var logic = partyState.PartyScreenLogic;
+            var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+            if (partyVm == null) return Failed("No active Party screen view model.");
+
+            var row = partyVm.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            if (row == null) return Failed($"{args[0]} is not in the right member roster.");
+
+            partyVm.OnTransferTroop(row, -1, 1, row.Side);
+            partyVm.ExecuteRemoveZeroCounts();
+            return Succeeded($"PARTY_SCREEN_EDIT_STAGED pending={logic.IsThereAnyChanges()}");
+        }
     }
 
     /// <summary>
     /// Reports the visible roster, Done baseline, and rendered VM state for one open Party-screen row.
     /// </summary>
-    [CommandLineArgumentFunction("party_screen_troop_state", "coop.debug.mobileparty")]
-    public static string PartyScreenTroopStateCommand(List<string> strings)
+    public sealed class PartyScreenTroopStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer) return "Command can only be run on a client.";
-        if (strings.Count != 1)
-            return "Usage: coop.debug.mobileparty.party_screen_troop_state <character id>";
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out CharacterObject character))
-            return $"Character with id {strings[0]} not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState))
-            return "No active party screen.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var logic = partyState.PartyScreenLogic;
-        var visible = GetRosterElement(logic.MemberRosters[1], character);
-        var baseline = GetRosterElement(logic._initialData.RightMemberRoster, character);
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        var row = partyVm?.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        var rendered = row == null
-            ? (number: -1, wounded: -1, xp: -1)
-            : (number: row.Troop.Number, wounded: row.Troop.WoundedNumber, xp: row.Troop.Xp);
+        public string Name => "party_screen_troop_state";
 
-        return $"PARTY_SCREEN_TROOP_STATE character={strings[0]} " +
-               $"visibleNumber={visible.number} visibleWounded={visible.wounded} visibleXp={visible.xp} " +
-               $"baselineNumber={baseline.number} baselineWounded={baseline.wounded} baselineXp={baseline.xp} " +
-               $"vmNumber={rendered.number} vmWounded={rendered.wounded} vmXp={rendered.xp} " +
-               $"selected={row?.IsSelected == true} upgradeTargets={row?.Upgrades.Count ?? 0} " +
-               $"ready={row?.NumOfReadyToUpgradeTroops ?? 0} upgradeable={row?.NumOfUpgradeableTroops ?? 0} " +
-               $"pending={logic.IsThereAnyChanges()}";
+        public string Description => "Reports party screen troop state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("character_id", "The character id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out CharacterObject character))
+                return Failed($"Character with id {args[0]} not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState))
+                return Failed("No active party screen.");
+
+            var logic = partyState.PartyScreenLogic;
+            var visible = GetRosterElement(logic.MemberRosters[1], character);
+            var baseline = GetRosterElement(logic._initialData.RightMemberRoster, character);
+            var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+            var row = partyVm?.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            var rendered = row == null
+                ? (number: -1, wounded: -1, xp: -1)
+                : (number: row.Troop.Number, wounded: row.Troop.WoundedNumber, xp: row.Troop.Xp);
+
+            return Succeeded($"PARTY_SCREEN_TROOP_STATE character={args[0]} " +
+                   $"visibleNumber={visible.number} visibleWounded={visible.wounded} visibleXp={visible.xp} " +
+                   $"baselineNumber={baseline.number} baselineWounded={baseline.wounded} baselineXp={baseline.xp} " +
+                   $"vmNumber={rendered.number} vmWounded={rendered.wounded} vmXp={rendered.xp} " +
+                   $"selected={row?.IsSelected == true} upgradeTargets={row?.Upgrades.Count ?? 0} " +
+                   $"ready={row?.NumOfReadyToUpgradeTroops ?? 0} upgradeable={row?.NumOfUpgradeableTroops ?? 0} " +
+                   $"pending={logic.IsThereAnyChanges()}");
+        }
     }
 
     private static (int number, int wounded, int xp) GetRosterElement(
@@ -522,76 +679,101 @@ internal class PartyCommands
     /// <summary>
     /// Add xp to all troops in a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("addtroopxp", "coop.debug.mobileparty")]
-    public static string AddTroopXpCommand(List<string> strings)
+    public sealed class AddTroopXpCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (strings.Count < 2) return "Hero name and xp amount required.";
+        public string Name => "add_troop_xp";
 
-        // The xp amount is the last token; the rest is the (possibly multi-word) hero name.
-        if (!int.TryParse(strings[strings.Count - 1], out int xpGain)) return "Please enter an integer for xp amount";
+        public string Description => "Runs the addtroopxp debug operation.";
 
-        var name = string.Join(" ", strings.Take(strings.Count - 1));
-        var heroes = FindHeroesWithParty(name);
-        if (heroes.Count == 0) return "No hero named \"" + name + "\" with a party found.";
-
-        foreach (var hero in heroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            var memberRoster = hero.PartyBelongedTo.MemberRoster;
-            foreach (var troop in memberRoster.data)
-            {
-                memberRoster.AddXpToTroop(troop.Character, xpGain);
-            }
-        }
+            new ExpectedArgs("hero_name", "The hero name.", true),
+            new ExpectedArgs("xp_amount", "The xp amount.", true),
+        };
 
-        return "Gave xp to the troops of " + heroes.Count + " party/parties named \"" + name + "\".";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            // The xp amount is the last token; the rest is the (possibly multi-word) hero name.
+            if (!int.TryParse(args[1], out int xpGain)) return Failed("Please enter an integer for xp amount");
+
+            var name = args[0];
+            var heroes = FindHeroesWithParty(name);
+            if (heroes.Count == 0) return Failed("No hero named \"" + name + "\" with a party found.");
+
+            foreach (var hero in heroes)
+            {
+                var memberRoster = hero.PartyBelongedTo.MemberRoster;
+                foreach (var troop in memberRoster.data)
+                {
+                    memberRoster.AddXpToTroop(troop.Character, xpGain);
+                }
+            }
+
+            return Succeeded("Gave xp to the troops of " + heroes.Count + " party/parties named \"" + name + "\".");
+        }
     }
 
     /// <summary>
     /// Add troops to a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("addtroops", "coop.debug.mobileparty")]
-    public static string AddRecruitsCommand(List<string> strings)
+    public sealed class AddTroopsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (strings.Count == 0) return "Hero name required";
+        public string Name => "add_troops";
 
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Description => "Runs the addtroops debug operation.";
 
-        var name = string.Join(" ", strings);
-        var heroes = FindHeroesWithParty(name);
-        if (heroes.Count == 0) return "No hero named \"" + name + "\" with a party found.";
-
-        var troopsToAdd = new Dictionary<string, int>()
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            { "imperial_vigla_recruit", 5 },
-            { "imperial_recruit", 2 },
-            { "imperial_equite", 2 },
-            { "imperial_heavy_horseman", 2 }
+            new ExpectedArgs("hero_name", "The hero name.", true),
         };
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in heroes)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var memberRoster = hero.PartyBelongedTo.MemberRoster;
-            foreach (var troopId in troopsToAdd.Keys)
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            var name = string.Join(" ", args);
+            var heroes = FindHeroesWithParty(name);
+            if (heroes.Count == 0) return Failed("No hero named \"" + name + "\" with a party found.");
+
+            var troopsToAdd = new Dictionary<string, int>()
             {
-                if (!objectManager.TryGetObject(troopId, out CharacterObject characterObject))
+                { "imperial_vigla_recruit", 5 },
+                { "imperial_recruit", 2 },
+                { "imperial_equite", 2 },
+                { "imperial_heavy_horseman", 2 }
+            };
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in heroes)
+            {
+                var memberRoster = hero.PartyBelongedTo.MemberRoster;
+                foreach (var troopId in troopsToAdd.Keys)
                 {
-                    stringBuilder.AppendLine("Failed to retrieve object for CharacterObject id: " + troopId);
+                    if (!objectManager.TryGetObject(troopId, out CharacterObject characterObject))
+                    {
+                        stringBuilder.AppendLine("Failed to retrieve object for CharacterObject id: " + troopId);
+                    }
+                    else
+                    {
+                        memberRoster.AddToCounts(characterObject, troopsToAdd[troopId]);
+                    }
                 }
-                else
-                {
-                    memberRoster.AddToCounts(characterObject, troopsToAdd[troopId]);
-                }
+
+                stringBuilder.AppendLine(hero.Name.ToString() + " was given troops.");
             }
 
-            stringBuilder.AppendLine(hero.Name.ToString() + " was given troops.");
+            return Succeeded(stringBuilder.ToString());
         }
-
-        return stringBuilder.ToString();
     }
 
     // coop.debug.mobileparty.siege_buff
@@ -600,34 +782,46 @@ internal class PartyCommands
     /// can march to and win a siege for testing without starving. Server only; the troop and item adds replicate
     /// via the roster sync. Get the party id from coop.debug.mobileparty.whoami on the client that owns the party.
     /// </summary>
-    [CommandLineArgumentFunction("siege_buff", "coop.debug.mobileparty")]
-    public static string SiegeBuffCommand(List<string> strings)
+    public sealed class SiegeBuffCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
-        if (strings.Count != 1) return "Usage: coop.debug.mobileparty.siege_buff <partyId>";
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out MobileParty party)) return $"Party with id {strings[0]} not found";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var troop = party.MapFaction?.Culture?.EliteBasicTroop ?? party.MapFaction?.Culture?.BasicTroop;
-        if (troop == null) return $"Could not resolve a troop for {party.Name}'s culture";
+        public string Name => "siege_buff";
 
-        int toAdd = 2000 - party.MemberRoster.TotalManCount;
-        if (toAdd > 0) party.MemberRoster.AddToCounts(troop, toAdd);
+        public string Description => "Runs the siege buff debug operation.";
 
-        party.RecentEventsMorale = 100f;
-        PartyDebugBuffPatches.Boost(party);
-
-        // Stock every food type so a 2000-troop army doesn't starve on the march to the siege. AddToCounts routes
-        // through the synced EquipmentElement overload, so the food replicates to the owning client.
-        int foodTypes = 0;
-        foreach (var item in MBObjectManager.Instance.GetObjectTypeList<ItemObject>())
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (item?.IsFood != true) continue;
-            party.ItemRoster.AddToCounts(item, 500);
-            foodTypes++;
-        }
+            new ExpectedArgs("party_id", "The party id.", true),
+        };
 
-        return $"Buffed {party.Name} ({party.StringId}): {party.MemberRoster.TotalManCount} troops, max morale, boosted speed and party-size limit, {foodTypes} food type(s) x500";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty party)) return Failed($"Party with id {args[0]} not found");
+
+            var troop = party.MapFaction?.Culture?.EliteBasicTroop ?? party.MapFaction?.Culture?.BasicTroop;
+            if (troop == null) return Failed($"Could not resolve a troop for {party.Name}'s culture");
+
+            int toAdd = 2000 - party.MemberRoster.TotalManCount;
+            if (toAdd > 0) party.MemberRoster.AddToCounts(troop, toAdd);
+
+            party.RecentEventsMorale = 100f;
+            PartyDebugBuffPatches.Boost(party);
+
+            // Stock every food type so a 2000-troop army doesn't starve on the march to the siege. AddToCounts routes
+            // through the synced EquipmentElement overload, so the food replicates to the owning client.
+            int foodTypes = 0;
+            foreach (var item in MBObjectManager.Instance.GetObjectTypeList<ItemObject>())
+            {
+                if (item?.IsFood != true) continue;
+                party.ItemRoster.AddToCounts(item, 500);
+                foodTypes++;
+            }
+
+            return Succeeded($"Buffed {party.Name} ({party.StringId}): {party.MemberRoster.TotalManCount} troops, max morale, boosted speed and party-size limit, {foodTypes} food type(s) x500");
+        }
     }
 
     // coop.debug.mobileparty.declare_war
@@ -635,137 +829,187 @@ internal class PartyCommands
     /// Declares war between a party's faction and a settlement's faction, so the party can besiege that
     /// settlement. Works for an independent clan (no kingdom needed). Server only; the war replicates.
     /// </summary>
-    [CommandLineArgumentFunction("declare_war", "coop.debug.mobileparty")]
-    public static string DeclareWarCommand(List<string> strings)
+    public sealed class DeclareWarCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
-        if (strings.Count != 2) return "Usage: coop.debug.mobileparty.declare_war <partyId> <settlementId>";
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(strings[0], out MobileParty party)) return $"Party with id {strings[0]} not found";
-        if (!objectManager.TryGetObject(strings[1], out Settlement settlement)) return $"Settlement with id {strings[1]} not found";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var attacker = party.MapFaction;
-        var defender = settlement.MapFaction;
-        if (attacker == null || defender == null) return "Could not resolve both factions";
-        if (attacker == defender) return "The party and the settlement share a faction";
-        if (attacker.IsAtWarWith(defender)) return $"{attacker.Name} is already at war with {defender.Name}";
+        public string Name => "declare_war";
 
-        DeclareWarAction.ApplyByDefault(attacker, defender);
-        return $"{attacker.Name} is now at war with {defender.Name}";
+        public string Description => "Runs the declare war debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The party id.", true),
+            new ExpectedArgs("settlement_id", "The settlement id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty party)) return Failed($"Party with id {args[0]} not found");
+            if (!objectManager.TryGetObject(args[1], out Settlement settlement)) return Failed($"Settlement with id {args[1]} not found");
+
+            var attacker = party.MapFaction;
+            var defender = settlement.MapFaction;
+            if (attacker == null || defender == null) return Failed("Could not resolve both factions");
+            if (attacker == defender) return Failed("The party and the settlement share a faction");
+            if (attacker.IsAtWarWith(defender)) return Failed($"{attacker.Name} is already at war with {defender.Name}");
+
+            DeclareWarAction.ApplyByDefault(attacker, defender);
+            return Succeeded($"{attacker.Name} is now at war with {defender.Name}");
+        }
     }
 
     /// <summary>
     /// Add prisoners to a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("addprisoners", "coop.debug.mobileparty")]
-    public static string AddPrisonersCommand(List<string> strings)
+    public sealed class AddPrisonersCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (strings.Count == 0) return "Hero name required";
+        public string Name => "add_prisoners";
 
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Description => "Runs the addprisoners debug operation.";
 
-        var name = string.Join(" ", strings);
-        var heroes = FindHeroesWithParty(name);
-        if (heroes.Count == 0) return "No hero named \"" + name + "\" with a party found.";
-
-        var troopsToAdd = new Dictionary<string, int>()
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            { "imperial_vigla_recruit", 5 },
-            { "imperial_recruit", 2 },
-            { "imperial_equite", 2 },
-            { "imperial_heavy_horseman", 2 }
+            new ExpectedArgs("hero_name", "The hero name.", true),
         };
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in heroes)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var prisonerRoster = hero.PartyBelongedTo.PrisonRoster;
-            foreach (var troopId in troopsToAdd.Keys)
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            var name = string.Join(" ", args);
+            var heroes = FindHeroesWithParty(name);
+            if (heroes.Count == 0) return Failed("No hero named \"" + name + "\" with a party found.");
+
+            var troopsToAdd = new Dictionary<string, int>()
             {
-                if (!objectManager.TryGetObject(troopId, out CharacterObject characterObject))
+                { "imperial_vigla_recruit", 5 },
+                { "imperial_recruit", 2 },
+                { "imperial_equite", 2 },
+                { "imperial_heavy_horseman", 2 }
+            };
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in heroes)
+            {
+                var prisonerRoster = hero.PartyBelongedTo.PrisonRoster;
+                foreach (var troopId in troopsToAdd.Keys)
                 {
-                    stringBuilder.AppendLine("Failed to retrieve object for CharacterObject id: " + troopId);
+                    if (!objectManager.TryGetObject(troopId, out CharacterObject characterObject))
+                    {
+                        stringBuilder.AppendLine("Failed to retrieve object for CharacterObject id: " + troopId);
+                    }
+                    else
+                    {
+                        prisonerRoster.AddToCounts(characterObject, troopsToAdd[troopId]);
+                    }
                 }
-                else
-                {
-                    prisonerRoster.AddToCounts(characterObject, troopsToAdd[troopId]);
-                }
+
+                stringBuilder.AppendLine(hero.Name.ToString() + " was given prisoners.");
             }
 
-            stringBuilder.AppendLine(hero.Name.ToString() + " was given prisoners.");
+            return Succeeded(stringBuilder.ToString());
         }
-
-        return stringBuilder.ToString();
     }
 
     /// <summary>
     /// Remove all prisoners from a hero's party
     /// </summary>
-    [CommandLineArgumentFunction("removeprisoners", "coop.debug.mobileparty")]
-    public static string RemovePrisonersCommand(List<string> strings)
+    public sealed class RemovePrisonersCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (strings.Count == 0) return "Hero name required";
+        public string Name => "remove_prisoners";
 
-        var name = string.Join(" ", strings);
-        var heroes = FindHeroesWithParty(name);
-        if (heroes.Count == 0) return "No hero named \"" + name + "\" with a party found.";
+        public string Description => "Runs the removeprisoners debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in heroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            var prisonerRoster = hero.PartyBelongedTo.PrisonRoster;
+            new ExpectedArgs("hero_name", "The hero name.", true),
+        };
 
-            // Walk from the end so removing the current element leaves the lower indices valid. Each
-            // subtract-to-zero with removeDepleted runs with patches live, so it replicates to clients.
-            for (int i = prisonerRoster.Count - 1; i >= 0; i--)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            var name = string.Join(" ", args);
+            var heroes = FindHeroesWithParty(name);
+            if (heroes.Count == 0) return Failed("No hero named \"" + name + "\" with a party found.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in heroes)
             {
-                var element = prisonerRoster.GetElementCopyAtIndex(i);
-                prisonerRoster.AddToCounts(element.Character, -element.Number, false, -element.WoundedNumber, 0, true);
+                var prisonerRoster = hero.PartyBelongedTo.PrisonRoster;
+
+                // Walk from the end so removing the current element leaves the lower indices valid. Each
+                // subtract-to-zero with removeDepleted runs with patches live, so it replicates to clients.
+                for (int i = prisonerRoster.Count - 1; i >= 0; i--)
+                {
+                    var element = prisonerRoster.GetElementCopyAtIndex(i);
+                    prisonerRoster.AddToCounts(element.Character, -element.Number, false, -element.WoundedNumber, 0, true);
+                }
+
+                stringBuilder.AppendLine(hero.Name.ToString() + " had their prisoners removed.");
             }
 
-            stringBuilder.AppendLine(hero.Name.ToString() + " had their prisoners removed.");
+            return Succeeded(stringBuilder.ToString());
         }
-
-        return stringBuilder.ToString();
     }
 
     /// <summary>
     /// Put a hero (e.g. a player companion) into a hero's party prison roster, to set up the
     /// companion-preserve test. Args: captor hero name, prisoner hero name.
     /// </summary>
-    [CommandLineArgumentFunction("imprison_companion", "coop.debug.mobileparty")]
-    public static string ImprisonCompanionCommand(List<string> strings)
+    public sealed class ImprisonCompanionCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (strings.Count < 2) return "Captor hero name and prisoner hero name required.";
+        public string Name => "imprison_companion";
 
-        // The console splits arguments on spaces, so the captor is the first token and the prisoner name is
-        // the rest joined back together. Companions always have a multi-word name (e.g. "Chandion the Bull"),
-        // which would otherwise arrive as several tokens and never match. (The captor must be a single-token
-        // name for this split to work, which the player's own hero typically is.) One captor only: a hero can
-        // only be a prisoner in one place, so imprisoning the companion in several prisons would be invalid.
-        if (!TryGetHeroWithParty(strings[0], out var captor, out var error)) return error;
+        public string Description => "Runs the imprison companion debug operation.";
 
-        var prisonerName = string.Join(" ", strings.Skip(1));
-        var prisoner = Hero.AllAliveHeroes.FirstOrDefault(h => h.Name.ToString() == prisonerName);
-        if (prisoner == null) return "Prisoner hero \"" + prisonerName + "\" not found.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("captor_hero", "The captor hero.", true),
+            new ExpectedArgs("prisoner_hero", "The prisoner hero.", true),
+        };
 
-        // The preserve only fires for a player companion, so a non-companion would be removed by both the
-        // fixed and the old code and prove nothing. Require a companion so the test actually exercises it.
-        if (!prisoner.IsPlayerCompanion) return prisoner.Name + " is not a player companion; this test needs one.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
 
-        // Place a copy of the companion in the prison roster as a test fixture for the snapshot path.
-        // Deliberately a raw AddToCounts, NOT a TakePrisonerAction: the full imprisonment doesn't replicate
-        // cleanly in co-op (it zeroes the prisoner's home party on its owning client - a separate captivity
-        // sync bug). The companion stays in its own party, so the snapshot test only ever clears the prison
-        // copy and there is nothing to restore afterwards.
-        captor.PartyBelongedTo.PrisonRoster.AddToCounts(prisoner.CharacterObject, 1);
-        return prisoner.Name + " (a player companion) placed in " + captor.Name + "'s prison roster (a test copy; it stays in its own party).";
+
+            // The console splits arguments on spaces, so the captor is the first token and the prisoner name is
+            // the rest joined back together. Companions always have a multi-word name (e.g. "Chandion the Bull"),
+            // which would otherwise arrive as several tokens and never match. (The captor must be a single-token
+            // name for this split to work, which the player's own hero typically is.) One captor only: a hero can
+            // only be a prisoner in one place, so imprisoning the companion in several prisons would be invalid.
+            if (!TryGetHeroWithParty(args[0], out var captor, out var error)) return Failed(error);
+
+            var prisonerName = string.Join(" ", args.Skip(1));
+            var prisoner = Hero.AllAliveHeroes.FirstOrDefault(h => h.Name.ToString() == prisonerName);
+            if (prisoner == null) return Failed("Prisoner hero \"" + prisonerName + "\" not found.");
+
+            // The preserve only fires for a player companion, so a non-companion would be removed by both the
+            // fixed and the old code and prove nothing. Require a companion so the test actually exercises it.
+            if (!prisoner.IsPlayerCompanion) return Failed(prisoner.Name + " is not a player companion; this test needs one.");
+
+            // Place a copy of the companion in the prison roster as a test fixture for the snapshot path.
+            // Deliberately a raw AddToCounts, NOT a TakePrisonerAction: the full imprisonment doesn't replicate
+            // cleanly in co-op (it zeroes the prisoner's home party on its owning client - a separate captivity
+            // sync bug). The companion stays in its own party, so the snapshot test only ever clears the prison
+            // copy and there is nothing to restore afterwards.
+            captor.PartyBelongedTo.PrisonRoster.AddToCounts(prisoner.CharacterObject, 1);
+            return Succeeded(prisoner.Name + " (a player companion) placed in " + captor.Name + "'s prison roster (a test copy; it stays in its own party).");
+        }
     }
 
     /// <summary>
@@ -773,46 +1017,58 @@ internal class PartyCommands
     /// if the server freed them. Drives TroopRosterInterface.UpdateWithData on a prison roster: hero prisoners
     /// (player companions included) must be removed, not preserved, and the removal replicates to clients.
     /// </summary>
-    [CommandLineArgumentFunction("snapshot_prison", "coop.debug.mobileparty")]
-    public static string SnapshotPrisonCommand(List<string> strings)
+    public sealed class SnapshotPrisonCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        if (strings.Count == 0) return "Hero name required";
+        public string Name => "snapshot_prison";
 
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Description => "Runs the snapshot prison debug operation.";
 
-        // One party only, to pair with imprison_companion (which targets one prison).
-        if (!TryGetHeroWithParty(string.Join(" ", strings), out var hero, out var error)) return error;
-
-        var prisonRoster = hero.PartyBelongedTo.PrisonRoster;
-        if (ContainerProvider.TryGetContainer(out var container) == false ||
-            container.TryResolve(out ITroopRosterInterface troopRosterInterface) == false)
-            return "Unable to resolve TroopRosterInterface.";
-
-        // Pack the prison roster, then drop the hero elements so the snapshot no longer carries them, as if
-        // the server had freed them. Resolve each element's CharacterObject to tell heroes from basic troops.
-        var packed = troopRosterInterface.PackTroopRosterData(prisonRoster);
-        var nonHeroElements = new List<TroopRosterElementData>();
-        foreach (var element in packed.Data)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (objectManager.TryGetObject(element.CharacterId, out CharacterObject troop) && troop.IsHero) continue;
-            nonHeroElements.Add(element);
-        }
-        var snapshot = new TroopRosterData(nonHeroElements);
+            new ExpectedArgs("hero_name_or_id", "The hero name or id.", true),
+        };
 
-        // Pass a non-null mainHero so the preserve decision turns on the prison-vs-member roster check (the
-        // thing under test), not on a null mainHero short-circuit.
-        troopRosterInterface.UpdateWithData(prisonRoster, snapshot, hero);
-
-        int heroesLeft = 0;
-        for (int i = 0; i < prisonRoster.Count; i++)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (prisonRoster.GetElementCopyAtIndex(i).Character?.IsHero == true) heroesLeft++;
-        }
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
 
-        return heroesLeft == 0
-            ? "Applied prison snapshot to " + hero.Name + "; all hero prisoners removed (companion-preserve correctly off for prison rosters)."
-            : "Applied prison snapshot to " + hero.Name + "; " + heroesLeft + " hero prisoner(s) still present (companion-preserve wrongly kept them).";
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            // One party only, to pair with imprison_companion (which targets one prison).
+            if (!TryGetHeroWithParty(string.Join(" ", args), out var hero, out var error)) return Failed(error);
+
+            var prisonRoster = hero.PartyBelongedTo.PrisonRoster;
+            if (ContainerProvider.TryGetContainer(out var container) == false ||
+                container.TryResolve(out ITroopRosterInterface troopRosterInterface) == false)
+                return Failed("Unable to resolve TroopRosterInterface.");
+
+            // Pack the prison roster, then drop the hero elements so the snapshot no longer carries them, as if
+            // the server had freed them. Resolve each element's CharacterObject to tell heroes from basic troops.
+            var packed = troopRosterInterface.PackTroopRosterData(prisonRoster);
+            var nonHeroElements = new List<TroopRosterElementData>();
+            foreach (var element in packed.Data)
+            {
+                if (objectManager.TryGetObject(element.CharacterId, out CharacterObject troop) && troop.IsHero) continue;
+                nonHeroElements.Add(element);
+            }
+            var snapshot = new TroopRosterData(nonHeroElements);
+
+            // Pass a non-null mainHero so the preserve decision turns on the prison-vs-member roster check (the
+            // thing under test), not on a null mainHero short-circuit.
+            troopRosterInterface.UpdateWithData(prisonRoster, snapshot, hero);
+
+            int heroesLeft = 0;
+            for (int i = 0; i < prisonRoster.Count; i++)
+            {
+                if (prisonRoster.GetElementCopyAtIndex(i).Character?.IsHero == true) heroesLeft++;
+            }
+
+            return Succeeded(heroesLeft == 0
+                ? "Applied prison snapshot to " + hero.Name + "; all hero prisoners removed (companion-preserve correctly off for prison rosters)."
+                : "Applied prison snapshot to " + hero.Name + "; " + heroesLeft + " hero prisoner(s) still present (companion-preserve wrongly kept them).");
+        }
     }
 }

--- a/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using GameInterface.Services.MobileParties.Extensions;
 using GameInterface.Services.ObjectManager;
@@ -17,7 +18,6 @@ using TaleWorlds.CampaignSystem.Roster;
 using TaleWorlds.Core;
 using TaleWorlds.Localization;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Party.Commands;
 
@@ -26,6 +26,12 @@ namespace GameInterface.Services.Party.Commands;
 /// </summary>
 internal static class TroopXpTransferFixtureCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private const string FixtureCompanionName = "Coop XP Transfer Fixture";
     private const int FixtureTroopCount = 1;
     private const int FixtureTroopXp = 200;
@@ -35,362 +41,527 @@ internal static class TroopXpTransferFixtureCommands
     private static TroopXpTransferRestoration pendingRestorationVerification;
     private static string pendingNoopRestorationControllerId;
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_capture", "coop.debug.mobileparty")]
-    public static string Capture(List<string> args)
+    public sealed class ClanPartyXpFixtureCaptureCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_capture <controllerId>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 1) return usage;
-        if (pendingSetupCapture != null || pendingFixture != null ||
-            pendingRestorationVerification != null || pendingNoopRestorationControllerId != null)
-            return "A clan-party XP transfer fixture lifecycle is already active.";
-        if (!TryResolvePlayer(args[0], out var objectManager, out var playerManager,
-            out var player, out _, out var playerClan, out var playerParty, out var error))
-            return "Failed to capture clan-party XP transfer fixture: " + error;
-        if (!playerManager.TryGetPeer(player.ControllerId, out _))
-            return $"Player '{player.ControllerId}' is not connected.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var character = playerClan.Culture?.BasicTroop;
-        if (character == null || character.IsHero ||
-            !objectManager.TryGetIdWithLogging(character, out var characterId) ||
-            !objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId))
-            return "Failed to capture clan-party XP transfer fixture: the player's culture has no registered basic troop.";
+        public string Name => "clan_party_xp_fixture_capture";
 
-        var originalPlayerState = ReadRosterState(playerParty.MemberRoster, character);
-        int originalCompanionCount = playerClan.Companions.Count();
-        return JsonResult(new
+        public string Description => "Runs the clan party xp fixture capture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            controllerId = player.ControllerId,
-            playerPartyId,
-            characterId,
-            playerCount = originalPlayerState.Number,
-            playerWounded = originalPlayerState.Wounded,
-            playerXp = originalPlayerState.Xp,
-            companionCount = originalCompanionCount
-        });
-    }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_setup", "coop.debug.mobileparty")]
-    public static string Setup(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_setup " +
-            "<controllerId> <playerPartyId> <characterId> <playerCount> <playerWounded> <playerXp> <companionCount>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 7 ||
-            !int.TryParse(args[3], out int expectedPlayerCount) ||
-            !int.TryParse(args[4], out int expectedPlayerWounded) ||
-            !int.TryParse(args[5], out int expectedPlayerXp) ||
-            !int.TryParse(args[6], out int expectedCompanionCount))
-            return usage;
-        if (pendingFixture != null) return "A clan-party XP transfer fixture is already active.";
-        if (pendingSetupCapture != null || pendingRestorationVerification != null ||
-            pendingNoopRestorationControllerId != null)
-            return "A clan-party XP transfer fixture lifecycle is already active.";
-        pendingNoopRestorationControllerId = args[0];
-        if (!TryResolvePlayer(args[0], out var objectManager, out var playerManager,
-            out var player, out var playerHero, out var playerClan, out var playerParty, out var error))
-            return "Failed to set up clan-party XP transfer fixture: " + error;
-        if (!playerManager.TryGetPeer(player.ControllerId, out _))
-            return $"Player '{player.ControllerId}' is not connected.";
-        var template = Hero.AllAliveHeroes.FirstOrDefault(hero =>
-            hero != playerHero && hero.IsWanderer && hero.CompanionOf == null);
-        if (template == null)
-            return "Failed to set up clan-party XP transfer fixture: no free living wanderer template is available.";
-
-        var character = playerClan.Culture?.BasicTroop;
-        if (character == null || character.IsHero ||
-            !objectManager.TryGetIdWithLogging(character, out var characterId) ||
-            !objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId))
-            return "Failed to set up clan-party XP transfer fixture: the player's culture has no registered basic troop.";
-        var originalPlayerState = ReadRosterState(playerParty.MemberRoster, character);
-        int originalCompanionCount = playerClan.Companions.Count();
-        if (playerPartyId != args[1] || characterId != args[2] ||
-            originalPlayerState.Number != expectedPlayerCount ||
-            originalPlayerState.Wounded != expectedPlayerWounded ||
-            originalPlayerState.Xp != expectedPlayerXp ||
-            originalCompanionCount != expectedCompanionCount)
-            return "Failed to set up clan-party XP transfer fixture: the captured fixture state changed.";
-
-        var capture = new TroopXpTransferCapture(
-            player.ControllerId,
-            playerPartyId,
-            characterId,
-            playerClan,
-            playerParty,
-            originalPlayerState,
-            originalCompanionCount);
-        pendingSetupCapture = capture;
-        Hero companion = null;
-        MobileParty clanParty = null;
-
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            companion = HeroCreator.CreateSpecialHero(template.CharacterObject, playerHero.HomeSettlement, age: 30);
-            var fixtureName = new TextObject(FixtureCompanionName);
-            companion.SetName(fixtureName, fixtureName);
-            companion.SetNewOccupation(Occupation.Wanderer);
-            AddCompanionAction.Apply(playerClan, companion);
-            AddHeroToPartyAction.Apply(companion, playerParty, true);
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (pendingSetupCapture != null || pendingFixture != null ||
+                pendingRestorationVerification != null || pendingNoopRestorationControllerId != null)
+                return Failed("A clan-party XP transfer fixture lifecycle is already active.");
+            if (!TryResolvePlayer(args[0], out var objectManager, out var playerManager,
+                out var player, out _, out var playerClan, out var playerParty, out var error))
+                return Failed("Failed to capture clan-party XP transfer fixture: " + error);
+            if (!playerManager.TryGetPeer(player.ControllerId, out _))
+                return Failed($"Player '{player.ControllerId}' is not connected.");
 
-            clanParty = MobilePartyHelper.CreateNewClanMobileParty(companion, playerClan);
-            clanParty.SetMoveModeHold();
-            RemoveRegularTroops(clanParty.MemberRoster);
-            clanParty.MemberRoster.AddToCounts(
-                character,
-                FixtureTroopCount,
-                false,
-                0,
-                FixtureTroopXp,
-                true,
-                -1);
+            var character = playerClan.Culture?.BasicTroop;
+            if (character == null || character.IsHero ||
+                !objectManager.TryGetIdWithLogging(character, out var characterId) ||
+                !objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId))
+                return Failed("Failed to capture clan-party XP transfer fixture: the player's culture has no registered basic troop.");
 
-            if (clanParty.ActualClan != playerClan || clanParty.IsPlayerParty())
-                throw new InvalidOperationException("The fixture party was not created as a non-player-controlled party in the player's clan.");
-            if (!objectManager.TryGetIdWithLogging(companion, out var companionId) ||
-                !objectManager.TryGetIdWithLogging(clanParty, out var clanPartyId))
-                throw new InvalidOperationException("The fixture hero or party was not registered.");
-
-            pendingFixture = new TroopXpTransferFixture(
-                player.ControllerId,
-                playerPartyId,
-                clanPartyId,
-                characterId,
-                playerClan,
-                playerParty,
-                clanParty,
-                companion,
-                capture.OriginalPlayerState,
-                capture.OriginalCompanionCount);
-            pendingSetupCapture = null;
-            pendingNoopRestorationControllerId = null;
-
-            return JsonResult(new
+            var originalPlayerState = ReadRosterState(playerParty.MemberRoster, character);
+            int originalCompanionCount = playerClan.Companions.Count();
+            return Succeeded(JsonResult(new
             {
                 controllerId = player.ControllerId,
                 playerPartyId,
-                clanPartyId,
-                companionId,
                 characterId,
-                sourceCount = FixtureTroopCount,
-                sourceXp = FixtureTroopXp,
-                playerCount = capture.OriginalPlayerState.Number,
-                playerXp = capture.OriginalPlayerState.Xp,
-                totalXp = capture.OriginalPlayerState.Xp + FixtureTroopXp
-            });
-        }
-        catch (Exception exception)
-        {
-            CleanupCreatedFixture(playerClan, clanParty, companion);
-            RestoreRosterState(playerParty.MemberRoster, character, capture.OriginalPlayerState);
-            return "Failed to set up clan-party XP transfer fixture: " + exception.Message;
+                playerCount = originalPlayerState.Number,
+                playerWounded = originalPlayerState.Wounded,
+                playerXp = originalPlayerState.Xp,
+                companionCount = originalCompanionCount
+            }));
         }
     }
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_state", "coop.debug.mobileparty")]
-    public static string State(List<string> args)
+    public sealed class ClanPartyXpFixtureSetupCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_state <playerPartyId> <clanPartyId> <characterId>";
-        if (args.Count != 3) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty playerParty))
-            return $"Player party '{args[0]}' was not found.";
-        if (!objectManager.TryGetObject(args[2], out CharacterObject character))
-            return $"Character '{args[2]}' was not found.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        var playerState = ReadRosterState(playerParty.MemberRoster, character);
-        bool clanPartyResolved = objectManager.TryGetObject(args[1], out MobileParty clanParty);
-        var clanPartyState = clanPartyResolved
-            ? ReadRosterState(clanParty.MemberRoster, character)
-            : default;
+        public string Name => "clan_party_xp_fixture_setup";
 
-        return JsonResult(new
+        public string Description => "Runs the clan party xp fixture setup debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            playerPartyId = args[0],
-            clanPartyId = args[1],
-            characterId = args[2],
-            clanPartyResolved,
-            clanPartyActive = clanPartyResolved && clanParty.IsActive,
-            sameClan = clanPartyResolved && clanParty.ActualClan != null &&
-                ReferenceEquals(clanParty.ActualClan, playerParty.ActualClan),
-            playerCount = playerState.Number,
-            playerWounded = playerState.Wounded,
-            playerXp = playerState.Xp,
-            clanPartyCount = clanPartyState.Number,
-            clanPartyWounded = clanPartyState.Wounded,
-            clanPartyXp = clanPartyState.Xp,
-            totalXp = playerState.Xp + clanPartyState.Xp
-        });
-    }
+            new ExpectedArgs("controller_id", "The controller id.", true),
+            new ExpectedArgs("player_party_id", "The player party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+            new ExpectedArgs("player_count", "The player count.", true),
+            new ExpectedArgs("player_wounded", "The player wounded.", true),
+            new ExpectedArgs("player_xp", "The player xp.", true),
+            new ExpectedArgs("companion_count", "The companion count.", true),
+        };
 
-    [CommandLineArgumentFunction("open_clan_party_transfer", "coop.debug.mobileparty")]
-    public static string OpenPartyScreen(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.open_clan_party_transfer <clanPartyId>";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 1) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty clanParty))
-            return $"Clan party '{args[0]}' was not found.";
-        if (Hero.MainHero?.PartyBelongedTo == null ||
-            clanParty.ActualClan == null ||
-            !ReferenceEquals(clanParty.ActualClan, Hero.MainHero.Clan))
-            return "The target party does not belong to the local player's clan.";
-        if (clanParty.IsPlayerParty()) return "The target party is directly controlled by a player.";
-
-        PartyScreenHelper.OpenScreenAsManageTroopsAndPrisoners(clanParty);
-        return "CLAN_PARTY_TRANSFER_SCREEN_OPENED";
-    }
-
-    [CommandLineArgumentFunction("stage_clan_party_transfer", "coop.debug.mobileparty")]
-    public static string StageTransfer(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.stage_clan_party_transfer <clanPartyId> <characterId>";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 2) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty clanParty))
-            return $"Clan party '{args[0]}' was not found.";
-        if (!objectManager.TryGetObject(args[1], out CharacterObject character))
-            return $"Character '{args[1]}' was not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
-            partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != clanParty)
-            return "The target clan-party transfer screen is not active.";
-
-        var logic = partyState.PartyScreenLogic;
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        var row = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        if (row == null) return $"Character '{args[1]}' is not rendered in the clan party's member roster.";
-
-        partyVm.OnTransferTroop(row, -1, FixtureTroopCount, row.Side);
-        partyVm.ExecuteRemoveZeroCounts();
-        if (!logic.IsThereAnyChanges()) return "CLAN_PARTY_TRANSFER_REJECTED";
-        return "CLAN_PARTY_TRANSFER_STAGED";
-    }
-
-    [CommandLineArgumentFunction("clan_party_transfer_screen_state", "coop.debug.mobileparty")]
-    public static string TransferScreenState(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_transfer_screen_state " +
-            "<clanPartyId> <characterId> <baseline|staged>";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 3 || (args[2] != "baseline" && args[2] != "staged")) return usage;
-        if (!TryGetObjectManager(out var objectManager)) return "Unable to resolve ObjectManager.";
-        if (!objectManager.TryGetObject(args[0], out MobileParty clanParty))
-            return $"Clan party '{args[0]}' was not found.";
-        if (!objectManager.TryGetObject(args[1], out CharacterObject character))
-            return $"Character '{args[1]}' was not found.";
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
-            partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != clanParty)
-            return "The target clan-party transfer screen is not active.";
-
-        var logic = partyState.PartyScreenLogic;
-        var leftState = ReadRosterState(
-            logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left], character);
-        var rightState = ReadRosterState(
-            logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right], character);
-        var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
-        var leftRow = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        var rightRow = partyVm?.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
-        bool viewReady = partyVm != null;
-        bool expectedStateReady = args[2] == "baseline"
-            ? viewReady && !logic.IsThereAnyChanges() && leftState.Number == FixtureTroopCount &&
-                leftState.Xp == FixtureTroopXp && leftRow?.Troop.Number == FixtureTroopCount &&
-                leftRow.Troop.Xp == FixtureTroopXp
-            : viewReady && logic.IsThereAnyChanges() && leftState.Number == 0 && leftRow == null &&
-                rightState.Number > 0 && rightRow?.Troop.Number == rightState.Number &&
-                rightRow.Troop.Xp == rightState.Xp;
-        if (!expectedStateReady)
-            return $"Clan-party transfer screen has not reached the expected '{args[2]}' state.";
-
-        return JsonResult(new
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            viewReady,
-            expectedState = args[2],
-            pending = logic.IsThereAnyChanges(),
-            leftCount = leftState.Number,
-            leftWounded = leftState.Wounded,
-            leftXp = leftState.Xp,
-            rightCount = rightState.Number,
-            rightWounded = rightState.Wounded,
-            rightXp = rightState.Xp,
-            leftVmCount = leftRow?.Troop.Number ?? 0,
-            leftVmXp = leftRow?.Troop.Xp ?? 0,
-            rightVmCount = rightRow?.Troop.Number ?? 0,
-            rightVmXp = rightRow?.Troop.Xp ?? 0
-        });
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (!int.TryParse(args[3], out int expectedPlayerCount) ||
+                !int.TryParse(args[4], out int expectedPlayerWounded) ||
+                !int.TryParse(args[5], out int expectedPlayerXp) ||
+                !int.TryParse(args[6], out int expectedCompanionCount))
+                return Failed("Invalid command argument value.");
+            if (pendingFixture != null) return Failed("A clan-party XP transfer fixture is already active.");
+            if (pendingSetupCapture != null || pendingRestorationVerification != null ||
+                pendingNoopRestorationControllerId != null)
+                return Failed("A clan-party XP transfer fixture lifecycle is already active.");
+            pendingNoopRestorationControllerId = args[0];
+            if (!TryResolvePlayer(args[0], out var objectManager, out var playerManager,
+                out var player, out var playerHero, out var playerClan, out var playerParty, out var error))
+                return Failed("Failed to set up clan-party XP transfer fixture: " + error);
+            if (!playerManager.TryGetPeer(player.ControllerId, out _))
+                return Failed($"Player '{player.ControllerId}' is not connected.");
+            var template = Hero.AllAliveHeroes.FirstOrDefault(hero =>
+                hero != playerHero && hero.IsWanderer && hero.CompanionOf == null);
+            if (template == null)
+                return Failed("Failed to set up clan-party XP transfer fixture: no free living wanderer template is available.");
+
+            var character = playerClan.Culture?.BasicTroop;
+            if (character == null || character.IsHero ||
+                !objectManager.TryGetIdWithLogging(character, out var characterId) ||
+                !objectManager.TryGetIdWithLogging(playerParty, out var playerPartyId))
+                return Failed("Failed to set up clan-party XP transfer fixture: the player's culture has no registered basic troop.");
+            var originalPlayerState = ReadRosterState(playerParty.MemberRoster, character);
+            int originalCompanionCount = playerClan.Companions.Count();
+            if (playerPartyId != args[1] || characterId != args[2] ||
+                originalPlayerState.Number != expectedPlayerCount ||
+                originalPlayerState.Wounded != expectedPlayerWounded ||
+                originalPlayerState.Xp != expectedPlayerXp ||
+                originalCompanionCount != expectedCompanionCount)
+                return Failed("Failed to set up clan-party XP transfer fixture: the captured fixture state changed.");
+
+            var capture = new TroopXpTransferCapture(
+                player.ControllerId,
+                playerPartyId,
+                characterId,
+                playerClan,
+                playerParty,
+                originalPlayerState,
+                originalCompanionCount);
+            pendingSetupCapture = capture;
+            Hero companion = null;
+            MobileParty clanParty = null;
+
+            try
+            {
+                companion = HeroCreator.CreateSpecialHero(template.CharacterObject, playerHero.HomeSettlement, age: 30);
+                var fixtureName = new TextObject(FixtureCompanionName);
+                companion.SetName(fixtureName, fixtureName);
+                companion.SetNewOccupation(Occupation.Wanderer);
+                AddCompanionAction.Apply(playerClan, companion);
+                AddHeroToPartyAction.Apply(companion, playerParty, true);
+
+                clanParty = MobilePartyHelper.CreateNewClanMobileParty(companion, playerClan);
+                clanParty.SetMoveModeHold();
+                RemoveRegularTroops(clanParty.MemberRoster);
+                clanParty.MemberRoster.AddToCounts(
+                    character,
+                    FixtureTroopCount,
+                    false,
+                    0,
+                    FixtureTroopXp,
+                    true,
+                    -1);
+
+                if (clanParty.ActualClan != playerClan || clanParty.IsPlayerParty())
+                    throw new InvalidOperationException("The fixture party was not created as a non-player-controlled party in the player's clan.");
+                if (!objectManager.TryGetIdWithLogging(companion, out var companionId) ||
+                    !objectManager.TryGetIdWithLogging(clanParty, out var clanPartyId))
+                    throw new InvalidOperationException("The fixture hero or party was not registered.");
+
+                pendingFixture = new TroopXpTransferFixture(
+                    player.ControllerId,
+                    playerPartyId,
+                    clanPartyId,
+                    characterId,
+                    playerClan,
+                    playerParty,
+                    clanParty,
+                    companion,
+                    capture.OriginalPlayerState,
+                    capture.OriginalCompanionCount);
+                pendingSetupCapture = null;
+                pendingNoopRestorationControllerId = null;
+
+                return Succeeded(JsonResult(new
+                {
+                    controllerId = player.ControllerId,
+                    playerPartyId,
+                    clanPartyId,
+                    companionId,
+                    characterId,
+                    sourceCount = FixtureTroopCount,
+                    sourceXp = FixtureTroopXp,
+                    playerCount = capture.OriginalPlayerState.Number,
+                    playerXp = capture.OriginalPlayerState.Xp,
+                    totalXp = capture.OriginalPlayerState.Xp + FixtureTroopXp
+                }));
+            }
+            catch (Exception exception)
+            {
+                CleanupCreatedFixture(playerClan, clanParty, companion);
+                RestoreRosterState(playerParty.MemberRoster, character, capture.OriginalPlayerState);
+                return Failed("Failed to set up clan-party XP transfer fixture: " + exception.Message);
+            }
+        }
     }
 
-    [CommandLineArgumentFunction("commit_clan_party_transfer", "coop.debug.mobileparty")]
-    public static string CommitTransfer(List<string> args)
+    public sealed class ClanPartyXpFixtureStateCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.mobileparty.commit_clan_party_transfer";
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (args.Count != 0) return usage;
-        if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
-            !partyState.PartyScreenLogic.IsThereAnyChanges())
-            return "No staged clan-party transfer is active.";
-        if (!((ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource is { } partyVm))
-            return "No active Party screen view model.";
+        public string Prefix => "coop.debug.mobile_party";
 
-        // ExecuteDone opens a confirmation inquiry when the save's player party is over its limit.
-        // CloseScreenInternal is the inquiry's affirmative action and always exercises DoneLogic.
-        partyVm.CloseScreenInternal();
-        return Game.Current.GameStateManager.ActiveState is PartyState
-            ? "CLAN_PARTY_TRANSFER_NOT_COMMITTED"
-            : "CLAN_PARTY_TRANSFER_COMMITTED";
-    }
+        public string Name => "clan_party_xp_fixture_state";
 
-    [CommandLineArgumentFunction("clan_party_xp_fixture_restore", "coop.debug.mobileparty")]
-    public static string Restore(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_restore <controllerId>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 1) return usage;
-        if (pendingFixture == null && pendingSetupCapture != null && pendingSetupCapture.ControllerId == args[0])
+        public string Description => "Reports clan party xp fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            pendingRestorationVerification = new TroopXpTransferRestoration(pendingSetupCapture);
-            pendingSetupCapture = null;
-            pendingNoopRestorationControllerId = null;
-            return JsonResult(new
+            new ExpectedArgs("player_party_id", "The player party id.", true),
+            new ExpectedArgs("clan_party_id", "The clan party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty playerParty))
+                return Failed($"Player party '{args[0]}' was not found.");
+            if (!objectManager.TryGetObject(args[2], out CharacterObject character))
+                return Failed($"Character '{args[2]}' was not found.");
+
+            var playerState = ReadRosterState(playerParty.MemberRoster, character);
+            bool clanPartyResolved = objectManager.TryGetObject(args[1], out MobileParty clanParty);
+            var clanPartyState = clanPartyResolved
+                ? ReadRosterState(clanParty.MemberRoster, character)
+                : default;
+
+            return Succeeded(JsonResult(new
+            {
+                playerPartyId = args[0],
+                clanPartyId = args[1],
+                characterId = args[2],
+                clanPartyResolved,
+                clanPartyActive = clanPartyResolved && clanParty.IsActive,
+                sameClan = clanPartyResolved && clanParty.ActualClan != null &&
+                    ReferenceEquals(clanParty.ActualClan, playerParty.ActualClan),
+                playerCount = playerState.Number,
+                playerWounded = playerState.Wounded,
+                playerXp = playerState.Xp,
+                clanPartyCount = clanPartyState.Number,
+                clanPartyWounded = clanPartyState.Wounded,
+                clanPartyXp = clanPartyState.Xp,
+                totalXp = playerState.Xp + clanPartyState.Xp
+            }));
+        }
+    }
+
+    public sealed class OpenClanPartyTransferCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "open_clan_party_transfer";
+
+        public string Description => "Runs the open clan party transfer debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("clan_party_id", "The clan party id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty clanParty))
+                return Failed($"Clan party '{args[0]}' was not found.");
+            if (Hero.MainHero?.PartyBelongedTo == null ||
+                clanParty.ActualClan == null ||
+                !ReferenceEquals(clanParty.ActualClan, Hero.MainHero.Clan))
+                return Failed("The target party does not belong to the local player's clan.");
+            if (clanParty.IsPlayerParty()) return Failed("The target party is directly controlled by a player.");
+
+            PartyScreenHelper.OpenScreenAsManageTroopsAndPrisoners(clanParty);
+            return Succeeded("CLAN_PARTY_TRANSFER_SCREEN_OPENED");
+        }
+    }
+
+    public sealed class StageClanPartyTransferCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "stage_clan_party_transfer";
+
+        public string Description => "Runs the stage clan party transfer debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("clan_party_id", "The clan party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty clanParty))
+                return Failed($"Clan party '{args[0]}' was not found.");
+            if (!objectManager.TryGetObject(args[1], out CharacterObject character))
+                return Failed($"Character '{args[1]}' was not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
+                partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != clanParty)
+                return Failed("The target clan-party transfer screen is not active.");
+
+            var logic = partyState.PartyScreenLogic;
+            var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+            var row = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            if (row == null) return Failed($"Character '{args[1]}' is not rendered in the clan party's member roster.");
+
+            partyVm.OnTransferTroop(row, -1, FixtureTroopCount, row.Side);
+            partyVm.ExecuteRemoveZeroCounts();
+            if (!logic.IsThereAnyChanges()) return Failed("CLAN_PARTY_TRANSFER_REJECTED");
+            return Succeeded("CLAN_PARTY_TRANSFER_STAGED");
+        }
+    }
+
+    public sealed class ClanPartyTransferScreenStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "clan_party_transfer_screen_state";
+
+        public string Description => "Reports clan party transfer screen state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("clan_party_id", "The clan party id.", true),
+            new ExpectedArgs("character_id", "The character id.", true),
+            new ExpectedArgs("expected_state", "The expected screen state.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if ((args[2] != "baseline" && args[2] != "staged")) return Failed("Invalid command argument value.");
+            if (!TryGetObjectManager(out var objectManager)) return Failed("Unable to resolve ObjectManager.");
+            if (!objectManager.TryGetObject(args[0], out MobileParty clanParty))
+                return Failed($"Clan party '{args[0]}' was not found.");
+            if (!objectManager.TryGetObject(args[1], out CharacterObject character))
+                return Failed($"Character '{args[1]}' was not found.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
+                partyState.PartyScreenLogic?.LeftOwnerParty?.MobileParty != clanParty)
+                return Failed("The target clan-party transfer screen is not active.");
+
+            var logic = partyState.PartyScreenLogic;
+            var leftState = ReadRosterState(
+                logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Left], character);
+            var rightState = ReadRosterState(
+                logic.MemberRosters[(int)PartyScreenLogic.PartyRosterSide.Right], character);
+            var partyVm = (ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource;
+            var leftRow = partyVm?.OtherPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            var rightRow = partyVm?.MainPartyTroops.FirstOrDefault(vm => vm.Character == character);
+            bool viewReady = partyVm != null;
+            bool expectedStateReady = args[2] == "baseline"
+                ? viewReady && !logic.IsThereAnyChanges() && leftState.Number == FixtureTroopCount &&
+                    leftState.Xp == FixtureTroopXp && leftRow?.Troop.Number == FixtureTroopCount &&
+                    leftRow.Troop.Xp == FixtureTroopXp
+                : viewReady && logic.IsThereAnyChanges() && leftState.Number == 0 && leftRow == null &&
+                    rightState.Number > 0 && rightRow?.Troop.Number == rightState.Number &&
+                    rightRow.Troop.Xp == rightState.Xp;
+            if (!expectedStateReady)
+                return Failed($"Clan-party transfer screen has not reached the expected '{args[2]}' state.");
+
+            return Succeeded(JsonResult(new
+            {
+                viewReady,
+                expectedState = args[2],
+                pending = logic.IsThereAnyChanges(),
+                leftCount = leftState.Number,
+                leftWounded = leftState.Wounded,
+                leftXp = leftState.Xp,
+                rightCount = rightState.Number,
+                rightWounded = rightState.Wounded,
+                rightXp = rightState.Xp,
+                leftVmCount = leftRow?.Troop.Number ?? 0,
+                leftVmXp = leftRow?.Troop.Xp ?? 0,
+                rightVmCount = rightRow?.Troop.Number ?? 0,
+                rightVmXp = rightRow?.Troop.Xp ?? 0
+            }));
+        }
+    }
+
+    public sealed class CommitClanPartyTransferCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "commit_clan_party_transfer";
+
+        public string Description => "Runs the commit clan party transfer debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (!(Game.Current?.GameStateManager?.ActiveState is PartyState partyState) ||
+                !partyState.PartyScreenLogic.IsThereAnyChanges())
+                return Failed("No staged clan-party transfer is active.");
+            if (!((ScreenManager.TopScreen as GauntletPartyScreen)?._dataSource is { } partyVm))
+                return Failed("No active Party screen view model.");
+
+            // ExecuteDone opens a confirmation inquiry when the save's player party is over its limit.
+            // CloseScreenInternal is the inquiry's affirmative action and always exercises DoneLogic.
+            partyVm.CloseScreenInternal();
+            return Game.Current.GameStateManager.ActiveState is PartyState
+                ? Failed("CLAN_PARTY_TRANSFER_NOT_COMMITTED")
+                : Succeeded("CLAN_PARTY_TRANSFER_COMMITTED");
+        }
+    }
+
+    public sealed class ClanPartyXpFixtureRestoreCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "clan_party_xp_fixture_restore";
+
+        public string Description => "Restores or clears clan party xp fixture restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (pendingFixture == null && pendingSetupCapture != null && pendingSetupCapture.ControllerId == args[0])
+            {
+                pendingRestorationVerification = new TroopXpTransferRestoration(pendingSetupCapture);
+                pendingSetupCapture = null;
+                pendingNoopRestorationControllerId = null;
+                return Succeeded(JsonResult(new
+                {
+                    restored = true,
+                    playerPartyId = pendingRestorationVerification.PlayerPartyId,
+                    clanPartyId = (string)null,
+                    characterId = pendingRestorationVerification.CharacterId,
+                    playerCount = pendingRestorationVerification.OriginalPlayerState.Number,
+                    playerWounded = pendingRestorationVerification.OriginalPlayerState.Wounded,
+                    playerXp = pendingRestorationVerification.OriginalPlayerState.Xp,
+                    companionCount = pendingRestorationVerification.OriginalCompanionCount,
+                    clanPartyActive = false
+                }));
+            }
+            if (pendingFixture == null && pendingNoopRestorationControllerId == args[0])
+            {
+                pendingRestorationVerification = new TroopXpTransferRestoration(args[0]);
+                pendingNoopRestorationControllerId = null;
+                return Succeeded(JsonResult(new { restored = true, noFixtureCreated = true }));
+            }
+            if (pendingFixture == null) return Failed("No clan-party XP transfer fixture is active.");
+            if (pendingFixture.ControllerId != args[0])
+                return Failed($"The active fixture belongs to '{pendingFixture.ControllerId}'.");
+
+            var fixture = pendingFixture;
+            if (!TryGetObjectManager(out var objectManager) ||
+                !objectManager.TryGetObject(fixture.CharacterId, out CharacterObject character))
+                return Failed("Failed to restore the fixture character.");
+
+            RestoreRosterState(fixture.PlayerParty.MemberRoster, character, fixture.OriginalPlayerState);
+            CleanupCreatedFixture(fixture.PlayerClan, fixture.ClanParty, fixture.Companion);
+
+            var restoredPlayerState = ReadRosterState(fixture.PlayerParty.MemberRoster, character);
+            int companionCount = fixture.PlayerClan.Companions.Count();
+            if (!restoredPlayerState.Equals(fixture.OriginalPlayerState) ||
+                companionCount != fixture.OriginalCompanionCount ||
+                fixture.ClanParty.IsActive)
+            {
+                return Succeeded(JsonResult(new
+                {
+                    restored = false,
+                    playerCount = restoredPlayerState.Number,
+                    playerWounded = restoredPlayerState.Wounded,
+                    playerXp = restoredPlayerState.Xp,
+                    expectedPlayerCount = fixture.OriginalPlayerState.Number,
+                    expectedPlayerWounded = fixture.OriginalPlayerState.Wounded,
+                    expectedPlayerXp = fixture.OriginalPlayerState.Xp,
+                    companionCount,
+                    expectedCompanionCount = fixture.OriginalCompanionCount,
+                    clanPartyActive = fixture.ClanParty.IsActive
+                }));
+            }
+
+            pendingFixture = null;
+            pendingRestorationVerification = new TroopXpTransferRestoration(fixture);
+            return Succeeded(JsonResult(new
             {
                 restored = true,
-                playerPartyId = pendingRestorationVerification.PlayerPartyId,
-                clanPartyId = (string)null,
-                characterId = pendingRestorationVerification.CharacterId,
-                playerCount = pendingRestorationVerification.OriginalPlayerState.Number,
-                playerWounded = pendingRestorationVerification.OriginalPlayerState.Wounded,
-                playerXp = pendingRestorationVerification.OriginalPlayerState.Xp,
-                companionCount = pendingRestorationVerification.OriginalCompanionCount,
+                playerPartyId = fixture.PlayerPartyId,
+                clanPartyId = fixture.ClanPartyId,
+                characterId = fixture.CharacterId,
+                playerCount = restoredPlayerState.Number,
+                playerWounded = restoredPlayerState.Wounded,
+                playerXp = restoredPlayerState.Xp,
+                companionCount,
                 clanPartyActive = false
-            });
+            }));
         }
-        if (pendingFixture == null && pendingNoopRestorationControllerId == args[0])
+    }
+
+    public sealed class ClanPartyXpFixtureVerifyRestoreCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobile_party";
+
+        public string Name => "clan_party_xp_fixture_verify_restore";
+
+        public string Description => "Restores or clears clan party xp fixture verify restore.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            pendingRestorationVerification = new TroopXpTransferRestoration(args[0]);
-            pendingNoopRestorationControllerId = null;
-            return JsonResult(new { restored = true, noFixtureCreated = true });
-        }
-        if (pendingFixture == null) return "No clan-party XP transfer fixture is active.";
-        if (pendingFixture.ControllerId != args[0])
-            return $"The active fixture belongs to '{pendingFixture.ControllerId}'.";
+            new ExpectedArgs("controller_id", "The controller id.", true),
+        };
 
-        var fixture = pendingFixture;
-        if (!TryGetObjectManager(out var objectManager) ||
-            !objectManager.TryGetObject(fixture.CharacterId, out CharacterObject character))
-            return "Failed to restore the fixture character.";
-
-        RestoreRosterState(fixture.PlayerParty.MemberRoster, character, fixture.OriginalPlayerState);
-        CleanupCreatedFixture(fixture.PlayerClan, fixture.ClanParty, fixture.Companion);
-
-        var restoredPlayerState = ReadRosterState(fixture.PlayerParty.MemberRoster, character);
-        int companionCount = fixture.PlayerClan.Companions.Count();
-        if (!restoredPlayerState.Equals(fixture.OriginalPlayerState) ||
-            companionCount != fixture.OriginalCompanionCount ||
-            fixture.ClanParty.IsActive)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return JsonResult(new
+            if (!ModInformation.IsServer) return Failed("Command can only be run on the server.");
+            if (pendingRestorationVerification == null ||
+                pendingRestorationVerification.ControllerId != args[0])
+                return Failed($"No restored clan-party XP transfer fixture is awaiting verification for '{args[0]}'.");
+            if (pendingRestorationVerification.NoFixtureCreated)
             {
-                restored = false,
+                pendingRestorationVerification = null;
+                return Succeeded(JsonResult(new { restored = true, noFixtureCreated = true }));
+            }
+            if (!TryGetObjectManager(out var objectManager) ||
+                !objectManager.TryGetObject(pendingRestorationVerification.CharacterId, out CharacterObject character))
+                return Failed("Failed to verify the restored fixture character.");
+
+            var fixture = pendingRestorationVerification;
+            var restoredPlayerState = ReadRosterState(fixture.PlayerParty.MemberRoster, character);
+            int companionCount = fixture.PlayerClan.Companions.Count();
+            bool restored = restoredPlayerState.Equals(fixture.OriginalPlayerState) &&
+                companionCount == fixture.OriginalCompanionCount &&
+                fixture.ClanParty?.IsActive != true;
+            if (restored) pendingRestorationVerification = null;
+
+            return Succeeded(JsonResult(new
+            {
+                restored,
+                playerPartyId = fixture.PlayerPartyId,
+                clanPartyId = fixture.ClanPartyId,
+                characterId = fixture.CharacterId,
                 playerCount = restoredPlayerState.Number,
                 playerWounded = restoredPlayerState.Wounded,
                 playerXp = restoredPlayerState.Xp,
@@ -399,68 +570,9 @@ internal static class TroopXpTransferFixtureCommands
                 expectedPlayerXp = fixture.OriginalPlayerState.Xp,
                 companionCount,
                 expectedCompanionCount = fixture.OriginalCompanionCount,
-                clanPartyActive = fixture.ClanParty.IsActive
-            });
+                clanPartyActive = fixture.ClanParty?.IsActive == true
+            }));
         }
-
-        pendingFixture = null;
-        pendingRestorationVerification = new TroopXpTransferRestoration(fixture);
-        return JsonResult(new
-        {
-            restored = true,
-            playerPartyId = fixture.PlayerPartyId,
-            clanPartyId = fixture.ClanPartyId,
-            characterId = fixture.CharacterId,
-            playerCount = restoredPlayerState.Number,
-            playerWounded = restoredPlayerState.Wounded,
-            playerXp = restoredPlayerState.Xp,
-            companionCount,
-            clanPartyActive = false
-        });
-    }
-
-    [CommandLineArgumentFunction("clan_party_xp_fixture_verify_restore", "coop.debug.mobileparty")]
-    public static string VerifyRestore(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.mobileparty.clan_party_xp_fixture_verify_restore <controllerId>";
-        if (!ModInformation.IsServer) return "Command can only be run on the server.";
-        if (args.Count != 1) return usage;
-        if (pendingRestorationVerification == null ||
-            pendingRestorationVerification.ControllerId != args[0])
-            return $"No restored clan-party XP transfer fixture is awaiting verification for '{args[0]}'.";
-        if (pendingRestorationVerification.NoFixtureCreated)
-        {
-            pendingRestorationVerification = null;
-            return JsonResult(new { restored = true, noFixtureCreated = true });
-        }
-        if (!TryGetObjectManager(out var objectManager) ||
-            !objectManager.TryGetObject(pendingRestorationVerification.CharacterId, out CharacterObject character))
-            return "Failed to verify the restored fixture character.";
-
-        var fixture = pendingRestorationVerification;
-        var restoredPlayerState = ReadRosterState(fixture.PlayerParty.MemberRoster, character);
-        int companionCount = fixture.PlayerClan.Companions.Count();
-        bool restored = restoredPlayerState.Equals(fixture.OriginalPlayerState) &&
-            companionCount == fixture.OriginalCompanionCount &&
-            fixture.ClanParty?.IsActive != true;
-        if (restored) pendingRestorationVerification = null;
-
-        return JsonResult(new
-        {
-            restored,
-            playerPartyId = fixture.PlayerPartyId,
-            clanPartyId = fixture.ClanPartyId,
-            characterId = fixture.CharacterId,
-            playerCount = restoredPlayerState.Number,
-            playerWounded = restoredPlayerState.Wounded,
-            playerXp = restoredPlayerState.Xp,
-            expectedPlayerCount = fixture.OriginalPlayerState.Number,
-            expectedPlayerWounded = fixture.OriginalPlayerState.Wounded,
-            expectedPlayerXp = fixture.OriginalPlayerState.Xp,
-            companionCount,
-            expectedCompanionCount = fixture.OriginalCompanionCount,
-            clanPartyActive = fixture.ClanParty?.IsActive == true
-        });
     }
 
     private static void RemoveRegularTroops(TroopRoster roster)

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using GameInterface.Services.PartyVisuals.Patches;
 using SandBox.View.Map.Managers;
 using System;
@@ -10,135 +11,176 @@ using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.PartyVisuals.Commands;
 
 internal class PartyVisualDebugCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
 #if DEBUG
     private const string FixturePartyIdPrefix = "issue2938_visual_fixture_";
     private static readonly List<MobileParty> stagedParties = new();
     private static int fixtureBaselineEligiblePartyCount = -1;
 #endif
 
-    [CommandLineArgumentFunction("buffer_state", "coop.debug.partyvisuals")]
-    public static string BufferState(List<string> args)
+    public sealed class BufferStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.party_visuals";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.partyvisuals.buffer_state";
+        public string Name => "buffer_state";
 
-        var manager = MobilePartyVisualManager.Current;
-        if (manager == null)
-            return "Mobile party visual manager is unavailable.";
+        public string Description => "Reports buffer state.";
 
-        int visualCount = manager._visualsFlattened.Count;
-        int bufferCapacity = manager._dirtyPartiesList.Length;
-        int dirtyCount = manager._dirtyPartyVisualCount;
-        bool navalManagerActive = NavalMobilePartyVisualManagerPatches.TryGetBufferState(
-            out int navalVisualCount,
-            out int navalBufferCapacity,
-            out int navalDirtyCount);
-        int campaignPartyCount = Campaign.Current?.MobileParties?.Count ?? 0;
-        string structuredState = JsonSerializer.Serialize(new
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            visualCount,
-            bufferCapacity,
-            dirtyCount,
-            navalManagerActive,
-            navalVisualCount,
-            navalBufferCapacity,
-            navalDirtyCount,
-            campaignPartyCount,
-        });
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
 
-        return $"visualCount={visualCount} bufferCapacity={bufferCapacity} dirtyCount={dirtyCount} " +
-               $"navalManagerActive={navalManagerActive} navalVisualCount={navalVisualCount} " +
-               $"navalBufferCapacity={navalBufferCapacity} navalDirtyCount={navalDirtyCount} " +
-               $"campaignPartyCount={campaignPartyCount}" + Environment.NewLine +
-               $"LIVE_TEST_JSON={structuredState}";
+
+            var manager = MobilePartyVisualManager.Current;
+            if (manager == null)
+                return Failed("Mobile party visual manager is unavailable.");
+
+            int visualCount = manager._visualsFlattened.Count;
+            int bufferCapacity = manager._dirtyPartiesList.Length;
+            int dirtyCount = manager._dirtyPartyVisualCount;
+            bool navalManagerActive = NavalMobilePartyVisualManagerPatches.TryGetBufferState(
+                out int navalVisualCount,
+                out int navalBufferCapacity,
+                out int navalDirtyCount);
+            int campaignPartyCount = Campaign.Current?.MobileParties?.Count ?? 0;
+            string structuredState = JsonSerializer.Serialize(new
+            {
+                visualCount,
+                bufferCapacity,
+                dirtyCount,
+                navalManagerActive,
+                navalVisualCount,
+                navalBufferCapacity,
+                navalDirtyCount,
+                campaignPartyCount,
+            });
+
+            return Succeeded($"visualCount={visualCount} bufferCapacity={bufferCapacity} dirtyCount={dirtyCount} " +
+                   $"navalManagerActive={navalManagerActive} navalVisualCount={navalVisualCount} " +
+                   $"navalBufferCapacity={navalBufferCapacity} navalDirtyCount={navalDirtyCount} " +
+                   $"campaignPartyCount={campaignPartyCount}" + Environment.NewLine +
+                   $"LIVE_TEST_JSON={structuredState}");
+        }
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("fixture_state", "coop.debug.partyvisuals")]
-    public static string FixtureState(List<string> args)
+    public sealed class FixtureStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.partyvisuals.fixture_state";
+        public string Prefix => "coop.debug.party_visuals";
 
-        return GetFixtureState(includeBaseline: true);
+        public string Name => "fixture_state";
+
+        public string Description => "Reports fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            return Succeeded(GetFixtureState(includeBaseline: true));
+        }
     }
 
-    [CommandLineArgumentFunction("stage_over_limit_fixture", "coop.debug.partyvisuals")]
-    public static string StageOverLimitFixture(List<string> args)
+    public sealed class StageOverLimitFixtureCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "stage_over_limit_fixture must be run on the server.";
+        public string Prefix => "coop.debug.party_visuals";
 
-        if (args.Count != 2 ||
-            !int.TryParse(args[0], out int targetEligiblePartyCount) ||
-            targetEligiblePartyCount < 2500)
+        public string Name => "stage_over_limit_fixture";
+
+        public string Description => "Runs the stage over limit fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.partyvisuals.stage_over_limit_fixture <targetEligiblePartyCount>=2500+ <settlementId>";
-        }
+            new ExpectedArgs("target_eligible_party_count", "The target eligible party count.", true),
+            new ExpectedArgs("settlement_id", "The settlement id.", true),
+        };
 
-        if (stagedParties.Count != 0 || GetLiveFixturePartyCount() != 0)
-            return "The party-visual fixture is already staged.";
-
-        Settlement settlement = Settlement.All.FirstOrDefault(candidate => candidate.StringId == args[1]);
-        if (settlement == null)
-            return $"Settlement '{args[1]}' was not found.";
-
-        Clan looterClan = Clan.BanditFactions.FirstOrDefault(candidate => candidate.StringId == "looters");
-        if (looterClan == null)
-            return "The looter clan was not found.";
-
-        fixtureBaselineEligiblePartyCount = GetEligiblePartyCount();
-        int partiesToCreate = targetEligiblePartyCount - fixtureBaselineEligiblePartyCount;
-        if (partiesToCreate <= 0)
-            return GetFixtureState(includeBaseline: true);
-
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            for (int index = 0; index < partiesToCreate; index++)
+            if (ModInformation.IsClient)
+                return Failed("stage_over_limit_fixture must be run on the server.");
+
+            if (!int.TryParse(args[0], out int targetEligiblePartyCount) ||
+                targetEligiblePartyCount < 2500)
             {
-                MobileParty party = BanditPartyComponent.CreateLooterParty(
-                    $"{FixturePartyIdPrefix}{index + 1}",
-                    looterClan,
-                    settlement,
-                    isBossParty: false,
-                    pt: null,
-                    settlement.GatePosition);
-                stagedParties.Add(party);
-                party.IsVisible = true;
-                party.IsInspected = true;
-                party.SetMoveModeHold();
+                return Failed("Invalid command argument value.");
             }
-        }
-        catch
-        {
-            RestoreFixtureParties();
-            throw;
-        }
 
-        return GetFixtureState(includeBaseline: true);
+            if (stagedParties.Count != 0 || GetLiveFixturePartyCount() != 0)
+                return Failed("The party-visual fixture is already staged.");
+
+            Settlement settlement = Settlement.All.FirstOrDefault(candidate => candidate.StringId == args[1]);
+            if (settlement == null)
+                return Failed($"Settlement '{args[1]}' was not found.");
+
+            Clan looterClan = Clan.BanditFactions.FirstOrDefault(candidate => candidate.StringId == "looters");
+            if (looterClan == null)
+                return Failed("The looter clan was not found.");
+
+            fixtureBaselineEligiblePartyCount = GetEligiblePartyCount();
+            int partiesToCreate = targetEligiblePartyCount - fixtureBaselineEligiblePartyCount;
+            if (partiesToCreate <= 0)
+                return Succeeded(GetFixtureState(includeBaseline: true));
+
+            try
+            {
+                for (int index = 0; index < partiesToCreate; index++)
+                {
+                    MobileParty party = BanditPartyComponent.CreateLooterParty(
+                        $"{FixturePartyIdPrefix}{index + 1}",
+                        looterClan,
+                        settlement,
+                        isBossParty: false,
+                        pt: null,
+                        settlement.GatePosition);
+                    stagedParties.Add(party);
+                    party.IsVisible = true;
+                    party.IsInspected = true;
+                    party.SetMoveModeHold();
+                }
+            }
+            catch
+            {
+                RestoreFixtureParties();
+                throw;
+            }
+
+            return Succeeded(GetFixtureState(includeBaseline: true));
+        }
     }
 
-    [CommandLineArgumentFunction("restore_over_limit_fixture", "coop.debug.partyvisuals")]
-    public static string RestoreOverLimitFixture(List<string> args)
+    public sealed class RestoreOverLimitFixtureCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "restore_over_limit_fixture must be run on the server.";
+        public string Prefix => "coop.debug.party_visuals";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.partyvisuals.restore_over_limit_fixture";
+        public string Name => "restore_over_limit_fixture";
 
-        int removedPartyCount = RestoreFixtureParties();
-        string state = GetFixtureState(includeBaseline: false);
-        return $"removedPartyCount={removedPartyCount}{Environment.NewLine}{state}";
+        public string Description => "Restores or clears restore over limit fixture.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("restore_over_limit_fixture must be run on the server.");
+
+
+            int removedPartyCount = RestoreFixtureParties();
+            string state = GetFixtureState(includeBaseline: false);
+            return Succeeded($"removedPartyCount={removedPartyCount}{Environment.NewLine}{state}");
+        }
     }
 
     private static int RestoreFixtureParties()

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
@@ -1,4 +1,5 @@
 ﻿#if DEBUG
+using Common.Commands;
 using Common;
 using Common.Messaging;
 using GameInterface.Services.Heroes.Extensions;
@@ -26,254 +27,347 @@ namespace GameInterface.Services.PlayerCaptivityService.Commands;
 /// </summary>
 internal static class AiLordPeaceReleaseFixtureCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static AiLordPeaceReleaseFixture fixture;
     private static StanceLinkSnapshot clientDiplomaticSnapshot;
 
-    [CommandLineArgumentFunction("observe_ai_lord_pair", "coop.debug.player_captivity")]
-    public static string ObserveAiLordPair(List<string> args)
+    public sealed class PlayerCaptivityObserveAiLordPairCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.player_captivity.observe_ai_lord_pair <prisonerHeroId> <captorHeroId>";
-        var context = new CommandContext("observe_ai_lord_pair", usage, args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!context.RequireArgCount(2, out var error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to observe AI lords: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
-            return "Failed to observe AI lords: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
-            return "Failed to observe AI lords: " + error;
+        public string Name => "observe_ai_lord_pair";
 
-        var heroParty = prisoner.PartyBelongedTo;
-        var captorParty = prisoner.PartyBelongedToAsPrisoner?.MobileParty;
-        var captorHeroParty = captorHero.PartyBelongedTo;
-        var prisonerFaction = prisoner.MapFaction;
-        var captorFaction = captorHero.MapFaction;
-        var output = new StringBuilder();
-        output.AppendLine("PrisonerHeroId=" + prisoner.StringId);
-        output.AppendLine("CaptorHeroId=" + captorHero.StringId);
-        output.AppendLine("PrisonerFactionId=" + (prisonerFaction?.StringId ?? "none"));
-        output.AppendLine("CaptorFactionId=" + (captorFaction?.StringId ?? "none"));
-        output.AppendLine("AtWar=" + (prisonerFaction != null && captorFaction != null
-            ? prisonerFaction.IsAtWarWith(captorFaction).ToString()
-            : "none"));
-        output.AppendLine("HeroState=" + prisoner.HeroState);
-        output.AppendLine("IsPrisoner=" + prisoner.IsPrisoner);
-        output.AppendLine("CaptorPartyId=" + (captorParty?.StringId ?? "none"));
-        output.AppendLine("CaptorPrisonerCount=" + (captorParty?.PrisonRoster.GetTroopCount(prisoner.CharacterObject) ?? 0));
-        output.AppendLine("HeroPartyId=" + (heroParty?.StringId ?? "none"));
-        output.AppendLine("HeroPartyActive=" + (heroParty?.IsActive.ToString() ?? "none"));
-        output.AppendLine("HeroPartyLeaderId=" + (heroParty?.LeaderHero?.StringId ?? "none"));
-        output.AppendLine("HeroPartyPosition=" + (heroParty == null ? "none" : FormatPosition(heroParty.Position)));
-        output.AppendLine("CaptorHeroPartyId=" + (captorHeroParty?.StringId ?? "none"));
-        output.AppendLine("CaptorHeroPartyActive=" + (captorHeroParty?.IsActive.ToString() ?? "none"));
-        output.AppendLine("CaptorHeroPartyPosition=" + (captorHeroParty == null ? "none" : FormatPosition(captorHeroParty.Position)));
-        output.Append("DiplomaticStateFingerprint=" + GetDiplomaticStateFingerprint(prisonerFaction, captorFaction));
-        return output.ToString();
-    }
+        public string Description => "Runs the observe ai lord pair debug operation.";
 
-    [CommandLineArgumentFunction("focus_hero_party", "coop.debug.player_captivity")]
-    public static string FocusHeroParty(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.focus_hero_party <heroId>";
-        var context = new CommandContext("focus_hero_party", usage, args);
-
-        if (!context.RequireArgCount(1, out var error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to focus hero party: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
-            return "Failed to focus hero party: " + error;
-
-        var party = hero.PartyBelongedTo ?? hero.PartyBelongedToAsPrisoner?.MobileParty;
-        if (party?.IsActive != true)
-            return $"Failed to focus hero party: '{hero.StringId}' has no active member or captor party.";
-
-        party.Party.SetAsCameraFollowParty();
-        return $"Following party '{party.StringId}' for hero '{hero.StringId}' on the campaign map.";
-    }
-
-    [CommandLineArgumentFunction("snapshot_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
-    public static string SnapshotAiLordDiplomacyFixture(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.snapshot_ai_lord_diplomacy_fixture <prisonerHeroId> <captorHeroId>";
-        var context = new CommandContext("snapshot_ai_lord_diplomacy_fixture", usage, args);
-
-        if (!ModInformation.IsClient) return "snapshot_ai_lord_diplomacy_fixture must be run on a client.";
-        if (!context.RequireArgCount(2, out var error)) return error;
-        if (clientDiplomaticSnapshot != null) return "A client AI-lord diplomatic fixture is already active.";
-        if (!TryGetHeroFactions(args, out var prisonerFaction, out var captorFaction, out error))
-            return "Failed to snapshot AI-lord diplomacy: " + error;
-
-        clientDiplomaticSnapshot = StanceLinkSnapshot.Capture(prisonerFaction, captorFaction);
-        return "Client AI-lord diplomatic fixture captured.\nOriginalDiplomaticStateFingerprint=" +
-            clientDiplomaticSnapshot.OriginalFingerprint;
-    }
-
-    [CommandLineArgumentFunction("restore_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
-    public static string RestoreAiLordDiplomacyFixture(List<string> args)
-    {
-        if (!ModInformation.IsClient)
-            return "restore_ai_lord_diplomacy_fixture must be run on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.player_captivity.restore_ai_lord_diplomacy_fixture";
-        if (clientDiplomaticSnapshot == null)
-            return "No client AI-lord diplomatic fixture is active.";
-
-        var pendingSnapshot = clientDiplomaticSnapshot;
-        pendingSnapshot.Restore(false);
-        var verification = pendingSnapshot.VerifyRestored();
-        if (verification != null)
-            return "Failed to restore client AI-lord diplomatic fixture: " + verification;
-
-        clientDiplomaticSnapshot = null;
-        return "Client AI-lord diplomatic fixture restored.";
-    }
-
-    [CommandLineArgumentFunction("capture_ai_lord_fixture", "coop.debug.player_captivity")]
-    public static string CaptureAiLordFixture(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.capture_ai_lord_fixture <prisonerHeroId> <captorHeroId>";
-        var context = new CommandContext("capture_ai_lord_fixture", usage, args);
-
-        if (!context.RequireServer(out var error)) return error;
-        if (!context.RequireArgCount(2, out error)) return error;
-        if (fixture != null) return "An AI-lord captivity fixture is already active.";
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to create AI-lord fixture: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
-            return "Failed to create AI-lord fixture: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
-            return "Failed to create AI-lord fixture: " + error;
-
-        if (prisoner.IsPrisoner)
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' is already a prisoner.";
-        if (!prisoner.IsLord || prisoner.IsPlayerHero())
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' is not an AI lord.";
-
-        var prisonerParty = prisoner.PartyBelongedTo;
-        var captorParty = captorHero.PartyBelongedTo;
-        if (prisonerParty?.IsActive != true)
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' has no active party.";
-        if (captorParty?.IsActive != true)
-            return $"Failed to create AI-lord fixture: '{captorHero.StringId}' has no active party.";
-        if (prisonerParty == captorParty)
-            return "Failed to create AI-lord fixture: prisoner and captor belong to the same party.";
-
-        var prisonerFaction = prisoner.MapFaction;
-        var captorFaction = captorHero.MapFaction;
-        if (prisonerFaction == null || captorFaction == null || prisonerFaction == captorFaction)
-            return "Failed to create AI-lord fixture: prisoner and captor need distinct map factions.";
-
-        var prisonerIndex = prisonerParty.MemberRoster.FindIndexOfTroop(prisoner.CharacterObject);
-        if (prisonerIndex < 0)
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' is absent from its party roster.";
-
-        if (!prisonerFaction.IsAtWarWith(captorFaction))
-            return "Failed to create AI-lord fixture: the prisoner and captor factions must already be at war.";
-
-        var pendingFixture = new AiLordPeaceReleaseFixture(
-            prisoner,
-            captorHero,
-            prisonerParty,
-            captorParty,
-            prisonerParty.MemberRoster.GetElementCopyAtIndex(prisonerIndex),
-            prisoner.HeroState,
-            prisonerParty.LeaderHero,
-            prisonerParty.CurrentSettlement,
-            prisonerParty.Position,
-            prisonerParty.IsActive,
-            captorParty.CurrentSettlement,
-            captorParty.Position,
-            captorParty.IsActive,
-            prisonerFaction,
-            captorFaction,
-            StanceLinkSnapshot.Capture(prisonerFaction, captorFaction));
-
-        fixture = pendingFixture;
-        try
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            TakePrisonerAction.Apply(captorParty.Party, prisoner);
-            if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner != captorParty.Party)
-            {
-                Restore(pendingFixture);
-                var verification = VerifyRestored(pendingFixture);
-                if (verification != null)
-                    return "Failed to create AI-lord fixture: the capture action did not establish captivity; rollback failed: " + verification;
+            new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+            new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+        };
 
-                fixture = null;
-                return "Failed to create AI-lord fixture: the capture action did not establish captivity; the baseline was restored.";
-            }
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("observe_ai_lord_pair", "Argument must not be empty.", new List<string>(args));
 
-            return "AI-lord captivity fixture created.\n" + Observe(fixture);
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to observe AI lords: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
+                return Failed("Failed to observe AI lords: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
+                return Failed("Failed to observe AI lords: " + error);
+
+            var heroParty = prisoner.PartyBelongedTo;
+            var captorParty = prisoner.PartyBelongedToAsPrisoner?.MobileParty;
+            var captorHeroParty = captorHero.PartyBelongedTo;
+            var prisonerFaction = prisoner.MapFaction;
+            var captorFaction = captorHero.MapFaction;
+            var output = new StringBuilder();
+            output.AppendLine("PrisonerHeroId=" + prisoner.StringId);
+            output.AppendLine("CaptorHeroId=" + captorHero.StringId);
+            output.AppendLine("PrisonerFactionId=" + (prisonerFaction?.StringId ?? "none"));
+            output.AppendLine("CaptorFactionId=" + (captorFaction?.StringId ?? "none"));
+            output.AppendLine("AtWar=" + (prisonerFaction != null && captorFaction != null
+                ? prisonerFaction.IsAtWarWith(captorFaction).ToString()
+                : "none"));
+            output.AppendLine("HeroState=" + prisoner.HeroState);
+            output.AppendLine("IsPrisoner=" + prisoner.IsPrisoner);
+            output.AppendLine("CaptorPartyId=" + (captorParty?.StringId ?? "none"));
+            output.AppendLine("CaptorPrisonerCount=" + (captorParty?.PrisonRoster.GetTroopCount(prisoner.CharacterObject) ?? 0));
+            output.AppendLine("HeroPartyId=" + (heroParty?.StringId ?? "none"));
+            output.AppendLine("HeroPartyActive=" + (heroParty?.IsActive.ToString() ?? "none"));
+            output.AppendLine("HeroPartyLeaderId=" + (heroParty?.LeaderHero?.StringId ?? "none"));
+            output.AppendLine("HeroPartyPosition=" + (heroParty == null ? "none" : FormatPosition(heroParty.Position)));
+            output.AppendLine("CaptorHeroPartyId=" + (captorHeroParty?.StringId ?? "none"));
+            output.AppendLine("CaptorHeroPartyActive=" + (captorHeroParty?.IsActive.ToString() ?? "none"));
+            output.AppendLine("CaptorHeroPartyPosition=" + (captorHeroParty == null ? "none" : FormatPosition(captorHeroParty.Position)));
+            output.Append("DiplomaticStateFingerprint=" + GetDiplomaticStateFingerprint(prisonerFaction, captorFaction));
+            return Succeeded(output.ToString());
         }
-        catch (Exception captureException)
+    }
+
+    public sealed class PlayerCaptivityFocusHeroPartyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "focus_hero_party";
+
+        public string Description => "Runs the focus hero party debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
+            new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("focus_hero_party", "Argument must not be empty.", new List<string>(args));
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to focus hero party: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
+                return Failed("Failed to focus hero party: " + error);
+
+            var party = hero.PartyBelongedTo ?? hero.PartyBelongedToAsPrisoner?.MobileParty;
+            if (party?.IsActive != true)
+                return Failed($"Failed to focus hero party: '{hero.StringId}' has no active member or captor party.");
+
+            party.Party.SetAsCameraFollowParty();
+            return Succeeded($"Following party '{party.StringId}' for hero '{hero.StringId}' on the campaign map.");
+        }
+    }
+
+    public sealed class PlayerCaptivitySnapshotAiLordDiplomacyFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "snapshot_ai_lord_diplomacy_fixture";
+
+        public string Description => "Runs the snapshot ai lord diplomacy fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+            new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("snapshot_ai_lord_diplomacy_fixture", "Argument must not be empty.", new List<string>(args));
+
+            if (!ModInformation.IsClient) return Failed("snapshot_ai_lord_diplomacy_fixture must be run on a client.");
+            if (clientDiplomaticSnapshot != null) return Failed("A client AI-lord diplomatic fixture is already active.");
+            if (!TryGetHeroFactions(args, out var prisonerFaction, out var captorFaction, out error))
+                return Failed("Failed to snapshot AI-lord diplomacy: " + error);
+
+            clientDiplomaticSnapshot = StanceLinkSnapshot.Capture(prisonerFaction, captorFaction);
+            return Succeeded("Client AI-lord diplomatic fixture captured.\nOriginalDiplomaticStateFingerprint=" +
+                clientDiplomaticSnapshot.OriginalFingerprint);
+        }
+    }
+
+    public sealed class PlayerCaptivityRestoreAiLordDiplomacyFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_ai_lord_diplomacy_fixture";
+
+        public string Description => "Runs the restore ai lord diplomacy fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient)
+                return Failed("restore_ai_lord_diplomacy_fixture must be run on a client.");
+            if (clientDiplomaticSnapshot == null)
+                return Failed("No client AI-lord diplomatic fixture is active.");
+
+            var pendingSnapshot = clientDiplomaticSnapshot;
+            pendingSnapshot.Restore(false);
+            var verification = pendingSnapshot.VerifyRestored();
+            if (verification != null)
+                return Failed("Failed to restore client AI-lord diplomatic fixture: " + verification);
+
+            clientDiplomaticSnapshot = null;
+            return Succeeded("Client AI-lord diplomatic fixture restored.");
+        }
+    }
+
+    public sealed class PlayerCaptivityCaptureAiLordFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "capture_ai_lord_fixture";
+
+        public string Description => "Runs the capture ai lord fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+            new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var context = new CommandContext("capture_ai_lord_fixture", "Argument must not be empty.", new List<string>(args));
+
+            if (!context.RequireServer(out var error)) return Failed(error);
+            if (fixture != null) return Failed("An AI-lord captivity fixture is already active.");
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to create AI-lord fixture: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
+                return Failed("Failed to create AI-lord fixture: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
+                return Failed("Failed to create AI-lord fixture: " + error);
+
+            if (prisoner.IsPrisoner)
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' is already a prisoner.");
+            if (!prisoner.IsLord || prisoner.IsPlayerHero())
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' is not an AI lord.");
+
+            var prisonerParty = prisoner.PartyBelongedTo;
+            var captorParty = captorHero.PartyBelongedTo;
+            if (prisonerParty?.IsActive != true)
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' has no active party.");
+            if (captorParty?.IsActive != true)
+                return Failed($"Failed to create AI-lord fixture: '{captorHero.StringId}' has no active party.");
+            if (prisonerParty == captorParty)
+                return Failed("Failed to create AI-lord fixture: prisoner and captor belong to the same party.");
+
+            var prisonerFaction = prisoner.MapFaction;
+            var captorFaction = captorHero.MapFaction;
+            if (prisonerFaction == null || captorFaction == null || prisonerFaction == captorFaction)
+                return Failed("Failed to create AI-lord fixture: prisoner and captor need distinct map factions.");
+
+            var prisonerIndex = prisonerParty.MemberRoster.FindIndexOfTroop(prisoner.CharacterObject);
+            if (prisonerIndex < 0)
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' is absent from its party roster.");
+
+            if (!prisonerFaction.IsAtWarWith(captorFaction))
+                return Failed("Failed to create AI-lord fixture: the prisoner and captor factions must already be at war.");
+
+            var pendingFixture = new AiLordPeaceReleaseFixture(
+                prisoner,
+                captorHero,
+                prisonerParty,
+                captorParty,
+                prisonerParty.MemberRoster.GetElementCopyAtIndex(prisonerIndex),
+                prisoner.HeroState,
+                prisonerParty.LeaderHero,
+                prisonerParty.CurrentSettlement,
+                prisonerParty.Position,
+                prisonerParty.IsActive,
+                captorParty.CurrentSettlement,
+                captorParty.Position,
+                captorParty.IsActive,
+                prisonerFaction,
+                captorFaction,
+                StanceLinkSnapshot.Capture(prisonerFaction, captorFaction));
+
+            fixture = pendingFixture;
             try
             {
-                Restore(pendingFixture);
-                var verification = VerifyRestored(pendingFixture);
-                if (verification != null)
-                    throw new InvalidOperationException(verification);
+                TakePrisonerAction.Apply(captorParty.Party, prisoner);
+                if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner != captorParty.Party)
+                {
+                    Restore(pendingFixture);
+                    var verification = VerifyRestored(pendingFixture);
+                    if (verification != null)
+                        return Failed("Failed to create AI-lord fixture: the capture action did not establish captivity; rollback failed: " + verification);
 
-                fixture = null;
+                    fixture = null;
+                    return Failed("Failed to create AI-lord fixture: the capture action did not establish captivity; the baseline was restored.");
+                }
+
+                return Succeeded("AI-lord captivity fixture created.\n" + Observe(fixture));
             }
-            catch (Exception restoreException)
+            catch (Exception captureException)
             {
-                throw new AggregateException(
-                    "AI-lord fixture capture failed and rollback failed; the retained fixture can be restored manually.",
-                    captureException,
-                    restoreException);
-            }
+                try
+                {
+                    Restore(pendingFixture);
+                    var verification = VerifyRestored(pendingFixture);
+                    if (verification != null)
+                        throw new InvalidOperationException(verification);
 
-            throw;
+                    fixture = null;
+                }
+                catch (Exception restoreException)
+                {
+                    throw new AggregateException(
+                        "AI-lord fixture capture failed and rollback failed; the retained fixture can be restored manually.",
+                        captureException,
+                        restoreException);
+                }
+
+                throw;
+            }
         }
     }
 
-    [CommandLineArgumentFunction("observe_ai_lord_fixture", "coop.debug.player_captivity")]
-    public static string ObserveAiLordFixture(List<string> args)
+    public sealed class PlayerCaptivityObserveAiLordFixtureCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.player_captivity.observe_ai_lord_fixture";
+        public string Prefix => "coop.debug.player_captivity";
 
-        return fixture == null
-            ? "No AI-lord captivity fixture is active."
-            : Observe(fixture);
+        public string Name => "observe_ai_lord_fixture";
+
+        public string Description => "Runs the observe ai lord fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (fixture == null)
+                return Failed("No AI-lord captivity fixture is active.");
+
+            return Succeeded(Observe(fixture));
+        }
     }
 
-    [CommandLineArgumentFunction("focus_party", "coop.debug.player_captivity")]
-    public static string FocusParty(List<string> args)
+    public sealed class PlayerCaptivityFocusPartyCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.player_captivity.focus_party <mobilePartyId>";
-        var context = new CommandContext("focus_party", usage, args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!context.RequireArgCount(1, out var error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to focus party: " + error;
-        if (!objectManager.TryGetObject(args[0], out MobileParty party) &&
-            !CommandHelpers.TryGetMobileParty(args[0], out party, out error))
-            return "Failed to focus party: " + error;
+        public string Name => "focus_party";
 
-        party.Party.SetAsCameraFollowParty();
-        return $"Following party '{party.StringId}' on the campaign map.";
+        public string Description => "Runs the focus party debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("mobile_party_id", "The registered mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("focus_party", "Argument must not be empty.", new List<string>(args));
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to focus party: " + error);
+            if (!objectManager.TryGetObject(args[0], out MobileParty party) &&
+                !CommandHelpers.TryGetMobileParty(args[0], out party, out error))
+                return Failed("Failed to focus party: " + error);
+
+            party.Party.SetAsCameraFollowParty();
+            return Succeeded($"Following party '{party.StringId}' on the campaign map.");
+        }
     }
 
-    [CommandLineArgumentFunction("restore_ai_lord_fixture", "coop.debug.player_captivity")]
-    public static string RestoreAiLordFixture(List<string> args)
+    public sealed class PlayerCaptivityRestoreAiLordFixtureCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "restore_ai_lord_fixture must be run on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.player_captivity.restore_ai_lord_fixture";
-        if (fixture == null)
-            return "No AI-lord captivity fixture is active.";
+        public string Prefix => "coop.debug.player_captivity";
 
-        var pendingFixture = fixture;
-        Restore(pendingFixture);
-        var verification = VerifyRestored(pendingFixture);
-        if (verification != null)
-            return "Failed to restore AI-lord captivity fixture: " + verification;
+        public string Name => "restore_ai_lord_fixture";
 
-        fixture = null;
-        return "AI-lord captivity fixture restored.";
+        public string Description => "Runs the restore ai lord fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("restore_ai_lord_fixture must be run on the server.");
+            if (fixture == null)
+                return Failed("No AI-lord captivity fixture is active.");
+
+            var pendingFixture = fixture;
+            Restore(pendingFixture);
+            var verification = VerifyRestored(pendingFixture);
+            if (verification != null)
+                return Failed("Failed to restore AI-lord captivity fixture: " + verification);
+
+            fixture = null;
+            return Succeeded("AI-lord captivity fixture restored.");
+        }
     }
 
     private static string Observe(AiLordPeaceReleaseFixture activeFixture)

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -36,875 +37,1018 @@ namespace GameInterface.Services.PlayerCaptivityService.Commands;
 
 internal class PlayerCaptivityCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     public static readonly ILogger Logger = LogManager.GetLogger<PlayerCaptivityCommands>();
     private static CaptivityRosterFixture pendingRosterFixture;
 
     private static LiveTestFixtureSnapshot liveTestFixtureSnapshot;
 
-    private const string RandomCapturePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.random_capture_player <heroId>
-
-Example:
-  coop.debug.player_captivity.random_capture_player Player
-
-Captures the given hero and assigns a random mobile party as the captor.";
-
-    [CommandLineArgumentFunction("random_capture_player", "coop.debug.player_captivity")]
-    public static string RandomCapturePlayer(List<string> args)
+        public sealed class PlayerCaptivityRandomCapturePlayerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "random_capture_player",
-            RandomCapturePlayerUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireServer(out var error))
-            return error;
+        public string Name => "random_capture_player";
 
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
+        public string Description => "Runs the random capture player debug operation.";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!TryGetRandomCaptor(out var newCaptor, out error))
-            return "Failed to capture hero: " + error;
-
-        return CaptureHero(hero, newCaptor);
-    }
-
-    private const string CapturePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.capture_player <heroId> <mobilePartyId>
-
-Example:
-  coop.debug.player_captivity.capture_player lord_1_29 MobileParty_looters_248
-
-Captures the given hero and assigns the given mobile party as the captor. The party argument accepts
-a co-op registry id or a local StringId.";
-
-    [CommandLineArgumentFunction("capture_player", "coop.debug.player_captivity")]
-    public static string CapturePlayer(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "capture_player",
-            CapturePlayerUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(2, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty newCaptor)
-            && !CommandHelpers.TryGetMobileParty(captorPartyId, out newCaptor, out error))
-            return "Failed to capture hero: " + error;
-
-        return CaptureHero(hero, newCaptor);
-    }
-
-    private const string CapturePlayerFixtureUsage =
-@"Usage:
-  coop.debug.player_captivity.capture_player_fixture <heroId> <mobilePartyId>
-
-Example:
-  coop.debug.player_captivity.capture_player_fixture Hero_Player2863 MobileParty_Player
-
-Captures a registered co-op player through the real captivity path and records the transferred regular
-troops for separate fixture cleanup. This is intended for automated tests.";
-
-    [CommandLineArgumentFunction("capture_player_fixture", "coop.debug.player_captivity")]
-    public static string CapturePlayerFixture(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "capture_player_fixture",
-            CapturePlayerFixtureUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(2, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to capture hero fixture: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to capture hero fixture: " + error;
-
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty)
-            && !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
-            return "Failed to capture hero fixture: " + error;
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
-            return "Failed to capture hero fixture: could not resolve PlayerManager.";
-
-        var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == heroId);
-        if (player == null)
-            return $"Failed to capture hero fixture: hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.";
-
-        if (!objectManager.TryGetObject(player.MobilePartyId, out MobileParty playerParty))
-            return $"Failed to capture hero fixture: player party '{player.MobilePartyId}' is not registered.";
-
-        if (hero.IsPrisoner)
-            return CaptureHero(hero, captorParty);
-
-        if (hero.PartyBelongedTo != playerParty)
-            return "Failed to capture hero fixture: the hero does not belong to the registered player party.";
-
-        if (captorParty == playerParty)
-            return "Failed to capture hero fixture: the player party cannot capture its own hero.";
-
-        if (!playerParty.IsActive)
-            return "Failed to capture hero fixture: the player party is not active.";
-
-        if (pendingRosterFixture != null)
-            return "Failed to capture hero fixture: another roster fixture is pending cleanup.";
-
-        var regularTroops = SnapshotRegularTroops(playerParty.MemberRoster);
-        if (HasOtherHero(playerParty.MemberRoster, hero))
-            return "Failed to capture hero fixture: the player party contains another hero.";
-
-        pendingRosterFixture = new CaptivityRosterFixture(hero, playerParty, captorParty, regularTroops);
-        var captureResult = CaptureHero(hero, captorParty);
-        if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != captorParty.Party)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "random_capture_player",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!TryGetRandomCaptor(out var newCaptor, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            return CaptureHero(hero, newCaptor);
+        }
+    }
+
+        public sealed class PlayerCaptivityCapturePlayerCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "capture_player";
+
+        public string Description => "Runs the capture player debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "capture_player",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty newCaptor)
+                && !CommandHelpers.TryGetMobileParty(captorPartyId, out newCaptor, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            return CaptureHero(hero, newCaptor);
+        }
+    }
+
+        public sealed class PlayerCaptivityCapturePlayerFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "capture_player_fixture";
+
+        public string Description => "Runs the capture player fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "capture_player_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to capture hero fixture: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to capture hero fixture: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty)
+                && !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
+                return Failed("Failed to capture hero fixture: " + error);
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+                return Failed("Failed to capture hero fixture: could not resolve PlayerManager.");
+
+            var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == heroId);
+            if (player == null)
+                return Failed($"Failed to capture hero fixture: hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.");
+
+            if (!objectManager.TryGetObject(player.MobilePartyId, out MobileParty playerParty))
+                return Failed($"Failed to capture hero fixture: player party '{player.MobilePartyId}' is not registered.");
+
+            if (hero.IsPrisoner)
+                return CaptureHero(hero, captorParty);
+
+            if (hero.PartyBelongedTo != playerParty)
+                return Failed("Failed to capture hero fixture: the hero does not belong to the registered player party.");
+
+            if (captorParty == playerParty)
+                return Failed("Failed to capture hero fixture: the player party cannot capture its own hero.");
+
+            if (!playerParty.IsActive)
+                return Failed("Failed to capture hero fixture: the player party is not active.");
+
+            if (pendingRosterFixture != null)
+                return Failed("Failed to capture hero fixture: another roster fixture is pending cleanup.");
+
+            var regularTroops = SnapshotRegularTroops(playerParty.MemberRoster);
+            if (HasOtherHero(playerParty.MemberRoster, hero))
+                return Failed("Failed to capture hero fixture: the player party contains another hero.");
+
+            pendingRosterFixture = new CaptivityRosterFixture(hero, playerParty, captorParty, regularTroops);
+            CoopCommandResult captureResult = CaptureHero(hero, captorParty);
+            if (!captureResult.Succeeded)
+            {
+                pendingRosterFixture = null;
+                return captureResult;
+            }
+
+            if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != captorParty.Party)
+            {
+                pendingRosterFixture = null;
+                return Failed(captureResult.Output + "\nFailed to capture the player through the expected captivity path.");
+            }
+
+            if (playerParty.IsActive)
+            {
+                pendingRosterFixture = null;
+                return Failed(captureResult.Output + "\nFailed to record fixture regular troops: the captivity handler did not park the player party.");
+            }
+
+            return Succeeded(captureResult.Output + "\nFixture regular troops recorded for cleanup: " +
+                regularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+        public sealed class PlayerCaptivityRestoreRosterFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_roster_fixture";
+
+        public string Description => "Runs the restore roster fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "restore_roster_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to restore roster fixture: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to restore roster fixture: " + error);
+
+            var fixture = pendingRosterFixture;
+            if (fixture == null)
+                return Failed("No roster fixture is pending cleanup.");
+
+            if (fixture.PlayerHero != hero)
+                return Failed($"Failed to restore roster fixture: the pending fixture belongs to '{GetHeroDisplayName(fixture.PlayerHero)}'.");
+
+            if (hero.IsPrisoner)
+                return Failed("Failed to restore roster fixture: the player hero is still a prisoner.");
+
+            var playerHeroIndex = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(fixture.PlayerHero.CharacterObject);
+            if (fixture.PlayerParty.MemberRoster.TotalManCount != 1 ||
+                playerHeroIndex < 0 ||
+                fixture.PlayerParty.MemberRoster.GetTroopCount(fixture.PlayerHero.CharacterObject) != 1)
+                return Failed("Failed to restore roster fixture: the player party is not the released hero's party of one.");
+
+            foreach (var troop in fixture.RegularTroops)
+            {
+                var captorIndex = fixture.CaptorParty.PrisonRoster.FindIndexOfTroop(troop.Character);
+                var availableTotal = captorIndex < 0
+                    ? 0
+                    : fixture.CaptorParty.PrisonRoster.GetTroopCount(troop.Character);
+                var availableWounded = captorIndex < 0
+                    ? 0
+                    : fixture.CaptorParty.PrisonRoster.GetElementWoundedNumber(captorIndex);
+                var availableHealthy = availableTotal - availableWounded;
+                var recordedHealthy = troop.Number - troop.WoundedNumber;
+                if (availableWounded < troop.WoundedNumber || availableHealthy < recordedHealthy)
+                    return Failed($"Failed to restore roster fixture: captor no longer holds the recorded '{troop.Character.StringId}' troops.");
+            }
+
+            foreach (var troop in fixture.RegularTroops)
+            {
+                fixture.CaptorParty.PrisonRoster.AddToCounts(
+                    troop.Character,
+                    -troop.Number,
+                    false,
+                    -troop.WoundedNumber,
+                    0,
+                    true);
+                fixture.PlayerParty.MemberRoster.AddToCounts(
+                    troop.Character,
+                    troop.Number,
+                    false,
+                    troop.WoundedNumber,
+                    troop.Xp,
+                    true);
+            }
+
             pendingRosterFixture = null;
-            return captureResult;
-        }
-
-        if (playerParty.IsActive)
-        {
-            pendingRosterFixture = null;
-            return captureResult + "\nFailed to record fixture regular troops: the captivity handler did not park the player party.";
-        }
-
-        return captureResult + "\nFixture regular troops recorded for cleanup: " +
-            regularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture);
-    }
-
-    private const string RestoreRosterFixtureUsage =
-@"Usage:
-  coop.debug.player_captivity.restore_roster_fixture <heroId>
-
-Example:
-  coop.debug.player_captivity.restore_roster_fixture Hero_Player2863
-
-Restores the regular troops recorded by capture_player_fixture after the player has left captivity.";
-
-    [CommandLineArgumentFunction("restore_roster_fixture", "coop.debug.player_captivity")]
-    public static string RestoreRosterFixture(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "restore_roster_fixture",
-            RestoreRosterFixtureUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to restore roster fixture: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to restore roster fixture: " + error;
-
-        var fixture = pendingRosterFixture;
-        if (fixture == null)
-            return "No roster fixture is pending cleanup.";
-
-        if (fixture.PlayerHero != hero)
-            return $"Failed to restore roster fixture: the pending fixture belongs to '{GetHeroDisplayName(fixture.PlayerHero)}'.";
-
-        if (hero.IsPrisoner)
-            return "Failed to restore roster fixture: the player hero is still a prisoner.";
-
-        var playerHeroIndex = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(fixture.PlayerHero.CharacterObject);
-        if (fixture.PlayerParty.MemberRoster.TotalManCount != 1 ||
-            playerHeroIndex < 0 ||
-            fixture.PlayerParty.MemberRoster.GetTroopCount(fixture.PlayerHero.CharacterObject) != 1)
-            return "Failed to restore roster fixture: the player party is not the released hero's party of one.";
-
-        foreach (var troop in fixture.RegularTroops)
-        {
-            var captorIndex = fixture.CaptorParty.PrisonRoster.FindIndexOfTroop(troop.Character);
-            var availableTotal = captorIndex < 0
-                ? 0
-                : fixture.CaptorParty.PrisonRoster.GetTroopCount(troop.Character);
-            var availableWounded = captorIndex < 0
-                ? 0
-                : fixture.CaptorParty.PrisonRoster.GetElementWoundedNumber(captorIndex);
-            var availableHealthy = availableTotal - availableWounded;
-            var recordedHealthy = troop.Number - troop.WoundedNumber;
-            if (availableWounded < troop.WoundedNumber || availableHealthy < recordedHealthy)
-                return $"Failed to restore roster fixture: captor no longer holds the recorded '{troop.Character.StringId}' troops.";
-        }
-
-        foreach (var troop in fixture.RegularTroops)
-        {
-            fixture.CaptorParty.PrisonRoster.AddToCounts(
-                troop.Character,
-                -troop.Number,
-                false,
-                -troop.WoundedNumber,
-                0,
-                true);
-            fixture.PlayerParty.MemberRoster.AddToCounts(
-                troop.Character,
-                troop.Number,
-                false,
-                troop.WoundedNumber,
-                troop.Xp,
-                true);
-        }
-
-        pendingRosterFixture = null;
-        return "Restored fixture regular troops: " +
-            fixture.RegularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture);
-    }
-
-    private const string ReleasePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.release_player <heroId>
-
-Example:
-  coop.debug.player_captivity.release_player Player
-
-Releases the given player hero from captivity.";
-
-    [CommandLineArgumentFunction("release_player", "coop.debug.player_captivity")]
-    public static string ReleasePlayer(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "release_player",
-            ReleasePlayerUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to release hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to release hero: " + error;
-
-        if (!hero.IsPrisoner)
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
-
-        var captorId = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "unknown";
-
-        try
-        {
-            EndCaptivityAction.ApplyByEscape(hero);
-
-            return
-                "Hero released successfully.\n" +
-                $"Hero: {GetHeroDisplayName(hero)}\n" +
-                $"Former captor StringId: {captorId}";
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException(
-                $"Failed to release hero '{GetHeroDisplayName(hero)}'",
-                ex);
+            return Succeeded("Restored fixture regular troops: " +
+                fixture.RegularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture));
         }
     }
 
-    private const string PrepareVisualTestFixtureUsage =
-@"Usage:
-  coop.debug.player_captivity.prepare_visual_test_fixture <heroId> <captorPartyId>
-
-Snapshots the player's party, removes its non-hero members, and moves it beside the captor. Server only.";
-
-    [CommandLineArgumentFunction("prepare_visual_test_fixture", "coop.debug.player_captivity")]
-    public static string PrepareVisualTestFixture(List<string> args)
+        public sealed class PlayerCaptivityReleasePlayerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "prepare_visual_test_fixture",
-            PrepareVisualTestFixtureUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireServer(out var error))
-            return error;
+        public string Name => "release_player";
 
-        if (!ctx.RequireArgCount(2, out error))
-            return error;
+        public string Description => "Runs the release player debug operation.";
 
-        if (liveTestFixtureSnapshot != null)
-            return "A visual test fixture is already prepared.";
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
-            !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to prepare visual test fixture: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to prepare visual test fixture: " + error;
-
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty) &&
-            !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
-            return "Failed to prepare visual test fixture: " + error;
-
-        var playerParty = hero.PartyBelongedTo;
-        if (playerParty == null || playerParty == captorParty)
-            return "Failed to prepare visual test fixture: player and captor parties must be distinct.";
-
-        if (hero.IsPrisoner || playerParty.PrisonRoster.TotalManCount != 0)
-            return "Failed to prepare visual test fixture: player must be free and their prison roster empty.";
-
-        if (!playerParty.IsActive ||
-            playerParty.LeaderHero != hero ||
-            playerParty.MemberRoster.GetTroopCount(hero.CharacterObject) != 1)
-            return "Failed to prepare visual test fixture: player must lead an active party containing them exactly once.";
-
-        if (playerParty.IsCurrentlyAtSea != captorParty.IsCurrentlyAtSea ||
-            playerParty.Position.IsOnLand != captorParty.Position.IsOnLand)
-            return "Failed to prepare visual test fixture: player and captor parties must use the same navigation layer.";
-
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
-            !behaviorSnapshot.TryCreate(playerParty, out var behavior))
-            return "Failed to prepare visual test fixture: unable to snapshot player party behavior.";
-
-        var snapshot = new LiveTestFixtureSnapshot(
-            playerParty,
-            hero.CharacterObject,
-            playerParty.MemberRoster.GetTroopRoster().ToArray(),
-            behavior);
-        liveTestFixtureSnapshot = snapshot;
-
-        foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            playerParty.MemberRoster.AddToCounts(
-                element.Character,
-                -element.Number,
-                false,
-                -element.WoundedNumber,
-                -element.Xp);
-        }
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        playerParty.Position = new CampaignVec2(
-            new TaleWorlds.Library.Vec2(captorParty.Position.X + 1f, captorParty.Position.Y),
-            captorParty.Position.IsOnLand);
-        playerParty.SetMoveModeHold();
-        playerParty.ResetNavigationToHold();
-        MessageBroker.Instance.Publish(
-            typeof(PlayerCaptivityCommands),
-            new PartyBehaviorChangeAttempted(
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "release_player",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to release hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to release hero: " + error);
+
+            if (!hero.IsPrisoner)
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.");
+
+            var captorId = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "unknown";
+
+            try
+            {
+                EndCaptivityAction.ApplyByEscape(hero);
+
+                return Succeeded("Hero released successfully.\n" +
+                    $"Hero: {GetHeroDisplayName(hero)}\n" +
+                    $"Former captor StringId: {captorId}");
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException(
+                    $"Failed to release hero '{GetHeroDisplayName(hero)}'",
+                    ex));
+            }
+        }
+    }
+
+        public sealed class PlayerCaptivityPrepareVisualTestFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "prepare_visual_test_fixture";
+
+        public string Description => "Runs the prepare visual test fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "prepare_visual_test_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (liveTestFixtureSnapshot != null)
+                return Failed("A visual test fixture is already prepared.");
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
+                !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to prepare visual test fixture: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to prepare visual test fixture: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty) &&
+                !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
+                return Failed("Failed to prepare visual test fixture: " + error);
+
+            var playerParty = hero.PartyBelongedTo;
+            if (playerParty == null || playerParty == captorParty)
+                return Failed("Failed to prepare visual test fixture: player and captor parties must be distinct.");
+
+            if (hero.IsPrisoner || playerParty.PrisonRoster.TotalManCount != 0)
+                return Failed("Failed to prepare visual test fixture: player must be free and their prison roster empty.");
+
+            if (!playerParty.IsActive ||
+                playerParty.LeaderHero != hero ||
+                playerParty.MemberRoster.GetTroopCount(hero.CharacterObject) != 1)
+                return Failed("Failed to prepare visual test fixture: player must lead an active party containing them exactly once.");
+
+            if (playerParty.IsCurrentlyAtSea != captorParty.IsCurrentlyAtSea ||
+                playerParty.Position.IsOnLand != captorParty.Position.IsOnLand)
+                return Failed("Failed to prepare visual test fixture: player and captor parties must use the same navigation layer.");
+
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
+                !behaviorSnapshot.TryCreate(playerParty, out var behavior))
+                return Failed("Failed to prepare visual test fixture: unable to snapshot player party behavior.");
+
+            var snapshot = new LiveTestFixtureSnapshot(
                 playerParty,
-                forcePosition: true,
-                isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
-                resetMovementToHold: true));
+                hero.CharacterObject,
+                playerParty.MemberRoster.GetTroopRoster().ToArray(),
+                behavior);
+            liveTestFixtureSnapshot = snapshot;
 
-        return
-            "Visual test fixture prepared.\n" +
-            $"Player party: {playerParty.StringId}\n" +
-            $"Original member count: {snapshot.MemberRoster.Sum(element => element.Number)}\n" +
-            $"Prepared position: {playerParty.Position.X:R},{playerParty.Position.Y:R}";
-    }
+            foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
+            {
+                playerParty.MemberRoster.AddToCounts(
+                    element.Character,
+                    -element.Number,
+                    false,
+                    -element.WoundedNumber,
+                    -element.Xp);
+            }
 
-    [CommandLineArgumentFunction("restore_visual_test_fixture", "coop.debug.player_captivity")]
-    public static string RestoreVisualTestFixture(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "restore_visual_test_fixture",
-            "Usage: coop.debug.player_captivity.restore_visual_test_fixture",
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(0, out error))
-            return error;
-
-        var snapshot = liveTestFixtureSnapshot;
-        if (snapshot == null)
-            return "No visual test fixture is prepared.";
-
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
-            return "Failed to restore visual test fixture: unable to resolve party behavior snapshot service.";
-
-        var playerParty = snapshot.PlayerParty;
-        var playerHero = snapshot.PlayerCharacter.HeroObject;
-        if (playerHero == null ||
-            playerHero.IsPrisoner ||
-            !playerParty.IsActive ||
-            playerHero.PartyBelongedTo != playerParty ||
-            playerParty.LeaderHero != playerHero)
-            return "Failed to restore visual test fixture: player must be free in their active party.";
-
-        if (!behaviorSnapshot.CanApply(playerParty, snapshot.Behavior))
-            return "Failed to restore visual test fixture: unable to resolve the party behavior snapshot.";
-
-        foreach (var element in playerParty.MemberRoster.GetTroopRoster()
-                     .Where(element => element.Character != snapshot.PlayerCharacter)
-                     .ToArray())
-        {
-            playerParty.MemberRoster.AddToCounts(
-                element.Character,
-                -element.Number,
-                false,
-                -element.WoundedNumber,
-                -element.Xp);
-        }
-
-        foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
-            playerParty.MemberRoster.Add(element);
-
-        playerParty.Position = snapshot.Behavior.PartyPosition;
-        playerParty.IsCurrentlyAtSea = snapshot.Behavior.IsCurrentlyAtSea;
-        if (!behaviorSnapshot.TryApply(playerParty, snapshot.Behavior, out _))
-            return "Failed to restore visual test fixture: unable to apply the party behavior snapshot.";
-
-        MessageBroker.Instance.Publish(
-            typeof(PlayerCaptivityCommands),
-            new PartyBehaviorChangeAttempted(
-                playerParty,
-                forcePosition: true,
-                isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
-                resetMovementToHold: false));
-
-        liveTestFixtureSnapshot = null;
-        return
-            "Visual test fixture restored.\n" +
-            $"Player party: {playerParty.StringId}\n" +
-            $"Member count: {playerParty.MemberRoster.TotalManCount}\n" +
-            $"Position: {playerParty.Position.X:R},{playerParty.Position.Y:R}\n" +
-            $"Move mode: {playerParty.PartyMoveMode}";
-    }
-
-    private const string LiberatePrisonerUsage =
-@"Usage:
-  coop.debug.player_captivity.liberate_prisoner <heroId>
-
-Example:
-  coop.debug.player_captivity.liberate_prisoner lord_1_29
-
-Runs the client-side rescued-prisoner liberation consequence for the given hero.";
-
-    [CommandLineArgumentFunction("liberate_prisoner", "coop.debug.player_captivity")]
-    public static string LiberatePrisoner(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run coop.debug.player_captivity.liberate_prisoner on a client.";
-
-        var ctx = new CommandContext(
-            "liberate_prisoner",
-            LiberatePrisonerUsage,
-            args);
-
-        if (!ctx.RequireArgCount(1, out var error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to liberate hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to liberate hero: " + error;
-
-        if (!hero.IsPrisoner)
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
-
-        var behavior = Campaign.Current?.GetCampaignBehavior<LordConversationsCampaignBehavior>();
-        if (behavior == null)
-            return $"Unable to find {nameof(LordConversationsCampaignBehavior)}.";
-
-        try
-        {
+            playerParty.Position = new CampaignVec2(
+                new TaleWorlds.Library.Vec2(captorParty.Position.X + 1f, captorParty.Position.Y),
+                captorParty.Position.IsOnLand);
+            playerParty.SetMoveModeHold();
+            playerParty.ResetNavigationToHold();
             MessageBroker.Instance.Publish(
-                behavior,
-                new LiberateLordPrisoner(Hero.MainHero, hero));
-            EndCaptivityAction.ApplyByReleasedAfterBattle(hero);
-            return $"Liberated '{GetHeroDisplayName(hero)}' after battle.";
+                typeof(PlayerCaptivityCommands),
+                new PartyBehaviorChangeAttempted(
+                    playerParty,
+                    forcePosition: true,
+                    isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
+                    resetMovementToHold: true));
+
+            return Succeeded("Visual test fixture prepared.\n" +
+                $"Player party: {playerParty.StringId}\n" +
+                $"Original member count: {snapshot.MemberRoster.Sum(element => element.Number)}\n" +
+                $"Prepared position: {playerParty.Position.X:R},{playerParty.Position.Y:R}");
         }
-        catch (Exception ex)
+    }
+
+    public sealed class PlayerCaptivityRestoreVisualTestFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_visual_test_fixture";
+
+        public string Description => "Runs the restore visual test fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return CommandHelpers.FormatException(
-                $"Failed to liberate hero '{GetHeroDisplayName(hero)}'",
-                ex);
+            var ctx = new CommandContext(
+                "restore_visual_test_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            var snapshot = liveTestFixtureSnapshot;
+            if (snapshot == null)
+                return Failed("No visual test fixture is prepared.");
+
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
+                return Failed("Failed to restore visual test fixture: unable to resolve party behavior snapshot service.");
+
+            var playerParty = snapshot.PlayerParty;
+            var playerHero = snapshot.PlayerCharacter.HeroObject;
+            if (playerHero == null ||
+                playerHero.IsPrisoner ||
+                !playerParty.IsActive ||
+                playerHero.PartyBelongedTo != playerParty ||
+                playerParty.LeaderHero != playerHero)
+                return Failed("Failed to restore visual test fixture: player must be free in their active party.");
+
+            if (!behaviorSnapshot.CanApply(playerParty, snapshot.Behavior))
+                return Failed("Failed to restore visual test fixture: unable to resolve the party behavior snapshot.");
+
+            foreach (var element in playerParty.MemberRoster.GetTroopRoster()
+                         .Where(element => element.Character != snapshot.PlayerCharacter)
+                         .ToArray())
+            {
+                playerParty.MemberRoster.AddToCounts(
+                    element.Character,
+                    -element.Number,
+                    false,
+                    -element.WoundedNumber,
+                    -element.Xp);
+            }
+
+            foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
+                playerParty.MemberRoster.Add(element);
+
+            playerParty.Position = snapshot.Behavior.PartyPosition;
+            playerParty.IsCurrentlyAtSea = snapshot.Behavior.IsCurrentlyAtSea;
+            if (!behaviorSnapshot.TryApply(playerParty, snapshot.Behavior, out _))
+                return Failed("Failed to restore visual test fixture: unable to apply the party behavior snapshot.");
+
+            MessageBroker.Instance.Publish(
+                typeof(PlayerCaptivityCommands),
+                new PartyBehaviorChangeAttempted(
+                    playerParty,
+                    forcePosition: true,
+                    isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
+                    resetMovementToHold: false));
+
+            liveTestFixtureSnapshot = null;
+            return Succeeded("Visual test fixture restored.\n" +
+                $"Player party: {playerParty.StringId}\n" +
+                $"Member count: {playerParty.MemberRoster.TotalManCount}\n" +
+                $"Position: {playerParty.Position.X:R},{playerParty.Position.Y:R}\n" +
+                $"Move mode: {playerParty.PartyMoveMode}");
         }
     }
 
-    private const string PrisonerStatusUsage =
-@"Usage:
-  coop.debug.player_captivity.status <heroId>
-
-Example:
-  coop.debug.player_captivity.status lord_1_29
-
-Reports the hero's current captivity state on this process.";
-
-    [CommandLineArgumentFunction("status", "coop.debug.player_captivity")]
-    public static string PrisonerStatus(List<string> args)
+        public sealed class PlayerCaptivityLiberatePrisonerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "status",
-            PrisonerStatusUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireArgCount(1, out var error))
-            return error;
+        public string Name => "liberate_prisoner";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
+        public string Description => "Runs the liberate prisoner debug operation.";
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to inspect hero: " + error;
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to inspect hero: " + error;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            if (ModInformation.IsServer)
+                return Failed("Run coop.debug.player_captivity.liberate_prisoner on a client.");
 
-        var captor = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none";
-        return
-            $"Hero: {GetHeroDisplayName(hero)} ({hero.StringId})\n" +
-            $"IsPrisoner: {hero.IsPrisoner}\n" +
-            $"Captor: {captor}";
+            var ctx = new CommandContext(
+                "liberate_prisoner",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to liberate hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to liberate hero: " + error);
+
+            if (!hero.IsPrisoner)
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.");
+
+            var behavior = Campaign.Current?.GetCampaignBehavior<LordConversationsCampaignBehavior>();
+            if (behavior == null)
+                return Failed($"Unable to find {nameof(LordConversationsCampaignBehavior)}.");
+
+            try
+            {
+                MessageBroker.Instance.Publish(
+                    behavior,
+                    new LiberateLordPrisoner(Hero.MainHero, hero));
+                EndCaptivityAction.ApplyByReleasedAfterBattle(hero);
+                return Succeeded($"Liberated '{GetHeroDisplayName(hero)}' after battle.");
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException(
+                    $"Failed to liberate hero '{GetHeroDisplayName(hero)}'",
+                    ex));
+            }
+        }
     }
 
-    private const string DiscardPlayerFromPartyScreenUsage =
-@"Usage:
-  coop.debug.player_captivity.discard_player_from_party_screen <heroId> <captorPartyId>
-
-Moves a captured player into the active normal Party screen's left dismissal roster and presses Done.
-Run this on the client that controls the captor after opening the Party screen.";
-
-    [CommandLineArgumentFunction("discard_player_from_party_screen", "coop.debug.player_captivity")]
-    public static string DiscardPlayerFromPartyScreen(List<string> args)
+        public sealed class PlayerCaptivityStatusCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "discard_player_from_party_screen",
-            DiscardPlayerFromPartyScreenUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ModInformation.IsClient)
-            return "Run this command on the client that controls the captor party.";
+        public string Name => "status";
 
-        if (!ctx.RequireArgCount(2, out var error))
-            return error;
+        public string Description => "Reports status.";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
-            !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
-            return error;
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to discard player prisoner: " + error;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var ctx = new CommandContext(
+                "status",
+                "Argument must not be empty.",
+                new List<string>(args));
 
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var prisoner, out error))
-            return "Failed to discard player prisoner: " + error;
 
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty captor) &&
-            !CommandHelpers.TryGetMobileParty(captorPartyId, out captor, out error))
-            return "Failed to discard player prisoner: " + error;
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
 
-        if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner?.MobileParty != captor)
-            return $"Hero '{GetHeroDisplayName(prisoner)}' is not a prisoner of '{captor.StringId}'.";
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to inspect hero: " + error);
 
-        if (captor.LeaderHero == null)
-            return $"Captor party '{captor.StringId}' has no leader hero.";
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to inspect hero: " + error);
 
-        if (MobileParty.MainParty != captor)
-            return "Run this command on the client that controls the captor party.";
+            var captor = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none";
+            return Succeeded($"Hero: {GetHeroDisplayName(hero)} ({hero.StringId})\n" +
+                $"IsPrisoner: {hero.IsPrisoner}\n" +
+                $"Captor: {captor}");
+        }
+    }
 
-        if (Game.Current?.GameStateManager?.ActiveState is not PartyState partyState ||
-            partyState.PartyScreenLogic == null)
-            return "Open the normal Party screen before running this command.";
+        public sealed class PlayerCaptivityDiscardPlayerFromPartyScreenCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (partyState.PartyScreenMode != PartyScreenHelper.PartyScreenMode.Normal)
-            return $"The active Party screen is '{partyState.PartyScreenMode}', not Normal.";
+        public string Name => "discard_player_from_party_screen";
 
-        var partyScreenLogic = partyState.PartyScreenLogic;
-        var leftPrisonerRoster =
-            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left];
-        if (partyScreenLogic.LeftOwnerParty != null ||
-            leftPrisonerRoster.OwnerParty != null ||
-            objectManager.TryGetId(leftPrisonerRoster, out _) ||
-            partyScreenLogic.RightOwnerParty?.MobileParty != captor ||
-            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right] != captor.PrisonRoster)
-            return "The active Party screen is not the captor's prisoner-dismissal screen.";
+        public string Description => "Runs the discard player from party screen debug operation.";
 
-        var rightPrisonerRoster =
-            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right];
-        var rightIndex = rightPrisonerRoster.FindIndexOfTroop(prisoner.CharacterObject);
-        if (rightIndex < 0)
-            return $"The active Party screen does not contain '{GetHeroDisplayName(prisoner)}' as a prisoner.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
 
-        var prisonerElement = rightPrisonerRoster.GetElementCopyAtIndex(rightIndex);
-        if (!partyScreenLogic.IsTroopTransferable(
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var ctx = new CommandContext(
+                "discard_player_from_party_screen",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ModInformation.IsClient)
+                return Failed("Run this command on the client that controls the captor party.");
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
+                !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to discard player prisoner: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var prisoner, out error))
+                return Failed("Failed to discard player prisoner: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty captor) &&
+                !CommandHelpers.TryGetMobileParty(captorPartyId, out captor, out error))
+                return Failed("Failed to discard player prisoner: " + error);
+
+            if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner?.MobileParty != captor)
+                return Failed($"Hero '{GetHeroDisplayName(prisoner)}' is not a prisoner of '{captor.StringId}'.");
+
+            if (captor.LeaderHero == null)
+                return Failed($"Captor party '{captor.StringId}' has no leader hero.");
+
+            if (MobileParty.MainParty != captor)
+                return Failed("Run this command on the client that controls the captor party.");
+
+            if (Game.Current?.GameStateManager?.ActiveState is not PartyState partyState ||
+                partyState.PartyScreenLogic == null)
+                return Failed("Open the normal Party screen before running this command.");
+
+            if (partyState.PartyScreenMode != PartyScreenHelper.PartyScreenMode.Normal)
+                return Failed($"The active Party screen is '{partyState.PartyScreenMode}', not Normal.");
+
+            var partyScreenLogic = partyState.PartyScreenLogic;
+            var leftPrisonerRoster =
+                partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left];
+            if (partyScreenLogic.LeftOwnerParty != null ||
+                leftPrisonerRoster.OwnerParty != null ||
+                objectManager.TryGetId(leftPrisonerRoster, out _) ||
+                partyScreenLogic.RightOwnerParty?.MobileParty != captor ||
+                partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right] != captor.PrisonRoster)
+                return Failed("The active Party screen is not the captor's prisoner-dismissal screen.");
+
+            var rightPrisonerRoster =
+                partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right];
+            var rightIndex = rightPrisonerRoster.FindIndexOfTroop(prisoner.CharacterObject);
+            if (rightIndex < 0)
+                return Failed($"The active Party screen does not contain '{GetHeroDisplayName(prisoner)}' as a prisoner.");
+
+            var prisonerElement = rightPrisonerRoster.GetElementCopyAtIndex(rightIndex);
+            if (!partyScreenLogic.IsTroopTransferable(
+                    PartyScreenLogic.TroopType.Prisoner,
+                    prisoner.CharacterObject,
+                    (int)PartyScreenLogic.PartyRosterSide.Right))
+                return Failed($"The active Party screen does not allow '{GetHeroDisplayName(prisoner)}' to be transferred.");
+
+            var targetIndex = partyScreenLogic.GetIndexToInsertTroop(
+                PartyScreenLogic.PartyRosterSide.Left,
+                PartyScreenLogic.TroopType.Prisoner,
+                prisonerElement);
+            var command = new PartyScreenLogic.PartyCommand();
+            command.FillForTransferTroop(
+                PartyScreenLogic.PartyRosterSide.Right,
                 PartyScreenLogic.TroopType.Prisoner,
                 prisoner.CharacterObject,
-                (int)PartyScreenLogic.PartyRosterSide.Right))
-            return $"The active Party screen does not allow '{GetHeroDisplayName(prisoner)}' to be transferred.";
+                prisonerElement.Number,
+                prisonerElement.WoundedNumber,
+                targetIndex);
 
-        var targetIndex = partyScreenLogic.GetIndexToInsertTroop(
-            PartyScreenLogic.PartyRosterSide.Left,
-            PartyScreenLogic.TroopType.Prisoner,
-            prisonerElement);
-        var command = new PartyScreenLogic.PartyCommand();
-        command.FillForTransferTroop(
-            PartyScreenLogic.PartyRosterSide.Right,
-            PartyScreenLogic.TroopType.Prisoner,
-            prisoner.CharacterObject,
-            prisonerElement.Number,
-            prisonerElement.WoundedNumber,
-            targetIndex);
+            // PartyCharacterVM.ApplyTransfer is patched with this same scope. Drive PartyScreenLogic directly
+            // so the automation exercises the real transfer history, both Done handlers, network messages,
+            // rollback, and state close without synthesizing either wire payload.
+            using (new AllowedThread())
+            {
+                partyScreenLogic.AddCommand(command);
+                partyScreenLogic.RemoveZeroCounts();
+            }
 
-        // PartyCharacterVM.ApplyTransfer is patched with this same scope. Drive PartyScreenLogic directly
-        // so the automation exercises the real transfer history, both Done handlers, network messages,
-        // rollback, and state close without synthesizing either wire payload.
-        using (new AllowedThread())
-        {
-            partyScreenLogic.AddCommand(command);
-            partyScreenLogic.RemoveZeroCounts();
+            var movedCount = leftPrisonerRoster.GetTroopCount(prisoner.CharacterObject);
+            if (movedCount != prisonerElement.Number ||
+                rightPrisonerRoster.GetTroopCount(prisoner.CharacterObject) != 0)
+                return Failed("PartyScreenLogic did not move the complete prisoner stack to the dismissal roster.");
+
+            PartyScreenHelper.CloseScreen(isForced: false);
+            var screenClosed = Game.Current.GameStateManager.ActiveState != partyState;
+
+            return Succeeded("Player prisoner discarded through the active Party screen.\n" +
+                $"Hero: {GetHeroDisplayName(prisoner)}\n" +
+                $"Captor StringId: {captor.StringId}\n" +
+                $"TransferredCount: {movedCount}\n" +
+                $"ActionPath: {nameof(PartyScreenLogic)}.{nameof(PartyScreenLogic.AddCommand)} -> " +
+                $"{nameof(PartyScreenHelper)}.{nameof(PartyScreenHelper.CloseScreen)}\n" +
+                $"ScreenClosed: {screenClosed}");
         }
-
-        var movedCount = leftPrisonerRoster.GetTroopCount(prisoner.CharacterObject);
-        if (movedCount != prisonerElement.Number ||
-            rightPrisonerRoster.GetTroopCount(prisoner.CharacterObject) != 0)
-            return "PartyScreenLogic did not move the complete prisoner stack to the dismissal roster.";
-
-        PartyScreenHelper.CloseScreen(isForced: false);
-        var screenClosed = Game.Current.GameStateManager.ActiveState != partyState;
-
-        return
-            "Player prisoner discarded through the active Party screen.\n" +
-            $"Hero: {GetHeroDisplayName(prisoner)}\n" +
-            $"Captor StringId: {captor.StringId}\n" +
-            $"TransferredCount: {movedCount}\n" +
-            $"ActionPath: {nameof(PartyScreenLogic)}.{nameof(PartyScreenLogic.AddCommand)} -> " +
-            $"{nameof(PartyScreenHelper)}.{nameof(PartyScreenHelper.CloseScreen)}\n" +
-            $"ScreenClosed: {screenClosed}";
     }
 
-    private const string ObservePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.observe_player <heroId>
-
-Reports captivity and registered party state without mutating it.";
-
-    [CommandLineArgumentFunction("observe_player", "coop.debug.player_captivity")]
-    public static string ObservePlayer(List<string> args)
+        public sealed class PlayerCaptivityObservePlayerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext("observe_player", ObservePlayerUsage, args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireArgCount(1, out var error))
-            return error;
+        public string Name => "observe_player";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
+        public string Description => "Runs the observe player debug operation.";
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to observe player: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to observe player: " + error;
-
-        if (!objectManager.TryGetId(hero, out var registeredHeroId))
-            return "Failed to observe player: hero is not registered.";
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
-            return "Failed to observe player: unable to resolve player manager.";
-
-        var player = playerManager.Players.FirstOrDefault(candidate => candidate.HeroId == registeredHeroId);
-        var partyId = player?.MobilePartyId;
-        MobileParty registeredParty = null;
-        if (!string.IsNullOrEmpty(partyId))
-            objectManager.TryGetObject(partyId, out registeredParty);
-        var captorParty = hero.PartyBelongedToAsPrisoner?.MobileParty;
-
-        var output = new StringBuilder();
-        output.AppendLine($"HeroId: {registeredHeroId}");
-        output.AppendLine($"IsPrisoner: {hero.IsPrisoner}");
-        output.AppendLine($"HeroPartyId: {hero.PartyBelongedTo?.StringId ?? "<none>"}");
-        output.AppendLine($"CaptorPartyId: {captorParty?.StringId ?? "<none>"}");
-        output.AppendLine($"RegisteredPartyId: {partyId ?? "<none>"}");
-        output.AppendLine($"PartyResolved: {registeredParty != null}");
-
-        if (registeredParty != null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            output.AppendLine($"PartyActive: {registeredParty.IsActive}");
-            output.AppendLine($"PartyVisible: {registeredParty.IsVisible}");
-            output.AppendLine($"PartyVisualPresent: {registeredParty.Party.GetPartyVisual() != null}");
-            output.AppendLine($"PartyLeaderId: {registeredParty.LeaderHero?.StringId ?? "<none>"}");
-            output.AppendLine($"HeroMemberCount: {registeredParty.MemberRoster.GetTroopCount(hero.CharacterObject)}");
-            output.AppendLine($"PartyMemberCount: {registeredParty.MemberRoster.TotalManCount}");
-            output.AppendLine($"PartyPrisonerCount: {registeredParty.PrisonRoster.TotalManCount}");
-            output.AppendLine($"PartyPosition: {registeredParty.Position.X:R},{registeredParty.Position.Y:R}");
-            output.AppendLine($"PartyIsOnLand: {registeredParty.Position.IsOnLand}");
-            output.AppendLine($"PartyMoveMode: {registeredParty.PartyMoveMode}");
-            output.AppendLine($"MoveTargetPoint: {registeredParty.MoveTargetPoint.X:R},{registeredParty.MoveTargetPoint.Y:R}");
-        }
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        output.AppendLine($"CaptorPrisonerCount: {captorParty?.PrisonRoster.GetTroopCount(hero.CharacterObject) ?? 0}");
-        return output.ToString();
-    }
-
-    private const string RansomPlayerAtSettlementUsage =
-@"Usage:
-  coop.debug.player_captivity.ransom_player_at_settlement <heroId>
-
-Example:
-  coop.debug.player_captivity.ransom_player_at_settlement Player
-
-Ransoms the captive player hero for zero gold and releases them at a nearby neutral or allied settlement.";
-
-    [CommandLineArgumentFunction("ransom_player_at_settlement", "coop.debug.player_captivity")]
-    public static string RansomPlayerAtSettlement(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "ransom_player_at_settlement",
-            RansomPlayerAtSettlementUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to ransom hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to ransom hero: " + error;
-
-        if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner == null)
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.Contains(hero))
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.";
-
-        var captorParty = hero.PartyBelongedToAsPrisoner;
-        var currentSettlement = captorParty.MobileParty?.CurrentSettlement;
-        if (currentSettlement == null)
-            return $"Captor for '{GetHeroDisplayName(hero)}' is not in a settlement.";
-
-        if (!ContainerProvider.TryResolve<IPrisonerSaleProcessor>(out var prisonerSaleProcessor))
-            return "Failed to ransom hero: could not resolve PrisonerSaleProcessor.";
-
-        if (!ContainerProvider.TryResolve<IPlayerRansomReleaseSettlementProvider>(out var releaseSettlementProvider))
-            return "Failed to ransom hero: could not resolve PlayerRansomReleaseSettlementProvider.";
-
-        var releaseSettlement = releaseSettlementProvider.GetReleaseSettlement(captorParty, hero);
-        var playerFaction = hero.MapFaction;
-        var releaseFaction = releaseSettlement.MapFaction;
-        var releaseSettlementHostile = playerFaction != null && releaseFaction != null &&
-            FactionManager.IsAtWarAgainstFaction(playerFaction, releaseFaction);
-
-        var requestedPrisoners = new TroopRoster();
-        requestedPrisoners.AddToCounts(hero.CharacterObject, 1);
-        var seller = captorParty.LeaderHero;
-        var sellerGoldBefore = seller?.Gold ?? 0;
-
-        prisonerSaleProcessor.Sell(captorParty, requestedPrisoners);
-
-        var sellerGoldAfter = seller?.Gold ?? 0;
-        return
-            "Hero ransomed successfully.\n" +
-            $"Hero: {GetHeroDisplayName(hero)}\n" +
-            $"Ransom settlement: {currentSettlement.Name} ({currentSettlement.StringId})\n" +
-            $"Release settlement: {releaseSettlement.Name} ({releaseSettlement.StringId})\n" +
-            $"Player faction: {playerFaction?.StringId ?? "none"}\n" +
-            $"Release settlement faction: {releaseFaction?.StringId ?? "none"}\n" +
-            $"Release settlement hostile: {releaseSettlementHostile}\n" +
-            $"Release gate X: {releaseSettlement.GatePosition.X.ToString(CultureInfo.InvariantCulture)}\n" +
-            $"Release gate Y: {releaseSettlement.GatePosition.Y.ToString(CultureInfo.InvariantCulture)}\n" +
-            $"Seller gold change: {sellerGoldAfter - sellerGoldBefore}";
-    }
-
-    [CommandLineArgumentFunction("captivity_state", "coop.debug.player_captivity")]
-    public static string CaptivityState(List<string> args)
-    {
-        if (args.Count != 1)
-            return "Usage: coop.debug.player_captivity.captivity_state <heroId>";
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
-            return "Failed to inspect captivity: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
-            return "Failed to inspect captivity: " + error;
-
-        MobileParty playerParty = null;
-        if (ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == args[0]);
-            if (player != null)
-                objectManager.TryGetObject(player.MobilePartyId, out playerParty);
-        }
+            string error;
+            var ctx = new CommandContext("observe_player", "Argument must not be empty.", new List<string>(args));
 
-        var result = new StringBuilder();
-        result.AppendLine("HeroId=" + hero.StringId);
-        result.AppendLine("IsPrisoner=" + hero.IsPrisoner);
-        result.AppendLine("CaptorPartyId=" + (hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none"));
-        result.AppendLine("PlayerPartyId=" + (playerParty?.StringId ?? "none"));
-        result.AppendLine("PlayerPartyActive=" + (playerParty?.IsActive.ToString() ?? "none"));
-        result.AppendLine("PlayerPartyLeaderHeroId=" + (playerParty?.LeaderHero?.StringId ?? "none"));
-        result.AppendLine("PlayerPartyMemberCount=" + (playerParty?.MemberRoster.TotalManCount.ToString(CultureInfo.InvariantCulture) ?? "none"));
-        result.AppendLine("PlayerPartyX=" + FormatCoordinate(playerParty?.Position.X));
-        result.AppendLine("PlayerPartyY=" + FormatCoordinate(playerParty?.Position.Y));
-        result.AppendLine("PlayerPartyIsOnLand=" + (playerParty?.Position.IsOnLand.ToString() ?? "none"));
-        result.AppendLine("PlayerPartySettlementId=" + (playerParty?.CurrentSettlement?.StringId ?? "none"));
-        return result.ToString();
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to observe player: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to observe player: " + error);
+
+            if (!objectManager.TryGetId(hero, out var registeredHeroId))
+                return Failed("Failed to observe player: hero is not registered.");
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+                return Failed("Failed to observe player: unable to resolve player manager.");
+
+            var player = playerManager.Players.FirstOrDefault(candidate => candidate.HeroId == registeredHeroId);
+            var partyId = player?.MobilePartyId;
+            MobileParty registeredParty = null;
+            if (!string.IsNullOrEmpty(partyId))
+                objectManager.TryGetObject(partyId, out registeredParty);
+            var captorParty = hero.PartyBelongedToAsPrisoner?.MobileParty;
+
+            var output = new StringBuilder();
+            output.AppendLine($"HeroId: {registeredHeroId}");
+            output.AppendLine($"IsPrisoner: {hero.IsPrisoner}");
+            output.AppendLine($"HeroPartyId: {hero.PartyBelongedTo?.StringId ?? "<none>"}");
+            output.AppendLine($"CaptorPartyId: {captorParty?.StringId ?? "<none>"}");
+            output.AppendLine($"RegisteredPartyId: {partyId ?? "<none>"}");
+            output.AppendLine($"PartyResolved: {registeredParty != null}");
+
+            if (registeredParty != null)
+            {
+                output.AppendLine($"PartyActive: {registeredParty.IsActive}");
+                output.AppendLine($"PartyVisible: {registeredParty.IsVisible}");
+                output.AppendLine($"PartyVisualPresent: {registeredParty.Party.GetPartyVisual() != null}");
+                output.AppendLine($"PartyLeaderId: {registeredParty.LeaderHero?.StringId ?? "<none>"}");
+                output.AppendLine($"HeroMemberCount: {registeredParty.MemberRoster.GetTroopCount(hero.CharacterObject)}");
+                output.AppendLine($"PartyMemberCount: {registeredParty.MemberRoster.TotalManCount}");
+                output.AppendLine($"PartyPrisonerCount: {registeredParty.PrisonRoster.TotalManCount}");
+                output.AppendLine($"PartyPosition: {registeredParty.Position.X:R},{registeredParty.Position.Y:R}");
+                output.AppendLine($"PartyIsOnLand: {registeredParty.Position.IsOnLand}");
+                output.AppendLine($"PartyMoveMode: {registeredParty.PartyMoveMode}");
+                output.AppendLine($"MoveTargetPoint: {registeredParty.MoveTargetPoint.X:R},{registeredParty.MoveTargetPoint.Y:R}");
+            }
+
+            output.AppendLine($"CaptorPrisonerCount: {captorParty?.PrisonRoster.GetTroopCount(hero.CharacterObject) ?? 0}");
+            return Succeeded(output.ToString());
+        }
     }
 
-    [CommandLineArgumentFunction("party_fixture_state", "coop.debug.player_captivity")]
-    public static string PartyFixtureState(List<string> args)
+        public sealed class PlayerCaptivityRansomPlayerAtSettlementCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-            return "Usage: coop.debug.player_captivity.party_fixture_state <partyId>";
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
-            return "Failed to inspect party: " + error;
+        public string Name => "ransom_player_at_settlement";
 
-        if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
-            return "Failed to inspect party: " + error;
+        public string Description => "Runs the ransom player at settlement debug operation.";
 
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "ransom_player_at_settlement",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to ransom hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to ransom hero: " + error);
+
+            if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner == null)
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.");
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.Contains(hero))
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.");
+
+            var captorParty = hero.PartyBelongedToAsPrisoner;
+            var currentSettlement = captorParty.MobileParty?.CurrentSettlement;
+            if (currentSettlement == null)
+                return Failed($"Captor for '{GetHeroDisplayName(hero)}' is not in a settlement.");
+
+            if (!ContainerProvider.TryResolve<IPrisonerSaleProcessor>(out var prisonerSaleProcessor))
+                return Failed("Failed to ransom hero: could not resolve PrisonerSaleProcessor.");
+
+            if (!ContainerProvider.TryResolve<IPlayerRansomReleaseSettlementProvider>(out var releaseSettlementProvider))
+                return Failed("Failed to ransom hero: could not resolve PlayerRansomReleaseSettlementProvider.");
+
+            var releaseSettlement = releaseSettlementProvider.GetReleaseSettlement(captorParty, hero);
+            var playerFaction = hero.MapFaction;
+            var releaseFaction = releaseSettlement.MapFaction;
+            var releaseSettlementHostile = playerFaction != null && releaseFaction != null &&
+                FactionManager.IsAtWarAgainstFaction(playerFaction, releaseFaction);
+
+            var requestedPrisoners = new TroopRoster();
+            requestedPrisoners.AddToCounts(hero.CharacterObject, 1);
+            var seller = captorParty.LeaderHero;
+            var sellerGoldBefore = seller?.Gold ?? 0;
+
+            prisonerSaleProcessor.Sell(captorParty, requestedPrisoners);
+
+            var sellerGoldAfter = seller?.Gold ?? 0;
+            return Succeeded("Hero ransomed successfully.\n" +
+                $"Hero: {GetHeroDisplayName(hero)}\n" +
+                $"Ransom settlement: {currentSettlement.Name} ({currentSettlement.StringId})\n" +
+                $"Release settlement: {releaseSettlement.Name} ({releaseSettlement.StringId})\n" +
+                $"Player faction: {playerFaction?.StringId ?? "none"}\n" +
+                $"Release settlement faction: {releaseFaction?.StringId ?? "none"}\n" +
+                $"Release settlement hostile: {releaseSettlementHostile}\n" +
+                $"Release gate X: {releaseSettlement.GatePosition.X.ToString(CultureInfo.InvariantCulture)}\n" +
+                $"Release gate Y: {releaseSettlement.GatePosition.Y.ToString(CultureInfo.InvariantCulture)}\n" +
+                $"Seller gold change: {sellerGoldAfter - sellerGoldBefore}");
+        }
+    }
+
+    public sealed class PlayerCaptivityCaptivityStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "captivity_state";
+
+        public string Description => "Reports captivity state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
+                return Failed("Failed to inspect captivity: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
+                return Failed("Failed to inspect captivity: " + error);
+
+            MobileParty playerParty = null;
+            if (ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+            {
+                var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == args[0]);
+                if (player != null)
+                    objectManager.TryGetObject(player.MobilePartyId, out playerParty);
+            }
+
+            var result = new StringBuilder();
+            result.AppendLine("HeroId=" + hero.StringId);
+            result.AppendLine("IsPrisoner=" + hero.IsPrisoner);
+            result.AppendLine("CaptorPartyId=" + (hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none"));
+            result.AppendLine("PlayerPartyId=" + (playerParty?.StringId ?? "none"));
+            result.AppendLine("PlayerPartyActive=" + (playerParty?.IsActive.ToString() ?? "none"));
+            result.AppendLine("PlayerPartyLeaderHeroId=" + (playerParty?.LeaderHero?.StringId ?? "none"));
+            result.AppendLine("PlayerPartyMemberCount=" + (playerParty?.MemberRoster.TotalManCount.ToString(CultureInfo.InvariantCulture) ?? "none"));
+            result.AppendLine("PlayerPartyX=" + FormatCoordinate(playerParty?.Position.X));
+            result.AppendLine("PlayerPartyY=" + FormatCoordinate(playerParty?.Position.Y));
+            result.AppendLine("PlayerPartyIsOnLand=" + (playerParty?.Position.IsOnLand.ToString() ?? "none"));
+            result.AppendLine("PlayerPartySettlementId=" + (playerParty?.CurrentSettlement?.StringId ?? "none"));
+            return Succeeded(result.ToString());
+        }
+    }
+
+    public sealed class PlayerCaptivityPartyFixtureStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "party_fixture_state";
+
+        public string Description => "Reports party fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
+                return Failed("Failed to inspect party: " + error);
+
+            if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
+                return Failed("Failed to inspect party: " + error);
+
+            return Succeeded(GetPartyFixtureState(party));
+        }
+    }
+
+    public sealed class PlayerCaptivityRestorePartyFixtureStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_party_fixture_state";
+
+        public string Description => "Reports restore party fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+            new ExpectedArgs("settlement_id_or_none", "The settlement id, or none.", isRequired: true),
+            new ExpectedArgs("x", "The map x coordinate.", isRequired: true),
+            new ExpectedArgs("y", "The map y coordinate.", isRequired: true),
+            new ExpectedArgs("is_on_land", "Whether the position is on land.", isRequired: true),
+            new ExpectedArgs("is_active", "Whether the party is active.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext("restore_party_fixture_state", "Argument must not be empty.", new List<string>(args));
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to restore party: " + error);
+            if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
+                return Failed("Failed to restore party: " + error);
+            if (!ContainerProvider.TryResolve<INetwork>(out var network))
+                return Failed("Failed to restore party: could not resolve Network.");
+            if (!objectManager.TryGetIdWithLogging(party, out var partyId))
+                return Failed("Failed to restore party: the party is not registered.");
+            if (!float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
+                !float.TryParse(args[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var y) ||
+                !bool.TryParse(args[4], out var isOnLand) ||
+                !bool.TryParse(args[5], out var isActive))
+                return Failed("Coordinates and active-state values must use valid numeric and boolean formats.");
+
+            if (args[1] == "none")
+            {
+                if (party.CurrentSettlement != null)
+                    LeaveSettlementAction.ApplyForParty(party);
+
+                party.Position = new CampaignVec2(new Vec2(x, y), isOnLand);
+            }
+            else
+            {
+                var settlement = Settlement.Find(args[1]);
+                if (settlement == null)
+                    return Failed($"Failed to restore party: settlement '{args[1]}' not found.");
+
+                if (party.CurrentSettlement != settlement)
+                {
+                    if (party.CurrentSettlement != null)
+                        LeaveSettlementAction.ApplyForParty(party);
+                    EnterSettlementAction.ApplyForParty(party, settlement);
+                }
+            }
+
+            party.IsActive = isActive;
+            network.SendAll(new NetworkPlayerCaptivityReleasePositionSet(partyId, party.Position));
+
+            return Succeeded("Restored party fixture state.\n" + GetPartyFixtureState(party));
+        }
+    }
+
+    private static string GetPartyFixtureState(MobileParty party)
+    {
         var result = new StringBuilder();
         result.AppendLine("PartyId=" + party.StringId);
         result.AppendLine("IsActive=" + party.IsActive);
@@ -917,57 +1061,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         result.AppendLine("MemberCount=" + party.MemberRoster.TotalManCount.ToString(CultureInfo.InvariantCulture));
         result.AppendLine("PrisonerCount=" + party.PrisonRoster.TotalManCount.ToString(CultureInfo.InvariantCulture));
         return result.ToString();
-    }
-
-    [CommandLineArgumentFunction("restore_party_fixture_state", "coop.debug.player_captivity")]
-    public static string RestorePartyFixtureState(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.restore_party_fixture_state <partyId> <settlementId|none> <x> <y> <isOnLand> <isActive>";
-        var ctx = new CommandContext("restore_party_fixture_state", usage, args);
-        if (!ctx.RequireServer(out var error))
-            return error;
-        if (!ctx.RequireArgCount(6, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to restore party: " + error;
-        if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
-            return "Failed to restore party: " + error;
-        if (!ContainerProvider.TryResolve<INetwork>(out var network))
-            return "Failed to restore party: could not resolve Network.";
-        if (!objectManager.TryGetIdWithLogging(party, out var partyId))
-            return "Failed to restore party: the party is not registered.";
-        if (!float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
-            !float.TryParse(args[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var y) ||
-            !bool.TryParse(args[4], out var isOnLand) ||
-            !bool.TryParse(args[5], out var isActive))
-            return usage;
-
-        if (args[1] == "none")
-        {
-            if (party.CurrentSettlement != null)
-                LeaveSettlementAction.ApplyForParty(party);
-
-            party.Position = new CampaignVec2(new Vec2(x, y), isOnLand);
-        }
-        else
-        {
-            var settlement = Settlement.Find(args[1]);
-            if (settlement == null)
-                return $"Failed to restore party: settlement '{args[1]}' not found.";
-
-            if (party.CurrentSettlement != settlement)
-            {
-                if (party.CurrentSettlement != null)
-                    LeaveSettlementAction.ApplyForParty(party);
-                EnterSettlementAction.ApplyForParty(party, settlement);
-            }
-        }
-
-        party.IsActive = isActive;
-        network.SendAll(new NetworkPlayerCaptivityReleasePositionSet(partyId, party.Position));
-
-        return "Restored party fixture state.\n" + PartyFixtureState(new List<string> { args[0] });
     }
 
     private static bool TryGetRandomCaptor(out MobileParty newCaptor, out string error)
@@ -1069,22 +1162,16 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         }
     }
 
-    private static string CaptureHero(Hero hero, MobileParty newCaptor)
+    private static CoopCommandResult CaptureHero(Hero hero, MobileParty newCaptor)
     {
         if (hero == null)
-        {
-            return "Failed to capture hero: hero is null.";
-        }
+            return Failed("Failed to capture hero: hero is null.");
 
         if (newCaptor == null)
-        {
-            return "Failed to capture hero: captor party is null.";
-        }
+            return Failed("Failed to capture hero: captor party is null.");
 
         if (newCaptor.Party == null)
-        {
-            return $"Failed to capture hero: MobileParty '{newCaptor.StringId}' has no Party.";
-        }
+            return Failed($"Failed to capture hero: MobileParty '{newCaptor.StringId}' has no Party.");
 
         if (hero.IsPrisoner)
         {
@@ -1092,9 +1179,9 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
                 ?? hero.PartyBelongedTo?.StringId
                 ?? "unknown";
 
-            return
+            return Failed(
                 $"Hero '{GetHeroDisplayName(hero)}' is already a prisoner.\n" +
-                $"Current captor: {currentCaptor}.";
+                $"Current captor: {currentCaptor}.");
         }
 
         try
@@ -1103,17 +1190,17 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
 
             var captorName = newCaptor.Name?.ToString() ?? newCaptor.StringId;
 
-            return
+            return Succeeded(
                 "Hero captured successfully.\n" +
                 $"Hero: {GetHeroDisplayName(hero)}\n" +
                 $"Captor: {captorName}\n" +
-                $"Captor StringId: {newCaptor.StringId}";
+                $"Captor StringId: {newCaptor.StringId}");
         }
         catch (Exception ex)
         {
-            return CommandHelpers.FormatException(
+            return Failed(CommandHelpers.FormatException(
                 $"Failed to capture hero '{GetHeroDisplayName(hero)}' by '{newCaptor.StringId}'",
-                ex);
+                ex));
         }
     }
 

--- a/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
+++ b/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
@@ -1,4 +1,6 @@
-﻿using Common;
+﻿using System;
+using Common.Commands;
+using Common;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -9,40 +11,67 @@ namespace GameInterface.Services.Save.Commands
 {
     public class SaveDebugCommand
     {
+        private static CoopCommandResult Succeeded(string output) =>
+            new CoopCommandResult(true, output);
+
+        private static CoopCommandResult Failed(string output) =>
+            new CoopCommandResult(false, output, "command_failed");
+
         private static readonly Regex SafeSaveName = new("^[A-Za-z0-9_-]{1,64}$");
 
 #if DEBUG
         private static int evidenceHoldMilliseconds;
 #endif
 
-        [CommandLineArgumentFunction("save_as", "coop.debug.save")]
-        public static string SaveAs(List<string> args)
+        public sealed class SaveSaveAsCoopCommand : ICoopCommand
         {
-            if (!ModInformation.IsServer)
-                return "Command can only be run on the server.";
-            if (args.Count != 1 || !SafeSaveName.IsMatch(args[0]))
-                return "Usage: coop.debug.save.save_as <1-64 letters, digits, underscores, or hyphens>";
+            public string Prefix => "coop.debug.save";
 
-            SaveHandler saveHandler = Campaign.Current?.SaveHandler;
-            if (saveHandler == null)
-                return "No active campaign / SaveHandler.";
-            if (saveHandler.IsSaving)
-                return "A save is already queued.";
+            public string Name => "save_as";
 
-            saveHandler.SaveAs(args[0]);
-            return $"Enqueued save as {args[0]} on the server.";
+            public string Description => "Runs the save as debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("save_name", "A save name using 1 through 64 letters, digits, underscores, or hyphens.", isRequired: true),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+                if (!ModInformation.IsServer)
+                    return Failed("Command can only be run on the server.");
+                if (!SafeSaveName.IsMatch(args[0]))
+                    return Failed("Save name must contain 1 through 64 letters, digits, underscores, or hyphens.");
+
+                SaveHandler saveHandler = Campaign.Current?.SaveHandler;
+                if (saveHandler == null)
+                    return Failed("No active campaign / SaveHandler.");
+                if (saveHandler.IsSaving)
+                    return Failed("A save is already queued.");
+
+                saveHandler.SaveAs(args[0]);
+                return Succeeded($"Enqueued save as {args[0]} on the server.");
+            }
         }
 
-        [CommandLineArgumentFunction("state", "coop.debug.save")]
-        public static string State(List<string> args)
+        public sealed class SaveStateCoopCommand : ICoopCommand
         {
-            if (args.Count != 0)
-                return "Usage: coop.debug.save.state";
+            public string Prefix => "coop.debug.save";
 
-            SaveHandler saveHandler = Campaign.Current?.SaveHandler;
-            return saveHandler == null
-                ? "saveHandler=unavailable"
-                : $"saveHandler=ready|isSaving={saveHandler.IsSaving}";
+            public string Name => "state";
+
+            public string Description => "Reports state.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+
+                SaveHandler saveHandler = Campaign.Current?.SaveHandler;
+                return Succeeded(saveHandler == null
+                    ? "saveHandler=unavailable"
+                    : $"saveHandler=ready|isSaving={saveHandler.IsSaving}");
+            }
         }
 
         /// <summary>
@@ -50,57 +79,69 @@ namespace GameInterface.Services.Save.Commands
         /// client save block can be exercised on demand. On a client SetSaveArgs is blocked, so
         /// nothing is enqueued and no file is written; on the host a save file appears.
         /// </summary>
-        [CommandLineArgumentFunction("force_autosave", "coop.debug.save")]
-        public static string ForceAutoSave(List<string> args)
+        public sealed class SaveForceAutosaveCoopCommand : ICoopCommand
         {
-            if (Campaign.Current?.SaveHandler == null) return "No active campaign / SaveHandler.";
+            public string Prefix => "coop.debug.save";
 
-            int holdMilliseconds = 0;
-            if (args.Count > 1 ||
-                (args.Count == 1 &&
-                 (int.TryParse(args[0], out holdMilliseconds) == false ||
-                  holdMilliseconds < 1 ||
-                  holdMilliseconds > 5000)))
+            public string Name => "force_autosave";
+
+            public string Description => "Runs the force autosave debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.save.force_autosave [evidence hold milliseconds from 1 to 5000]";
-            }
+                new ExpectedArgs("evidence_hold_milliseconds", "The optional evidence hold from 1 through 5000 milliseconds.", isRequired: false),
+            };
 
-#if DEBUG
-            if (args.Count == 1)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                if (ModInformation.IsClient)
-                {
-                    return "The evidence hold is server-only.";
-                }
+                            if (Campaign.Current?.SaveHandler == null) return Failed("No active campaign / SaveHandler.");
 
-                if (Campaign.Current.SaveHandler.IsSaving)
-                {
-                    return "Cannot add an evidence hold while a save is already queued.";
-                }
+                            int holdMilliseconds = 0;
+                            if (args.Count == 1 &&
+                                (int.TryParse(args[0], out holdMilliseconds) == false ||
+                                 holdMilliseconds < 1 ||
+                                 holdMilliseconds > 5000))
+                            {
+                                return Failed("Evidence hold must be an integer from 1 through 5000 milliseconds.");
+                            }
+
+                #if DEBUG
+                            if (args.Count == 1)
+                            {
+                                if (ModInformation.IsClient)
+                                {
+                                    return Failed("The evidence hold is server-only.");
+                                }
+
+                                if (Campaign.Current.SaveHandler.IsSaving)
+                                {
+                                    return Failed("Cannot add an evidence hold while a save is already queued.");
+                                }
+                            }
+                #else
+                            if (args.Count == 1)
+                            {
+                                return Failed("The evidence hold is only available in DEBUG builds.");
+                            }
+                #endif
+
+                            Campaign.Current.SaveHandler.ForceAutoSave();
+
+                #if DEBUG
+                            if (args.Count == 1)
+                            {
+                                if (Campaign.Current.SaveHandler.IsSaving == false)
+                                {
+                                    return Failed("Autosaves are disabled; no save was enqueued.");
+                                }
+
+                                Interlocked.Exchange(ref evidenceHoldMilliseconds, holdMilliseconds);
+                            }
+                #endif
+
+                            string side = ModInformation.IsClient ? "client (save should be BLOCKED)" : "host (save should succeed)";
+                            return Succeeded($"Enqueued autosave on {side}. Check the Saves folder.");
             }
-#else
-            if (args.Count == 1)
-            {
-                return "The evidence hold is only available in DEBUG builds.";
-            }
-#endif
-
-            Campaign.Current.SaveHandler.ForceAutoSave();
-
-#if DEBUG
-            if (args.Count == 1)
-            {
-                if (Campaign.Current.SaveHandler.IsSaving == false)
-                {
-                    return "Autosaves are disabled; no save was enqueued.";
-                }
-
-                Interlocked.Exchange(ref evidenceHoldMilliseconds, holdMilliseconds);
-            }
-#endif
-
-            string side = ModInformation.IsClient ? "client (save should be BLOCKED)" : "host (save should succeed)";
-            return $"Enqueued autosave on {side}. Check the Saves folder.";
         }
 
         internal static void HoldForEvidenceIfRequested()

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -1490,13 +1490,13 @@ public class SiegeDebugCommand
 
             if (settlement.SiegeEvent == null)
             {
-                var finalizedRestoreResult = PartyCommands.RestorePositionCommand(new List<string>
+                string finalizedRestoreResult = PartyCommands.RestorePartyPosition(new List<string>
                 {
                     leader.StringId,
                     args[1],
                     args[2],
                     args[3],
-                });
+                }).Output;
                 return Succeeded($"Finalized the assault and stopped the siege of {settlement.Name}\n" + finalizedRestoreResult);
             }
 
@@ -1516,16 +1516,15 @@ public class SiegeDebugCommand
                     $"{settlement.SiegeEvent.BesiegerCamp?._besiegerParties.Count ?? 0} parties remain");
             }
 
-            var restoreResult = PartyCommands.RestorePositionCommand(new List<string>
+            string restoreResult = PartyCommands.RestorePartyPosition(new List<string>
             {
                 leader.StringId,
                 args[1],
                 args[2],
                 args[3],
-            });
+            }).Output;
             return Succeeded($"Stopped the siege of {settlement.Name} led by {leader.Name} ({leader.StringId})\n" +
                 restoreResult);
-
         }
     }
 

--- a/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
+++ b/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System;
+using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using GameInterface.Configuration;
@@ -18,6 +20,12 @@ namespace GameInterface.Services.Smithing.Commands;
 
 internal class SmithingCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<SmithingCommands>();
 
     /// <summary>
@@ -34,337 +42,429 @@ internal class SmithingCommands
     /// <summary>
     /// Give debug crafting materials to heroes with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givesupplies", "coop.debug.crafting")]
-    public static string SmithingSuppliesCommand(List<string> strings)
+    public sealed class CraftingGiveSuppliesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Name => "give_supplies";
 
-        if (TryGetObjectManager(out var objectManager) == false)
-        {
-            return "Unable to resolve ObjectManager.";
-        }
+        public string Description => "Runs the give supplies debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false)
             {
-                var itemsToAdd = new Dictionary<string, int>()
-                {
-                    { "hardwood", 100 },
-                    { "iron", 50 },
-                    { "charcoal", 100 },
-                    { "ironIngot1", 50 },
-                    { "ironIngot2", 50 },
-                    { "ironIngot3", 50 },
-                    { "ironIngot4", 50 },
-                    { "ironIngot5", 50 },
-                    { "ironIngot6", 50 },
-                    { "empire_sword_4_t4", 3 }
-                };
-
-                foreach (var itemId in itemsToAdd.Keys)
-                {
-                    if (!objectManager.TryGetObject(itemId, out ItemObject itemObject)) 
-                    {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
-                    }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
-                    }
-                }
-
-                stringBuilder.AppendLine(strings[0] + " was given smithing supplies.");
+                return Failed("Unable to resolve ObjectManager.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
+            {
+                if (hero.Name.ToString() == strings[0])
+                {
+                    var itemsToAdd = new Dictionary<string, int>()
+                    {
+                        { "hardwood", 100 },
+                        { "iron", 50 },
+                        { "charcoal", 100 },
+                        { "ironIngot1", 50 },
+                        { "ironIngot2", 50 },
+                        { "ironIngot3", 50 },
+                        { "ironIngot4", 50 },
+                        { "ironIngot5", 50 },
+                        { "ironIngot6", 50 },
+                        { "empire_sword_4_t4", 3 }
+                    };
+
+                    foreach (var itemId in itemsToAdd.Keys)
+                    {
+                        if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
+                        }
+                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given smithing supplies.");
+                }
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Unlock all crafting pieces on a client
     /// OpenPart is patched to already update CoopSession and persist across sessions
     /// </summary>
-    [CommandLineArgumentFunction("unlockallcraftingpieces", "coop.debug.crafting")]
-    public static string UnlockAllCraftingPiecesCommand(List<string> strings)
+    public sealed class CraftingUnlockAllCraftingPiecesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Command can only be run on a client.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
-            return "Cheats are currently disabled on clients. Enable in mod-config.";
+        public string Name => "unlock_all_crafting_pieces";
 
-        var craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-        if (craftingCampaignBehavior == null)
-            return "Unable to get crafting campaign behavior.";
+        public string Description => "Runs the unlock all crafting pieces debug operation.";
 
-        foreach (var craftingTemplate in CraftingTemplate.All)
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (var craftingPiece in craftingTemplate.Pieces)
-            {
-                // Turn off notification, otherwise unlocking client gets hundreds of notifications
-                craftingCampaignBehavior.OpenPart(craftingPiece, craftingTemplate, false);
-            }
-        }
+            if (ModInformation.IsServer)
+                return Failed("Command can only be run on a client.");
 
-        return "All crafting pieces unlocked.";
+            if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
+                return Failed("Cheats are currently disabled on clients. Enable in mod-config.");
+
+            var craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+            if (craftingCampaignBehavior == null)
+                return Failed("Unable to get crafting campaign behavior.");
+
+            foreach (var craftingTemplate in CraftingTemplate.All)
+            {
+                foreach (var craftingPiece in craftingTemplate.Pieces)
+                {
+                    // Turn off notification, otherwise unlocking client gets hundreds of notifications
+                    craftingCampaignBehavior.OpenPart(craftingPiece, craftingTemplate, false);
+                }
+            }
+
+            return Succeeded("All crafting pieces unlocked.");
+        }
     }
 
     /// <summary>
     /// View town orders for a specified town
     /// </summary>
-    [CommandLineArgumentFunction("townorders", "coop.debug.crafting")]
-    public static string ViewTownOrdersCommand(List<string> strings)
+    public sealed class CraftingTownOrdersCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0) return "Town name argument required.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Name => "town_orders";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var town in Town.AllTowns)
+        public string Description => "Runs the town orders debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (town.Name.ToString() == strings[0])
+            new ExpectedArgs("town_name", "The exact town display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var town in Town.AllTowns)
             {
-                stringBuilder.AppendLine("Target town " + town.Name.ToString() + " has orders:");
-                CraftingOrder[] slots = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftingOrders[town].Slots;
-                foreach (CraftingOrder order in slots)
+                if (town.Name.ToString() == strings[0])
                 {
-                    stringBuilder.AppendLine("Order slot: " + order?.OrderDifficulty + " for hero: " + order?.OrderOwner);
+                    stringBuilder.AppendLine("Target town " + town.Name.ToString() + " has orders:");
+                    CraftingOrder[] slots = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftingOrders[town].Slots;
+                    foreach (CraftingOrder order in slots)
+                    {
+                        stringBuilder.AppendLine("Order slot: " + order?.OrderDifficulty + " for hero: " + order?.OrderOwner);
+                    }
                 }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Town not found.");
         }
-        return "Town not found.";
     }
 
     /// <summary>
     /// Add orders to a town by a hero in that town
     /// </summary>
-    [CommandLineArgumentFunction("addtownorder", "coop.debug.crafting")]
-    public static string AddTestingTownOrderCommand(List<string> strings)
+    public sealed class CraftingAddTownOrderCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (strings.Count == 0) return "Hero name argument required.";
+        public string Name => "add_town_order";
 
-        var heroName = strings[0]; // Example hero name: "Vaminesa the Minter"
+        public string Description => "Runs the add town order debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == heroName)
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            var heroName = strings[0]; // Example hero name: "Vaminesa the Minter"
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                for (int i = 0; i < 6; i++)
+                if (hero.Name.ToString() == heroName)
                 {
-                    Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>().CreateTownOrder(hero, i);
+                    for (int i = 0; i < 6; i++)
+                    {
+                        Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>().CreateTownOrder(hero, i);
+                    }
+
+                    stringBuilder.AppendLine("Orders have been added for " + heroName + " in " + hero.CurrentSettlement.Town.Name.ToString());
                 }
-
-                stringBuilder.AppendLine("Orders have been added for " + heroName + " in " + hero.CurrentSettlement.Town.Name.ToString());
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Town not found.");
         }
-        return "Town not found.";
     }
 
     /// <summary>
     /// Add all existing crafted items to a given hero
     /// </summary>
-    [CommandLineArgumentFunction("addcrafteditems", "coop.debug.crafting")]
-    public static string AddCraftedItemCommand(List<string> strings)
+    public sealed class CraftingAddCraftedItemsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (strings.Count == 0) return "Hero name argument required.";
+        public string Name => "add_crafted_items";
 
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Description => "Runs the add crafted items debug operation.";
 
-        var craftedItemPrefix = "crafted_item_";
-
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            var craftedItemPrefix = "crafted_item_";
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                int craftedItemCount = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftedItemCount;
-                for (int i = 0; i < craftedItemCount; i++)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    string craftedItemId = craftedItemPrefix + i.ToString();
-                    if (!objectManager.TryGetObject(craftedItemId, out ItemObject itemObject))
+                    int craftedItemCount = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftedItemCount;
+                    for (int i = 0; i < craftedItemCount; i++)
                     {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + craftedItemId);
+                        string craftedItemId = craftedItemPrefix + i.ToString();
+                        if (!objectManager.TryGetObject(craftedItemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + craftedItemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, 1);
+                        }
                     }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, 1);
-                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given all crafted items.");
                 }
-
-                stringBuilder.AppendLine(strings[0] + " was given all crafted items.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Town not found.");
         }
-        return "Town not found.";
     }
 
     /// <summary>
     /// View crafting stamina of all heroes in party on client and all heroes on server
     /// </summary>
-    [CommandLineArgumentFunction("stamina", "coop.debug.crafting")]
-    public static string ViewCraftingStaminaCommand(List<string> strings)
+    public sealed class CraftingStaminaCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+        public string Prefix => "coop.debug.crafting";
 
-        foreach (var heroCraftingRecord in craftingCampaignBehavior._heroCraftingRecords)
+        public string Name => "stamina";
+
+        public string Description => "Runs the stamina debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (ModInformation.IsServer || heroCraftingRecord.Key.PartyBelongedTo == Hero.MainHero.PartyBelongedTo)
+            StringBuilder stringBuilder = new StringBuilder();
+            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+
+            foreach (var heroCraftingRecord in craftingCampaignBehavior._heroCraftingRecords)
             {
-                stringBuilder.AppendLine($"{heroCraftingRecord.Key.Name} ({heroCraftingRecord.Key.StringId}): {heroCraftingRecord.Value.CraftingStamina}");
+                if (ModInformation.IsServer || heroCraftingRecord.Key.PartyBelongedTo == Hero.MainHero.PartyBelongedTo)
+                {
+                    stringBuilder.AppendLine($"{heroCraftingRecord.Key.Name} ({heroCraftingRecord.Key.StringId}): {heroCraftingRecord.Value.CraftingStamina}");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("No hero crafting stamina data was found.");
         }
-        return "No hero crafting stamina data was found.";
     }
 
     /// <summary>
     /// View crafted item history, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("crafteditemhistory", "coop.debug.crafting")]
-    public static string ViewCraftedItemHistoryCommand(List<string> strings)
+    public sealed class CraftingCraftedItemHistoryCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
+        public string Prefix => "coop.debug.crafting";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Name => "crafted_item_history";
+
+        public string Description => "Runs the crafted item history debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (KeyValuePair<string, List<string>> craftedItemHistory in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerCraftedItemsHistory)
+            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                stringBuilder.AppendLine(craftedItemHistory.Key);
-                foreach (string craftedItemId in craftedItemHistory.Value)
+                foreach (KeyValuePair<string, List<string>> craftedItemHistory in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerCraftedItemsHistory)
                 {
-                    stringBuilder.AppendLine(craftedItemId);
+                    stringBuilder.AppendLine(craftedItemHistory.Key);
+                    foreach (string craftedItemId in craftedItemHistory.Value)
+                    {
+                        stringBuilder.AppendLine(craftedItemId);
+                    }
                 }
             }
-        }
-        else
-        {
-            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-            foreach (ItemObject item in craftingCampaignBehavior._cratingItemsHistory)
+            else
             {
-                stringBuilder.AppendLine(item.StringId);
+                CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+                foreach (ItemObject item in craftingCampaignBehavior._cratingItemsHistory)
+                {
+                    stringBuilder.AppendLine(item.StringId);
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Error finding crafting player data or no crafted item history");
         }
-        return "Error finding crafting player data or no crafted item history";
     }
 
     /// <summary>
     /// View crafted pieces xp, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("craftingpiecesxp", "coop.debug.crafting")]
-    public static string ViewPartsXpCommand(List<string> strings)
+    public sealed class CraftingCraftingPiecesXpCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
+        public string Prefix => "coop.debug.crafting";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Name => "crafting_pieces_xp";
+
+        public string Description => "Runs the crafting pieces xp debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (KeyValuePair<string, Dictionary<string, float>> playerPartXp in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenNewPartXpDictionary)
+            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                stringBuilder.AppendLine(playerPartXp.Key);
-                foreach (KeyValuePair<string, float> partXp in playerPartXp.Value)
+                foreach (KeyValuePair<string, Dictionary<string, float>> playerPartXp in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenNewPartXpDictionary)
+                {
+                    stringBuilder.AppendLine(playerPartXp.Key);
+                    foreach (KeyValuePair<string, float> partXp in playerPartXp.Value)
+                    {
+                        stringBuilder.AppendLine(partXp.Key + ": " + partXp.Value);
+                    }
+                }
+            }
+            else
+            {
+                CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+                foreach (KeyValuePair<CraftingTemplate, float> partXp in craftingCampaignBehavior._openNewPartXpDictionary)
                 {
                     stringBuilder.AppendLine(partXp.Key + ": " + partXp.Value);
                 }
             }
-        }
-        else
-        {
-            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-            foreach (KeyValuePair<CraftingTemplate, float> partXp in craftingCampaignBehavior._openNewPartXpDictionary)
-            {
-                stringBuilder.AppendLine(partXp.Key + ": " + partXp.Value);
-            }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Error finding crafting player data or no parts xp data");
         }
-        return "Error finding crafting player data or no parts xp data";
     }
 
     /// <summary>
     /// View unlocked crafted pieces, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("unlockedcraftingpieces", "coop.debug.crafting")]
-    public static string ViewUnlockedCraftingPieces(List<string> strings)
+    public sealed class CraftingUnlockedCraftingPiecesCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
+        public string Prefix => "coop.debug.crafting";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Name => "unlocked_crafting_pieces";
+
+        public string Description => "Runs the unlocked crafting pieces debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (KeyValuePair<string, Dictionary<string, List<string>>> playerUnlockedPieces in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenedPartsDictionary)
+            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                stringBuilder.AppendLine(playerUnlockedPieces.Key);
-                foreach (KeyValuePair<string, List<string>> templateUnlockedPieces in playerUnlockedPieces.Value)
+                foreach (KeyValuePair<string, Dictionary<string, List<string>>> playerUnlockedPieces in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenedPartsDictionary)
+                {
+                    stringBuilder.AppendLine(playerUnlockedPieces.Key);
+                    foreach (KeyValuePair<string, List<string>> templateUnlockedPieces in playerUnlockedPieces.Value)
+                    {
+                        stringBuilder.AppendLine(templateUnlockedPieces.Key + ": " + templateUnlockedPieces.Value.Count);
+                    }
+                }
+            }
+            else
+            {
+                CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+                foreach (KeyValuePair<CraftingTemplate, List<CraftingPiece>> templateUnlockedPieces in craftingCampaignBehavior._openedPartsDictionary)
                 {
                     stringBuilder.AppendLine(templateUnlockedPieces.Key + ": " + templateUnlockedPieces.Value.Count);
                 }
             }
-        }
-        else
-        {
-            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-            foreach (KeyValuePair<CraftingTemplate, List<CraftingPiece>> templateUnlockedPieces in craftingCampaignBehavior._openedPartsDictionary)
-            {
-                stringBuilder.AppendLine(templateUnlockedPieces.Key + ": " + templateUnlockedPieces.Value.Count);
-            }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Error finding crafting player data or no unlocked parts");
         }
-        return "Error finding crafting player data or no unlocked parts";
     }
 }

--- a/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
+++ b/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using Common.Commands;
+using System.Collections.Generic;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Template.Commands;
@@ -8,12 +10,28 @@ namespace GameInterface.Services.Template.Commands;
 /// </summary>
 internal class TemplateCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// TODO fill me out
     /// </summary>
-    [CommandLineArgumentFunction("template", "coop.debug")]
-    public static string TemplateCommand(List<string> strings)
+    public sealed class TemplateCoopCommand : ICoopCommand
     {
-        return "This is a template command";
+        public string Prefix => "coop.debug";
+
+        public string Name => "template";
+
+        public string Description => "Runs the template debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return Succeeded("This is a template command");
+        }
     }
 }

--- a/source/GameInterface/Services/Time/Commands/TimeCommands.cs
+++ b/source/GameInterface/Services/Time/Commands/TimeCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.Heroes.Interaces;
@@ -13,100 +14,155 @@ namespace GameInterface.Services.Time.Commands;
 
 internal class TimeCommands
 {
-    [CommandLineArgumentFunction("get_time_mode", "coop.debug")]
-    public static string GetTimeMode(List<string> strings)
-    {
-        if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
-        {
-            return "Failed to get time control interface";
-        }
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 
-        return $"{timeControlInterface.GetTimeControl()}";
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class GetTimeModeCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug";
+
+        public string Name => "get_time_mode";
+
+        public string Description => "Reports get time mode.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
+            {
+                return Failed("Failed to get time control interface");
+            }
+
+            return Succeeded($"{timeControlInterface.GetTimeControl()}");
+        }
     }
 
-    [CommandLineArgumentFunction("set_time_mode", "coop.debug")]
-    public static string SetTimeMode(List<string> strings)
+    public sealed class SetTimeModeCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer)
+            public string Prefix => "coop.debug";
+
+            public string Name => "set_time_mode";
+
+            public string Description => "Runs the set time mode debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+        #if DEBUG
+                new ExpectedArgs("force_live_test", "The DEBUG live-test override token.", isRequired: false),
+        #endif
+            };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            return "set_time_mode must be run on the server/host.";
+                    if (!ModInformation.IsServer)
+                    {
+                        return Failed("set_time_mode must be run on the server/host.");
+                    }
+
+            #if DEBUG
+                    bool forceForLiveTest = strings.Count == 2 &&
+                        strings[1].Equals("force-live-test", StringComparison.OrdinalIgnoreCase);
+                    if (strings.Count == 2 && !forceForLiveTest)
+                        return Failed("The optional override token must be force-live-test.");
+            #endif
+
+                    if (!Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
+                        return Failed($"Invalid time mode '{strings[0]}'. Expected Pause, Play_1x, or Play_2x.");
+
+                    if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
+                    {
+                        return Failed("Failed to get time control interface");
+                    }
+
+            #if DEBUG
+                    if (forceForLiveTest)
+                    {
+                        timeControlInterface.ServerSetTimeControlForLiveTest(timeMode);
+                        return Succeeded($"Time control force-set for live testing to {timeControlInterface.GetTimeControl()}");
+                    }
+            #endif
+
+                    timeControlInterface.ServerSetTimeControl(timeMode);
+                    return Succeeded($"Time control set to {timeControlInterface.GetTimeControl()}");
         }
-
-#if DEBUG
-        bool forceForLiveTest = strings.Count == 2 &&
-            strings[1].Equals("force-live-test", StringComparison.OrdinalIgnoreCase);
-#else
-        const bool forceForLiveTest = false;
-#endif
-
-        if ((strings.Count != 1 && !forceForLiveTest) ||
-            !Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
-        {
-            return "Usage: coop.debug.set_time_mode <Pause|Play_1x|Play_2x>";
-        }
-
-        if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
-        {
-            return "Failed to get time control interface";
-        }
-
-#if DEBUG
-        if (forceForLiveTest)
-        {
-            timeControlInterface.ServerSetTimeControlForLiveTest(timeMode);
-            return $"Time control force-set for live testing to {timeControlInterface.GetTimeControl()}";
-        }
-#endif
-
-        timeControlInterface.ServerSetTimeControl(timeMode);
-        return $"Time control set to {timeControlInterface.GetTimeControl()}";
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("request_time_mode", "coop.debug")]
-    public static string RequestTimeMode(List<string> strings)
+    public sealed class RequestTimeModeCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "request_time_mode must be run on a client.";
-        if (strings.Count != 1 ||
-            !Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
-            return "Usage: coop.debug.request_time_mode <Pause|Play_1x|Play_2x>";
+        public string Prefix => "coop.debug";
 
-        MessageBroker.Instance.Publish(typeof(TimeCommands), new TimeSpeedChangedAttempted(timeMode));
-        return $"Requested time control {timeMode}.";
+        public string Name => "request_time_mode";
+
+        public string Description => "Runs the request time mode debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsServer)
+                return Failed("request_time_mode must be run on a client.");
+            if (!Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
+                return Failed($"Invalid time mode '{strings[0]}'. Expected Pause, Play_1x, or Play_2x.");
+
+            MessageBroker.Instance.Publish(typeof(TimeCommands), new TimeSpeedChangedAttempted(timeMode));
+            return Succeeded($"Requested time control {timeMode}.");
+        }
     }
 #endif
 
-    [CommandLineArgumentFunction("advance_time", "coop.debug")]
-    public static string AdvanceTime(List<string> strings)
+    public sealed class AdvanceTimeCoopCommand : ICoopCommand
     {
-        // Time is authoritative on the server; advancing it elsewhere would just be
-        // overwritten by the next server sync.
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug";
+
+        public string Name => "advance_time";
+
+        public string Description => "Runs the advance time debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "advance_time must be run on the server/host. The server is authoritative for campaign time.";
-        }
+            new ExpectedArgs("days", "The number of campaign days to advance.", isRequired: false),
+        };
 
-        if (Campaign.Current == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            return "No campaign is currently loaded.";
+            // Time is authoritative on the server; advancing it elsewhere would just be
+            // overwritten by the next server sync.
+            if (ModInformation.IsClient)
+            {
+                return Failed("advance_time must be run on the server/host. The server is authoritative for campaign time.");
+            }
+
+            if (Campaign.Current == null)
+            {
+                return Failed("No campaign is currently loaded.");
+            }
+
+            float days = 5f;
+            if (strings.Count > 0)
+            {
+                if (!float.TryParse(strings[0], out days))
+                    return Failed("Days must be a valid number.");
+            }
+
+            if (!ContainerProvider.TryResolve<IMapTimeTrackerInterface>(out var mapTimeTrackerInterface))
+            {
+                return Failed("Failed to get map time tracker interface");
+            }
+
+            long ticks = CampaignTime.Days(days).NumTicks;
+            mapTimeTrackerInterface.AdvanceTime(ticks);
+
+            return Succeeded($"Advanced campaign time forward by {days} day(s) ({ticks} ticks). " +
+                $"Connected clients should apply the jump on the next time update.");
         }
-
-        float days = 5f;
-        if (strings.Count > 0 && float.TryParse(strings[0], out var parsedDays))
-        {
-            days = parsedDays;
-        }
-
-        if (!ContainerProvider.TryResolve<IMapTimeTrackerInterface>(out var mapTimeTrackerInterface))
-        {
-            return "Failed to get map time tracker interface";
-        }
-
-        long ticks = CampaignTime.Days(days).NumTicks;
-        mapTimeTrackerInterface.AdvanceTime(ticks);
-
-        return $"Advanced campaign time forward by {days} day(s) ({ticks} ticks). " +
-            $"Connected clients should apply the jump on the next time update.";
     }
 }

--- a/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
@@ -1,4 +1,6 @@
-﻿using Common.Messaging;
+﻿using System;
+using Common.Commands;
+using Common.Messaging;
 using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
@@ -16,6 +18,12 @@ namespace GameInterface.Services.UI.Commands;
 /// </summary>
 public class SteamDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     [CommandLineArgumentFunction("status", "coop.debug.steam")]
     public static string Status(List<string> args)
     {
@@ -32,36 +40,57 @@ public class SteamDebugCommand
         return $"Steam integration active; advertising={advertiser.IsAdvertising}";
     }
 
-    [CommandLineArgumentFunction("host_lobby", "coop.debug.steam")]
-    public static string HostLobby(List<string> args)
+    public sealed class SteamHostLobbyCoopCommand : ICoopCommand
     {
-        if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive";
-        if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "No session advertiser; join a session first";
-        if (!ContainerProvider.TryResolve<ISessionJoinInfoSource>(out var joinInfoSource)) return "No join info source; join a session first";
-        if (!ContainerProvider.TryResolve<INetworkConfig>(out var networkConfig)) return "No network config; join a session first";
-        if (!ContainerProvider.TryResolve<ISessionTunnelHost>(out var tunnelHost)) return "No session tunnel host; join a session first";
+        public string Prefix => "coop.debug.steam";
 
-        // Only the host's own client (connected over loopback) may advertise the session; a
-        // tunneled joiner's loopback address is its own join pump, not a local server.
-        if (networkConfig.IsTunneled || !TunnelAdvertisement.IsLoopbackAddress(networkConfig.Address))
-            return "Run coop.debug.steam.host_lobby on the host's own client (connected to localhost)";
+        public string Name => "host_lobby";
 
-        var info = joinInfoSource.Get();
-        TunnelAdvertisement.StartAndStamp(tunnelHost, networkConfig, info);
+        public string Description => "Runs the host lobby debug operation.";
 
-        advertiser.Advertise(info);
-        return $"Advertising session (address='{info.Address}', port={info.Port}, version={info.Version})";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!SessionDiscovery.SteamAvailable) return Failed("Steam integration inactive");
+            if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return Failed("No session advertiser; join a session first");
+            if (!ContainerProvider.TryResolve<ISessionJoinInfoSource>(out var joinInfoSource)) return Failed("No join info source; join a session first");
+            if (!ContainerProvider.TryResolve<INetworkConfig>(out var networkConfig)) return Failed("No network config; join a session first");
+            if (!ContainerProvider.TryResolve<ISessionTunnelHost>(out var tunnelHost)) return Failed("No session tunnel host; join a session first");
+
+            // Only the host's own client (connected over loopback) may advertise the session; a
+            // tunneled joiner's loopback address is its own join pump, not a local server.
+            if (networkConfig.IsTunneled || !TunnelAdvertisement.IsLoopbackAddress(networkConfig.Address))
+                return Failed("Run coop.debug.steam.host_lobby on the host's own client (connected to localhost)");
+
+            var info = joinInfoSource.Get();
+            TunnelAdvertisement.StartAndStamp(tunnelHost, networkConfig, info);
+
+            advertiser.Advertise(info);
+            return Succeeded($"Advertising session (address='{info.Address}', port={info.Port}, version={info.Version})");
+        }
     }
 
-    [CommandLineArgumentFunction("invite", "coop.debug.steam")]
-    public static string Invite(List<string> args)
+    public sealed class SteamInviteCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "No session advertiser; join a session first";
-        if (!advertiser.IsAdvertising) return "Not advertising; run coop.debug.steam.host_lobby first or enable Steam invites when connecting";
+        public string Prefix => "coop.debug.steam";
 
-        return advertiser.InviteFriends()
-            ? "Invite dialog opened"
-            : SessionInviteText.OverlayUnavailableHint;
+        public string Name => "invite";
+
+        public string Description => "Runs the invite debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return Failed("No session advertiser; join a session first");
+            if (!advertiser.IsAdvertising) return Failed("Not advertising; run coop.debug.steam.host_lobby first or enable Steam invites when connecting");
+
+            if (!advertiser.InviteFriends())
+                return Failed(SessionInviteText.OverlayUnavailableHint);
+
+            return Succeeded("Invite dialog opened");
+        }
     }
 
     [CommandLineArgumentFunction("join", "coop.debug.steam")]

--- a/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Autofac;
 using GameInterface.Services.UI.Handlers;
 using GameInterface.Utils.Commands;
@@ -8,41 +9,57 @@ namespace GameInterface.Services.UI.Commands;
 
 public class TacticalUnitSymbolsDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private const string CommandName = "coop.debug.ui.tactical_symbols";
-    private const string Usage = "Usage: coop.debug.ui.tactical_symbols <on|off|toggle|status>";
-
-    [CommandLineArgumentFunction("tactical_symbols", "coop.debug.ui")]
-    public static string TacticalSymbols(List<string> args)
+    public sealed class UiTacticalSymbolsCoopCommand : ICoopCommand
     {
-        if (!CommandHelpers.IsServerOnlyCommand(out var error, CommandName)) return error;
-        if (args.Count != 1) return Usage;
+        public string Prefix => "coop.debug.ui";
 
-        switch (args[0].ToLowerInvariant())
+        public string Name => "tactical_symbols";
+
+        public string Description => "Runs the tactical symbols debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "on":
-            case "true":
-            case "1":
-                return Apply(false);
-            case "off":
-            case "false":
-            case "0":
-                return Apply(true);
-            case "toggle":
-                return Apply(!TacticalUnitSymbolsSettings.HideTacticalUnitSymbols);
-            case "status":
-                return StatusText;
-            default:
-                return Usage;
+            new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!CommandHelpers.IsServerOnlyCommand(out var error, CommandName)) return Failed(error);
+
+            switch (args[0].ToLowerInvariant())
+            {
+                case "on":
+                case "true":
+                case "1":
+                    return Apply(false);
+                case "off":
+                case "false":
+                case "0":
+                    return Apply(true);
+                case "toggle":
+                    return Apply(!TacticalUnitSymbolsSettings.HideTacticalUnitSymbols);
+                case "status":
+                    return Succeeded(StatusText);
+                default:
+                    return Failed($"Invalid mode '{args[0]}'. Expected on, off, toggle, or status.");
+            }
         }
     }
 
-    private static string Apply(bool hideTacticalUnitSymbols)
+    private static CoopCommandResult Apply(bool hideTacticalUnitSymbols)
     {
         if (!ContainerProvider.TryResolve<TacticalUnitSymbolsConfigHandler>(out var handler))
-            return "Tactical unit symbols configuration is unavailable.";
+            return Failed("Tactical unit symbols configuration is unavailable.");
 
         handler.SetAndBroadcast(hideTacticalUnitSymbols);
-        return StatusText;
+        return Succeeded(StatusText);
     }
 
     private static string StatusText =>

--- a/source/Missions/Agents/Handlers/MovementDebugCommands.cs
+++ b/source/Missions/Agents/Handlers/MovementDebugCommands.cs
@@ -1,156 +1,218 @@
 ﻿#if DEBUG
+using System;
+using Common.Commands;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using TaleWorlds.MountAndBlade;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace Missions.Agents.Handlers;
 
 internal static class MovementDebugCommands
 {
-    [CommandLineArgumentFunction("state", "coop.debug.movement")]
-    public static string State(List<string> args)
-    {
-        if (args.Count != 0)
-            return "Usage: coop.debug.movement.state";
-        if (!TryGetHandler(out IAgentMovementHandler handler) ||
-            !TryGetDebugControl(handler, out IAgentMovementDebugControl debugControl))
-            return "No active co-op mission movement handler.";
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 
-        MovementRateSnapshot state = handler.MovementRate;
-        int activeHumans = Mission.Current?.Agents.Count(agent =>
-            agent != null && agent.IsActive() && agent.IsHuman) ?? 0;
-        int movingAgents = Mission.Current?.Agents.Count(agent =>
-            agent != null &&
-            agent.IsActive() &&
-            agent.GetRealGlobalVelocity().AsVec2.LengthSquared > 0.01f) ?? 0;
-        return string.Join("|", new[]
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class StateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.movement";
+
+        public string Name => "state";
+
+        public string Description => "Reports state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            $"profile={state.Profile}",
-            $"bulkHz={state.BulkHz}",
-            $"priorityHz={state.PriorityHz}",
-            $"frameLimitHz={state.FrameLimitHz}",
-            $"performanceCeilingHz={state.PerformanceCeilingHz}",
-            $"localAdaptiveHz={state.LocalAdaptiveHz}",
-            $"receiverCapHz={state.AdvertisedReceiverCapHz}",
-            $"peerCapHz={FormatNullable(state.PeerReceiverCapHz)}",
-            $"peerCapSource={state.PeerReceiverCapSource ?? "none"}",
-            $"forcedBulkHz={FormatNullable(state.ForcedBulkHz)}",
-            $"forcedReceiverCapHz={FormatNullable(state.ForcedReceiverCapHz)}",
-            $"activeAgents={state.ActiveAgents}",
-            $"activeHumans={activeHumans}",
-            $"movingAgents={movingAgents}",
-            $"localAgents={state.LocallyControlledAgents}",
-            $"controllers={state.Controllers}",
-            $"fps={state.FramesPerSecond.ToString("0.0", CultureInfo.InvariantCulture)}",
-            $"senderMsPerSecond={state.SenderMillisecondsPerSecond.ToString("0.00", CultureInfo.InvariantCulture)}",
-            $"receiverApplyMsPerSecond={state.ReceiverApplyMillisecondsPerSecond.ToString("0.00", CultureInfo.InvariantCulture)}",
-            $"receiverQueueMs={state.MaximumReceiverQueueMilliseconds.ToString("0.00", CultureInfo.InvariantCulture)}",
-            $"wireBytesPerSecond={state.WireBytesPerSecond}",
-            $"configuredOutgoingBytesPerSecond={state.ConfiguredOutgoingBytesPerSecond}",
-            $"availableOutgoingBytes={handler.AvailableOutgoingMovementBytes}",
-            $"configuredIncomingBytesPerSecond={state.ConfiguredIncomingBytesPerSecond}",
-            $"incomingBytesPerSender={state.AdvertisedIncomingBytesPerSender}",
-            $"focusAgentId={state.FocusAgentId}",
-            $"deferred={state.MaximumDeferredSnapshots}",
-            $"deferredAge={state.MaximumDeferredAgeSeconds.ToString("0.000", CultureInfo.InvariantCulture)}",
-            $"bulkPolls={state.BulkPollsPerSecond}",
-            $"priorityOnlyPolls={state.PriorityOnlyPollsPerSecond}",
-            $"initialConfiguredBulkHz={debugControl.InitialConfiguredBulkHz}",
-            $"syntheticReceivePressureActive={debugControl.SyntheticReceivePressureActive.ToString().ToLowerInvariant()}",
-            $"syntheticReceivePressureRemainingSeconds={debugControl.SyntheticReceivePressureRemainingSeconds.ToString("0.00", CultureInfo.InvariantCulture)}",
-            $"reason={state.Reason}",
-        });
-    }
+            if (!TryGetHandler(out IAgentMovementHandler handler) ||
+                !TryGetDebugControl(handler, out IAgentMovementDebugControl debugControl))
+                return Failed("No active co-op mission movement handler.");
 
-    [CommandLineArgumentFunction("force_rate", "coop.debug.movement")]
-    public static string ForceRate(List<string> args)
-    {
-        if (!TryParseRate(
-                args,
-                "coop.debug.movement.force_rate",
-                "rate",
-                out int? rate,
-                out string error))
-            return error;
-        if (!TryGetHandler(out IAgentMovementHandler handler))
-            return "No active co-op mission movement handler.";
-        if (!handler.TrySetForcedBulkHz(rate, out error))
-            return error;
-
-        return rate.HasValue
-            ? $"MOVEMENT_RATE_FORCED hz={rate.Value}"
-            : "MOVEMENT_RATE_AUTOMATIC";
-    }
-
-    [CommandLineArgumentFunction("force_receiver_cap", "coop.debug.movement")]
-    public static string ForceReceiverCap(List<string> args)
-    {
-        if (!TryParseRate(
-                args,
-                "coop.debug.movement.force_receiver_cap",
-                "receiver cap",
-                out int? rate,
-                out string error))
-        {
-            return error;
+            MovementRateSnapshot state = handler.MovementRate;
+            int activeHumans = Mission.Current?.Agents.Count(agent =>
+                agent != null && agent.IsActive() && agent.IsHuman) ?? 0;
+            int movingAgents = Mission.Current?.Agents.Count(agent =>
+                agent != null &&
+                agent.IsActive() &&
+                agent.GetRealGlobalVelocity().AsVec2.LengthSquared > 0.01f) ?? 0;
+            return Succeeded(string.Join("|", new[]
+            {
+                $"profile={state.Profile}",
+                $"bulkHz={state.BulkHz}",
+                $"priorityHz={state.PriorityHz}",
+                $"frameLimitHz={state.FrameLimitHz}",
+                $"performanceCeilingHz={state.PerformanceCeilingHz}",
+                $"localAdaptiveHz={state.LocalAdaptiveHz}",
+                $"receiverCapHz={state.AdvertisedReceiverCapHz}",
+                $"peerCapHz={FormatNullable(state.PeerReceiverCapHz)}",
+                $"peerCapSource={state.PeerReceiverCapSource ?? "none"}",
+                $"forcedBulkHz={FormatNullable(state.ForcedBulkHz)}",
+                $"forcedReceiverCapHz={FormatNullable(state.ForcedReceiverCapHz)}",
+                $"activeAgents={state.ActiveAgents}",
+                $"activeHumans={activeHumans}",
+                $"movingAgents={movingAgents}",
+                $"localAgents={state.LocallyControlledAgents}",
+                $"controllers={state.Controllers}",
+                $"fps={state.FramesPerSecond.ToString("0.0", CultureInfo.InvariantCulture)}",
+                $"senderMsPerSecond={state.SenderMillisecondsPerSecond.ToString("0.00", CultureInfo.InvariantCulture)}",
+                $"receiverApplyMsPerSecond={state.ReceiverApplyMillisecondsPerSecond.ToString("0.00", CultureInfo.InvariantCulture)}",
+                $"receiverQueueMs={state.MaximumReceiverQueueMilliseconds.ToString("0.00", CultureInfo.InvariantCulture)}",
+                $"wireBytesPerSecond={state.WireBytesPerSecond}",
+                $"configuredOutgoingBytesPerSecond={state.ConfiguredOutgoingBytesPerSecond}",
+                $"availableOutgoingBytes={handler.AvailableOutgoingMovementBytes}",
+                $"configuredIncomingBytesPerSecond={state.ConfiguredIncomingBytesPerSecond}",
+                $"incomingBytesPerSender={state.AdvertisedIncomingBytesPerSender}",
+                $"focusAgentId={state.FocusAgentId}",
+                $"deferred={state.MaximumDeferredSnapshots}",
+                $"deferredAge={state.MaximumDeferredAgeSeconds.ToString("0.000", CultureInfo.InvariantCulture)}",
+                $"bulkPolls={state.BulkPollsPerSecond}",
+                $"priorityOnlyPolls={state.PriorityOnlyPollsPerSecond}",
+                $"initialConfiguredBulkHz={debugControl.InitialConfiguredBulkHz}",
+                $"syntheticReceivePressureActive={debugControl.SyntheticReceivePressureActive.ToString().ToLowerInvariant()}",
+                $"syntheticReceivePressureRemainingSeconds={debugControl.SyntheticReceivePressureRemainingSeconds.ToString("0.00", CultureInfo.InvariantCulture)}",
+                $"reason={state.Reason}",
+            }));
         }
-        if (!TryGetHandler(out IAgentMovementHandler handler))
-            return "No active co-op mission movement handler.";
-        if (!handler.TrySetForcedReceiverCapHz(rate, out error))
-            return error;
-
-        return rate.HasValue
-            ? $"MOVEMENT_RECEIVER_CAP_FORCED hz={rate.Value}"
-            : "MOVEMENT_RECEIVER_CAP_AUTOMATIC";
     }
 
-    [CommandLineArgumentFunction("simulate_receive_pressure", "coop.debug.movement")]
-    public static string SimulateReceivePressure(List<string> args)
+    public sealed class ForceRateCoopCommand : ICoopCommand
     {
-        if (args.Count != 4 ||
-            !float.TryParse(args[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float durationSeconds) ||
-            !double.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double queueMilliseconds) ||
-            !double.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out double applyMilliseconds) ||
-            !int.TryParse(args[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out int snapshots))
-        {
-            return "Usage: coop.debug.movement.simulate_receive_pressure <duration-seconds> <queue-ms> <apply-ms> <snapshots>";
-        }
-        if (!TryGetHandler(out IAgentMovementHandler handler) ||
-            !TryGetDebugControl(handler, out IAgentMovementDebugControl debugControl))
-            return "No active co-op mission movement handler.";
-        if (!debugControl.TrySetSyntheticReceivePressure(
-                durationSeconds,
-                queueMilliseconds,
-                applyMilliseconds,
-                snapshots,
-                out string error))
-        {
-            return error;
-        }
+        public string Prefix => "coop.debug.movement";
 
-        return string.Join(" ", new[]
+        public string Name => "force_rate";
+
+        public string Description => "Runs the force rate debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            "MOVEMENT_RECEIVE_PRESSURE_ACTIVE",
-            $"durationSeconds={durationSeconds.ToString("0.00", CultureInfo.InvariantCulture)}",
-            $"queueMilliseconds={queueMilliseconds.ToString("0.00", CultureInfo.InvariantCulture)}",
-            $"applyMilliseconds={applyMilliseconds.ToString("0.00", CultureInfo.InvariantCulture)}",
-            $"snapshots={snapshots}",
-        });
+            new ExpectedArgs("rate", "The rate.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryParseRate(
+                    args,
+                    "rate",
+                    out int? rate,
+                    out string error))
+                return Failed(error);
+            if (!TryGetHandler(out IAgentMovementHandler handler))
+                return Failed("No active co-op mission movement handler.");
+            if (!handler.TrySetForcedBulkHz(rate, out error))
+                return Failed(error);
+
+            return Succeeded(rate.HasValue
+                ? $"MOVEMENT_RATE_FORCED hz={rate.Value}"
+                : "MOVEMENT_RATE_AUTOMATIC");
+        }
     }
 
-    [CommandLineArgumentFunction("clear_receive_pressure", "coop.debug.movement")]
-    public static string ClearReceivePressure(List<string> args)
+    public sealed class ForceReceiverCapCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.movement.clear_receive_pressure";
-        if (!TryGetHandler(out IAgentMovementHandler handler) ||
-            !TryGetDebugControl(handler, out IAgentMovementDebugControl debugControl))
-            return "No active co-op mission movement handler.";
+        public string Prefix => "coop.debug.movement";
 
-        debugControl.ClearSyntheticReceivePressure();
-        return "MOVEMENT_RECEIVE_PRESSURE_CLEARED";
+        public string Name => "force_receiver_cap";
+
+        public string Description => "Runs the force receiver cap debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("receiver_cap", "The receiver cap.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryParseRate(
+                    args,
+                    "receiver cap",
+                    out int? rate,
+                    out string error))
+            {
+                return Failed(error);
+            }
+            if (!TryGetHandler(out IAgentMovementHandler handler))
+                return Failed("No active co-op mission movement handler.");
+            if (!handler.TrySetForcedReceiverCapHz(rate, out error))
+                return Failed(error);
+
+            return Succeeded(rate.HasValue
+                ? $"MOVEMENT_RECEIVER_CAP_FORCED hz={rate.Value}"
+                : "MOVEMENT_RECEIVER_CAP_AUTOMATIC");
+        }
+    }
+
+    public sealed class SimulateReceivePressureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.movement";
+
+        public string Name => "simulate_receive_pressure";
+
+        public string Description => "Runs the simulate receive pressure debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("duration_seconds", "The duration seconds.", true),
+            new ExpectedArgs("queue_ms", "The queue ms.", true),
+            new ExpectedArgs("apply_ms", "The apply ms.", true),
+            new ExpectedArgs("snapshots", "The snapshots.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!float.TryParse(args[0], NumberStyles.Float, CultureInfo.InvariantCulture, out float durationSeconds) ||
+                !double.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out double queueMilliseconds) ||
+                !double.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out double applyMilliseconds) ||
+                !int.TryParse(args[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out int snapshots))
+            {
+                return Failed("Invalid command argument value.");
+            }
+            if (!TryGetHandler(out IAgentMovementHandler handler) ||
+                !TryGetDebugControl(handler, out IAgentMovementDebugControl debugControl))
+                return Failed("No active co-op mission movement handler.");
+            if (!debugControl.TrySetSyntheticReceivePressure(
+                    durationSeconds,
+                    queueMilliseconds,
+                    applyMilliseconds,
+                    snapshots,
+                    out string error))
+            {
+                return Failed(error);
+            }
+
+            return Succeeded(string.Join(" ", new[]
+            {
+                "MOVEMENT_RECEIVE_PRESSURE_ACTIVE",
+                $"durationSeconds={durationSeconds.ToString("0.00", CultureInfo.InvariantCulture)}",
+                $"queueMilliseconds={queueMilliseconds.ToString("0.00", CultureInfo.InvariantCulture)}",
+                $"applyMilliseconds={applyMilliseconds.ToString("0.00", CultureInfo.InvariantCulture)}",
+                $"snapshots={snapshots}",
+            }));
+        }
+    }
+
+    public sealed class ClearReceivePressureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.movement";
+
+        public string Name => "clear_receive_pressure";
+
+        public string Description => "Restores or clears clear receive pressure.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryGetHandler(out IAgentMovementHandler handler) ||
+                !TryGetDebugControl(handler, out IAgentMovementDebugControl debugControl))
+                return Failed("No active co-op mission movement handler.");
+
+            debugControl.ClearSyntheticReceivePressure();
+            return Succeeded("MOVEMENT_RECEIVE_PRESSURE_CLEARED");
+        }
     }
 
     private static bool TryGetHandler(out IAgentMovementHandler handler)
@@ -170,18 +232,12 @@ internal static class MovementDebugCommands
     }
 
     private static bool TryParseRate(
-        List<string> args,
-        string commandName,
+        IReadOnlyList<string> args,
         string valueName,
         out int? rate,
         out string error)
     {
         rate = null;
-        if (args.Count != 1)
-        {
-            error = $"Usage: {commandName} <auto|10|15|20|30|40|60>";
-            return false;
-        }
         if (args[0].ToLowerInvariant() == "auto")
         {
             error = null;

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using GameInterface;
 using GameInterface.Registry.Auto;
 using GameInterface.Services.MapEvents;
@@ -23,13 +24,18 @@ using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TaleWorlds.MountAndBlade.View.Screens;
 using TaleWorlds.ScreenSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace Missions.Battles;
 
 /// <summary>Reports state needed to verify co-op battle synchronization.</summary>
 internal static class BattleDebugCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly Dictionary<int, Vec3> EnemyPositions = new Dictionary<int, Vec3>();
     private static int ownDamageEvents;
     private static readonly Dictionary<Agent, AgentControllerType> CavalryControllers =
@@ -126,63 +132,72 @@ internal static class BattleDebugCommands
         public Agent[] Agents { get; set; }
     }
 
-    [CommandLineArgumentFunction("replication_fixture", "coop.debug.battle")]
-    public static string ReplicationFixture(List<string> args)
+    public sealed class ReplicationFixtureCoopCommand : ICoopCommand
     {
-        if (args.Count < 1 || args.Count > 2)
-        {
-            return "Usage: coop.debug.battle.replication_fixture <catchup <connectedControllerId>|initial>";
-        }
+        public string Prefix => "coop.debug.battle";
 
-        Mission mission = Mission.Current;
-        CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
-        if (mission == null || controller == null)
-            return "BATTLE_REPLICATION_FIXTURE no active coop battle";
-        if (!BattleSpawnConfig.Enabled || !BattleSpawnGate.IsCoopBattleActive)
-            return "BATTLE_REPLICATION_FIXTURE coop spawn capture is not active";
-        if (!controller.Deployment.IsActivated || !controller.Deployment.IsCommitted)
-            return "BATTLE_REPLICATION_FIXTURE finish local deployment first";
+        public string Name => "replication_fixture";
 
-        ResetReplicationFixtureForMission(mission);
-        switch (args[0].ToLowerInvariant())
+        public string Description => "Runs the replication fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "catchup":
-                return TriggerCatchUpReplicationFixture(controller, args);
-            case "initial":
-                return TriggerInitialReplicationFixture(controller, mission, args);
-            default:
-                return "Usage: coop.debug.battle.replication_fixture <catchup <connectedControllerId>|initial>";
+            new ExpectedArgs("mode", "The mode.", true),
+            new ExpectedArgs("connected_controller_id", "The connected controller id.", false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            Mission mission = Mission.Current;
+            CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
+            if (mission == null || controller == null)
+                return Failed("BATTLE_REPLICATION_FIXTURE no active coop battle");
+            if (!BattleSpawnConfig.Enabled || !BattleSpawnGate.IsCoopBattleActive)
+                return Failed("BATTLE_REPLICATION_FIXTURE coop spawn capture is not active");
+            if (!controller.Deployment.IsActivated || !controller.Deployment.IsCommitted)
+                return Failed("BATTLE_REPLICATION_FIXTURE finish local deployment first");
+
+            ResetReplicationFixtureForMission(mission);
+            switch (args[0].ToLowerInvariant())
+            {
+                case "catchup":
+                    return TriggerCatchUpReplicationFixture(controller, args);
+                case "initial":
+                    return TriggerInitialReplicationFixture(controller, mission, args);
+                default:
+                    return Failed("Invalid command argument value.");
+            }
         }
     }
 
-    private static string TriggerCatchUpReplicationFixture(
+    private static CoopCommandResult TriggerCatchUpReplicationFixture(
         CoopBattleController controller,
-        List<string> args)
+        IReadOnlyList<string> args)
     {
         if (args.Count != 2)
-            return "Usage: coop.debug.battle.replication_fixture catchup <connectedControllerId>";
+            return Failed("Invalid command argument value.");
 
         string target = args[1];
         if (replicationFixtureCatchUpTargets.Contains(target))
-            return $"BATTLE_REPLICATION_FIXTURE_CATCHUP already queued peer={target}";
+            return Failed($"BATTLE_REPLICATION_FIXTURE_CATCHUP already queued peer={target}");
         if (!controller.TryDebugReplayOwnedAgentsToConnectedPeer(target, out string error))
-            return $"BATTLE_REPLICATION_FIXTURE_CATCHUP blocked reason={error}";
+            return Failed($"BATTLE_REPLICATION_FIXTURE_CATCHUP blocked reason={error}");
 
         replicationFixtureCatchUpTargets.Add(target);
-        return $"BATTLE_REPLICATION_FIXTURE_CATCHUP queued peer={target}";
+        return Succeeded($"BATTLE_REPLICATION_FIXTURE_CATCHUP queued peer={target}");
     }
 
-    private static string TriggerInitialReplicationFixture(
+    private static CoopCommandResult TriggerInitialReplicationFixture(
         CoopBattleController controller,
         Mission mission,
-        List<string> args)
+        IReadOnlyList<string> args)
     {
         if (args.Count != 1)
-            return "Usage: coop.debug.battle.replication_fixture initial";
+            return Failed("Invalid command argument value.");
         if (replicationFixtureInitialAgentIndex >= 0)
-            return $"BATTLE_REPLICATION_FIXTURE_INITIAL already queued agentIndex={replicationFixtureInitialAgentIndex}";
+            return Failed($"BATTLE_REPLICATION_FIXTURE_INITIAL already queued agentIndex={replicationFixtureInitialAgentIndex}");
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL network agent registry is unavailable";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL network agent registry is unavailable");
 
         var ownedAgents = registry.GetAgents(controller.Session.OwnControllerId).ToArray();
         Agent source = ownedAgents
@@ -199,7 +214,7 @@ internal static class BattleDebugCommands
                 origin.Party != null &&
                 !string.IsNullOrEmpty(origin.MapEventPartyId));
         if (source == null)
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL no active locally owned troop is available";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL no active locally owned troop is available");
 
         var sourceOrigin = (CoopAgentOrigin)source.Origin;
         var character = (CharacterObject)source.Character;
@@ -211,7 +226,7 @@ internal static class BattleDebugCommands
         while (fixtureSeeds.Contains(fixtureSeed))
         {
             if (fixtureSeed == int.MinValue)
-                return "BATTLE_REPLICATION_FIXTURE_INITIAL no unused fixture seed is available";
+                return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL no unused fixture seed is available");
             fixtureSeed--;
         }
 
@@ -223,7 +238,7 @@ internal static class BattleDebugCommands
             sourceOrigin.Banner,
             new UniqueTroopDescriptor(fixtureSeed));
         if (mission.PlayerTeam == null)
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL the player team is unavailable";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL the player team is unavailable");
 
         bool isPlayerSide = source.Team == mission.PlayerTeam;
         Agent fixtureAgent;
@@ -244,11 +259,11 @@ internal static class BattleDebugCommands
                 formationIndex: source.Formation.FormationIndex);
         }
         if (fixtureAgent == null)
-            return "BATTLE_REPLICATION_FIXTURE_INITIAL native spawn returned no agent";
+            return Failed("BATTLE_REPLICATION_FIXTURE_INITIAL native spawn returned no agent");
 
         replicationFixtureInitialAgentIndex = fixtureAgent.Index;
-        return "BATTLE_REPLICATION_FIXTURE_INITIAL spawned through Mission.SpawnTroop; " +
-               $"agentIndex={fixtureAgent.Index} the normal capture and next controller tick will emit Initial";
+        return Succeeded("BATTLE_REPLICATION_FIXTURE_INITIAL spawned through Mission.SpawnTroop; " +
+               $"agentIndex={fixtureAgent.Index} the normal capture and next controller tick will emit Initial");
     }
 
     private static void ResetReplicationFixtureForMission(Mission mission)
@@ -260,26 +275,36 @@ internal static class BattleDebugCommands
         replicationFixtureInitialAgentIndex = -1;
     }
 
-    [CommandLineArgumentFunction("column_reinforcement_fixture", "coop.debug.battle")]
-    public static string ColumnReinforcementFixture(List<string> args)
+    public sealed class ColumnReinforcementFixtureCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-            return "Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>";
+        public string Prefix => "coop.debug.battle";
 
-        switch (args[0].ToLowerInvariant())
+        public string Name => "column_reinforcement_fixture";
+
+        public string Description => "Runs the column reinforcement fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "start":
-                return StartColumnReinforcementFixture();
-            case "state":
-                return GetColumnReinforcementFixtureState();
-            case "restore":
-                return RestoreColumnReinforcementFixture();
-            default:
-                return "Usage: coop.debug.battle.column_reinforcement_fixture <start|state|restore>";
+            new ExpectedArgs("action", "The action.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            switch (args[0].ToLowerInvariant())
+            {
+                case "start":
+                    return StartColumnReinforcementFixture();
+                case "state":
+                    return GetColumnReinforcementFixtureState();
+                case "restore":
+                    return RestoreColumnReinforcementFixture();
+                default:
+                    return Failed("Invalid command argument value.");
+            }
         }
     }
 
-    private static string StartColumnReinforcementFixture()
+    private static CoopCommandResult StartColumnReinforcementFixture()
     {
         if (columnReinforcementFixtureMission != null &&
             Mission.Current != columnReinforcementFixtureMission)
@@ -287,18 +312,18 @@ internal static class BattleDebugCommands
             ClearColumnReinforcementFixture();
         }
         if (columnReinforcementFixtureMission != null)
-            return "COLUMN_REINFORCEMENT_FIXTURE already active";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE already active");
 
         Mission mission = Mission.Current;
         CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
         DefaultBattleMissionAgentSpawnLogic spawnLogic =
             mission?.GetMissionBehavior<DefaultBattleMissionAgentSpawnLogic>();
         if (mission == null || controller == null || spawnLogic == null)
-            return "COLUMN_REINFORCEMENT_FIXTURE no active coop battle";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE no active coop battle");
         if (!controller.Deployment.IsActivated)
-            return "COLUMN_REINFORCEMENT_FIXTURE finish deployment first";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE finish deployment first");
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable");
 
         ColumnReinforcementCandidate candidate = null;
         foreach (BattleSideEnum side in new[] { BattleSideEnum.Defender, BattleSideEnum.Attacker })
@@ -346,7 +371,7 @@ internal static class BattleDebugCommands
 
         if (candidate == null)
         {
-            return "COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to an eligible locally controlled formation";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE no reserve is assigned to an eligible locally controlled formation");
         }
 
         columnReinforcementFixtureMission = mission;
@@ -361,10 +386,10 @@ internal static class BattleDebugCommands
         foreach (Agent agent in candidate.Agents)
             BattleTeamKillCommands.Kill(agent);
 
-        return "COLUMN_REINFORCEMENT_FIXTURE_STARTED " +
+        return Succeeded("COLUMN_REINFORCEMENT_FIXTURE_STARTED " +
                $"side={candidate.Side} formation={candidate.FormationIndex} " +
                $"killed={candidate.Agents.Length} active=0 " +
-               $"reserved={candidate.SpawnContext.ReservedTroopsCount} arrangement=Column";
+               $"reserved={candidate.SpawnContext.ReservedTroopsCount} arrangement=Column");
     }
 
     private static ColumnReinforcementCandidate FindColumnReinforcementCandidate(
@@ -406,18 +431,18 @@ internal static class BattleDebugCommands
         return null;
     }
 
-    private static string GetColumnReinforcementFixtureState()
+    private static CoopCommandResult GetColumnReinforcementFixtureState()
     {
         if (columnReinforcementFixtureMission == null)
-            return "COLUMN_REINFORCEMENT_FIXTURE inactive";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE inactive");
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE network agent registry is unavailable");
         if (Mission.Current != columnReinforcementFixtureMission ||
             columnReinforcementFixtureFormation == null ||
             columnReinforcementFixtureSpawnContext == null)
         {
             ClearColumnReinforcementFixture();
-            return "COLUMN_REINFORCEMENT_FIXTURE mission ended";
+            return Succeeded("COLUMN_REINFORCEMENT_FIXTURE mission ended");
         }
 
         int active = Mission.Current.Agents.Count(agent => agent != null
@@ -430,7 +455,7 @@ internal static class BattleDebugCommands
             ? column.GetUnitPositionsOnVanguardFileIndex().Count
             : -1;
 
-        return "COLUMN_REINFORCEMENT_FIXTURE_STATE " +
+        return Succeeded("COLUMN_REINFORCEMENT_FIXTURE_STATE " +
                $"side={columnReinforcementFixtureSide} " +
                $"formation={columnReinforcementFixtureFormationIndex} " +
                $"killed={columnReinforcementFixtureKilled} active={active} " +
@@ -438,13 +463,13 @@ internal static class BattleDebugCommands
                $"reserved={columnReinforcementFixtureSpawnContext.ReservedTroopsCount} " +
                $"reinforcementActive={columnReinforcementFixtureSpawnContext.ReinforcementSpawnActive} " +
                $"arrangement={columnReinforcementFixtureFormation.Arrangement.GetType().Name} " +
-               $"vanguardPositions={vanguardPositions}";
+               $"vanguardPositions={vanguardPositions}");
     }
 
-    private static string RestoreColumnReinforcementFixture()
+    private static CoopCommandResult RestoreColumnReinforcementFixture()
     {
         if (columnReinforcementFixtureMission == null)
-            return "COLUMN_REINFORCEMENT_FIXTURE inactive";
+            return Failed("COLUMN_REINFORCEMENT_FIXTURE inactive");
 
         bool missionActive = Mission.Current == columnReinforcementFixtureMission;
         if (missionActive && columnReinforcementFixtureFormation != null)
@@ -452,8 +477,8 @@ internal static class BattleDebugCommands
 
         int killed = columnReinforcementFixtureKilled;
         ClearColumnReinforcementFixture();
-        return "COLUMN_REINFORCEMENT_FIXTURE_RESTORED " +
-               $"arrangementRestored={missionActive} casualtiesRemain={killed}";
+        return Succeeded("COLUMN_REINFORCEMENT_FIXTURE_RESTORED " +
+               $"arrangementRestored={missionActive} casualtiesRemain={killed}");
     }
 
     private static void ClearColumnReinforcementFixture()
@@ -467,106 +492,126 @@ internal static class BattleDebugCommands
         columnReinforcementFixtureKilled = 0;
     }
 
-    [CommandLineArgumentFunction("action_performance", "coop.debug.battle")]
-    public static string ActionPerformance(List<string> args)
+    public sealed class ActionPerformanceCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.battle.action_performance " +
-                   "<start|snapshot|stop|status>";
-        }
+        public string Prefix => "coop.debug.battle";
 
-        switch (args[0].ToLowerInvariant())
+        public string Name => "action_performance";
+
+        public string Description => "Runs the action performance debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "start":
-                MissionActionDiagnostics.StartPerformance();
-                return "Action performance instrumentation is ON.";
-            case "snapshot":
-                return "ACTION_PERFORMANCE " +
-                       MissionActionDiagnostics.SnapshotPerformance(
-                           stop: false);
-            case "stop":
-                return "ACTION_PERFORMANCE " +
-                       MissionActionDiagnostics.SnapshotPerformance(
-                           stop: true);
-            case "status":
-                return "Action performance instrumentation is " +
-                       (MissionActionDiagnostics.PerformanceEnabled
-                           ? "ON."
-                           : "OFF.");
-            default:
-                return "Usage: coop.debug.battle.action_performance " +
-                       "<start|snapshot|stop|status>";
+            new ExpectedArgs("action", "The action.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            switch (args[0].ToLowerInvariant())
+            {
+                case "start":
+                    MissionActionDiagnostics.StartPerformance();
+                    return Succeeded("Action performance instrumentation is ON.");
+                case "snapshot":
+                    return Succeeded("ACTION_PERFORMANCE " +
+                           MissionActionDiagnostics.SnapshotPerformance(
+                               stop: false));
+                case "stop":
+                    return Succeeded("ACTION_PERFORMANCE " +
+                           MissionActionDiagnostics.SnapshotPerformance(
+                               stop: true));
+                case "status":
+                    return Succeeded("Action performance instrumentation is " +
+                           (MissionActionDiagnostics.PerformanceEnabled
+                               ? "ON."
+                               : "OFF."));
+                default:
+                    return Failed("Invalid command argument value.");
+            }
         }
     }
 
-    [CommandLineArgumentFunction("animation_trace", "coop.debug.battle")]
-    public static string AnimationTrace(List<string> args)
+    public sealed class AnimationTraceCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.battle.animation_trace " +
-                   "<start|snapshot|stop|status>";
-        }
+        public string Prefix => "coop.debug.battle";
 
-        switch (args[0].ToLowerInvariant())
+        public string Name => "animation_trace";
+
+        public string Description => "Runs the animation trace debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "start":
-                MissionActionDiagnostics.StartAnimationTrace();
-                return "Battle animation trace is ON.";
-            case "snapshot":
-                return "BATTLE_ANIMATION_TRACE " +
-                       MissionActionDiagnostics.SnapshotAnimationTrace(
-                           stop: false);
-            case "stop":
-                return "BATTLE_ANIMATION_TRACE " +
-                       MissionActionDiagnostics.SnapshotAnimationTrace(
-                           stop: true);
-            case "status":
-                return "Battle animation trace is " +
-                       (MissionActionDiagnostics.AnimationTraceEnabled
-                           ? "ON."
-                           : "OFF.");
-            default:
-                return "Usage: coop.debug.battle.animation_trace " +
-                       "<start|snapshot|stop|status>";
+            new ExpectedArgs("action", "The action.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            switch (args[0].ToLowerInvariant())
+            {
+                case "start":
+                    MissionActionDiagnostics.StartAnimationTrace();
+                    return Succeeded("Battle animation trace is ON.");
+                case "snapshot":
+                    return Succeeded("BATTLE_ANIMATION_TRACE " +
+                           MissionActionDiagnostics.SnapshotAnimationTrace(
+                               stop: false));
+                case "stop":
+                    return Succeeded("BATTLE_ANIMATION_TRACE " +
+                           MissionActionDiagnostics.SnapshotAnimationTrace(
+                               stop: true));
+                case "status":
+                    return Succeeded("Battle animation trace is " +
+                           (MissionActionDiagnostics.AnimationTraceEnabled
+                               ? "ON."
+                               : "OFF."));
+                default:
+                    return Failed("Invalid command argument value.");
+            }
         }
     }
 
-    [CommandLineArgumentFunction("wield_test", "coop.debug.battle")]
-    public static string WieldTest(List<string> args)
+    public sealed class WieldTestCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.battle.wield_test <start|restore|status>";
-        }
+        public string Prefix => "coop.debug.battle";
 
-        switch (args[0].ToLowerInvariant())
+        public string Name => "wield_test";
+
+        public string Description => "Runs the wield test debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "start":
-                return StartWieldTest();
-            case "restore":
-                return RestoreWieldTest();
-            case "status":
-                return wieldTestActive
-                    ? $"WIELD_TEST active agent={wieldTestAgentId:D}"
-                    : "WIELD_TEST inactive";
-            default:
-                return "Usage: coop.debug.battle.wield_test <start|restore|status>";
+            new ExpectedArgs("action", "The action.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            switch (args[0].ToLowerInvariant())
+            {
+                case "start":
+                    return StartWieldTest();
+                case "restore":
+                    return RestoreWieldTest();
+                case "status":
+                    return Failed(wieldTestActive
+                        ? $"WIELD_TEST active agent={wieldTestAgentId:D}"
+                        : "WIELD_TEST inactive");
+                default:
+                    return Failed("Invalid command argument value.");
+            }
         }
     }
 
-    private static string StartWieldTest()
+    private static CoopCommandResult StartWieldTest()
     {
-        if (wieldTestActive) return "WIELD_TEST already active";
+        if (wieldTestActive) return Failed("WIELD_TEST already active");
         Agent agent = Agent.Main;
         if (agent == null || !agent.IsActive() || agent.Mission != Mission.Current)
-            return "WIELD_TEST no active main agent";
+            return Failed("WIELD_TEST no active main agent");
         if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry)
             || !registry.TryGetAgentInfo(agent, out var info)
             || !registry.IsLocallyControlled(info.AgentId))
         {
-            return "WIELD_TEST main agent is not locally controlled";
+            return Failed("WIELD_TEST main agent is not locally controlled");
         }
 
         EquipmentIndex original = agent.GetPrimaryWieldedItemIndex();
@@ -582,7 +627,7 @@ internal static class BattleDebugCommands
                 break;
             }
             if (target == EquipmentIndex.None)
-                return "WIELD_TEST main agent has no weapon";
+                return Failed("WIELD_TEST main agent has no weapon");
         }
 
         wieldTestAgent = agent;
@@ -602,18 +647,18 @@ internal static class BattleDebugCommands
                 Agent.HandIndex.MainHand,
                 Agent.WeaponWieldActionType.WithAnimationUninterruptible);
         }
-        return $"WIELD_TEST_STARTED agent={wieldTestAgentId:D} " +
-            $"original={(int)original} target={(int)target}";
+        return Succeeded($"WIELD_TEST_STARTED agent={wieldTestAgentId:D} " +
+            $"original={(int)original} target={(int)target}");
     }
 
-    private static string RestoreWieldTest()
+    private static CoopCommandResult RestoreWieldTest()
     {
-        if (!wieldTestActive) return "WIELD_TEST inactive";
+        if (!wieldTestActive) return Failed("WIELD_TEST inactive");
         if (wieldTestAgent == null
             || !wieldTestAgent.IsActive()
             || wieldTestAgent.Mission != Mission.Current)
         {
-            return "WIELD_TEST agent unavailable";
+            return Failed("WIELD_TEST agent unavailable");
         }
 
         if (wieldTestOriginalMainHand == EquipmentIndex.None)
@@ -634,397 +679,457 @@ internal static class BattleDebugCommands
         wieldTestAgentId = Guid.Empty;
         wieldTestOriginalMainHand = EquipmentIndex.None;
         wieldTestActive = false;
-        return $"WIELD_TEST_RESTORED agent={restoredAgentId:D}";
+        return Succeeded($"WIELD_TEST_RESTORED agent={restoredAgentId:D}");
     }
 
 #endif
 
 #if DEBUG
-    [CommandLineArgumentFunction("item_modifier_state", "coop.debug.battle")]
-    public static string ItemModifierState(List<string> args)
+    public sealed class ItemModifierStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.battle.item_modifier_state";
+        public string Prefix => "coop.debug.battle";
 
-        Mission mission = Mission.Current;
-        CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
-        if (mission == null || controller == null)
-            return "No active coop battle mission";
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-            return "Object manager is unavailable";
+        public string Name => "item_modifier_state";
 
-        int activeAgents = 0;
-        int weaponCount = 0;
-        int modifiedWeapons = 0;
-        int unmodifiedWeapons = 0;
-        int canonicalModifiers = 0;
-        int unregisteredModifiers = 0;
-        int nonCanonicalModifiers = 0;
-        var modifierIds = new HashSet<string>();
+        public string Description => "Reports item modifier state.";
 
-        foreach (Agent agent in mission.Agents)
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (!agent.IsActive() || !agent.IsHuman) continue;
+            Mission mission = Mission.Current;
+            CoopBattleController controller = mission?.GetMissionBehavior<CoopBattleController>();
+            if (mission == null || controller == null)
+                return Failed("No active coop battle mission");
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+                return Failed("Object manager is unavailable");
 
-            activeAgents++;
-            MissionEquipment equipment = agent.Equipment;
-            if (equipment == null) continue;
+            int activeAgents = 0;
+            int weaponCount = 0;
+            int modifiedWeapons = 0;
+            int unmodifiedWeapons = 0;
+            int canonicalModifiers = 0;
+            int unregisteredModifiers = 0;
+            int nonCanonicalModifiers = 0;
+            var modifierIds = new HashSet<string>();
 
-            for (EquipmentIndex index = EquipmentIndex.WeaponItemBeginSlot;
-                 index < EquipmentIndex.NumAllWeaponSlots;
-                 index++)
+            foreach (Agent agent in mission.Agents)
             {
-                MissionWeapon weapon = equipment[index];
-                if (weapon.Item == null) continue;
+                if (!agent.IsActive() || !agent.IsHuman) continue;
 
-                weaponCount++;
-                ItemModifier modifier = weapon.ItemModifier;
-                if (modifier == null)
+                activeAgents++;
+                MissionEquipment equipment = agent.Equipment;
+                if (equipment == null) continue;
+
+                for (EquipmentIndex index = EquipmentIndex.WeaponItemBeginSlot;
+                     index < EquipmentIndex.NumAllWeaponSlots;
+                     index++)
                 {
-                    unmodifiedWeapons++;
-                    continue;
-                }
+                    MissionWeapon weapon = equipment[index];
+                    if (weapon.Item == null) continue;
 
-                modifiedWeapons++;
-                if (!objectManager.TryGetId(modifier, out string modifierId))
-                {
-                    unregisteredModifiers++;
-                    continue;
-                }
+                    weaponCount++;
+                    ItemModifier modifier = weapon.ItemModifier;
+                    if (modifier == null)
+                    {
+                        unmodifiedWeapons++;
+                        continue;
+                    }
 
-                modifierIds.Add(modifierId);
-                if (!objectManager.TryGetObject(modifierId, out ItemModifier canonicalModifier) ||
-                    !ReferenceEquals(modifier, canonicalModifier))
-                {
-                    nonCanonicalModifiers++;
-                    continue;
-                }
+                    modifiedWeapons++;
+                    if (!objectManager.TryGetId(modifier, out string modifierId))
+                    {
+                        unregisteredModifiers++;
+                        continue;
+                    }
 
-                canonicalModifiers++;
+                    modifierIds.Add(modifierId);
+                    if (!objectManager.TryGetObject(modifierId, out ItemModifier canonicalModifier) ||
+                        !ReferenceEquals(modifier, canonicalModifier))
+                    {
+                        nonCanonicalModifiers++;
+                        continue;
+                    }
+
+                    canonicalModifiers++;
+                }
             }
+
+            string structuredState = JsonConvert.SerializeObject(new
+            {
+                controllerId = controller.Session.OwnControllerId,
+                activeAgents,
+                weaponCount,
+                modifiedWeapons,
+                unmodifiedWeapons,
+                canonicalModifiers,
+                unregisteredModifiers,
+                nonCanonicalModifiers,
+                distinctModifierIds = modifierIds.OrderBy(id => id).ToArray(),
+            });
+
+            return Succeeded($"ITEM_MODIFIER_STATE activeAgents={activeAgents}|weapons={weaponCount}|" +
+                $"modified={modifiedWeapons}|unmodified={unmodifiedWeapons}|" +
+                $"canonical={canonicalModifiers}|unregistered={unregisteredModifiers}|" +
+                $"nonCanonical={nonCanonicalModifiers}\n" +
+                $"LIVE_TEST_JSON={structuredState}");
         }
-
-        string structuredState = JsonConvert.SerializeObject(new
-        {
-            controllerId = controller.Session.OwnControllerId,
-            activeAgents,
-            weaponCount,
-            modifiedWeapons,
-            unmodifiedWeapons,
-            canonicalModifiers,
-            unregisteredModifiers,
-            nonCanonicalModifiers,
-            distinctModifierIds = modifierIds.OrderBy(id => id).ToArray(),
-        });
-
-        return
-            $"ITEM_MODIFIER_STATE activeAgents={activeAgents}|weapons={weaponCount}|" +
-            $"modified={modifiedWeapons}|unmodified={unmodifiedWeapons}|" +
-            $"canonical={canonicalModifiers}|unregistered={unregisteredModifiers}|" +
-            $"nonCanonical={nonCanonicalModifiers}\n" +
-            $"LIVE_TEST_JSON={structuredState}";
     }
 #endif
 
-    [CommandLineArgumentFunction("state", "coop.debug.battle")]
-    public static string State(List<string> args)
+    public sealed class StateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.battle.state";
-        }
+        public string Prefix => "coop.debug.battle";
 
-        var mission = Mission.Current;
-        var controller = mission?.GetMissionBehavior<CoopBattleController>();
-        var playerTeam = mission?.PlayerTeam;
-        if (mission == null || controller == null)
-        {
-            return "No active coop battle mission";
-        }
+        public string Name => "state";
 
-        ObserveMission(mission);
-        EnsureBattleDebugTickBehavior(mission);
+        public string Description => "Reports state.";
 
-        var enemies = new List<Agent>();
-        int enemyParties = 0;
-        if (playerTeam != null)
-        {
-            var enemySide = playerTeam.Side == BattleSideEnum.Attacker
-                ? BattleSideEnum.Defender
-                : BattleSideEnum.Attacker;
-            enemies.AddRange(mission.Agents
-                .Where(agent => agent.IsActive() && agent.IsHuman && agent.Team?.Side == enemySide));
-            enemyParties = playerTeam.Side == BattleSideEnum.Attacker
-                ? MobileParty.MainParty?.MapEvent?.DefenderSide?.Parties?.Count ?? 0
-                : MobileParty.MainParty?.MapEvent?.AttackerSide?.Parties?.Count ?? 0;
-        }
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        int moved = 0;
-        foreach (var enemy in enemies)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (EnemyPositions.TryGetValue(enemy.Index, out var previous)
-                && previous.DistanceSquared(enemy.Position) > 0.25f)
+            var mission = Mission.Current;
+            var controller = mission?.GetMissionBehavior<CoopBattleController>();
+            var playerTeam = mission?.PlayerTeam;
+            if (mission == null || controller == null)
             {
-                moved++;
-            }
-            EnemyPositions[enemy.Index] = enemy.Position;
-        }
-
-        bool deploymentReady = mission.GetMissionBehavior<DeploymentMissionController>()?.TeamSetupOver == true;
-        int activeAgents = mission.Agents.Count(agent => agent.IsActive());
-        int enemyFleeing = enemies.Count(agent => agent.IsRunningAway);
-        var result = mission.MissionResult;
-        var suppliers = CoopTroopSupplierRegistry.GetSuppliers(controller.Session.InstanceId);
-        var receiverReserves = suppliers
-            .Where(supplier => !string.IsNullOrEmpty(supplier.PlayerPartyId))
-            .Select(supplier => $"{supplier.Side}:{supplier.PlayerPartyId}")
-            .ToArray();
-
-        return $"instance={controller.Session.InstanceId} host={controller.Session.IsLocalHost} " +
-            $"activated={controller.Deployment.IsActivated} committed={controller.Deployment.IsCommitted} " +
-            $"deploymentReady={deploymentReady} mainAgent={Agent.Main != null} activeAgents={activeAgents} " +
-            $"reserveSuppliers={suppliers.Count} populatedReserves={suppliers.Count(supplier => supplier.IsPopulated)} " +
-            $"receiverOwnedReserves={receiverReserves.Length} receiverReserve={string.Join(",", receiverReserves)} " +
-            $"playerSide={playerTeam?.Side.ToString() ?? "None"} enemyParties={enemyParties} enemyActive={enemies.Count} " +
-            $"enemyAi={enemies.Count(agent => agent.IsAIControlled)} enemyFleeing={enemyFleeing} " +
-            $"enemyMovedSinceLast={moved} damageReceivedEvents={ownDamageEvents} " +
-            $"resultState={result?.BattleState.ToString() ?? "None"} " +
-            $"battleResolved={result?.BattleResolved ?? false} playerVictory={result?.PlayerVictory ?? false}";
-    }
-
-    [CommandLineArgumentFunction("size_state", "coop.debug.battle")]
-    public static string SizeState(List<string> args)
-    {
-        if (args.Count != 0)
-            return "Usage: coop.debug.battle.size_state";
-
-        Mission mission = Mission.Current;
-        var controller = mission?.GetMissionBehavior<CoopBattleController>();
-        var spawnHandler = mission?.GetMissionBehavior<CoopBattleMissionSpawnHandler>();
-        if (mission == null || controller == null || spawnHandler == null)
-            return "No active coop battle mission";
-        if (!ContainerProvider.TryResolve<IBattleAgentBudget>(out var agentBudget))
-            return "Battle agent budget is unavailable";
-
-        CoopBattleMissionSpawnHandler.BattleSizeState state = spawnHandler.CaptureBattleSizeState();
-        int activeAgents = mission.Agents.Count(agent => agent.IsActive());
-        int targetTotal = state.DefenderTarget + state.AttackerTarget;
-        string structuredState = JsonConvert.SerializeObject(new
-        {
-            controllerId = controller.Session.OwnControllerId,
-            state.IsSized,
-            authoritativeBattleSize = state.BattleSize,
-            state.DefenderTotal,
-            state.AttackerTotal,
-            state.DefenderTarget,
-            state.AttackerTarget,
-            authoritativeTargetTotal = targetTotal,
-            state.AllocationRevision,
-            activeAgents,
-            renderedAgentLimit = agentBudget.MaxRenderedAgents,
-        });
-
-        return
-            $"BATTLE_SIZE_STATE battleSize={state.BattleSize}|" +
-            $"defenderTotal={state.DefenderTotal}|attackerTotal={state.AttackerTotal}|" +
-            $"defenderTarget={state.DefenderTarget}|attackerTarget={state.AttackerTarget}|" +
-            $"targetTotal={targetTotal}|activeAgents={activeAgents}|" +
-            $"renderedAgentLimit={agentBudget.MaxRenderedAgents}\n" +
-            $"LIVE_TEST_JSON={structuredState}";
-    }
-
-    [CommandLineArgumentFunction("charge_owned_formations", "coop.debug.battle")]
-    public static string ChargeOwnedFormations(List<string> args)
-    {
-        if (args.Count != 0)
-            return "Usage: coop.debug.battle.charge_owned_formations";
-
-        var mission = Mission.Current;
-        var controller = mission?.GetMissionBehavior<CoopBattleController>();
-        if (mission == null || controller == null)
-            return "No active coop battle mission";
-        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "Network agent registry is unavailable";
-
-        CoopAgentInfo[] ownedAgents = registry.GetAgents(controller.Session.OwnControllerId)
-            .Where(info => info.OriginalOwner == controller.Session.OwnControllerId)
-            .Where(info => info.Agent != null
-                && info.Agent.IsActive()
-                && info.Agent.IsHuman
-                && info.Agent.Team == mission.PlayerTeam
-                && info.Agent.Formation != null)
-            .ToArray();
-        Formation[] formations = ownedAgents
-            .Select(info => info.Agent.Formation)
-            .Distinct()
-            .ToArray();
-        if (formations.Length == 0)
-            return "The local player has no active owned formations";
-
-        foreach (Formation formation in formations)
-            formation.SetMovementOrder(MovementOrder.MovementOrderCharge);
-
-        return $"Charged {formations.Length} locally owned formation(s) with {ownedAgents.Length} active agent(s)";
-    }
-
-    [CommandLineArgumentFunction("mount_state", "coop.debug.battle")]
-    public static string MountState(List<string> args)
-    {
-        if (args.Count > 1)
-            return "Usage: coop.debug.battle.mount_state [host|host-player-team|local|controllerId]";
-
-        var mission = Mission.Current;
-        var controller = mission?.GetMissionBehavior<CoopBattleController>();
-        if (mission == null || controller == null)
-            return "No active coop battle mission";
-        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "Network agent registry is unavailable";
-
-        string filter = args.Count == 1 ? args[0] : null;
-        var mounts = registry.GetControllerIds()
-            .SelectMany(registry.GetAgents)
-            .Where(info => MatchesAuthority(
-                controller.Session,
-                info,
-                filter,
-                mission.PlayerTeam))
-            .Where(info => info.Agent != null && info.Agent.IsMount && info.Agent.IsActive())
-            .OrderBy(info => info.AgentId)
-            .ToArray();
-
-        int stationaryCount = 0;
-        int stationaryAnimatedCount = 0;
-        int stationaryTurningCount = 0;
-        var output = new StringBuilder();
-        foreach (var info in mounts)
-        {
-            Agent mount = info.Agent;
-            float speed = mount.GetRealGlobalVelocity().AsVec2.Length;
-            bool stationary = speed <= AgentMountData.StationarySpeedThreshold;
-            AgentMountData.GetRenderedAction0State(
-                mount,
-                out string animationName,
-                out float animationSpeed,
-                out float animationProgress);
-            int actionIndex = mount.GetCurrentAction(0).Index;
-            string actionName = AgentActionData.GetActionNameWithCode(actionIndex);
-            int turnDirection = AgentMountData.GetTurnDirection(actionName, animationName);
-            bool locomotionAction = AgentMountData.IsLocomotionAction(actionIndex, animationName);
-            bool stationaryAnimated = stationary
-                && locomotionAction
-                && animationSpeed > 0.001f;
-            bool stationaryTurning = stationary
-                && turnDirection != AgentMountData.NoTurn
-                && animationSpeed > 0.001f;
-            if (stationary) stationaryCount++;
-            if (stationaryAnimated) stationaryAnimatedCount++;
-            if (stationaryTurning) stationaryTurningCount++;
-
-            string riderId = "none";
-            if (mount.RiderAgent != null
-                && registry.TryGetAgentInfo(mount.RiderAgent, out var riderInfo))
-            {
-                riderId = riderInfo.AgentId.ToString("N");
+                return Failed("No active coop battle mission");
             }
 
-            output.Append("id=").Append(info.AgentId.ToString("N"))
-                .Append(" authority=").Append(info.CurrentAuthority)
-                .Append(" local=").Append(controller.Session.IsOwn(info.CurrentAuthority))
-                .Append(" rider=").Append(riderId)
-                .Append(" position=").Append(mount.Position.X.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(',').Append(mount.Position.Y.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" speed=").Append(speed.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" input=").Append(mount.MovementInputVector.X.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(',').Append(mount.MovementInputVector.Y.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" direction=").Append(mount.GetMovementDirection().X.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(',').Append(mount.GetMovementDirection().Y.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" action0=").Append(actionIndex)
-                .Append(" actionName=").Append(actionName ?? "none")
-                .Append(" actionProgress=").Append(animationProgress.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" animation=").Append(animationName ?? "none")
-                .Append(" animationSpeed=").Append(animationSpeed.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" locomotion=").Append(locomotionAction)
-                .Append(" turnDirection=").Append(turnDirection)
-                .Append(" stationaryTurning=").Append(stationaryTurning)
-                .Append(" stationaryAnimated=").Append(stationaryAnimated)
-                .AppendLine();
-        }
+            ObserveMission(mission);
+            EnsureBattleDebugTickBehavior(mission);
 
-        output.Insert(
-            0,
-            $"mounts={mounts.Length} stationary={stationaryCount} stationaryAnimated={stationaryAnimatedCount} " +
-            $"stationaryTurning={stationaryTurningCount} " +
-            $"own={controller.Session.OwnControllerId} host={controller.Session.IsLocalHost}{Environment.NewLine}");
-        return output.ToString().TrimEnd();
+            var enemies = new List<Agent>();
+            int enemyParties = 0;
+            if (playerTeam != null)
+            {
+                var enemySide = playerTeam.Side == BattleSideEnum.Attacker
+                    ? BattleSideEnum.Defender
+                    : BattleSideEnum.Attacker;
+                enemies.AddRange(mission.Agents
+                    .Where(agent => agent.IsActive() && agent.IsHuman && agent.Team?.Side == enemySide));
+                enemyParties = playerTeam.Side == BattleSideEnum.Attacker
+                    ? MobileParty.MainParty?.MapEvent?.DefenderSide?.Parties?.Count ?? 0
+                    : MobileParty.MainParty?.MapEvent?.AttackerSide?.Parties?.Count ?? 0;
+            }
+
+            int moved = 0;
+            foreach (var enemy in enemies)
+            {
+                if (EnemyPositions.TryGetValue(enemy.Index, out var previous)
+                    && previous.DistanceSquared(enemy.Position) > 0.25f)
+                {
+                    moved++;
+                }
+                EnemyPositions[enemy.Index] = enemy.Position;
+            }
+
+            bool deploymentReady = mission.GetMissionBehavior<DeploymentMissionController>()?.TeamSetupOver == true;
+            int activeAgents = mission.Agents.Count(agent => agent.IsActive());
+            int enemyFleeing = enemies.Count(agent => agent.IsRunningAway);
+            var result = mission.MissionResult;
+            var suppliers = CoopTroopSupplierRegistry.GetSuppliers(controller.Session.InstanceId);
+            var receiverReserves = suppliers
+                .Where(supplier => !string.IsNullOrEmpty(supplier.PlayerPartyId))
+                .Select(supplier => $"{supplier.Side}:{supplier.PlayerPartyId}")
+                .ToArray();
+
+            return Succeeded($"instance={controller.Session.InstanceId} host={controller.Session.IsLocalHost} " +
+                $"activated={controller.Deployment.IsActivated} committed={controller.Deployment.IsCommitted} " +
+                $"deploymentReady={deploymentReady} mainAgent={Agent.Main != null} activeAgents={activeAgents} " +
+                $"reserveSuppliers={suppliers.Count} populatedReserves={suppliers.Count(supplier => supplier.IsPopulated)} " +
+                $"receiverOwnedReserves={receiverReserves.Length} receiverReserve={string.Join(",", receiverReserves)} " +
+                $"playerSide={playerTeam?.Side.ToString() ?? "None"} enemyParties={enemyParties} enemyActive={enemies.Count} " +
+                $"enemyAi={enemies.Count(agent => agent.IsAIControlled)} enemyFleeing={enemyFleeing} " +
+                $"enemyMovedSinceLast={moved} damageReceivedEvents={ownDamageEvents} " +
+                $"resultState={result?.BattleState.ToString() ?? "None"} " +
+                $"battleResolved={result?.BattleResolved ?? false} playerVictory={result?.PlayerVictory ?? false}");
+        }
     }
 
-    [CommandLineArgumentFunction("capture_mount_pose", "coop.debug.battle")]
-    public static string CaptureMountPose(List<string> args)
+    public sealed class SizeStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 1 || !Guid.TryParseExact(args[0], "N", out Guid mountId))
-            return "Usage: coop.debug.battle.capture_mount_pose <mountAgentId>";
+        public string Prefix => "coop.debug.battle";
 
-        var mission = Mission.Current;
-        if (mission == null)
-            return "No active mission";
-        if (!TryGetActiveMount(mountId, out Agent mount))
-            return $"Active mount {mountId:N} was not found";
+        public string Name => "size_state";
 
-        MBAgentVisuals visuals = mount.AgentVisuals;
-        Skeleton skeleton = visuals?.GetSkeleton();
-        if (ReferenceEquals(visuals, null)
-            || !visuals.IsValid()
-            || ReferenceEquals(skeleton, null)
-            || !skeleton.IsValid)
+        public string Description => "Reports size state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Mount {mountId:N} has no active skeleton";
-        }
+            Mission mission = Mission.Current;
+            var controller = mission?.GetMissionBehavior<CoopBattleController>();
+            var spawnHandler = mission?.GetMissionBehavior<CoopBattleMissionSpawnHandler>();
+            if (mission == null || controller == null || spawnHandler == null)
+                return Failed("No active coop battle mission");
+            if (!ContainerProvider.TryResolve<IBattleAgentBudget>(out var agentBudget))
+                return Failed("Battle agent budget is unavailable");
 
-        ObserveMission(mission);
-        EnsureBattleDebugTickBehavior(mission);
-        capturedMount = mount;
-        capturedMountId = mountId;
-        mountPoseCaptureStartTime = mission.CurrentTime;
-        MountPoseSamples.Clear();
-        CaptureMountPoseFrame();
-        return $"Capturing rendered horse-head pose for mount {mountId:N}";
+            CoopBattleMissionSpawnHandler.BattleSizeState state = spawnHandler.CaptureBattleSizeState();
+            int activeAgents = mission.Agents.Count(agent => agent.IsActive());
+            int targetTotal = state.DefenderTarget + state.AttackerTarget;
+            string structuredState = JsonConvert.SerializeObject(new
+            {
+                controllerId = controller.Session.OwnControllerId,
+                state.IsSized,
+                authoritativeBattleSize = state.BattleSize,
+                state.DefenderTotal,
+                state.AttackerTotal,
+                state.DefenderTarget,
+                state.AttackerTarget,
+                authoritativeTargetTotal = targetTotal,
+                state.AllocationRevision,
+                activeAgents,
+                renderedAgentLimit = agentBudget.MaxRenderedAgents,
+            });
+
+            return Succeeded($"BATTLE_SIZE_STATE battleSize={state.BattleSize}|" +
+                $"defenderTotal={state.DefenderTotal}|attackerTotal={state.AttackerTotal}|" +
+                $"defenderTarget={state.DefenderTarget}|attackerTarget={state.AttackerTarget}|" +
+                $"targetTotal={targetTotal}|activeAgents={activeAgents}|" +
+                $"renderedAgentLimit={agentBudget.MaxRenderedAgents}\n" +
+                $"LIVE_TEST_JSON={structuredState}");
+        }
     }
 
-    [CommandLineArgumentFunction("mount_pose_samples", "coop.debug.battle")]
-    public static string MountPoseSamplesState(List<string> args)
+    public sealed class ChargeOwnedFormationsCoopCommand : ICoopCommand
     {
-        if (args.Count != 1 || !Guid.TryParseExact(args[0], "N", out Guid mountId))
-            return "Usage: coop.debug.battle.mount_pose_samples <mountAgentId>";
-        if (capturedMount == null || capturedMountId != mountId)
-            return $"No pose capture is active for mount {mountId:N}";
+        public string Prefix => "coop.debug.battle";
 
-        var output = new StringBuilder();
-        output.Append("mount=").Append(capturedMountId.ToString("N"))
-            .Append(" samples=").Append(MountPoseSamples.Count)
-            .AppendLine();
-        for (int index = 0; index < MountPoseSamples.Count; index++)
+        public string Name => "charge_owned_formations";
+
+        public string Description => "Runs the charge owned formations debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            MountPoseSample sample = MountPoseSamples[index];
-            output.Append("sample=").Append(index)
-                .Append(" time=").Append(sample.Time.ToString("0.0000", CultureInfo.InvariantCulture))
-                .Append(" speed=").Append(sample.Speed.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" action0=").Append(sample.ActionIndex)
-                .Append(" actionName=").Append(sample.ActionName ?? "none")
-                .Append(" animation=").Append(sample.AnimationName ?? "none")
-                .Append(" animationProgress=").Append(sample.AnimationProgress.ToString("0.0000", CultureInfo.InvariantCulture))
-                .Append(" animationSpeed=").Append(sample.AnimationSpeed.ToString("0.000", CultureInfo.InvariantCulture))
-                .Append(" turnDirection=").Append(sample.TurnDirection)
-                .Append(" channelWeight=").Append(sample.ChannelWeight.ToString("0.0000", CultureInfo.InvariantCulture))
-                .Append(" currentActionWeight=").Append(sample.CurrentActionWeight.ToString("0.0000", CultureInfo.InvariantCulture))
-                .Append(" headPosition=").Append(sample.HeadPosition.X.ToString("0.00000", CultureInfo.InvariantCulture))
-                .Append(',').Append(sample.HeadPosition.Y.ToString("0.00000", CultureInfo.InvariantCulture))
-                .Append(',').Append(sample.HeadPosition.Z.ToString("0.00000", CultureInfo.InvariantCulture))
-                .Append(" headForward=").Append(sample.HeadForward.X.ToString("0.00000", CultureInfo.InvariantCulture))
-                .Append(',').Append(sample.HeadForward.Y.ToString("0.00000", CultureInfo.InvariantCulture))
-                .Append(',').Append(sample.HeadForward.Z.ToString("0.00000", CultureInfo.InvariantCulture))
-                .AppendLine();
+            var mission = Mission.Current;
+            var controller = mission?.GetMissionBehavior<CoopBattleController>();
+            if (mission == null || controller == null)
+                return Failed("No active coop battle mission");
+            if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+                return Failed("Network agent registry is unavailable");
+
+            CoopAgentInfo[] ownedAgents = registry.GetAgents(controller.Session.OwnControllerId)
+                .Where(info => info.OriginalOwner == controller.Session.OwnControllerId)
+                .Where(info => info.Agent != null
+                    && info.Agent.IsActive()
+                    && info.Agent.IsHuman
+                    && info.Agent.Team == mission.PlayerTeam
+                    && info.Agent.Formation != null)
+                .ToArray();
+            Formation[] formations = ownedAgents
+                .Select(info => info.Agent.Formation)
+                .Distinct()
+                .ToArray();
+            if (formations.Length == 0)
+                return Failed("The local player has no active owned formations");
+
+            foreach (Formation formation in formations)
+                formation.SetMovementOrder(MovementOrder.MovementOrderCharge);
+
+            return Succeeded($"Charged {formations.Length} locally owned formation(s) with {ownedAgents.Length} active agent(s)");
         }
-        return output.ToString().TrimEnd();
+    }
+
+    public sealed class MountStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.battle";
+
+        public string Name => "mount_state";
+
+        public string Description => "Reports mount state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("authority", "The authority.", false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var mission = Mission.Current;
+            var controller = mission?.GetMissionBehavior<CoopBattleController>();
+            if (mission == null || controller == null)
+                return Failed("No active coop battle mission");
+            if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+                return Failed("Network agent registry is unavailable");
+
+            string filter = args.Count == 1 ? args[0] : null;
+            var mounts = registry.GetControllerIds()
+                .SelectMany(registry.GetAgents)
+                .Where(info => MatchesAuthority(
+                    controller.Session,
+                    info,
+                    filter,
+                    mission.PlayerTeam))
+                .Where(info => info.Agent != null && info.Agent.IsMount && info.Agent.IsActive())
+                .OrderBy(info => info.AgentId)
+                .ToArray();
+
+            int stationaryCount = 0;
+            int stationaryAnimatedCount = 0;
+            int stationaryTurningCount = 0;
+            var output = new StringBuilder();
+            foreach (var info in mounts)
+            {
+                Agent mount = info.Agent;
+                float speed = mount.GetRealGlobalVelocity().AsVec2.Length;
+                bool stationary = speed <= AgentMountData.StationarySpeedThreshold;
+                AgentMountData.GetRenderedAction0State(
+                    mount,
+                    out string animationName,
+                    out float animationSpeed,
+                    out float animationProgress);
+                int actionIndex = mount.GetCurrentAction(0).Index;
+                string actionName = AgentActionData.GetActionNameWithCode(actionIndex);
+                int turnDirection = AgentMountData.GetTurnDirection(actionName, animationName);
+                bool locomotionAction = AgentMountData.IsLocomotionAction(actionIndex, animationName);
+                bool stationaryAnimated = stationary
+                    && locomotionAction
+                    && animationSpeed > 0.001f;
+                bool stationaryTurning = stationary
+                    && turnDirection != AgentMountData.NoTurn
+                    && animationSpeed > 0.001f;
+                if (stationary) stationaryCount++;
+                if (stationaryAnimated) stationaryAnimatedCount++;
+                if (stationaryTurning) stationaryTurningCount++;
+
+                string riderId = "none";
+                if (mount.RiderAgent != null
+                    && registry.TryGetAgentInfo(mount.RiderAgent, out var riderInfo))
+                {
+                    riderId = riderInfo.AgentId.ToString("N");
+                }
+
+                output.Append("id=").Append(info.AgentId.ToString("N"))
+                    .Append(" authority=").Append(info.CurrentAuthority)
+                    .Append(" local=").Append(controller.Session.IsOwn(info.CurrentAuthority))
+                    .Append(" rider=").Append(riderId)
+                    .Append(" position=").Append(mount.Position.X.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(',').Append(mount.Position.Y.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" speed=").Append(speed.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" input=").Append(mount.MovementInputVector.X.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(',').Append(mount.MovementInputVector.Y.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" direction=").Append(mount.GetMovementDirection().X.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(',').Append(mount.GetMovementDirection().Y.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" action0=").Append(actionIndex)
+                    .Append(" actionName=").Append(actionName ?? "none")
+                    .Append(" actionProgress=").Append(animationProgress.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" animation=").Append(animationName ?? "none")
+                    .Append(" animationSpeed=").Append(animationSpeed.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" locomotion=").Append(locomotionAction)
+                    .Append(" turnDirection=").Append(turnDirection)
+                    .Append(" stationaryTurning=").Append(stationaryTurning)
+                    .Append(" stationaryAnimated=").Append(stationaryAnimated)
+                    .AppendLine();
+            }
+
+            output.Insert(
+                0,
+                $"mounts={mounts.Length} stationary={stationaryCount} stationaryAnimated={stationaryAnimatedCount} " +
+                $"stationaryTurning={stationaryTurningCount} " +
+                $"own={controller.Session.OwnControllerId} host={controller.Session.IsLocalHost}{Environment.NewLine}");
+            return Succeeded(output.ToString().TrimEnd());
+        }
+    }
+
+    public sealed class CaptureMountPoseCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.battle";
+
+        public string Name => "capture_mount_pose";
+
+        public string Description => "Runs the capture mount pose debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!Guid.TryParseExact(args[0], "N", out Guid mountId))
+                return Failed("Invalid command argument value.");
+
+            var mission = Mission.Current;
+            if (mission == null)
+                return Failed("No active mission");
+            if (!TryGetActiveMount(mountId, out Agent mount))
+                return Failed($"Active mount {mountId:N} was not found");
+
+            MBAgentVisuals visuals = mount.AgentVisuals;
+            Skeleton skeleton = visuals?.GetSkeleton();
+            if (ReferenceEquals(visuals, null)
+                || !visuals.IsValid()
+                || ReferenceEquals(skeleton, null)
+                || !skeleton.IsValid)
+            {
+                return Failed($"Mount {mountId:N} has no active skeleton");
+            }
+
+            ObserveMission(mission);
+            EnsureBattleDebugTickBehavior(mission);
+            capturedMount = mount;
+            capturedMountId = mountId;
+            mountPoseCaptureStartTime = mission.CurrentTime;
+            MountPoseSamples.Clear();
+            CaptureMountPoseFrame();
+            return Succeeded($"Capturing rendered horse-head pose for mount {mountId:N}");
+        }
+    }
+
+    public sealed class MountPoseSamplesCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.battle";
+
+        public string Name => "mount_pose_samples";
+
+        public string Description => "Runs the mount pose samples debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!Guid.TryParseExact(args[0], "N", out Guid mountId))
+                return Failed("Invalid command argument value.");
+            if (capturedMount == null || capturedMountId != mountId)
+                return Failed($"No pose capture is active for mount {mountId:N}");
+
+            var output = new StringBuilder();
+            output.Append("mount=").Append(capturedMountId.ToString("N"))
+                .Append(" samples=").Append(MountPoseSamples.Count)
+                .AppendLine();
+            for (int index = 0; index < MountPoseSamples.Count; index++)
+            {
+                MountPoseSample sample = MountPoseSamples[index];
+                output.Append("sample=").Append(index)
+                    .Append(" time=").Append(sample.Time.ToString("0.0000", CultureInfo.InvariantCulture))
+                    .Append(" speed=").Append(sample.Speed.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" action0=").Append(sample.ActionIndex)
+                    .Append(" actionName=").Append(sample.ActionName ?? "none")
+                    .Append(" animation=").Append(sample.AnimationName ?? "none")
+                    .Append(" animationProgress=").Append(sample.AnimationProgress.ToString("0.0000", CultureInfo.InvariantCulture))
+                    .Append(" animationSpeed=").Append(sample.AnimationSpeed.ToString("0.000", CultureInfo.InvariantCulture))
+                    .Append(" turnDirection=").Append(sample.TurnDirection)
+                    .Append(" channelWeight=").Append(sample.ChannelWeight.ToString("0.0000", CultureInfo.InvariantCulture))
+                    .Append(" currentActionWeight=").Append(sample.CurrentActionWeight.ToString("0.0000", CultureInfo.InvariantCulture))
+                    .Append(" headPosition=").Append(sample.HeadPosition.X.ToString("0.00000", CultureInfo.InvariantCulture))
+                    .Append(',').Append(sample.HeadPosition.Y.ToString("0.00000", CultureInfo.InvariantCulture))
+                    .Append(',').Append(sample.HeadPosition.Z.ToString("0.00000", CultureInfo.InvariantCulture))
+                    .Append(" headForward=").Append(sample.HeadForward.X.ToString("0.00000", CultureInfo.InvariantCulture))
+                    .Append(',').Append(sample.HeadForward.Y.ToString("0.00000", CultureInfo.InvariantCulture))
+                    .Append(',').Append(sample.HeadForward.Z.ToString("0.00000", CultureInfo.InvariantCulture))
+                    .AppendLine();
+            }
+            return Succeeded(output.ToString().TrimEnd());
+        }
     }
 
     private static void CaptureMountPoseFrame()
@@ -1081,178 +1186,209 @@ internal static class BattleDebugCommands
         });
     }
 
-    [CommandLineArgumentFunction("move_cavalry", "coop.debug.battle")]
-    public static string MoveCavalry(List<string> args)
+    public sealed class MoveCavalryCoopCommand : ICoopCommand
     {
-        if (args.Count != 1
-            || !float.TryParse(
-                args[0],
-                NumberStyles.Float,
-                CultureInfo.InvariantCulture,
-                out float distance)
-            || distance < 5f
-            || distance > 100f)
+        public string Prefix => "coop.debug.battle";
+
+        public string Name => "move_cavalry";
+
+        public string Description => "Runs the move cavalry debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.battle.move_cavalry <distance: 5-100>";
-        }
+            new ExpectedArgs("distance", "The distance.", true),
+        };
 
-        var mission = Mission.Current;
-        var controller = mission?.GetMissionBehavior<CoopBattleController>();
-        if (mission == null || controller == null)
-            return "No active coop battle mission";
-        if (!controller.Session.IsLocalHost)
-            return "Run this command on the battle-host client";
-        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "Network agent registry is unavailable";
-
-        Agent[] riders = GetBattleHostCavalryRiders(
-            mission,
-            controller,
-            registry);
-        Formation[] formations = riders
-            .Select(agent => agent.Formation)
-            .Distinct()
-            .ToArray();
-        if (formations.Length == 0)
-            return "The battle host has no active cavalry formations";
-
-        foreach (Agent rider in riders)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            RestoreCavalryController(rider);
-            if (rider.MountAgent != null)
-                RestoreCavalryController(rider.MountAgent);
-            rider.SetScriptedFlags(Agent.AIScriptedFrameFlags.None);
-            rider.SetMaximumSpeedLimit(-1f, isMultiplier: false);
-            rider.MountAgent?.SetMaximumSpeedLimit(-1f, isMultiplier: false);
-            rider.SetIsAIPaused(false);
-            rider.MountAgent?.SetIsAIPaused(false);
+            if (!float.TryParse(
+                    args[0],
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out float distance)
+                || distance < 5f
+                || distance > 100f)
+            {
+                return Failed("Invalid command argument value.");
+            }
+
+            var mission = Mission.Current;
+            var controller = mission?.GetMissionBehavior<CoopBattleController>();
+            if (mission == null || controller == null)
+                return Failed("No active coop battle mission");
+            if (!controller.Session.IsLocalHost)
+                return Failed("Run this command on the battle-host client");
+            if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+                return Failed("Network agent registry is unavailable");
+
+            Agent[] riders = GetBattleHostCavalryRiders(
+                mission,
+                controller,
+                registry);
+            Formation[] formations = riders
+                .Select(agent => agent.Formation)
+                .Distinct()
+                .ToArray();
+            if (formations.Length == 0)
+                return Failed("The battle host has no active cavalry formations");
+
+            foreach (Agent rider in riders)
+            {
+                RestoreCavalryController(rider);
+                if (rider.MountAgent != null)
+                    RestoreCavalryController(rider.MountAgent);
+                rider.SetScriptedFlags(Agent.AIScriptedFrameFlags.None);
+                rider.SetMaximumSpeedLimit(-1f, isMultiplier: false);
+                rider.MountAgent?.SetMaximumSpeedLimit(-1f, isMultiplier: false);
+                rider.SetIsAIPaused(false);
+                rider.MountAgent?.SetIsAIPaused(false);
+            }
+
+            foreach (Formation formation in formations)
+            {
+                Vec2 direction = formation.Direction;
+                if (direction.LengthSquared <= 0.0001f)
+                    direction = Vec2.Forward;
+                else
+                    direction.Normalize();
+
+                WorldPosition destination = formation.CachedMedianPosition;
+                destination.SetVec2(formation.CurrentPosition + (direction * distance));
+                formation.SetMovementOrder(MovementOrder.MovementOrderMove(destination));
+            }
+
+            return Succeeded($"Moved {formations.Length} battle-host cavalry formations {distance:0.0} meters");
         }
-
-        foreach (Formation formation in formations)
-        {
-            Vec2 direction = formation.Direction;
-            if (direction.LengthSquared <= 0.0001f)
-                direction = Vec2.Forward;
-            else
-                direction.Normalize();
-
-            WorldPosition destination = formation.CachedMedianPosition;
-            destination.SetVec2(formation.CurrentPosition + (direction * distance));
-            formation.SetMovementOrder(MovementOrder.MovementOrderMove(destination));
-        }
-
-        return $"Moved {formations.Length} battle-host cavalry formations {distance:0.0} meters";
     }
 
-    [CommandLineArgumentFunction("hold_cavalry", "coop.debug.battle")]
-    public static string HoldCavalry(List<string> args)
+    public sealed class HoldCavalryCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.battle.hold_cavalry";
+        public string Prefix => "coop.debug.battle";
 
-        var mission = Mission.Current;
-        var controller = mission?.GetMissionBehavior<CoopBattleController>();
-        if (mission == null || controller == null)
-            return "No active coop battle mission";
-        if (!controller.Session.IsLocalHost)
-            return "Run this command on the battle-host client";
-        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "Network agent registry is unavailable";
+        public string Name => "hold_cavalry";
 
-        Agent[] riders = GetBattleHostCavalryRiders(
-            mission,
-            controller,
-            registry);
-        Formation[] formations = riders
-            .Select(agent => agent.Formation)
-            .Distinct()
-            .ToArray();
-        if (formations.Length == 0)
-            return "The battle host has no active cavalry formations";
+        public string Description => "Runs the hold cavalry debug operation.";
 
-        foreach (Formation formation in formations)
-            formation.SetMovementOrder(MovementOrder.MovementOrderStop);
-        foreach (Agent rider in riders)
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            FreezeCavalryController(rider);
-            rider.SetMaximumSpeedLimit(0f, isMultiplier: false);
-            rider.MovementInputVector = Vec2.Zero;
-            rider.SetIsAIPaused(true);
-            if (rider.MountAgent != null)
-            {
-                FreezeCavalryController(rider.MountAgent);
-                rider.MountAgent.SetMaximumSpeedLimit(0f, isMultiplier: false);
-                rider.MountAgent.MovementInputVector = Vec2.Zero;
-                rider.MountAgent.SetIsAIPaused(true);
-            }
-        }
+            var mission = Mission.Current;
+            var controller = mission?.GetMissionBehavior<CoopBattleController>();
+            if (mission == null || controller == null)
+                return Failed("No active coop battle mission");
+            if (!controller.Session.IsLocalHost)
+                return Failed("Run this command on the battle-host client");
+            if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+                return Failed("Network agent registry is unavailable");
 
-        return $"Stopped {formations.Length} battle-host cavalry formations";
+            Agent[] riders = GetBattleHostCavalryRiders(
+                mission,
+                controller,
+                registry);
+            Formation[] formations = riders
+                .Select(agent => agent.Formation)
+                .Distinct()
+                .ToArray();
+            if (formations.Length == 0)
+                return Failed("The battle host has no active cavalry formations");
+
+            foreach (Formation formation in formations)
+                formation.SetMovementOrder(MovementOrder.MovementOrderStop);
+            foreach (Agent rider in riders)
+            {
+                FreezeCavalryController(rider);
+                rider.SetMaximumSpeedLimit(0f, isMultiplier: false);
+                rider.MovementInputVector = Vec2.Zero;
+                rider.SetIsAIPaused(true);
+                if (rider.MountAgent != null)
+                {
+                    FreezeCavalryController(rider.MountAgent);
+                    rider.MountAgent.SetMaximumSpeedLimit(0f, isMultiplier: false);
+                    rider.MountAgent.MovementInputVector = Vec2.Zero;
+                    rider.MountAgent.SetIsAIPaused(true);
+                }
+            }
+
+            return Succeeded($"Stopped {formations.Length} battle-host cavalry formations");
+        }
     }
 
-    [CommandLineArgumentFunction("turn_cavalry", "coop.debug.battle")]
-    public static string TurnCavalry(List<string> args)
+    public sealed class TurnCavalryCoopCommand : ICoopCommand
     {
-        if (args.Count != 1
-            || !float.TryParse(
-                args[0],
-                NumberStyles.Float,
-                CultureInfo.InvariantCulture,
-                out float degrees)
-            || float.IsNaN(degrees)
-            || float.IsInfinity(degrees)
-            || Math.Abs(degrees) < 1f
-            || Math.Abs(degrees) > 180f)
+        public string Prefix => "coop.debug.battle";
+
+        public string Name => "turn_cavalry";
+
+        public string Description => "Runs the turn cavalry debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.battle.turn_cavalry <degrees: -180 to -1 or 1 to 180>";
-        }
+            new ExpectedArgs("degrees", "The degrees.", true),
+        };
 
-        var mission = Mission.Current;
-        var controller = mission?.GetMissionBehavior<CoopBattleController>();
-        if (mission == null || controller == null)
-            return "No active coop battle mission";
-        if (!controller.Session.IsLocalHost)
-            return "Run this command on the battle-host client";
-        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "Network agent registry is unavailable";
-
-        Agent[] riders = GetBattleHostCavalryRiders(
-            mission,
-            controller,
-            registry);
-        Formation[] formations = riders
-            .Select(agent => agent.Formation)
-            .Distinct()
-            .ToArray();
-        if (formations.Length == 0)
-            return "The battle host has no active cavalry formations";
-
-        float radians = degrees * ((float)Math.PI / 180f);
-        float cosine = (float)Math.Cos(radians);
-        float sine = (float)Math.Sin(radians);
-        foreach (Formation formation in formations)
-            formation.SetMovementOrder(MovementOrder.MovementOrderStop);
-
-        foreach (Agent rider in riders)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            Vec2 riderDirection = rider.GetMovementDirection();
-            var turnedRiderDirection = new Vec2(
-                (riderDirection.X * cosine) - (riderDirection.Y * sine),
-                (riderDirection.X * sine) + (riderDirection.Y * cosine));
-            rider.SetMovementDirection(in turnedRiderDirection);
-
-            Agent mount = rider.MountAgent;
-            if (mount != null)
+            if (!float.TryParse(
+                    args[0],
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out float degrees)
+                || float.IsNaN(degrees)
+                || float.IsInfinity(degrees)
+                || Math.Abs(degrees) < 1f
+                || Math.Abs(degrees) > 180f)
             {
-                Vec2 mountDirection = mount.GetMovementDirection();
-                var turnedMountDirection = new Vec2(
-                    (mountDirection.X * cosine) - (mountDirection.Y * sine),
-                    (mountDirection.X * sine) + (mountDirection.Y * cosine));
-                mount.SetMovementDirection(in turnedMountDirection);
+                return Failed("Invalid command argument value.");
             }
-        }
 
-        return $"Turned {formations.Length} battle-host cavalry formations {degrees:0.0} degrees in place";
+            var mission = Mission.Current;
+            var controller = mission?.GetMissionBehavior<CoopBattleController>();
+            if (mission == null || controller == null)
+                return Failed("No active coop battle mission");
+            if (!controller.Session.IsLocalHost)
+                return Failed("Run this command on the battle-host client");
+            if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+                return Failed("Network agent registry is unavailable");
+
+            Agent[] riders = GetBattleHostCavalryRiders(
+                mission,
+                controller,
+                registry);
+            Formation[] formations = riders
+                .Select(agent => agent.Formation)
+                .Distinct()
+                .ToArray();
+            if (formations.Length == 0)
+                return Failed("The battle host has no active cavalry formations");
+
+            float radians = degrees * ((float)Math.PI / 180f);
+            float cosine = (float)Math.Cos(radians);
+            float sine = (float)Math.Sin(radians);
+            foreach (Formation formation in formations)
+                formation.SetMovementOrder(MovementOrder.MovementOrderStop);
+
+            foreach (Agent rider in riders)
+            {
+                Vec2 riderDirection = rider.GetMovementDirection();
+                var turnedRiderDirection = new Vec2(
+                    (riderDirection.X * cosine) - (riderDirection.Y * sine),
+                    (riderDirection.X * sine) + (riderDirection.Y * cosine));
+                rider.SetMovementDirection(in turnedRiderDirection);
+
+                Agent mount = rider.MountAgent;
+                if (mount != null)
+                {
+                    Vec2 mountDirection = mount.GetMovementDirection();
+                    var turnedMountDirection = new Vec2(
+                        (mountDirection.X * cosine) - (mountDirection.Y * sine),
+                        (mountDirection.X * sine) + (mountDirection.Y * cosine));
+                    mount.SetMovementDirection(in turnedMountDirection);
+                }
+            }
+
+            return Succeeded($"Turned {formations.Length} battle-host cavalry formations {degrees:0.0} degrees in place");
+        }
     }
 
     private static void FreezeCavalryController(Agent rider)
@@ -1350,100 +1486,120 @@ internal static class BattleDebugCommands
         return info.CurrentAuthority == filter;
     }
 
-    [CommandLineArgumentFunction("focus_mount", "coop.debug.battle")]
-    public static string FocusMount(List<string> args)
+    public sealed class FocusMountCoopCommand : ICoopCommand
     {
-        if (args.Count != 1 || !Guid.TryParseExact(args[0], "N", out Guid mountId))
-            return "Usage: coop.debug.battle.focus_mount <mountAgentId>";
+        public string Prefix => "coop.debug.battle";
 
-        var mission = Mission.Current;
-        if (mission == null)
-            return "No active mission";
-        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
-            return "Network agent registry is unavailable";
-        if (!registry.TryGetAgentInfo(mountId, out var info)
-            || info.Agent == null
-            || !info.Agent.IsMount
-            || !info.Agent.IsActive())
+        public string Name => "focus_mount";
+
+        public string Description => "Runs the focus mount debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Active mount {mountId:N} was not found";
-        }
+            new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
+        };
 
-        if (!(ScreenManager.TopScreen is MissionScreen missionScreen)
-            || ReferenceEquals(missionScreen.CombatCamera, null))
-            return "The mission screen is not active";
-
-        ReleaseLadderCamera();
-        ObserveMission(mission);
-        Agent mount = info.Agent;
-        MBAgentVisuals visuals = mount.AgentVisuals;
-        GameEntity visualEntity = visuals?.GetEntity();
-        if (ReferenceEquals(visualEntity, null))
-            return $"Mount {mountId:N} has no active visual entity";
-
-        EnsureBattleDebugTickBehavior(mission);
-
-        if (ReferenceEquals(mountCamera, null)
-            || ReferenceEquals(mountCamera.Entity, null))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            ReleaseMountCamera();
-            mountCamera = Camera.CreateCamera();
-            mountCamera.FillParametersFrom(missionScreen.CombatCamera);
-            var localTarget = new Vec3(0f, 0f, 1.4f);
-            var localPosition = new Vec3(-4f, -11f, 5.4f);
-            mountCamera.LookAt(localPosition, localTarget, Vec3.Up);
-            mountCameraLocalFrame = mountCamera.Frame;
-            mountCamera.Entity = GameEntity.CreateEmpty(
-                mission.Scene,
-                isModifiableFromEditor: false,
-                createPhysics: false,
-                callScriptCallbacks: false);
+            if (!Guid.TryParseExact(args[0], "N", out Guid mountId))
+                return Failed("Invalid command argument value.");
+
+            var mission = Mission.Current;
+            if (mission == null)
+                return Failed("No active mission");
+            if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var registry))
+                return Failed("Network agent registry is unavailable");
+            if (!registry.TryGetAgentInfo(mountId, out var info)
+                || info.Agent == null
+                || !info.Agent.IsMount
+                || !info.Agent.IsActive())
+            {
+                return Failed($"Active mount {mountId:N} was not found");
+            }
+
+            if (!(ScreenManager.TopScreen is MissionScreen missionScreen)
+                || ReferenceEquals(missionScreen.CombatCamera, null))
+                return Failed("The mission screen is not active");
+
+            ReleaseLadderCamera();
+            ObserveMission(mission);
+            Agent mount = info.Agent;
+            MBAgentVisuals visuals = mount.AgentVisuals;
+            GameEntity visualEntity = visuals?.GetEntity();
+            if (ReferenceEquals(visualEntity, null))
+                return Failed($"Mount {mountId:N} has no active visual entity");
+
+            EnsureBattleDebugTickBehavior(mission);
+
+            if (ReferenceEquals(mountCamera, null)
+                || ReferenceEquals(mountCamera.Entity, null))
+            {
+                ReleaseMountCamera();
+                mountCamera = Camera.CreateCamera();
+                mountCamera.FillParametersFrom(missionScreen.CombatCamera);
+                var localTarget = new Vec3(0f, 0f, 1.4f);
+                var localPosition = new Vec3(-4f, -11f, 5.4f);
+                mountCamera.LookAt(localPosition, localTarget, Vec3.Up);
+                mountCameraLocalFrame = mountCamera.Frame;
+                mountCamera.Entity = GameEntity.CreateEmpty(
+                    mission.Scene,
+                    isModifiableFromEditor: false,
+                    createPhysics: false,
+                    callScriptCallbacks: false);
+            }
+
+            focusedMount = mount;
+            focusedMountId = mountId;
+            UpdateMountCameraFrame();
+            missionScreen.CustomCamera = mountCamera;
+
+            return Succeeded($"Focused the mission camera on mount {mountId:N}");
         }
-
-        focusedMount = mount;
-        focusedMountId = mountId;
-        UpdateMountCameraFrame();
-        missionScreen.CustomCamera = mountCamera;
-
-        return $"Focused the mission camera on mount {mountId:N}";
     }
 
-    [CommandLineArgumentFunction("mount_camera_state", "coop.debug.battle")]
-    public static string MountCameraState(List<string> args)
+    public sealed class MountCameraStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.battle.mount_camera_state";
+        public string Prefix => "coop.debug.battle";
 
-        if (ReferenceEquals(mountCamera, null)
-            || ReferenceEquals(focusedMount, null)
-            || !focusedMount.IsActive()
-            || !(ScreenManager.TopScreen is MissionScreen missionScreen)
-            || ReferenceEquals(missionScreen.CombatCamera, null)
-            || ReferenceEquals(mountCamera.Entity, null))
+        public string Name => "mount_camera_state";
+
+        public string Description => "Reports mount camera state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "active=False";
+            if (ReferenceEquals(mountCamera, null)
+                || ReferenceEquals(focusedMount, null)
+                || !focusedMount.IsActive()
+                || !(ScreenManager.TopScreen is MissionScreen missionScreen)
+                || ReferenceEquals(missionScreen.CombatCamera, null)
+                || ReferenceEquals(mountCamera.Entity, null))
+            {
+                return Succeeded("active=False");
+            }
+
+            MatrixFrame cameraEntityFrame = mountCamera.Entity.GetGlobalFrame();
+            Vec3 renderedPosition = missionScreen.CombatCamera.Position;
+            Vec3 entityDirection = -cameraEntityFrame.rotation.u;
+            entityDirection.Normalize();
+            Vec3 renderedDirection = missionScreen.CombatCamera.Direction;
+            float directionDot =
+                (renderedDirection.X * entityDirection.X)
+                + (renderedDirection.Y * entityDirection.Y)
+                + (renderedDirection.Z * entityDirection.Z);
+
+            float positionDelta =
+                (renderedPosition - cameraEntityFrame.origin).Length;
+            bool active = ReferenceEquals(missionScreen.CustomCamera, mountCamera);
+            return Succeeded(string.Format(
+                CultureInfo.InvariantCulture,
+                "active={0} mount={1:N} positionDelta={2:F3} directionDot={3:F3}",
+                active,
+                focusedMountId,
+                positionDelta,
+                directionDot));
         }
-
-        MatrixFrame cameraEntityFrame = mountCamera.Entity.GetGlobalFrame();
-        Vec3 renderedPosition = missionScreen.CombatCamera.Position;
-        Vec3 entityDirection = -cameraEntityFrame.rotation.u;
-        entityDirection.Normalize();
-        Vec3 renderedDirection = missionScreen.CombatCamera.Direction;
-        float directionDot =
-            (renderedDirection.X * entityDirection.X)
-            + (renderedDirection.Y * entityDirection.Y)
-            + (renderedDirection.Z * entityDirection.Z);
-
-        float positionDelta =
-            (renderedPosition - cameraEntityFrame.origin).Length;
-        bool active = ReferenceEquals(missionScreen.CustomCamera, mountCamera);
-        return string.Format(
-            CultureInfo.InvariantCulture,
-            "active={0} mount={1:N} positionDelta={2:F3} directionDot={3:F3}",
-            active,
-            focusedMountId,
-            positionDelta,
-            directionDot);
     }
 
     private static bool UpdateMountCameraFrame()
@@ -1467,14 +1623,23 @@ internal static class BattleDebugCommands
         return true;
     }
 
-    [CommandLineArgumentFunction("release_mount_camera", "coop.debug.battle")]
-    public static string ReleaseMountCameraCommand(List<string> args)
+    public sealed class ReleaseMountCameraCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.battle.release_mount_camera";
+        public string Prefix => "coop.debug.battle";
 
-        bool released = ReleaseMountCamera();
-        return released ? "Released the mount camera" : "No mount camera was active";
+        public string Name => "release_mount_camera";
+
+        public string Description => "Restores or clears release mount camera.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            bool released = ReleaseMountCamera();
+            return released
+                ? Succeeded("Released the mount camera")
+                : Failed("No mount camera was active");
+        }
     }
 
     private static bool ReleaseMountCamera()
@@ -1497,122 +1662,155 @@ internal static class BattleDebugCommands
         return true;
     }
 
-    [CommandLineArgumentFunction("ladder_state", "coop.debug.battle")]
-    public static string LadderState(List<string> args)
+    public sealed class LadderStateCoopCommand : ICoopCommand
     {
-        if (args.Count > 1 || (args.Count == 1 && !int.TryParse(args[0], out _)))
-        {
-            return "Usage: coop.debug.battle.ladder_state [machineId]";
-        }
+        public string Prefix => "coop.debug.battle";
 
-        var mission = Mission.Current;
-        if (mission == null || !mission.IsSiegeBattle)
-        {
-            return "No active siege mission";
-        }
+        public string Name => "ladder_state";
 
-        if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var agentRegistry))
-        {
-            return "Unable to resolve NetworkAgentRegistry";
-        }
+        public string Description => "Reports ladder state.";
 
-        int? selectedId = args.Count == 1 ? int.Parse(args[0]) : null;
-        var ladders = mission.MissionObjects
-            .OfType<SiegeLadder>()
-            .Where(ladder => selectedId == null || ladder.Id.Id == selectedId.Value)
-            .OrderBy(ladder => ladder.Id.Id)
-            .ToArray();
-        if (ladders.Length == 0)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return selectedId == null
-                ? "No siege ladders are registered"
-                : $"Siege ladder {selectedId.Value} was not found";
-        }
+            new ExpectedArgs("machine_id", "The machine id.", false),
+        };
 
-        var output = new StringBuilder();
-        output.AppendLine($"ladders={ladders.Length} authority={SiegeMissionAuthorityGate.IsLocalAuthority} " +
-            $"known={SiegeMissionAuthorityGate.IsAuthorityKnown}");
-        foreach (var ladder in ladders)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            int animationIndex = ladder._ladderSkeleton.GetAnimationIndexAtChannel(0);
-            float animationProgress = animationIndex >= 0
-                ? ladder._ladderSkeleton.GetAnimationParameterAtChannel(0)
-                : 0f;
-
-            var users = new List<string>();
-            int deactivatedPoints = 0;
-            foreach (var standingPoint in ladder.StandingPoints)
+            if ((args.Count == 1 && !int.TryParse(args[0], out _)))
             {
-                if (standingPoint.IsDeactivated) deactivatedPoints++;
-
-                var agent = standingPoint.UserAgent ?? standingPoint.MovingAgent;
-                if (agent == null) continue;
-
-                string role = standingPoint.GameEntity.HasTag(ladder.AttackerTag)
-                    ? "attacker"
-                    : standingPoint.GameEntity.HasTag(ladder.DefenderTag) ? "defender" : "other";
-                string controller = agentRegistry.TryGetAgentInfo(agent, out var info)
-                    ? info.CurrentAuthority
-                    : "unregistered";
-                users.Add($"{role}:{controller}:{agent.Index}");
+                return Failed("Invalid command argument value.");
             }
 
-            output.AppendLine($"ladder={ladder.Id.Id:D5} state={ladder.State} animation={ladder._animationState} " +
-                $"animationIndex={animationIndex} progress={animationProgress:0.000} " +
-                $"simLocal={SiegeMissionAuthorityGate.IsMachineSimulatedLocally(ladder.Id.Id)} " +
-                $"points={ladder.StandingPoints.Count} pointsOff={deactivatedPoints} " +
-                $"users={(users.Count > 0 ? string.Join(",", users) : "none")}");
-        }
+            var mission = Mission.Current;
+            if (mission == null || !mission.IsSiegeBattle)
+            {
+                return Failed("No active siege mission");
+            }
 
-        return output.ToString();
+            if (!ContainerProvider.TryResolve<INetworkAgentRegistry>(out var agentRegistry))
+            {
+                return Failed("Unable to resolve NetworkAgentRegistry");
+            }
+
+            int? selectedId = args.Count == 1 ? int.Parse(args[0]) : null;
+            var ladders = mission.MissionObjects
+                .OfType<SiegeLadder>()
+                .Where(ladder => selectedId == null || ladder.Id.Id == selectedId.Value)
+                .OrderBy(ladder => ladder.Id.Id)
+                .ToArray();
+            if (ladders.Length == 0)
+            {
+                return Failed(selectedId == null
+                    ? "No siege ladders are registered"
+                    : $"Siege ladder {selectedId.Value} was not found");
+            }
+
+            var output = new StringBuilder();
+            output.AppendLine($"ladders={ladders.Length} authority={SiegeMissionAuthorityGate.IsLocalAuthority} " +
+                $"known={SiegeMissionAuthorityGate.IsAuthorityKnown}");
+            foreach (var ladder in ladders)
+            {
+                int animationIndex = ladder._ladderSkeleton.GetAnimationIndexAtChannel(0);
+                float animationProgress = animationIndex >= 0
+                    ? ladder._ladderSkeleton.GetAnimationParameterAtChannel(0)
+                    : 0f;
+
+                var users = new List<string>();
+                int deactivatedPoints = 0;
+                foreach (var standingPoint in ladder.StandingPoints)
+                {
+                    if (standingPoint.IsDeactivated) deactivatedPoints++;
+
+                    var agent = standingPoint.UserAgent ?? standingPoint.MovingAgent;
+                    if (agent == null) continue;
+
+                    string role = standingPoint.GameEntity.HasTag(ladder.AttackerTag)
+                        ? "attacker"
+                        : standingPoint.GameEntity.HasTag(ladder.DefenderTag) ? "defender" : "other";
+                    string controller = agentRegistry.TryGetAgentInfo(agent, out var info)
+                        ? info.CurrentAuthority
+                        : "unregistered";
+                    users.Add($"{role}:{controller}:{agent.Index}");
+                }
+
+                output.AppendLine($"ladder={ladder.Id.Id:D5} state={ladder.State} animation={ladder._animationState} " +
+                    $"animationIndex={animationIndex} progress={animationProgress:0.000} " +
+                    $"simLocal={SiegeMissionAuthorityGate.IsMachineSimulatedLocally(ladder.Id.Id)} " +
+                    $"points={ladder.StandingPoints.Count} pointsOff={deactivatedPoints} " +
+                    $"users={(users.Count > 0 ? string.Join(",", users) : "none")}");
+            }
+
+            return Succeeded(output.ToString());
+        }
     }
 
-    [CommandLineArgumentFunction("focus_ladder", "coop.debug.battle")]
-    public static string FocusLadder(List<string> args)
+    public sealed class FocusLadderCoopCommand : ICoopCommand
     {
-        if (args.Count != 1 || !int.TryParse(args[0], out int machineId))
+        public string Prefix => "coop.debug.battle";
+
+        public string Name => "focus_ladder";
+
+        public string Description => "Runs the focus ladder debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.battle.focus_ladder <machineId>";
-        }
+            new ExpectedArgs("machine_id", "The machine id.", true),
+        };
 
-        var mission = Mission.Current;
-        var ladder = mission?.MissionObjects
-            .OfType<SiegeLadder>()
-            .FirstOrDefault(candidate => candidate.Id.Id == machineId);
-        if (ladder == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Siege ladder {machineId} was not found";
+            if (!int.TryParse(args[0], out int machineId))
+            {
+                return Failed("Invalid command argument value.");
+            }
+
+            var mission = Mission.Current;
+            var ladder = mission?.MissionObjects
+                .OfType<SiegeLadder>()
+                .FirstOrDefault(candidate => candidate.Id.Id == machineId);
+            if (ladder == null)
+            {
+                return Failed($"Siege ladder {machineId} was not found");
+            }
+
+            if (!(ScreenManager.TopScreen is MissionScreen missionScreen) || missionScreen.CombatCamera == null)
+            {
+                return Failed("The mission screen is not active");
+            }
+
+            ReleaseMountCamera();
+            ReleaseLadderCamera();
+            ladderCamera = Camera.CreateCamera();
+            ladderCamera.FillParametersFrom(missionScreen.CombatCamera);
+
+            var frame = ladder.GameEntity.GetGlobalFrame();
+            var target = frame.origin + (Vec3.Up * 2.5f);
+            var position = target - (frame.rotation.f * 12f) + (Vec3.Up * 4f);
+            ladderCamera.LookAt(position, target, Vec3.Up);
+            missionScreen.CustomCamera = ladderCamera;
+
+            return Succeeded($"Focused the mission camera on siege ladder {machineId}");
         }
-
-        if (!(ScreenManager.TopScreen is MissionScreen missionScreen) || missionScreen.CombatCamera == null)
-        {
-            return "The mission screen is not active";
-        }
-
-        ReleaseMountCamera();
-        ReleaseLadderCamera();
-        ladderCamera = Camera.CreateCamera();
-        ladderCamera.FillParametersFrom(missionScreen.CombatCamera);
-
-        var frame = ladder.GameEntity.GetGlobalFrame();
-        var target = frame.origin + (Vec3.Up * 2.5f);
-        var position = target - (frame.rotation.f * 12f) + (Vec3.Up * 4f);
-        ladderCamera.LookAt(position, target, Vec3.Up);
-        missionScreen.CustomCamera = ladderCamera;
-
-        return $"Focused the mission camera on siege ladder {machineId}";
     }
 
-    [CommandLineArgumentFunction("release_ladder_camera", "coop.debug.battle")]
-    public static string ReleaseLadderCameraCommand(List<string> args)
+    public sealed class ReleaseLadderCameraCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.battle.release_ladder_camera";
-        }
+        public string Prefix => "coop.debug.battle";
 
-        bool released = ReleaseLadderCamera();
-        return released ? "Released the ladder camera" : "No ladder camera was active";
+        public string Name => "release_ladder_camera";
+
+        public string Description => "Restores or clears release ladder camera.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            bool released = ReleaseLadderCamera();
+            return released
+                ? Succeeded("Released the ladder camera")
+                : Failed("No ladder camera was active");
+        }
     }
 
     private static bool ReleaseLadderCamera()

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.Network.Session;
 using GameInterface;
 using GameInterface.Services.Locations;
@@ -44,6 +45,13 @@ public class MissionModule : Module
 
         foreach (HarmonyPatchCategoryRegistration registration in CreatePatchCategoryRegistrations())
             builder.RegisterInstance(registration);
+
+        builder.RegisterAssemblyTypes(typeof(MissionModule).Assembly)
+            .Where(type => type.IsClass &&
+                           !type.IsAbstract &&
+                           typeof(ICoopCommand).IsAssignableFrom(type))
+            .As<ICoopCommand>()
+            .InstancePerDependency();
 
         builder.RegisterType<LiteNetP2PClient>().As<IBattleNetwork>().InstancePerLifetimeScope();
         builder.RegisterType<MovementPacketCompressor>()


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

Map-event, party/roster, party-visual, mission-movement, and mission-battle debug commands still use attributed static methods with command-specific argument handling.

## What is the new behavior?

Migrates all 146 commands in place. Each attributed method is replaced in its owning file by a concrete `ICoopCommand`, with registry-owned argument counts and explicit command results.

Resolves #3425
Resolves #3427
Resolves #3428
Resolves #3442
Resolves #3443

## Bot Changelog Entry

## Other information

Supersedes #3486.

Tests:

- Release `CoopTests.slnf` build
- Release `CoopUnitTests.slnf` tests
- Debug and Release `Missions` builds
