### PR TITLE
Migrate world and settlement commands in place

### DIFF
--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Network;
 using Common.Network.Session;
@@ -8,6 +9,8 @@ using Coop.Core.Server;
 using Coop.Core.Server.Services.Telemetry;
 using Coop.Tests.Mocks;
 using GameInterface;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Coop.Tests.Autofac
@@ -29,6 +32,10 @@ namespace Coop.Tests.Autofac
 
             var logic = container.Resolve<ILogic>();
             Assert.NotNull(logic);
+
+            ICoopCommand[] commands = container.Resolve<IEnumerable<ICoopCommand>>().ToArray();
+            Assert.Contains(commands, command =>
+                $"{command.Prefix}.{command.Name}" == "coop.debug.workshop.set_workshop_custom_name");
         }
 
         [Fact]

--- a/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
+++ b/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Commands;
 using Common.Messaging;
 using Common.Network;
 using Coop.Core.Client.Services.MobileParties.Messages;
@@ -1457,8 +1458,11 @@ public class VillageHostileActionTests : MapEventTestBase
 
             client.Call(() =>
             {
-                var result = RaidDebugCommands.AllowRaidAiIntervention(new List<string> { "off" });
-                Assert.Contains("server update requested", result);
+                var command = new RaidDebugCommands.AllowRaidAiInterventionCoopCommand();
+                CoopCommandResult result = command.ProcessCommand(
+                    new CoopCommandArgsFactory().FromValues(new[] { "off" }));
+                Assert.True(result.Succeeded);
+                Assert.Contains("server update requested", result.Output);
             });
 
             var request = client.NetworkSentMessages.GetMessages<NetworkRequestRaidAiInterventionConfigChange>().Single();

--- a/source/GameInterface.Tests/Utils/Commands/WorldSettlementDirectCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/WorldSettlementDirectCommandTests.cs
@@ -1,0 +1,290 @@
+﻿using Autofac;
+using Common;
+using Common.Commands;
+using Common.Util;
+using GameInterface.Services.ObjectManager;
+using Serilog;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.CampaignSystem.Siege;
+using TaleWorlds.Library;
+using TaleWorlds.Localization;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+[Collection(global::GameInterface.Tests.ModInformationRoleCollection.Name)]
+public class WorldSettlementDirectCommandTests
+{
+    private static readonly HashSet<string> OwningTypes = new HashSet<string>
+    {
+        "ArenaMasterCommands",
+        "BesiegerCampDebugCommand",
+        "LocationDebugCommand",
+        "FollowPartyFixtureCommands",
+        "MercenaryStockDebugCommand",
+        "MobilePartyDebugCommand",
+        "SettlementAuditorCommand",
+        "SettlementCommands",
+        "SiegeDebugCommand",
+        "TournamentDebugCommand",
+        "TownAuditorDebugCommand",
+        "TownDebugCommand",
+        "RaidDebugCommands",
+        "VillageDebugCommand",
+        "VillagerPartiesCommands",
+        "WorkshopDebugCommand",
+    };
+
+    [Fact]
+    public void MigratedCommands_ReplaceAllAttributedMethodsWithDirectCommands()
+    {
+        Type[] commandTypes = GetCommandTypes();
+
+#if DEBUG
+        Assert.Equal(134, commandTypes.Length);
+#else
+        Assert.Equal(123, commandTypes.Length);
+#endif
+        Assert.All(commandTypes, type =>
+        {
+            Assert.Equal(typeof(object), type.BaseType);
+            Assert.Equal(new[] { typeof(ICoopCommand) }, type.GetInterfaces());
+            Assert.EndsWith("CoopCommand", type.Name);
+            Assert.Contains(type.DeclaringType.Name, OwningTypes);
+        });
+
+        MethodInfo[] attributedMethods = typeof(GameInterfaceModule).Assembly.GetTypes()
+            .Where(type => OwningTypes.Contains(type.Name))
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            .Where(method => method.IsDefined(
+                typeof(CommandLineFunctionality.CommandLineArgumentFunction), inherit: false))
+            .ToArray();
+
+        Assert.Empty(attributedMethods);
+    }
+
+    [Fact]
+    public void MigratedCommands_HaveUniqueNormalizedMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var registry = new CoopCommandRegistry(commands, new LoggerConfiguration().CreateLogger());
+
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.Equal(
+            commands.Length,
+            commands.Select(command => $"{command.Prefix}.{command.Name}").Distinct().Count());
+        Assert.All(commands, command =>
+        {
+            Assert.Matches("^coop(?:\\.[a-z0-9_]+)+$", command.Prefix);
+            Assert.Matches("^[a-z0-9]+(?:_[a-z0-9]+)*$", command.Name);
+            Assert.False(string.IsNullOrWhiteSpace(command.Description));
+            Assert.NotNull(command.ExpectedArgs);
+            Assert.All(command.ExpectedArgs, expectedArg =>
+            {
+                Assert.Matches(new Regex("^[a-z][A-Za-z0-9]*$"), expectedArg.Name);
+                Assert.False(string.IsNullOrWhiteSpace(expectedArg.Description));
+            });
+        });
+    }
+
+    [Fact]
+    public void Registry_RejectsInvalidArgumentCountBeforeCommandLogic()
+    {
+        ICoopCommand command = CreateCommand("coop.debug.besiegercamp.set_progress");
+        var registry = new CoopCommandRegistry(
+            new[] { command },
+            new LoggerConfiguration().CreateLogger());
+
+        CoopCommandResult result = registry.ProcessCommand(
+            $"{command.Prefix}.{command.Name}",
+            new TestArgs(Array.Empty<string>()));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+        Assert.Contains("<besiegerCampId>", result.Output);
+    }
+
+    [Fact]
+    public void TournamentClientRoleRejection_IsExplicitFailure()
+    {
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = false;
+            ICoopCommand command = CreateCommand("coop.debug.tournaments.add_tournament_to_town");
+
+            CoopCommandResult result = command.ProcessCommand(new TestArgs(new[] { "Danustica" }));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
+    }
+
+    [Fact]
+    public void GetTownName_RegisteredNonSettlement_IsExplicitFailure()
+    {
+        var objectManager = new ObjectManager(Serilog.Core.Logger.None);
+        Assert.True(objectManager.AddExisting("registered-object", new object()));
+
+        CoopCommandResult result = RunWithObjectManager(objectManager, () =>
+            CreateCommand("coop.debug.settlements.get_town_name")
+                .ProcessCommand(new TestArgs(new[] { "registered-object" })));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("command_failed", result.ErrorCode);
+        Assert.Contains("was not of type Settlement", result.Output);
+    }
+
+    [Fact]
+    public void StartRebellion_TownUnderSiege_IsExplicitFailure()
+    {
+        var objectManager = new ObjectManager(Serilog.Core.Logger.None);
+        var clan = ObjectHelper.SkipConstructor<Clan>();
+        var town = ObjectHelper.SkipConstructor<Town>();
+        var settlement = ObjectHelper.SkipConstructor<Settlement>();
+        var party = ObjectHelper.SkipConstructor<PartyBase>();
+        town._ownerClan = clan;
+        town._owner = party;
+        settlement._name = new TextObject("Danustica");
+        settlement.Party = party;
+        settlement.Town = town;
+        settlement.SiegeEvent = ObjectHelper.SkipConstructor<SiegeEvent>();
+        party.Settlement = settlement;
+        Assert.True(objectManager.AddExisting("town_comp_ES1", town));
+
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            CoopCommandResult result = RunWithObjectManager(objectManager, () =>
+                CreateCommand("coop.debug.town.start_rebellion")
+                    .ProcessCommand(new TestArgs(new[] { "town_comp_ES1" })));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+            Assert.Contains("is under siege", result.Output);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
+    }
+
+#if DEBUG
+    [Theory]
+    [InlineData("coop.debug.tournaments.danustica_fixture_state")]
+    [InlineData("coop.debug.tournaments.danustica_observe")]
+    public void TournamentObservation_MissingDanusticaContext_IsExplicitFailure(string fullName)
+    {
+        Campaign previousCampaign = Campaign.Current;
+        try
+        {
+            Campaign.Current = null;
+
+            CoopCommandResult result = CreateCommand(fullName)
+                .ProcessCommand(new TestArgs(Array.Empty<string>()));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+            Assert.Contains("Unable to resolve Danustica", result.Output);
+        }
+        finally
+        {
+            Campaign.Current = previousCampaign;
+        }
+    }
+#endif
+
+    [Theory]
+    [InlineData("coop.debug.workshop.set_workshop_custom_name")]
+    [InlineData("coop.debug.workshop.set_workshop_owner")]
+    public void WorkshopCommands_RequireSettlementStringId(string fullName)
+    {
+        ICoopCommand command = CreateCommand(fullName);
+        IExpectedArgs settlementArgument = command.ExpectedArgs[0];
+
+        Assert.Equal("settlementId", settlementArgument.Name);
+        Assert.Equal("The settlement id.", settlementArgument.Description);
+    }
+
+    private static CoopCommandResult RunWithObjectManager(
+        IObjectManager objectManager,
+        Func<CoopCommandResult> invoke)
+    {
+        bool hadPreviousContainer = ContainerProvider.TryGetContainer(out var previousContainer);
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(objectManager).As<IObjectManager>();
+        using var container = builder.Build();
+
+        try
+        {
+            using (ContainerProvider.UseContainerThreadSafe(container))
+            {
+                return invoke();
+            }
+        }
+        finally
+        {
+            if (hadPreviousContainer)
+                ContainerProvider.SetContainer(previousContainer);
+            else
+                ContainerProvider.Clear();
+        }
+    }
+
+    private static ICoopCommand CreateCommand(string fullName)
+    {
+        return Assert.Single(
+            CreateCommands(),
+            command => $"{command.Prefix}.{command.Name}" == fullName);
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return GetCommandTypes()
+            .Select(type => (ICoopCommand)Activator.CreateInstance(type))
+            .ToArray();
+    }
+
+    private static Type[] GetCommandTypes()
+    {
+        return typeof(GameInterfaceModule).Assembly.GetTypes()
+            .Where(type => type.IsClass &&
+                           !type.IsAbstract &&
+                           type.DeclaringType != null &&
+                           OwningTypes.Contains(type.DeclaringType.Name) &&
+                           typeof(ICoopCommand).IsAssignableFrom(type))
+            .ToArray();
+    }
+
+    private sealed class TestArgs : ICoopCommandArgs
+    {
+        private readonly IReadOnlyList<string> values;
+
+        public TestArgs(IReadOnlyList<string> values)
+        {
+            this.values = values;
+        }
+
+        public int Count => values.Count;
+
+        public string this[int index] => values[index];
+
+        public IEnumerator<string> GetEnumerator() => values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/source/GameInterface/Services/Arenas/Commands/ArenaMasterCommands.cs
+++ b/source/GameInterface/Services/Arenas/Commands/ArenaMasterCommands.cs
@@ -1,57 +1,73 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using GameInterface.CoopSessionData;
 using SandBox.CampaignBehaviors;
 using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.CampaignSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Arenas.Commands;
 
 internal class ArenaMasterCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// View arena master interactions data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("list_interactions", "coop.debug.arenas")]
-    public static string ViewArenaMasterInteractionsCommand(List<string> strings)
+    public sealed class ViewArenaMasterInteractionsCommandCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.arenas";
+
+        public string Name => "list_interactions";
+
+        public string Description => "Lists interactions for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerMetArenaMasters in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerMetArenaMasters)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerMetArenaMasters.Key == null || playerMetArenaMasters.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                if (!coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerKnowTournaments.ContainsKey(playerMetArenaMasters.Key)) continue;
-
-                stringBuilder.AppendLine($"{playerMetArenaMasters.Key} knows of tournaments: {coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerKnowTournaments[playerMetArenaMasters.Key]}");
-                stringBuilder.AppendLine($"They have met the arena masters at the following settlements:");
-                foreach (var metArenaMasterSettlementId in playerMetArenaMasters.Value)
+                foreach (var playerMetArenaMasters in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerMetArenaMasters)
                 {
-                    stringBuilder.AppendLine($"    {metArenaMasterSettlementId}");
+                    if (playerMetArenaMasters.Key == null || playerMetArenaMasters.Value == null) continue;
+
+                    if (!coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerKnowTournaments.ContainsKey(playerMetArenaMasters.Key)) continue;
+
+                    stringBuilder.AppendLine($"{playerMetArenaMasters.Key} knows of tournaments: {coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerKnowTournaments[playerMetArenaMasters.Key]}");
+                    stringBuilder.AppendLine($"They have met the arena masters at the following settlements:");
+                    foreach (var metArenaMasterSettlementId in playerMetArenaMasters.Value)
+                    {
+                        stringBuilder.AppendLine($"    {metArenaMasterSettlementId}");
+                    }
                 }
             }
-        }
-        else
-        {
-            var arenaMasterBehavior = Campaign.Current.GetCampaignBehavior<ArenaMasterCampaignBehavior>();
-
-            stringBuilder.AppendLine($"{Hero.MainHero.Name} knows of tournaments: {arenaMasterBehavior._knowTournaments}");
-            stringBuilder.AppendLine($"They have met the arena masters at the following settlements:");
-            foreach (var metArenaMasterSettlement in arenaMasterBehavior._arenaMasterHasMetInSettlements)
+            else
             {
-                stringBuilder.AppendLine($"    {metArenaMasterSettlement.StringId}");
-            }
-        }
+                var arenaMasterBehavior = Campaign.Current.GetCampaignBehavior<ArenaMasterCampaignBehavior>();
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+                stringBuilder.AppendLine($"{Hero.MainHero.Name} knows of tournaments: {arenaMasterBehavior._knowTournaments}");
+                stringBuilder.AppendLine($"They have met the arena masters at the following settlements:");
+                foreach (var metArenaMasterSettlement in arenaMasterBehavior._arenaMasterHasMetInSettlements)
+                {
+                    stringBuilder.AppendLine($"    {metArenaMasterSettlement.StringId}");
+                }
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve player arena master interactions data.");
+
         }
-        return "Failed to retrieve player arena master interactions data.";
     }
 }

--- a/source/GameInterface/Services/BesiegerCamps/Commands/BesiegerCampDebugCommand.cs
+++ b/source/GameInterface/Services/BesiegerCamps/Commands/BesiegerCampDebugCommand.cs
@@ -1,16 +1,21 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using GameInterface.Services.ObjectManager;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Siege;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Villages.Commands;
 
 public class BesiegerCampDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// Attempts to get the ObjectManager
     /// </summary>
@@ -30,35 +35,46 @@ public class BesiegerCampDebugCommand
     /// </summary>
     /// <param name="args">first arg : besiegerCampId ; second arg : value</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("set_number_of_troops_killed_on_side", "coop.debug.besiegercamp")]
-    public static string SetBesiegerCampNumberOfTroopsKilledOnSide(List<string> args)
+    public sealed class SetBesiegerCampNumberOfTroopsKilledOnSideCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.besiegercamp";
+
+        public string Name => "set_number_of_troops_killed_on_side";
+
+        public string Description => "Sets number of troops killed on side for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.besiegercamp.set_number_of_troops_killed_on_side <besiegerCampId> <value> ";
-        }
+            new ExpectedArgs("besiegerCampId", "The besieger camp id."),
+            new ExpectedArgs("value", "The value."),
+        };
 
-        string besiegerCampId = args[0];
-        string troopsValueString = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            string besiegerCampId = args[0];
+            string troopsValueString = args[1];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(besiegerCampId, out BesiegerCamp besiegerCamp) == false)
+            {
+                return Failed($"BesiegerCamp with ID: '{besiegerCampId}' not found");
+            }
+
+            if (int.TryParse(troopsValueString, out int troopsValue) == false)
+            {
+                return Failed($"Argument2: {troopsValueString} is not a int.");
+            }
+
+            besiegerCamp.NumberOfTroopsKilledOnSide = troopsValue;
+
+            return Succeeded($"BesiegerCamp NumberOfTroopsKilledOnSide has changed to: {besiegerCamp.NumberOfTroopsKilledOnSide}");
+
         }
-
-        if (objectManager.TryGetObject(besiegerCampId, out BesiegerCamp besiegerCamp) == false)
-        {
-            return $"BesiegerCamp with ID: '{besiegerCampId}' not found";
-        }
-
-        if (int.TryParse(troopsValueString, out int troopsValue) == false)
-        {
-            return $"Argument2: {troopsValueString} is not a int.";
-        }
-
-        besiegerCamp.NumberOfTroopsKilledOnSide = troopsValue;
-
-        return $"BesiegerCamp NumberOfTroopsKilledOnSide has changed to: {besiegerCamp.NumberOfTroopsKilledOnSide}";
     }
 
     // coop.debug.besiegercamp.set_progress
@@ -67,35 +83,46 @@ public class BesiegerCampDebugCommand
     /// </summary>
     /// <param name="args">first arg : besiegerCampId ; second arg : value</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("coop.debug.besiegercamp.set_progress", "coop.debug.besiegercamp")]
-    public static string SetBesiegerCampPreparationsProgress(List<string> args)
+    public sealed class SetBesiegerCampPreparationsProgressCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.besiegercamp";
+
+        public string Name => "set_progress";
+
+        public string Description => "Sets progress for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.besiegercamp.set_progress <besiegerCampId> <progress> ";
-        }
+            new ExpectedArgs("besiegerCampId", "The besieger camp id."),
+            new ExpectedArgs("progress", "The progress."),
+        };
 
-        string besiegerCampId = args[0];
-        string percentageValueString = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            string besiegerCampId = args[0];
+            string percentageValueString = args[1];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(besiegerCampId, out BesiegerCamp besiegerCamp) == false)
+            {
+                return Failed($"BesiegerCamp with ID: '{besiegerCampId}' not found");
+            }
+
+            if (float.TryParse(percentageValueString, out float progressPercentage) == false)
+            {
+                return Failed($"Argument2: {percentageValueString} is not a int.");
+            }
+
+            besiegerCamp.SiegeEngines.SiegePreparations.SetProgress(progressPercentage);
+
+            return Succeeded($"BesiegerCamp preparations progress has changed to: {besiegerCamp.SiegeEngines.SiegePreparations.Progress}");
+
         }
-
-        if (objectManager.TryGetObject(besiegerCampId, out BesiegerCamp besiegerCamp) == false)
-        {
-            return $"BesiegerCamp with ID: '{besiegerCampId}' not found";
-        }
-
-        if (float.TryParse(percentageValueString, out float progressPercentage) == false)
-        {
-            return $"Argument2: {percentageValueString} is not a int.";
-        }
-
-        besiegerCamp.SiegeEngines.SiegePreparations.SetProgress(progressPercentage);
-
-        return $"BesiegerCamp preparations progress has changed to: {besiegerCamp.SiegeEngines.SiegePreparations.Progress}";
     }
 
     // coop.debug.besiegercamp.set_siege_strategy
@@ -104,41 +131,52 @@ public class BesiegerCampDebugCommand
     /// </summary>
     /// <param name="args">first arg: besiegerCampId; second arg: strategyId</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("set_siege_strategy", "coop.debug.besiegercamp")]
-    public static string SetBesiegerCampSiegeStrategy(List<string> args)
+    public sealed class SetBesiegerCampSiegeStrategyCoopCommand : ICoopCommand
     {
-        string getPossibleStragegyIds() => string.Join(Environment.NewLine, SiegeStrategy.All.Select(x => x.StringId));
-        string idTipMsg = $"{Environment.NewLine}SiegeStrategy Id must be one of the following:{getPossibleStragegyIds()}";
+        public string Prefix => "coop.debug.besiegercamp";
 
-        if (args.Count != 2)
+        public string Name => "set_siege_strategy";
+
+        public string Description => "Sets siege strategy for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.besiegercamp.set_siege_strategy <besiegerCampId> <strategyId>" + idTipMsg;
-        }
+            new ExpectedArgs("besiegerCampId", "The besieger camp id."),
+            new ExpectedArgs("strategyId", "The strategy id."),
+        };
 
-        string besiegerCampId = args[0];
-        string strategyId = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+            string getPossibleStragegyIds() => string.Join(Environment.NewLine, SiegeStrategy.All.Select(x => x.StringId));
+            string idTipMsg = $"{Environment.NewLine}SiegeStrategy Id must be one of the following:{getPossibleStragegyIds()}";
+
+
+            string besiegerCampId = args[0];
+            string strategyId = args[1];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject<BesiegerCamp>(besiegerCampId, out var besiegerCamp) == false)
+            {
+                return Failed($"BesiegerCamp with ID: '{besiegerCampId}' not found");
+            }
+
+            // Attempt to create or retrieve the SiegeStrategy based on the strategyId
+            SiegeStrategy siegeStrategy = SiegeStrategy.All.FirstOrDefault(x => string.Equals(x.StringId, strategyId, StringComparison.OrdinalIgnoreCase));
+            if (siegeStrategy == null)
+            {
+                return Failed($"Invalid SiegeStrategy ID :'{strategyId}'{idTipMsg}");
+            }
+
+            // Assign the strategy to the besieger camp
+            besiegerCamp.SiegeStrategy = siegeStrategy;
+
+            return Succeeded($"SiegeStrategy for BesiegerCamp {besiegerCampId} has been set to: {siegeStrategy.StringId}");
+
         }
-
-        if (objectManager.TryGetObject<BesiegerCamp>(besiegerCampId, out var besiegerCamp) == false)
-        {
-            return $"BesiegerCamp with ID: '{besiegerCampId}' not found";
-        }
-
-        // Attempt to create or retrieve the SiegeStrategy based on the strategyId
-        SiegeStrategy siegeStrategy = SiegeStrategy.All.FirstOrDefault(x => string.Equals(x.StringId, strategyId, StringComparison.OrdinalIgnoreCase));
-        if (siegeStrategy == null)
-        {
-            return $"Invalid SiegeStrategy ID :'{strategyId}'{idTipMsg}";
-        }
-
-        // Assign the strategy to the besieger camp
-        besiegerCamp.SiegeStrategy = siegeStrategy;
-
-        return $"SiegeStrategy for BesiegerCamp {besiegerCampId} has been set to: {siegeStrategy.StringId}";
     }
 
     // coop.debug.besiegerCamp.set_leader_party
@@ -147,35 +185,46 @@ public class BesiegerCampDebugCommand
     /// </summary>
     /// <param name="args">besiegerCampId and the partyId to set</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("set_leader_party", "coop.debug.besiegercamp")]
-    public static string SetBesiegerCampLeaderParty(List<string> args)
+    public sealed class SetBesiegerCampLeaderPartyCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.besiegercamp";
+
+        public string Name => "set_leader_party";
+
+        public string Description => "Sets leader party for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.besiegercamp.set_leader_party <besiegerCampId> <partyId> ";
-        }
+            new ExpectedArgs("besiegerCampId", "The besieger camp id."),
+            new ExpectedArgs("partyId", "The party id."),
+        };
 
-        string besiegerCampId = args[0];
-        string partyId = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            string besiegerCampId = args[0];
+            string partyId = args[1];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(besiegerCampId, out BesiegerCamp besiegerCamp) == false)
+            {
+                return Failed($"{nameof(BesiegerCamp)} with ID: '{besiegerCampId}' not found");
+            }
+
+            if (objectManager.TryGetObject(partyId, out MobileParty party) == false)
+            {
+                return Failed($"{nameof(MobileParty)} with ID: '{partyId}' not found");
+            }
+
+            besiegerCamp._leaderParty = party;
+
+            return Succeeded($"{nameof(BesiegerCamp._leaderParty)} has changed to: {besiegerCamp._leaderParty.Name} party with ID: {besiegerCamp._leaderParty.StringId}");
+
         }
-
-        if (objectManager.TryGetObject(besiegerCampId, out BesiegerCamp besiegerCamp) == false)
-        {
-            return $"{nameof(BesiegerCamp)} with ID: '{besiegerCampId}' not found";
-        }
-
-        if (objectManager.TryGetObject(partyId, out MobileParty party) == false)
-        {
-            return $"{nameof(MobileParty)} with ID: '{partyId}' not found";
-        }
-
-        besiegerCamp._leaderParty = party;
-
-        return $"{nameof(BesiegerCamp._leaderParty)} has changed to: {besiegerCamp._leaderParty.Name} party with ID: {besiegerCamp._leaderParty.StringId}";
     }
 
     // coop.debug.besiegercamp.add_party
@@ -184,35 +233,46 @@ public class BesiegerCampDebugCommand
     /// </summary>
     /// <param name="args">besiegerCampId and the partyId to add</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("add_besiegerparty", "coop.debug.besiegercamp")]
-    public static string AddPartyToBesiegerCamp(List<string> args)
+    public sealed class AddPartyToBesiegerCampCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.besiegercamp";
+
+        public string Name => "add_besieger_party";
+
+        public string Description => "Adds besieger party for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.besiegercamp.add_party <besiegerCampId> <partyId>";
-        }
+            new ExpectedArgs("besiegerCampId", "The besieger camp id."),
+            new ExpectedArgs("partyId", "The party id."),
+        };
 
-        string besiegerCampId = args[0];
-        string partyId = args[1];
-
-        if (!TryGetObjectManager(out var objectManager))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            string besiegerCampId = args[0];
+            string partyId = args[1];
+
+            if (!TryGetObjectManager(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject<BesiegerCamp>(besiegerCampId, out var besiegerCamp))
+            {
+                return Failed($"BesiegerCamp with ID: '{besiegerCampId}' not found");
+            }
+
+            if (!objectManager.TryGetObject<MobileParty>(partyId, out var mobileParty))
+            {
+                return Failed($"MobileParty with ID: '{partyId}' not found");
+            }
+
+            besiegerCamp._besiegerParties.Add(mobileParty);
+
+            return Succeeded($"MobileParty {partyId} added to BesiegerCamp {besiegerCampId}");
+
         }
-
-        if (!objectManager.TryGetObject<BesiegerCamp>(besiegerCampId, out var besiegerCamp))
-        {
-            return $"BesiegerCamp with ID: '{besiegerCampId}' not found";
-        }
-
-        if (!objectManager.TryGetObject<MobileParty>(partyId, out var mobileParty))
-        {
-            return $"MobileParty with ID: '{partyId}' not found";
-        }
-
-        besiegerCamp._besiegerParties.Add(mobileParty);
-
-        return $"MobileParty {partyId} added to BesiegerCamp {besiegerCampId}";
     }
 
     // coop.debug.besiegercamp.remove_party
@@ -221,37 +281,48 @@ public class BesiegerCampDebugCommand
     /// </summary>
     /// <param name="args">besiegerCampId and the partyId to remove</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("remove_party", "coop.debug.besiegercamp")]
-    public static string RemovePartyFromBesiegerCamp(List<string> args)
+    public sealed class RemovePartyFromBesiegerCampCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.besiegercamp";
+
+        public string Name => "remove_party";
+
+        public string Description => "Removes party for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.besiegercamp.remove_party <besiegerCampId> <partyId>";
-        }
+            new ExpectedArgs("besiegerCampId", "The besieger camp id."),
+            new ExpectedArgs("partyId", "The party id."),
+        };
 
-        string besiegerCampId = args[0];
-        string partyId = args[1];
-
-        if (!TryGetObjectManager(out var objectManager))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (!objectManager.TryGetObject<BesiegerCamp>(besiegerCampId, out var besiegerCamp))
-        {
-            return $"BesiegerCamp with ID: '{besiegerCampId}' not found";
-        }
+            string besiegerCampId = args[0];
+            string partyId = args[1];
 
-        if (!objectManager.TryGetObject<MobileParty>(partyId, out var mobileParty))
-        {
-            return $"MobileParty with ID: '{partyId}' not found";
-        }
+            if (!TryGetObjectManager(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        if (!besiegerCamp._besiegerParties.Remove(mobileParty))
-        {
-            return $"MobileParty {partyId} not found in BesiegerCamp {besiegerCampId}";
-        }
+            if (!objectManager.TryGetObject<BesiegerCamp>(besiegerCampId, out var besiegerCamp))
+            {
+                return Failed($"BesiegerCamp with ID: '{besiegerCampId}' not found");
+            }
 
-        return $"MobileParty {partyId} removed from BesiegerCamp {besiegerCampId}";
+            if (!objectManager.TryGetObject<MobileParty>(partyId, out var mobileParty))
+            {
+                return Failed($"MobileParty with ID: '{partyId}' not found");
+            }
+
+            if (!besiegerCamp._besiegerParties.Remove(mobileParty))
+            {
+                return Failed($"MobileParty {partyId} not found in BesiegerCamp {besiegerCampId}");
+            }
+
+            return Succeeded($"MobileParty {partyId} removed from BesiegerCamp {besiegerCampId}");
+
+        }
     }
 }

--- a/source/GameInterface/Services/Locations/Commands/LocationDebugCommand.cs
+++ b/source/GameInterface/Services/Locations/Commands/LocationDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.Locations.Messages;
 using GameInterface.Services.ObjectManager;
@@ -12,8 +13,6 @@ using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements.Locations;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Locations.Commands;
 
 /// <summary>
@@ -21,280 +20,391 @@ namespace GameInterface.Services.Locations.Commands;
 /// </summary>
 public class LocationDebugCommand
 {
-    [CommandLineArgumentFunction("enter", "coop.debug.location")]
-    public static string EnterLocation(List<string> args)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class EnterLocationCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.location";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.location.enter <LocationId>. Warning: this starts a client-local encounter and can desync from the server.";
+        public string Name => "enter";
 
-        if (TryResolveLocation(args[0], out var location, out var error) == false)
-            return error;
+        public string Description => "Enters the relevant state for co-op debugging.";
 
-        var settlement = Campaign.Current.Settlements.FirstOrDefault(
-            candidate => candidate.LocationComplex?
-                .GetListOfLocations()
-                .Contains(location) == true);
-        if (settlement == null)
-            return $"Unable to resolve the settlement for location '{args[0]}'.";
-
-        if (PlayerEncounter.Current == null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
-                return "Unable to resolve the settlement interface.";
+            new ExpectedArgs("locationId", "The location id."),
+        };
 
-            settlementInterface.StartSettlementEncounter(MobileParty.MainParty, settlement);
-            return PlayerEncounter.Current == null
-                ? $"Unable to start a local encounter with '{settlement.StringId}'."
-                : $"Started a local encounter with '{settlement.StringId}'.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            if (TryResolveLocation(args[0], out var location, out var error) == false)
+                return Failed(error);
+
+            var settlement = Campaign.Current.Settlements.FirstOrDefault(
+                candidate => candidate.LocationComplex?
+                    .GetListOfLocations()
+                    .Contains(location) == true);
+            if (settlement == null)
+                return Failed($"Unable to resolve the settlement for location '{args[0]}'.");
+
+            if (PlayerEncounter.Current == null)
+            {
+                if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
+                    return Failed("Unable to resolve the settlement interface.");
+
+                settlementInterface.StartSettlementEncounter(MobileParty.MainParty, settlement);
+                return PlayerEncounter.Current == null
+                    ? Failed($"Unable to start a local encounter with '{settlement.StringId}'.")
+                    : Succeeded($"Started a local encounter with '{settlement.StringId}'.");
+            }
+
+            if (PlayerEncounter.EncounterSettlement != settlement)
+                return Failed($"A player encounter with another settlement is already active.");
+
+            if (Mission.Current != null)
+                return Failed("A mission is already active.");
+
+            PlayerEncounter.EnterSettlement();
+            var mission = PlayerEncounter.LocationEncounter?
+                .CreateAndOpenMissionController(location);
+            return mission == null
+                ? Failed($"Unable to open location '{args[0]}'.")
+                : Succeeded($"Opening location '{args[0]}'.");
+
         }
-
-        if (PlayerEncounter.EncounterSettlement != settlement)
-            return $"A player encounter with another settlement is already active.";
-
-        if (Mission.Current != null)
-            return "A mission is already active.";
-
-        PlayerEncounter.EnterSettlement();
-        var mission = PlayerEncounter.LocationEncounter?
-            .CreateAndOpenMissionController(location);
-        return mission == null
-            ? $"Unable to open location '{args[0]}'."
-            : $"Opening location '{args[0]}'.";
     }
 
-    [CommandLineArgumentFunction("leave", "coop.debug.location")]
-    public static string LeaveLocation(List<string> args)
+    public sealed class LeaveLocationCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.location";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.location.leave";
+        public string Name => "leave";
 
-        if (Mission.Current == null)
-            return "No mission is active.";
+        public string Description => "Leaves the relevant state for co-op debugging.";
 
-        Mission.Current.EndMission();
-        return "Ending the current location mission.";
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            if (Mission.Current == null)
+                return Failed("No mission is active.");
+
+            Mission.Current.EndMission();
+            return Succeeded("Ending the current location mission.");
+
+        }
     }
 
     // coop.debug.location.list
     /// <summary>
     /// Lists all registered locations
     /// </summary>
-    [CommandLineArgumentFunction("list", "coop.debug.location")]
-    public static string ListLocations(List<string> args)
+    public sealed class ListLocationsCoopCommand : ICoopCommand
     {
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "list";
+
+        public string Description => "Lists the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Unable to resolve {nameof(IObjectManager)}";
-        }
-
-        var stringBuilder = new StringBuilder();
-
-        foreach (var settlement in Campaign.Current.Settlements)
-        {
-            if (settlement.LocationComplex == null) continue;
-
-            foreach (var location in settlement.LocationComplex.GetListOfLocations())
+            if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
             {
-                if (objectManager.TryGetId(location, out var locationId) == false) continue;
-
-                stringBuilder.AppendLine($"Id: '{locationId}' Characters: {location.GetCharacterList()?.Count() ?? 0} SpecialItems: {location.SpecialItems?.Count ?? 0}");
+                return Failed($"Unable to resolve {nameof(IObjectManager)}");
             }
-        }
 
-        return stringBuilder.ToString();
+            var stringBuilder = new StringBuilder();
+
+            foreach (var settlement in Campaign.Current.Settlements)
+            {
+                if (settlement.LocationComplex == null) continue;
+
+                foreach (var location in settlement.LocationComplex.GetListOfLocations())
+                {
+                    if (objectManager.TryGetId(location, out var locationId) == false) continue;
+
+                    stringBuilder.AppendLine($"Id: '{locationId}' Characters: {location.GetCharacterList()?.Count() ?? 0} SpecialItems: {location.SpecialItems?.Count ?? 0}");
+                }
+            }
+
+            return Succeeded(stringBuilder.ToString());
+
+        }
     }
 
     // coop.debug.location.info Location_town_V1_tavern
     /// <summary>
     /// Shows the state of a single location
     /// </summary>
-    [CommandLineArgumentFunction("info", "coop.debug.location")]
-    public static string Info(List<string> args)
+    public sealed class InfoCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "info";
+
+        public string Description => "Shows the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.location.info <LocationId>";
+            new ExpectedArgs("locationId", "The location id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine($"StringId: '{location.StringId}'");
+            stringBuilder.AppendLine($"Characters: {location.GetCharacterList()?.Count() ?? 0}");
+            stringBuilder.AppendLine($"SpecialItems: {location.SpecialItems?.Count ?? 0}");
+
+            return Succeeded(stringBuilder.ToString());
+
         }
-
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-
-        var stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine($"StringId: '{location.StringId}'");
-        stringBuilder.AppendLine($"Characters: {location.GetCharacterList()?.Count() ?? 0}");
-        stringBuilder.AppendLine($"SpecialItems: {location.SpecialItems?.Count ?? 0}");
-
-        return stringBuilder.ToString();
     }
 
     // coop.debug.location.list_characters Location_town_V1_tavern
     /// <summary>
     /// Lists the characters currently in a location
     /// </summary>
-    [CommandLineArgumentFunction("list_characters", "coop.debug.location")]
-    public static string ListCharacters(List<string> args)
+    public sealed class ListCharactersCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "list_characters";
+
+        public string Description => "Lists characters for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.location.list_characters <LocationId>";
-        }
+            new ExpectedArgs("locationId", "The location id."),
+        };
 
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-
-        var stringBuilder = new StringBuilder();
-
-        foreach (var locationCharacter in location.GetCharacterList() ?? Enumerable.Empty<LocationCharacter>())
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            stringBuilder.AppendLine($"'{locationCharacter.Character?.StringId}' Hero: {locationCharacter.Character?.IsHero} Tag: '{locationCharacter.SpecialTargetTag}'");
-        }
 
-        return stringBuilder.Length == 0 ? "No characters" : stringBuilder.ToString();
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+
+            var stringBuilder = new StringBuilder();
+
+            foreach (var locationCharacter in location.GetCharacterList() ?? Enumerable.Empty<LocationCharacter>())
+            {
+                stringBuilder.AppendLine($"'{locationCharacter.Character?.StringId}' Hero: {locationCharacter.Character?.IsHero} Tag: '{locationCharacter.SpecialTargetTag}'");
+            }
+
+            return Succeeded(stringBuilder.Length == 0 ? "No characters" : stringBuilder.ToString());
+
+        }
     }
 
     // coop.debug.location.list_special_items Location_town_V1_tavern
     /// <summary>
     /// Lists a location's special items
     /// </summary>
-    [CommandLineArgumentFunction("list_special_items", "coop.debug.location")]
-    public static string ListSpecialItems(List<string> args)
+    public sealed class ListSpecialItemsCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "list_special_items";
+
+        public string Description => "Lists special items for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.location.list_special_items <LocationId>";
-        }
+            new ExpectedArgs("locationId", "The location id."),
+        };
 
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-
-        var stringBuilder = new StringBuilder();
-
-        foreach (var item in location.SpecialItems ?? Enumerable.Empty<ItemObject>().ToList())
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            stringBuilder.AppendLine($"'{item?.StringId}'");
-        }
 
-        return stringBuilder.Length == 0 ? "No special items" : stringBuilder.ToString();
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+
+            var stringBuilder = new StringBuilder();
+
+            foreach (var item in location.SpecialItems ?? Enumerable.Empty<ItemObject>().ToList())
+            {
+                stringBuilder.AppendLine($"'{item?.StringId}'");
+            }
+
+            return Succeeded(stringBuilder.Length == 0 ? "No special items" : stringBuilder.ToString());
+
+        }
     }
 
     // coop.debug.location.add_character Location_town_V1_tavern lord_1_1
     /// <summary>
     /// Adds a character to a location on the server and clients
     /// </summary>
-    [CommandLineArgumentFunction("add_character", "coop.debug.location")]
-    public static string AddCharacter(List<string> args)
+    public sealed class AddCharacterCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "add_character";
+
+        public string Description => "Adds character for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Command is only available to run on the server";
-        }
+            new ExpectedArgs("locationId", "The location id."),
+            new ExpectedArgs("characterObjectId", "The character object id."),
+        };
 
-        if (args.Count != 2)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.location.add_character <LocationId> <CharacterObjectId>";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Command is only available to run on the server");
+            }
+
+
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+            if (TryResolveObject<CharacterObject>(args[1], out var character, out error) == false) return Failed(error);
+
+            var locationCharacter = LocationCharacterFactory.Create(
+                character,
+                originParty: null,
+                specialItem: null,
+                spawnTag: "sp_notable",
+                actionSetCode: null,
+                behaviorsMethodName: null,
+                characterRelation: (int)LocationCharacter.CharacterRelations.Neutral,
+                fixedLocation: false,
+                useCivilianEquipment: true);
+
+            // The real mutator runs so the patched chokepoint broadcasts the change.
+            GameThread.Run(() => location.AddCharacter(locationCharacter));
+
+            return Succeeded($"Added '{args[1]}' to '{args[0]}'");
+
         }
-
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-        if (TryResolveObject<CharacterObject>(args[1], out var character, out error) == false) return error;
-
-        var locationCharacter = LocationCharacterFactory.Create(
-            character,
-            originParty: null,
-            specialItem: null,
-            spawnTag: "sp_notable",
-            actionSetCode: null,
-            behaviorsMethodName: null,
-            characterRelation: (int)LocationCharacter.CharacterRelations.Neutral,
-            fixedLocation: false,
-            useCivilianEquipment: true);
-
-        // The real mutator runs so the patched chokepoint broadcasts the change.
-        GameThread.Run(() => location.AddCharacter(locationCharacter));
-
-        return $"Added '{args[1]}' to '{args[0]}'";
     }
 
     // coop.debug.location.remove_character Location_town_V1_tavern lord_1_1
     /// <summary>
     /// Removes a character from a location on the server and clients
     /// </summary>
-    [CommandLineArgumentFunction("remove_character", "coop.debug.location")]
-    public static string RemoveCharacter(List<string> args)
+    public sealed class RemoveCharacterCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "remove_character";
+
+        public string Description => "Removes character for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Command is only available to run on the server";
-        }
+            new ExpectedArgs("locationId", "The location id."),
+            new ExpectedArgs("characterObjectId", "The character object id."),
+        };
 
-        if (args.Count != 2)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.location.remove_character <LocationId> <CharacterObjectId>";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Command is only available to run on the server");
+            }
+
+
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+            if (TryResolveObject<CharacterObject>(args[1], out var character, out error) == false) return Failed(error);
+
+            var entry = SyncedLocationCharacters.Find(location, character);
+            if (entry == null)
+            {
+                return Failed($"No character '{args[1]}' in '{args[0]}'");
+            }
+
+            GameThread.Run(() => location.RemoveLocationCharacter(entry));
+
+            return Succeeded($"Removed '{args[1]}' from '{args[0]}'");
+
         }
-
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-        if (TryResolveObject<CharacterObject>(args[1], out var character, out error) == false) return error;
-
-        var entry = SyncedLocationCharacters.Find(location, character);
-        if (entry == null)
-        {
-            return $"No character '{args[1]}' in '{args[0]}'";
-        }
-
-        GameThread.Run(() => location.RemoveLocationCharacter(entry));
-
-        return $"Removed '{args[1]}' from '{args[0]}'";
     }
 
     // coop.debug.location.remove_all_characters Location_town_V1_tavern
     /// <summary>
     /// Clears a location's character list on the server and clients
     /// </summary>
-    [CommandLineArgumentFunction("remove_all_characters", "coop.debug.location")]
-    public static string RemoveAllCharacters(List<string> args)
+    public sealed class RemoveAllCharactersCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "remove_all_characters";
+
+        public string Description => "Removes all characters for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Command is only available to run on the server";
-        }
+            new ExpectedArgs("locationId", "The location id."),
+        };
 
-        if (args.Count != 1)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.location.remove_all_characters <LocationId>";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Command is only available to run on the server");
+            }
+
+
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+
+            GameThread.Run(() => location.RemoveAllCharacters());
+
+            return Succeeded($"Cleared '{args[0]}'");
+
         }
-
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-
-        GameThread.Run(() => location.RemoveAllCharacters());
-
-        return $"Cleared '{args[0]}'";
     }
 
     // coop.debug.location.add_special_item Location_town_V1_tavern mule
     /// <summary>
     /// Adds a special item to a location on the server and clients
     /// </summary>
-    [CommandLineArgumentFunction("add_special_item", "coop.debug.location")]
-    public static string AddSpecialItem(List<string> args)
+    public sealed class AddSpecialItemCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "add_special_item";
+
+        public string Description => "Adds special item for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Command is only available to run on the server";
-        }
+            new ExpectedArgs("locationId", "The location id."),
+            new ExpectedArgs("itemObjectId", "The item object id."),
+        };
 
-        if (args.Count != 2)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.location.add_special_item <LocationId> <ItemObjectId>";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Command is only available to run on the server");
+            }
+
+
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+            if (TryResolveObject<ItemObject>(args[1], out var item, out error) == false) return Failed(error);
+
+            GameThread.Run(() => location.AddSpecialItem(item));
+
+            return Succeeded($"Added '{args[1]}' to '{args[0]}'");
+
         }
-
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-        if (TryResolveObject<ItemObject>(args[1], out var item, out error) == false) return error;
-
-        GameThread.Run(() => location.AddSpecialItem(item));
-
-        return $"Added '{args[1]}' to '{args[0]}'";
     }
 
     // coop.debug.location.remove_special_item Location_town_V1_tavern mule
@@ -302,34 +412,45 @@ public class LocationDebugCommand
     /// Removes a special item from a location on the server and clients. Vanilla only removes
     /// special items from inside a mission scene, so the command publishes the removal directly.
     /// </summary>
-    [CommandLineArgumentFunction("remove_special_item", "coop.debug.location")]
-    public static string RemoveSpecialItem(List<string> args)
+    public sealed class RemoveSpecialItemCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "remove_special_item";
+
+        public string Description => "Removes special item for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Command is only available to run on the server";
+            new ExpectedArgs("locationId", "The location id."),
+            new ExpectedArgs("itemObjectId", "The item object id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+            {
+                return Failed("Command is only available to run on the server");
+            }
+
+
+            if (TryResolveLocation(args[0], out var location, out var error) == false) return Failed(error);
+            if (TryResolveObject<ItemObject>(args[1], out var item, out error) == false) return Failed(error);
+
+            if (location.SpecialItems?.Contains(item) != true)
+            {
+                return Failed($"No item '{args[1]}' in '{args[0]}'");
+            }
+
+            GameThread.Run(() =>
+            {
+                location.SpecialItems.Remove(item);
+                MessageBroker.Instance.Publish(location, new LocationSpecialItemRemoved(location, item));
+            });
+
+            return Succeeded($"Removed '{args[1]}' from '{args[0]}'");
+
         }
-
-        if (args.Count != 2)
-        {
-            return "Usage: coop.debug.location.remove_special_item <LocationId> <ItemObjectId>";
-        }
-
-        if (TryResolveLocation(args[0], out var location, out var error) == false) return error;
-        if (TryResolveObject<ItemObject>(args[1], out var item, out error) == false) return error;
-
-        if (location.SpecialItems?.Contains(item) != true)
-        {
-            return $"No item '{args[1]}' in '{args[0]}'";
-        }
-
-        GameThread.Run(() =>
-        {
-            location.SpecialItems.Remove(item);
-            MessageBroker.Instance.Publish(location, new LocationSpecialItemRemoved(location, item));
-        });
-
-        return $"Removed '{args[1]}' from '{args[0]}'";
     }
 
     // coop.debug.location.populate town_V1
@@ -337,33 +458,43 @@ public class LocationDebugCommand
     /// Populates a settlement's locations and broadcasts the roster snapshot, as if a player
     /// party had entered
     /// </summary>
-    [CommandLineArgumentFunction("populate", "coop.debug.location")]
-    public static string Populate(List<string> args)
+    public sealed class PopulateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.location";
+
+        public string Name => "populate";
+
+        public string Description => "Runs the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Command is only available to run on the server";
-        }
+            new ExpectedArgs("settlementStringId", "The settlement string id."),
+        };
 
-        if (args.Count != 1)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.location.populate <SettlementStringId>";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Command is only available to run on the server");
+            }
+
+
+            if (ContainerProvider.TryResolve<SettlementPopulationTracker>(out var tracker) == false)
+            {
+                return Failed($"Unable to resolve {nameof(SettlementPopulationTracker)}");
+            }
+
+            var settlement = Campaign.Current.Settlements.FirstOrDefault(x => x.StringId == args[0]);
+            if (settlement == null)
+            {
+                return Failed($"Unable to find settlement '{args[0]}'");
+            }
+
+            tracker.DebugPopulate(settlement);
+
+            return Succeeded($"Populating '{args[0]}'");
+
         }
-
-        if (ContainerProvider.TryResolve<SettlementPopulationTracker>(out var tracker) == false)
-        {
-            return $"Unable to resolve {nameof(SettlementPopulationTracker)}";
-        }
-
-        var settlement = Campaign.Current.Settlements.FirstOrDefault(x => x.StringId == args[0]);
-        if (settlement == null)
-        {
-            return $"Unable to find settlement '{args[0]}'";
-        }
-
-        tracker.DebugPopulate(settlement);
-
-        return $"Populating '{args[0]}'";
     }
 
     private static bool TryResolveLocation(string locationId, out Location location, out string error)

--- a/source/GameInterface/Services/MobileParties/Commands/FollowPartyFixtureCommands.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/FollowPartyFixtureCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.MobileParties.Data;
 using GameInterface.Services.MobileParties.Extensions;
@@ -10,172 +11,231 @@ using System.Globalization;
 using System.Linq;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.MobileParties.Commands;
 
 internal static class FollowPartyFixtureCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static FixtureState fixture;
 
-    [CommandLineArgumentFunction("follow_fixture_setup", "coop.debug.mobileparty")]
-    public static string Setup(List<string> args)
+    public sealed class SetupCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Command can only be run on the server.";
-        if (args.Count != 1)
-            return "Usage: coop.debug.mobileparty.follow_fixture_setup <playerPartyId>";
-        if (fixture != null)
-            return "Follow fixture is already active; restore it before starting another.";
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
-            !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
-            return "Unable to resolve fixture services.";
-        if (!TryFindParty(args[0], out MobileParty playerParty))
-            return $"Player party '{args[0]}' was not found.";
-        if (!playerParty.IsPlayerParty())
-            return $"Party '{args[0]}' is not registered as a player party.";
-        if (!IsAvailableOnMap(playerParty))
-            return $"Player party '{args[0]}' must be active on the campaign map and outside a map event, settlement, or army.";
+        public string Prefix => "coop.debug.mobileparty";
 
-        MobileParty targetParty = MobileParty.All
-            .Where(party => party != playerParty &&
-                party.IsLordParty &&
-                !party.IsPlayerParty() &&
-                IsAvailableOnMap(party) &&
-                party.DefaultBehavior == AiBehavior.PatrolAroundPoint &&
-                party.IsCurrentlyAtSea == playerParty.IsCurrentlyAtSea &&
-                objectManager.TryGetId(party, out _))
-            .OrderBy(party => party.Position.DistanceSquared(playerParty.Position))
-            .FirstOrDefault();
-        if (targetParty == null)
-            return "No eligible patrolling registered AI lord party is available for the follow fixture.";
-        if (!behaviorSnapshot.TryCreate(playerParty, out PartyBehaviorUpdateData playerState) ||
-            !behaviorSnapshot.TryCreate(targetParty, out PartyBehaviorUpdateData targetState))
-            return "Unable to capture the original movement state for both fixture parties.";
+        public string Name => "follow_fixture_setup";
 
-        MobileParty.NavigationType navigationType = playerParty.IsCurrentlyAtSea
-            ? MobileParty.NavigationType.Naval
-            : MobileParty.NavigationType.Default;
-        CampaignVec2 targetPosition = NavigationHelper.FindPointAroundPosition(
-            playerParty.Position,
-            navigationType,
-            8f,
-            5f);
-        if (!targetPosition.IsValid() || targetPosition == playerParty.Position)
-            return "Unable to find a reachable staging point near the player party.";
+        public string Description => "Runs fixture setup for co-op debugging.";
 
-        fixture = new FixtureState(
-            playerParty,
-            targetParty,
-            playerState,
-            targetState);
-        StageAtHold(playerParty, playerParty.Position);
-        StageAtHold(targetParty, targetPosition);
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("playerPartyId", "The player party id."),
+        };
 
-        return $"Follow fixture ready|player={playerParty.StringId}|target={targetParty.StringId}|" +
-            $"distance={Distance(playerParty, targetParty).ToString("R", CultureInfo.InvariantCulture)}";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Command can only be run on the server.");
+            if (fixture != null)
+                return Failed("Follow fixture is already active; restore it before starting another.");
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
+                !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
+                return Failed("Unable to resolve fixture services.");
+            if (!TryFindParty(args[0], out MobileParty playerParty))
+                return Failed($"Player party '{args[0]}' was not found.");
+            if (!playerParty.IsPlayerParty())
+                return Failed($"Party '{args[0]}' is not registered as a player party.");
+            if (!IsAvailableOnMap(playerParty))
+                return Failed($"Player party '{args[0]}' must be active on the campaign map and outside a map event, settlement, or army.");
+
+            MobileParty targetParty = MobileParty.All
+                .Where(party => party != playerParty &&
+                    party.IsLordParty &&
+                    !party.IsPlayerParty() &&
+                    IsAvailableOnMap(party) &&
+                    party.DefaultBehavior == AiBehavior.PatrolAroundPoint &&
+                    party.IsCurrentlyAtSea == playerParty.IsCurrentlyAtSea &&
+                    objectManager.TryGetId(party, out _))
+                .OrderBy(party => party.Position.DistanceSquared(playerParty.Position))
+                .FirstOrDefault();
+            if (targetParty == null)
+                return Failed("No eligible patrolling registered AI lord party is available for the follow fixture.");
+            if (!behaviorSnapshot.TryCreate(playerParty, out PartyBehaviorUpdateData playerState) ||
+                !behaviorSnapshot.TryCreate(targetParty, out PartyBehaviorUpdateData targetState))
+                return Failed("Unable to capture the original movement state for both fixture parties.");
+
+            MobileParty.NavigationType navigationType = playerParty.IsCurrentlyAtSea
+                ? MobileParty.NavigationType.Naval
+                : MobileParty.NavigationType.Default;
+            CampaignVec2 targetPosition = NavigationHelper.FindPointAroundPosition(
+                playerParty.Position,
+                navigationType,
+                8f,
+                5f);
+            if (!targetPosition.IsValid() || targetPosition == playerParty.Position)
+                return Failed("Unable to find a reachable staging point near the player party.");
+
+            fixture = new FixtureState(
+                playerParty,
+                targetParty,
+                playerState,
+                targetState);
+            StageAtHold(playerParty, playerParty.Position);
+            StageAtHold(targetParty, targetPosition);
+
+            return Succeeded($"Follow fixture ready|player={playerParty.StringId}|target={targetParty.StringId}|" +
+                $"distance={Distance(playerParty, targetParty).ToString("R", CultureInfo.InvariantCulture)}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("follow_fixture_follow", "coop.debug.mobileparty")]
-    public static string Follow(List<string> args)
+    public sealed class FollowCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient)
-            return "Command can only be run on a client.";
-        if (args.Count != 1)
-            return "Usage: coop.debug.mobileparty.follow_fixture_follow <targetPartyId>";
-        if (!TryFindParty(args[0], out MobileParty targetParty))
-            return $"Target party '{args[0]}' was not found.";
+        public string Prefix => "coop.debug.mobileparty";
 
-        MobileParty playerParty = MobileParty.MainParty;
-        if (!IsAvailableOnMap(playerParty) || !IsAvailableOnMap(targetParty))
-            return "Both parties must be active on the campaign map.";
-        if (playerParty.IsCurrentlyAtSea != targetParty.IsCurrentlyAtSea)
-            return "The parties must use the same navigation layer.";
+        public string Name => "follow_fixture_follow";
 
-        MobileParty.NavigationType navigationType = playerParty.IsCurrentlyAtSea
-            ? MobileParty.NavigationType.Naval
-            : MobileParty.NavigationType.Default;
-        playerParty.SetMoveEscortParty(targetParty, navigationType, isTargetingPort: false);
+        public string Description => "Runs fixture follow for co-op debugging.";
 
-        return $"Follow command submitted|player={playerParty.StringId}|target={targetParty.StringId}";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("targetPartyId", "The target party id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient)
+                return Failed("Command can only be run on a client.");
+            if (!TryFindParty(args[0], out MobileParty targetParty))
+                return Failed($"Target party '{args[0]}' was not found.");
+
+            MobileParty playerParty = MobileParty.MainParty;
+            if (!IsAvailableOnMap(playerParty) || !IsAvailableOnMap(targetParty))
+                return Failed("Both parties must be active on the campaign map.");
+            if (playerParty.IsCurrentlyAtSea != targetParty.IsCurrentlyAtSea)
+                return Failed("The parties must use the same navigation layer.");
+
+            MobileParty.NavigationType navigationType = playerParty.IsCurrentlyAtSea
+                ? MobileParty.NavigationType.Naval
+                : MobileParty.NavigationType.Default;
+            playerParty.SetMoveEscortParty(targetParty, navigationType, isTargetingPort: false);
+
+            return Succeeded($"Follow command submitted|player={playerParty.StringId}|target={targetParty.StringId}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("follow_fixture_move_target", "coop.debug.mobileparty")]
-    public static string MoveTarget(List<string> args)
+    public sealed class MoveTargetCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Command can only be run on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mobileparty.follow_fixture_move_target";
-        if (fixture == null)
-            return "Follow fixture is not active.";
+        public string Prefix => "coop.debug.mobileparty";
 
-        MobileParty.NavigationType navigationType = fixture.TargetParty.IsCurrentlyAtSea
-            ? MobileParty.NavigationType.Naval
-            : MobileParty.NavigationType.Default;
-        CampaignVec2 targetPoint = NavigationHelper.FindPointAroundPosition(
-            fixture.PlayerParty.Position,
-            navigationType,
-            22f,
-            18f);
-        if (!targetPoint.IsValid() || targetPoint == fixture.TargetParty.Position)
-            return "Unable to find a reachable target movement point.";
+        public string Name => "follow_fixture_move_target";
 
-        fixture.TargetParty.SetNavigationModePoint(targetPoint);
-        fixture.TargetParty.SetMoveGoToPoint(targetPoint, navigationType);
-        return $"AI target movement started|target={fixture.TargetParty.StringId}|" +
-            $"x={targetPoint.X.ToString("R", CultureInfo.InvariantCulture)}|" +
-            $"y={targetPoint.Y.ToString("R", CultureInfo.InvariantCulture)}";
+        public string Description => "Runs fixture move target for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Command can only be run on the server.");
+            if (fixture == null)
+                return Failed("Follow fixture is not active.");
+
+            MobileParty.NavigationType navigationType = fixture.TargetParty.IsCurrentlyAtSea
+                ? MobileParty.NavigationType.Naval
+                : MobileParty.NavigationType.Default;
+            CampaignVec2 targetPoint = NavigationHelper.FindPointAroundPosition(
+                fixture.PlayerParty.Position,
+                navigationType,
+                22f,
+                18f);
+            if (!targetPoint.IsValid() || targetPoint == fixture.TargetParty.Position)
+                return Failed("Unable to find a reachable target movement point.");
+
+            fixture.TargetParty.SetNavigationModePoint(targetPoint);
+            fixture.TargetParty.SetMoveGoToPoint(targetPoint, navigationType);
+            return Succeeded($"AI target movement started|target={fixture.TargetParty.StringId}|" +
+                $"x={targetPoint.X.ToString("R", CultureInfo.InvariantCulture)}|" +
+                $"y={targetPoint.Y.ToString("R", CultureInfo.InvariantCulture)}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("follow_fixture_state", "coop.debug.mobileparty")]
-    public static string State(List<string> args)
+    public sealed class StateCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
-            return "Usage: coop.debug.mobileparty.follow_fixture_state <playerPartyId> <targetPartyId>";
-        if (!TryFindParty(args[0], out MobileParty playerParty))
-            return $"Player party '{args[0]}' was not found.";
-        if (!TryFindParty(args[1], out MobileParty targetParty))
-            return $"Target party '{args[1]}' was not found.";
+        public string Prefix => "coop.debug.mobileparty";
 
-        return $"player={playerParty.StringId}|target={targetParty.StringId}|" +
-            $"distance={Distance(playerParty, targetParty).ToString("R", CultureInfo.InvariantCulture)}|" +
-            $"playerDefault={playerParty.DefaultBehavior}|playerShort={playerParty.ShortTermBehavior}|" +
-            $"playerMoveMode={playerParty.PartyMoveMode}|playerMoving={playerParty.IsMoving}|" +
-            $"playerWaiting={playerParty.ComputeIsWaiting()}|" +
-            $"playerX={playerParty.Position.X.ToString("R", CultureInfo.InvariantCulture)}|" +
-            $"playerY={playerParty.Position.Y.ToString("R", CultureInfo.InvariantCulture)}|" +
-            $"targetDefault={targetParty.DefaultBehavior}|targetShort={targetParty.ShortTermBehavior}|" +
-            $"targetMoveMode={targetParty.PartyMoveMode}|targetMoving={targetParty.IsMoving}|" +
-            $"targetX={targetParty.Position.X.ToString("R", CultureInfo.InvariantCulture)}|" +
-            $"targetY={targetParty.Position.Y.ToString("R", CultureInfo.InvariantCulture)}";
+        public string Name => "follow_fixture_state";
+
+        public string Description => "Runs fixture state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("playerPartyId", "The player party id."),
+            new ExpectedArgs("targetPartyId", "The target party id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryFindParty(args[0], out MobileParty playerParty))
+                return Failed($"Player party '{args[0]}' was not found.");
+            if (!TryFindParty(args[1], out MobileParty targetParty))
+                return Failed($"Target party '{args[1]}' was not found.");
+
+            return Succeeded($"player={playerParty.StringId}|target={targetParty.StringId}|" +
+                $"distance={Distance(playerParty, targetParty).ToString("R", CultureInfo.InvariantCulture)}|" +
+                $"playerDefault={playerParty.DefaultBehavior}|playerShort={playerParty.ShortTermBehavior}|" +
+                $"playerMoveMode={playerParty.PartyMoveMode}|playerMoving={playerParty.IsMoving}|" +
+                $"playerWaiting={playerParty.ComputeIsWaiting()}|" +
+                $"playerX={playerParty.Position.X.ToString("R", CultureInfo.InvariantCulture)}|" +
+                $"playerY={playerParty.Position.Y.ToString("R", CultureInfo.InvariantCulture)}|" +
+                $"targetDefault={targetParty.DefaultBehavior}|targetShort={targetParty.ShortTermBehavior}|" +
+                $"targetMoveMode={targetParty.PartyMoveMode}|targetMoving={targetParty.IsMoving}|" +
+                $"targetX={targetParty.Position.X.ToString("R", CultureInfo.InvariantCulture)}|" +
+                $"targetY={targetParty.Position.Y.ToString("R", CultureInfo.InvariantCulture)}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("follow_fixture_restore", "coop.debug.mobileparty")]
-    public static string Restore(List<string> args)
+    public sealed class RestoreCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Command can only be run on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.mobileparty.follow_fixture_restore";
-        if (fixture == null)
-            return "Follow fixture is not active.";
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
-            return "Unable to resolve the movement snapshot service.";
+        public string Prefix => "coop.debug.mobileparty";
 
-        FixtureState restoring = fixture;
-        bool targetRestored = RestoreParty(behaviorSnapshot, restoring.TargetParty, restoring.TargetState);
-        bool playerRestored = RestoreParty(behaviorSnapshot, restoring.PlayerParty, restoring.PlayerState);
-        bool targetVerified = targetRestored &&
-            TryVerifyRestored(behaviorSnapshot, restoring.TargetParty, restoring.TargetState);
-        bool playerVerified = playerRestored &&
-            TryVerifyRestored(behaviorSnapshot, restoring.PlayerParty, restoring.PlayerState);
-        if (!targetVerified || !playerVerified)
-            return $"Follow fixture restoration failed|player={playerVerified}|target={targetVerified}";
+        public string Name => "follow_fixture_restore";
 
-        fixture = null;
-        return $"Follow fixture restored|player={restoring.PlayerParty.StringId}|" +
-            $"target={restoring.TargetParty.StringId}|verified=true";
+        public string Description => "Runs fixture restore for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Command can only be run on the server.");
+            if (fixture == null)
+                return Failed("Follow fixture is not active.");
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
+                return Failed("Unable to resolve the movement snapshot service.");
+
+            FixtureState restoring = fixture;
+            bool targetRestored = RestoreParty(behaviorSnapshot, restoring.TargetParty, restoring.TargetState);
+            bool playerRestored = RestoreParty(behaviorSnapshot, restoring.PlayerParty, restoring.PlayerState);
+            bool targetVerified = targetRestored &&
+                TryVerifyRestored(behaviorSnapshot, restoring.TargetParty, restoring.TargetState);
+            bool playerVerified = playerRestored &&
+                TryVerifyRestored(behaviorSnapshot, restoring.PlayerParty, restoring.PlayerState);
+            if (!targetVerified || !playerVerified)
+                return Failed($"Follow fixture restoration failed|player={playerVerified}|target={targetVerified}");
+
+            fixture = null;
+            return Succeeded($"Follow fixture restored|player={restoring.PlayerParty.StringId}|" +
+                $"target={restoring.TargetParty.StringId}|verified=true");
+
+        }
     }
 
     private static bool IsAvailableOnMap(MobileParty party) =>

--- a/source/GameInterface/Services/MobileParties/Commands/MercenaryStockDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MercenaryStockDebugCommand.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Common;
 using Common.Network;
 using GameInterface.Services.MobileParties.Handlers;
@@ -13,106 +14,116 @@ using System.Reflection;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Settlements;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.MobileParties.Commands;
 
 internal class MercenaryStockDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private const string RefreshCommand = "coop.debug.town.refresh_mercenary_stocks";
     private const string RequestCommand = "coop.debug.town.request_mercenary_stock";
-    private const string RefreshUsage = "Usage: coop.debug.town.refresh_mercenary_stocks <townName|ALL>";
-    private const string RequestUsage = "Usage: coop.debug.town.request_mercenary_stock <townName>";
     private const string AllTowns = "ALL";
 
     private static readonly MethodInfo UpdateCurrentMercenaryTroopAndCount =
         AccessTools.Method(typeof(RecruitmentCampaignBehavior), "UpdateCurrentMercenaryTroopAndCount", new[] { typeof(Town), typeof(bool) });
 
-    [CommandLineArgumentFunction("refresh_mercenary_stocks", "coop.debug.town")]
-    public static string RefreshMercenaryStocks(List<string> args)
+    public sealed class RefreshMercenaryStocksCoopCommand : ICoopCommand
     {
-        var context = new CommandContext(RefreshCommand, RefreshUsage, args);
-        if (!context.RequireServer(out var error)) return error;
-        if (!TryGetTownName(context, out var townName, out error)) return error;
+        public string Prefix => "coop.debug.town";
 
-        var behavior = Campaign.Current?.GetCampaignBehavior<RecruitmentCampaignBehavior>();
-        if (behavior == null)
+        public string Name => "refresh_mercenary_stocks";
+
+        public string Description => "Refreshes mercenary stocks for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unable to find {nameof(RecruitmentCampaignBehavior)}.";
-        }
+            new ExpectedArgs("townName", "The exact town name; quote values containing spaces."),
+        };
 
-        if (UpdateCurrentMercenaryTroopAndCount == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to find RecruitmentCampaignBehavior.UpdateCurrentMercenaryTroopAndCount.";
-        }
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
 
-        var allTowns = string.Equals(townName, AllTowns, StringComparison.OrdinalIgnoreCase);
-        var towns = allTowns ? GetTowns().ToList() : new List<Town>();
-        if (!allTowns)
-        {
-            if (!TryGetTownByName(townName, out var town, out error)) return error;
-
-            towns.Add(town);
-        }
-
-        var refreshed = 0;
-        GameThread.RunSafe(() =>
-        {
-            foreach (var town in towns)
+            string townName = args[0];
+            var behavior = Campaign.Current?.GetCampaignBehavior<RecruitmentCampaignBehavior>();
+            if (behavior == null)
             {
-                UpdateCurrentMercenaryTroopAndCount.Invoke(behavior, new object[] { town, true });
-                RecruitmentCampaignBehaviorPatch.PublishMercenaryStock(behavior, town);
-                refreshed++;
+                return Failed($"Unable to find {nameof(RecruitmentCampaignBehavior)}.");
             }
-        }, blocking: true, context: RefreshCommand);
 
-        if (allTowns) return $"Refreshed mercenary stocks for {refreshed} towns.";
+            if (UpdateCurrentMercenaryTroopAndCount == null)
+            {
+                return Failed("Unable to find RecruitmentCampaignBehavior.UpdateCurrentMercenaryTroopAndCount.");
+            }
 
-        return $"Refreshed mercenary stock for {towns[0].Name}.";
+            var allTowns = string.Equals(townName, AllTowns, StringComparison.OrdinalIgnoreCase);
+            var towns = allTowns ? GetTowns().ToList() : new List<Town>();
+            if (!allTowns)
+            {
+                if (!TryGetTownByName(townName, out var town, out string error)) return Failed(error);
+
+                towns.Add(town);
+            }
+
+            var refreshed = 0;
+            GameThread.RunSafe(() =>
+            {
+                foreach (var town in towns)
+                {
+                    UpdateCurrentMercenaryTroopAndCount.Invoke(behavior, new object[] { town, true });
+                    RecruitmentCampaignBehaviorPatch.PublishMercenaryStock(behavior, town);
+                    refreshed++;
+                }
+            }, blocking: true, context: RefreshCommand);
+
+            if (allTowns) return Succeeded($"Refreshed mercenary stocks for {refreshed} towns.");
+
+            return Succeeded($"Refreshed mercenary stock for {towns[0].Name}.");
+
+        }
     }
 
-    [CommandLineArgumentFunction("request_mercenary_stock", "coop.debug.town")]
-    public static string RequestMercenaryStock(List<string> args)
+    public sealed class RequestMercenaryStockCoopCommand : ICoopCommand
     {
-        var context = new CommandContext(RequestCommand, RequestUsage, args);
-        if (!context.RequireServer(out var error)) return error;
-        if (!TryGetTownName(context, out var townName, out error)) return error;
+        public string Prefix => "coop.debug.town";
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return error;
-        if (!TryGetTownByName(townName, out var town, out error)) return error;
+        public string Name => "request_mercenary_stock";
 
-        if (!objectManager.TryGetIdWithLogging(town, out var resolvedTownId))
+        public string Description => "Requests mercenary stock for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unable to resolve network id for {nameof(Town)} '{townName}'.";
-        }
+            new ExpectedArgs("townName", "The exact town name; quote values containing spaces."),
+        };
 
-        if (!ContainerProvider.TryResolve<INetwork>(out var network))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Unable to get {nameof(INetwork)}.";
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            string townName = args[0];
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out string error)) return Failed(error);
+            if (!TryGetTownByName(townName, out var town, out error)) return Failed(error);
+
+            if (!objectManager.TryGetIdWithLogging(town, out var resolvedTownId))
+            {
+                return Failed($"Unable to resolve network id for {nameof(Town)} '{townName}'.");
+            }
+
+            if (!ContainerProvider.TryResolve<INetwork>(out var network))
+            {
+                return Failed($"Unable to get {nameof(INetwork)}.");
+            }
+
+            network.SendAll(new NetworkRequestMercenaryStockAudit(resolvedTownId));
+
+            var serverStock = FormatServerStock(town, objectManager);
+            return Succeeded($"Requested mercenary stock from all clients for {town.Name} ({resolvedTownId}). Server shows {serverStock}. Check the server log for client responses.");
+
         }
-
-        network.SendAll(new NetworkRequestMercenaryStockAudit(resolvedTownId));
-
-        var serverStock = FormatServerStock(town, objectManager);
-        return $"Requested mercenary stock from all clients for {town.Name} ({resolvedTownId}). Server shows {serverStock}. Check the server log for client responses.";
-    }
-
-    private static bool TryGetTownName(CommandContext context, out string townName, out string error)
-    {
-        townName = null;
-        error = null;
-
-        if (context.Args == null || context.Args.Count == 0)
-        {
-            error = context.Usage;
-            return false;
-        }
-
-        townName = string.Join(" ", context.Args);
-        if (!string.IsNullOrWhiteSpace(townName)) return true;
-
-        error = $"Missing required argument: townName.\n\n{context.Usage}";
-        return false;
     }
 
     private static string FormatServerStock(Town town, IObjectManager objectManager)

--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using GameInterface.Services.MobileParties.Audit;
 using GameInterface.Services.ObjectManager;
@@ -15,75 +16,99 @@ using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.ViewModelCollection.ClanManagement;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.MobileParties.Commands;
 
 internal class MobilePartyDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyDebugCommand>();
 
-    [CommandLineArgumentFunction("info", "coop.debug.mobileparty")]
-    public static string Info(List<string> args)
+    public sealed class InfoCoopCommand : ICoopCommand
     {
-        if (args.Count < 1)
+        public string Prefix => "coop.debug.mobileparty";
+
+        public string Name => "info";
+
+        public string Description => "Shows the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.mobileparty.info <PartyStringID>";
-        }
+            new ExpectedArgs("partyStringId", "The party string id."),
+        };
 
-        MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
-
-        if (mobileParty == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return string.Format("ID: '{0}' not found", args[0]);
+
+            MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
+
+            if (mobileParty == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine($"MobileParty info for: {SafeToString(mobileParty)}");
+            stringBuilder.AppendLine($"StringID: {SafeToString(mobileParty.StringId)}");
+            stringBuilder.AppendLine($"Name: {SafeToString(mobileParty.Name)}");
+            stringBuilder.AppendLine($"Morale: {mobileParty.Morale}");
+            stringBuilder.AppendLine($"RecentEventsMorale: {mobileParty.RecentEventsMorale}");
+            stringBuilder.AppendLine($"HasUnpaidWages: {mobileParty.HasUnpaidWages}");
+            stringBuilder.AppendLine();
+
+            stringBuilder.AppendLine("Fields:");
+            AppendFields(stringBuilder, mobileParty);
+
+            var partyResult = stringBuilder.ToString();
+
+            stringBuilder = new StringBuilder();
+
+            AppendFields(stringBuilder, mobileParty.Party);
+
+            var partyBaseResults = stringBuilder.ToString();
+
+            Logger.Debug("{Party}, {PartyBase}", partyResult, partyBaseResults);
+
+            return Succeeded($"{partyResult}\n{partyBaseResults}");
+
         }
-
-        var stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine($"MobileParty info for: {SafeToString(mobileParty)}");
-        stringBuilder.AppendLine($"StringID: {SafeToString(mobileParty.StringId)}");
-        stringBuilder.AppendLine($"Name: {SafeToString(mobileParty.Name)}");
-        stringBuilder.AppendLine($"Morale: {mobileParty.Morale}");
-        stringBuilder.AppendLine($"RecentEventsMorale: {mobileParty.RecentEventsMorale}");
-        stringBuilder.AppendLine($"HasUnpaidWages: {mobileParty.HasUnpaidWages}");
-        stringBuilder.AppendLine();
-
-        stringBuilder.AppendLine("Fields:");
-        AppendFields(stringBuilder, mobileParty);
-
-        var partyResult = stringBuilder.ToString();
-
-        stringBuilder = new StringBuilder();
-
-        AppendFields(stringBuilder, mobileParty.Party);
-
-        var partyBaseResults = stringBuilder.ToString();
-
-        Logger.Debug("{Party}, {PartyBase}", partyResult, partyBaseResults);
-
-        return $"{partyResult}\n{partyBaseResults}";
     }
 
     // coop.debug.mobileparty.component_info <PartyStringID>
     // Dumps the party's _partyComponent fields (LordPartyComponent/Caravan/Garrison/etc.), which the plain
     // info cheat does NOT show (it dumps MobileParty + PartyBase only). e.g. LordPartyComponent._wagePaymentLimit.
-    [CommandLineArgumentFunction("component_info", "coop.debug.mobileparty")]
-    public static string ComponentInfo(List<string> args)
+    public sealed class ComponentInfoCoopCommand : ICoopCommand
     {
-        if (args.Count < 1)
-        {
-            return "Usage: coop.debug.mobileparty.component_info <PartyStringID>";
-        }
+        public string Prefix => "coop.debug.mobileparty";
 
-        MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
-        if (mobileParty == null)
-        {
-            return string.Format("ID: '{0}' not found", args[0]);
-        }
+        public string Name => "component_info";
 
-        var stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine($"PartyComponent ({mobileParty.PartyComponent?.GetType().Name ?? "null"}) for: {SafeToString(mobileParty.Name)}");
-        AppendFields(stringBuilder, mobileParty.PartyComponent);
-        return stringBuilder.ToString();
+        public string Description => "Runs info for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("partyStringId", "The party string id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
+            if (mobileParty == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine($"PartyComponent ({mobileParty.PartyComponent?.GetType().Name ?? "null"}) for: {SafeToString(mobileParty.Name)}");
+            AppendFields(stringBuilder, mobileParty.PartyComponent);
+            return Succeeded(stringBuilder.ToString());
+
+        }
     }
 
     // coop.debug.mobileparty.attachment_ids <PartyStringID>
@@ -91,96 +116,116 @@ internal class MobilePartyDebugCommand
     // attachments. Run on the server and on each client and compare: a party the client got via live create
     // matches the server's runtime "Created_N"/concrete-type ids, while a party re-derived at join carries
     // "{Type}_{StringId}" ids that never reconcile with the server's, so its synced updates fail to resolve.
-    [CommandLineArgumentFunction("attachment_ids", "coop.debug.mobileparty")]
-    public static string AttachmentIds(List<string> args)
+    public sealed class AttachmentIdsCoopCommand : ICoopCommand
     {
-        if (args.Count < 1)
+        public string Prefix => "coop.debug.mobileparty";
+
+        public string Name => "attachment_ids";
+
+        public string Description => "Runs ids for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.mobileparty.attachment_ids <PartyStringID>";
-        }
+            new ExpectedArgs("partyStringId", "The party string id."),
+        };
 
-        MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
-        if (mobileParty == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return string.Format("ID: '{0}' not found", args[0]);
+
+            MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
+            if (mobileParty == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            var party = mobileParty.Party;
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Attachment ids on {(ModInformation.IsServer ? "SERVER" : "CLIENT")} for {SafeToString(mobileParty.Name)} (StringId {mobileParty.StringId}):");
+            AppendAttachmentId(sb, objectManager, "MobileParty", mobileParty);
+            AppendAttachmentId(sb, objectManager, "PartyBase", party);
+            AppendAttachmentId(sb, objectManager, "MemberRoster", party?.MemberRoster);
+            AppendAttachmentId(sb, objectManager, "PrisonRoster", party?.PrisonRoster);
+            AppendAttachmentId(sb, objectManager, "ItemRoster", party?.ItemRoster);
+            AppendAttachmentId(sb, objectManager, "PartyComponent", mobileParty.PartyComponent);
+
+            var result = sb.ToString();
+            Logger.Debug("{AttachmentIds}", result);
+            return Succeeded(result);
+
         }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
-
-        var party = mobileParty.Party;
-
-        var sb = new StringBuilder();
-        sb.AppendLine($"Attachment ids on {(ModInformation.IsServer ? "SERVER" : "CLIENT")} for {SafeToString(mobileParty.Name)} (StringId {mobileParty.StringId}):");
-        AppendAttachmentId(sb, objectManager, "MobileParty", mobileParty);
-        AppendAttachmentId(sb, objectManager, "PartyBase", party);
-        AppendAttachmentId(sb, objectManager, "MemberRoster", party?.MemberRoster);
-        AppendAttachmentId(sb, objectManager, "PrisonRoster", party?.PrisonRoster);
-        AppendAttachmentId(sb, objectManager, "ItemRoster", party?.ItemRoster);
-        AppendAttachmentId(sb, objectManager, "PartyComponent", mobileParty.PartyComponent);
-
-        var result = sb.ToString();
-        Logger.Debug("{AttachmentIds}", result);
-        return result;
     }
 
-    [CommandLineArgumentFunction("verify_ai_authority", "coop.debug.mobileparty")]
-    public static string VerifyAiAuthority(List<string> args)
+    public sealed class VerifyAiAuthorityCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "verify_ai_authority is server-only";
-        }
+        public string Prefix => "coop.debug.mobileparty";
 
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.mobileparty.verify_ai_authority <MobilePartyId>";
-        }
+        public string Name => "verify_ai_authority";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return $"Unable to get {nameof(IObjectManager)}";
-        }
+        public string Description => "Verifies ai authority for co-op debugging.";
 
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unable to get {nameof(IPlayerManager)}";
-        }
+            new ExpectedArgs("mobilePartyId", "The mobile party id."),
+        };
 
-        if (!objectManager.TryGetObjectWithLogging<MobileParty>(args[0], out var mobileParty))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Unable to get {nameof(MobileParty)} with id: {args[0]}";
-        }
+            if (ModInformation.IsClient)
+            {
+                return Failed("verify_ai_authority is server-only");
+            }
 
-        if (!playerManager.Contains(mobileParty))
-        {
-            return $"Party {args[0]} is not registered as a player party";
-        }
 
-        var partyAi = mobileParty.Ai;
-        if (partyAi == null)
-        {
-            return $"Party {args[0]} has no {nameof(MobilePartyAi)}";
-        }
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed($"Unable to get {nameof(IObjectManager)}");
+            }
 
-        bool previousNeedsUpdate = partyAi.DefaultBehaviorNeedsUpdate;
-        bool tickWasBlocked;
-        try
-        {
-            partyAi.DefaultBehaviorNeedsUpdate = true;
-            partyAi.Tick(0f);
-            tickWasBlocked = partyAi.DefaultBehaviorNeedsUpdate;
-        }
-        finally
-        {
-            partyAi.DefaultBehaviorNeedsUpdate = previousNeedsUpdate;
-        }
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+            {
+                return Failed($"Unable to get {nameof(IPlayerManager)}");
+            }
 
-        return tickWasBlocked
-            ? $"Server AI tick blocked for player party {args[0]}"
-            : $"Server AI tick ran for player party {args[0]}";
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(args[0], out var mobileParty))
+            {
+                return Failed($"Unable to get {nameof(MobileParty)} with id: {args[0]}");
+            }
+
+            if (!playerManager.Contains(mobileParty))
+            {
+                return Failed($"Party {args[0]} is not registered as a player party");
+            }
+
+            var partyAi = mobileParty.Ai;
+            if (partyAi == null)
+            {
+                return Failed($"Party {args[0]} has no {nameof(MobilePartyAi)}");
+            }
+
+            bool previousNeedsUpdate = partyAi.DefaultBehaviorNeedsUpdate;
+            bool tickWasBlocked;
+            try
+            {
+                partyAi.DefaultBehaviorNeedsUpdate = true;
+                partyAi.Tick(0f);
+                tickWasBlocked = partyAi.DefaultBehaviorNeedsUpdate;
+            }
+            finally
+            {
+                partyAi.DefaultBehaviorNeedsUpdate = previousNeedsUpdate;
+            }
+
+            return Succeeded(tickWasBlocked
+                ? $"Server AI tick blocked for player party {args[0]}"
+                : $"Server AI tick ran for player party {args[0]}");
+
+        }
     }
 
     private static void AppendAttachmentId(StringBuilder sb, IObjectManager objectManager, string label, object obj)
@@ -309,175 +354,233 @@ internal class MobilePartyDebugCommand
     }
 
     // coop.debug.mobileparty.createParty lord_1_1 town_V1
-    [CommandLineArgumentFunction("createParty", "coop.debug.mobileparty")]
-    public static string CreateNewParty(List<string> args)
+    public sealed class CreateNewPartyCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.mobileparty";
+
+        public string Name => "create_party";
+
+        public string Description => "Creates party for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Create party is only to be called on the server";
-        }
+            new ExpectedArgs("heroId", "The hero id."),
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        if (args.Count != 2)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.mobileParty.createParty <Hero.StringId> <Settlment.StringId>";
+            if (ModInformation.IsClient)
+            {
+                return Failed("Create party is only to be called on the server");
+            }
+
+
+            if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
+            {
+                return Failed($"Unable to get {nameof(IObjectManager)}");
+            }
+
+            string heroStringId = args[0];
+            string settlementId = args[1];
+
+            if (objectManager.TryGetObject<Hero>(heroStringId, out var hero) == false)
+            {
+                return Failed($"Unable to get {typeof(Hero)} with id: {heroStringId}");
+            }
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+            {
+                return Failed($"Unable to get {typeof(Settlement)} with id: {settlementId}");
+            }
+
+            var newParty = MobilePartyHelper.SpawnLordParty(hero, settlement);
+
+            return Succeeded($"Created new {nameof(MobileParty)} with string id: {newParty.StringId}");
+
         }
-
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
-        {
-            return $"Unable to get {nameof(IObjectManager)}";
-        }
-
-        string heroStringId = args[0];
-        string settlementId = args[1];
-
-        if (objectManager.TryGetObject<Hero>(heroStringId, out var hero) == false)
-        {
-            return $"Unable to get {typeof(Hero)} with id: {heroStringId}";
-        }
-
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-        {
-            return $"Unable to get {typeof(Settlement)} with id: {settlementId}";
-        }
-
-        var newParty = MobilePartyHelper.SpawnLordParty(hero, settlement);
-
-        return $"Created new {nameof(MobileParty)} with string id: {newParty.StringId}";
     }
 
     // coop.debug.mobileparty.spawn_test_parties [count] [settlementId]
     // Server-only. Spawns N lord parties from currently party-less lords near the settlement
     // (default Danustica, town_ES1) to exercise mid-session party creation/replication to clients.
-    [CommandLineArgumentFunction("spawn_test_parties", "coop.debug.mobileparty")]
-    public static string SpawnTestParties(List<string> args)
+    public sealed class SpawnTestPartiesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "spawn_test_parties is server-only";
-        }
+        public string Prefix => "coop.debug.mobileparty";
 
-        int count = 5;
-        if (args.Count >= 1 && int.TryParse(args[0], out var parsed) && parsed > 0)
-        {
-            count = parsed;
-        }
+        public string Name => "spawn_test_parties";
 
-        // Spawn near a settlement (default Danustica, town_ES1 -- a common client location).
-        string settlementId = args.Count >= 2 ? args[1] : "town_ES1";
-        var settlement = Settlement.All.FirstOrDefault(s => s.StringId == settlementId);
-        if (settlement == null)
-        {
-            var towns = string.Join(", ", Settlement.All.Where(s => s.IsTown).Take(15).Select(s => s.StringId));
-            return $"Settlement '{settlementId}' not found. Try one of: {towns}";
-        }
+        public string Description => "Spawns test parties for co-op debugging.";
 
-        var candidates = Hero.AllAliveHeroes
-            .Where(h => h != Hero.MainHero && h.Clan != null && !h.IsPrisoner && !h.IsChild
-                        && h.IsLord && h.PartyBelongedTo == null)
-            .Take(count)
-            .ToList();
-
-        if (candidates.Count == 0)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "No party-less lords available to spawn";
-        }
+            new ExpectedArgs("count", "The count.", isRequired: false),
+            new ExpectedArgs("settlementId", "The settlement id.", isRequired: false),
+        };
 
-        var sb = new StringBuilder();
-        int spawned = 0;
-        foreach (var hero in candidates)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            try
+            if (ModInformation.IsClient)
             {
-                var party = MobilePartyHelper.SpawnLordParty(hero, settlement);
-                sb.AppendLine($"Spawned {party.StringId} for {hero.Name} at {settlement.Name} ({party.MemberRoster.TotalManCount} troops)");
-                spawned++;
+                return Failed("spawn_test_parties is server-only");
             }
-            catch (Exception e)
-            {
-                sb.AppendLine($"Failed to spawn for {hero.Name}: {e.Message}");
-            }
-        }
 
-        return $"Spawned {spawned} test parties near {settlement.Name}:\n{sb}";
+            int count = 5;
+            if (args.Count >= 1 && int.TryParse(args[0], out var parsed) && parsed > 0)
+            {
+                count = parsed;
+            }
+
+            // Spawn near a settlement (default Danustica, town_ES1 -- a common client location).
+            string settlementId = args.Count >= 2 ? args[1] : "town_ES1";
+            var settlement = Settlement.All.FirstOrDefault(s => s.StringId == settlementId);
+            if (settlement == null)
+            {
+                var towns = string.Join(", ", Settlement.All.Where(s => s.IsTown).Take(15).Select(s => s.StringId));
+                return Failed($"Settlement '{settlementId}' not found. Try one of: {towns}");
+            }
+
+            var candidates = Hero.AllAliveHeroes
+                .Where(h => h != Hero.MainHero && h.Clan != null && !h.IsPrisoner && !h.IsChild
+                            && h.IsLord && h.PartyBelongedTo == null)
+                .Take(count)
+                .ToList();
+
+            if (candidates.Count == 0)
+            {
+                return Failed("No party-less lords available to spawn");
+            }
+
+            var sb = new StringBuilder();
+            int spawned = 0;
+            foreach (var hero in candidates)
+            {
+                try
+                {
+                    var party = MobilePartyHelper.SpawnLordParty(hero, settlement);
+                    sb.AppendLine($"Spawned {party.StringId} for {hero.Name} at {settlement.Name} ({party.MemberRoster.TotalManCount} troops)");
+                    spawned++;
+                }
+                catch (Exception e)
+                {
+                    sb.AppendLine($"Failed to spawn for {hero.Name}: {e.Message}");
+                }
+            }
+
+            return Succeeded($"Spawned {spawned} test parties near {settlement.Name}:\n{sb}");
+
+        }
     }
 
     // coop.debug.mobileParty.destroyParty tbd
-    [CommandLineArgumentFunction("destroyParty", "coop.debug.mobileparty")]
-    public static string DestroyParty(List<string> args)
+    public sealed class DestroyPartyCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.mobileparty";
+
+        public string Name => "destroy_party";
+
+        public string Description => "Destroys party for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Create party is only to be called on the server";
-        }
-        if (args.Count != 1)
+            new ExpectedArgs("mobilePartyId", "The mobile party id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.mobileParty.destroyParty <MobileParty.StringId>";
-        }
-
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
-        {
-            return $"Unable to get {nameof(IObjectManager)}";
-        }
-
-        string partyId = args[0];
-
-        if (objectManager.TryGetObject<MobileParty>(partyId, out var party) == false)
-        {
-            return $"Unable to get {typeof(MobileParty)} with id: {partyId}";
-        }
-
-        // DestroyPartyAction is the destruction path synced to clients; plain
-        // RemoveParty is not. A null destroyer replicates like any other.
-        DestroyPartyAction.Apply(null, party);
-
-        return $"Destroyed {nameof(MobileParty)} with string id: {partyId}";
-    }
-
-    // coop.debug.mobileparty.destroyAllBanditParties
-    [CommandLineArgumentFunction("destroyAllBanditParties", "coop.debug.mobileparty")]
-    public static string DestroyAllBanditParties(List<string> args)
-    {
-        if (ModInformation.IsClient)
-        {
-            return "Destroy all bandit parties is only to be called on the server";
-        }
-
-        var banditParties = MobileParty.All.Where(party => party.IsBandit).ToList();
-
-        int destroyed = 0;
-        int skipped = 0;
-        foreach (var banditParty in banditParties)
-        {
-            if (banditParty.MapEvent != null)
+            if (ModInformation.IsClient)
             {
-                skipped++;
-                continue;
+                return Failed("Create party is only to be called on the server");
+            }
+
+            if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
+            {
+                return Failed($"Unable to get {nameof(IObjectManager)}");
+            }
+
+            string partyId = args[0];
+
+            if (objectManager.TryGetObject<MobileParty>(partyId, out var party) == false)
+            {
+                return Failed($"Unable to get {typeof(MobileParty)} with id: {partyId}");
             }
 
             // DestroyPartyAction is the destruction path synced to clients; plain
-            // RemoveParty is not. A null destroyer replicates like any other, so
-            // no party needs to be credited with the kill.
-            DestroyPartyAction.Apply(null, banditParty);
-            destroyed++;
-        }
+            // RemoveParty is not. A null destroyer replicates like any other.
+            DestroyPartyAction.Apply(null, party);
 
-        return $"Destroyed {destroyed} bandit parties, skipped {skipped} in active map events";
+            return Succeeded($"Destroyed {nameof(MobileParty)} with string id: {partyId}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("list", "coop.debug.mobileparty")]
-    public static string ListMobileParties(List<string> args)
+    // coop.debug.mobileparty.destroyAllBanditParties
+    public sealed class DestroyAllBanditPartiesCoopCommand : ICoopCommand
     {
-    	StringBuilder stringBuilder = new StringBuilder();
+        public string Prefix => "coop.debug.mobileparty";
 
-        List<MobileParty> mobileParty = Campaign.Current.CampaignObjectManager.MobileParties.ToList();
+        public string Name => "destroy_all_bandit_parties";
 
-        mobileParty.ForEach((party) =>
+        public string Description => "Destroys all bandit parties for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-        	stringBuilder.Append(string.Format("ID: '{0}'\nName: '{1}'\n", party.StringId, party.Name));
-        });
+            if (ModInformation.IsClient)
+            {
+                return Failed("Destroy all bandit parties is only to be called on the server");
+            }
 
-        return stringBuilder.ToString();
-	}
+            var banditParties = MobileParty.All.Where(party => party.IsBandit).ToList();
+
+            int destroyed = 0;
+            int skipped = 0;
+            foreach (var banditParty in banditParties)
+            {
+                if (banditParty.MapEvent != null)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                // DestroyPartyAction is the destruction path synced to clients; plain
+                // RemoveParty is not. A null destroyer replicates like any other, so
+                // no party needs to be credited with the kill.
+                DestroyPartyAction.Apply(null, banditParty);
+                destroyed++;
+            }
+
+            return Succeeded($"Destroyed {destroyed} bandit parties, skipped {skipped} in active map events");
+
+        }
+    }
+
+    public sealed class ListMobilePartiesCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mobileparty";
+
+        public string Name => "list";
+
+        public string Description => "Lists the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+
+            List<MobileParty> mobileParty = Campaign.Current.CampaignObjectManager.MobileParties.ToList();
+
+            mobileParty.ForEach((party) =>
+            {
+                stringBuilder.Append(string.Format("ID: '{0}'\nName: '{1}'\n", party.StringId, party.Name));
+            });
+
+            return Succeeded(stringBuilder.ToString());
+
+        }
+    }
 
     // coop.debug.mobileparty.set_wage_limit_updated CoopParty 45
     /// <summary>
@@ -485,38 +588,49 @@ internal class MobilePartyDebugCommand
     /// </summary>
     /// <param name="args">mobile party and value</param>
     /// <returns>success message</returns>
-    [CommandLineArgumentFunction("set_wage_limit_updated", "coop.debug.mobileparty")]
-    public static string SetWagePaymentLimit(List<string> args)
+    public sealed class SetWagePaymentLimitCoopCommand : ICoopCommand
     {
-    	if (args.Count < 2)
+        public string Prefix => "coop.debug.mobileparty";
+
+        public string Name => "set_wage_limit_updated";
+
+        public string Description => "Sets wage limit updated for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-        	return "Usage: coop.debug.mobileparty.set_wage_limit <PartyStringID> <value>";
+            new ExpectedArgs("partyStringId", "The party string id."),
+            new ExpectedArgs("value", "The value."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            int newValue = 0;
+            try
+            {
+                newValue = int.Parse(args[1]);
+            }
+            catch (Exception e)
+            {
+                return Failed($"Error setting int: {e}");
+            }
+
+            MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
+
+
+            if (mobileParty == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            var obj = new ClanFinanceExpenseItemVM(mobileParty);
+
+            obj.OnCurrentWageLimitUpdated(newValue);
+
+            return Succeeded($"Successfully called OnCurrentWageLimitUpdated({newValue});");
+
         }
-
-        int newValue = 0;
-        try
-        {
-        	newValue = int.Parse(args[1]);
-		}
-        catch (Exception e)
-        {
-        	return $"Error setting int: {e}";
-		}
-
-        MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
-
-
-        if (mobileParty == null)
-        {
-        	return string.Format("ID: '{0}' not found", args[0]);
-        }
-
-        var obj = new ClanFinanceExpenseItemVM(mobileParty);
-
-        obj.OnCurrentWageLimitUpdated(newValue);
-		
-		return $"Successfully called OnCurrentWageLimitUpdated({newValue});";
-	}
+    }
 
 
     // coop.debug.mobileparty.set_wage_unlimited CoopParty true
@@ -525,48 +639,70 @@ internal class MobilePartyDebugCommand
     /// </summary>
     /// <param name="args">mobile party and value</param>
     /// <returns>success message</returns>
-	[CommandLineArgumentFunction("set_wage_unlimited", "coop.debug.mobileparty")]
-	public static string SetUnlimitedWageToggle(List<string> args)
+    public sealed class SetUnlimitedWageToggleCoopCommand : ICoopCommand
     {
-    	if (args.Count < 2)
+        public string Prefix => "coop.debug.mobileparty";
+
+        public string Name => "set_wage_unlimited";
+
+        public string Description => "Sets wage unlimited for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-        	return "Usage: coop.debug.mobileparty.set_wage_limit <PartyStringID> <value>";
-        }
+            new ExpectedArgs("partyStringId", "The party string id."),
+            new ExpectedArgs("value", "The value."),
+        };
 
-        bool newValue = false;
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-        	newValue = bool.Parse(args[1]);
+
+            bool newValue = false;
+            try
+            {
+                newValue = bool.Parse(args[1]);
+            }
+            catch (Exception e)
+            {
+                return Failed($"Error setting bool: {e}");
+            }
+
+            MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
+
+
+            if (mobileParty == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            var obj = new ClanFinanceExpenseItemVM(mobileParty);
+
+            obj.OnUnlimitedWageToggled(newValue);
+
+            return Succeeded($"Successfully called OnUnlimitedWageToggled({newValue});");
+
         }
-        catch (Exception e)
-        {
-        	return $"Error setting bool: {e}";
-        }
-
-        MobileParty mobileParty = Campaign.Current.CampaignObjectManager.Find<MobileParty>(args[0]);
-
-
-        if (mobileParty == null)
-        {
-        	return string.Format("ID: '{0}' not found", args[0]);
-        }
-
-        var obj = new ClanFinanceExpenseItemVM(mobileParty);
-
-        obj.OnUnlimitedWageToggled(newValue);
-
-        return $"Successfully called OnUnlimitedWageToggled({newValue});";
     }
 
     // coop.debug.mobileParty.audit
-    [CommandLineArgumentFunction("audit", "coop.debug.mobileparty")]
-    public static string AuditParties(List<string> args)
+    public sealed class AuditPartiesCoopCommand : ICoopCommand
     {
-        if (ContainerProvider.TryResolve<MobilePartyAuditor>(out var auditor) == false)
-        {
-            return $"Unable to get {nameof(MobilePartyAuditor)}";
-        }
+        public string Prefix => "coop.debug.mobileparty";
 
-        return auditor.Audit();
+        public string Name => "audit";
+
+        public string Description => "Audits the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ContainerProvider.TryResolve<MobilePartyAuditor>(out var auditor) == false)
+            {
+                return Failed($"Unable to get {nameof(MobilePartyAuditor)}");
+            }
+
+            return Succeeded(auditor.Audit());
+
+        }
     }
 }

--- a/source/GameInterface/Services/Settlements/Commands/SettlementAuditorCommand.cs
+++ b/source/GameInterface/Services/Settlements/Commands/SettlementAuditorCommand.cs
@@ -1,26 +1,42 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using GameInterface.Services.Settlements.Audit;
 using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Settlements.Commands;
 internal class SettlementAuditorCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
 
 
-    [CommandLineArgumentFunction("audit", "coop.debug.settlements")]
-    public static string Audit(List<string> args)
+
+    public sealed class AuditCoopCommand : ICoopCommand
     {
+        public string Prefix => "coop.debug.settlements";
 
-        if(ModInformation.IsServer)
-        {
-            return "The Settlement Auditor can only be called by the client";
-        }
-        if (ContainerProvider.TryResolve<SettlementAuditor>(out var auditor) == false)
-        {
-            return $"Unable to get {nameof(SettlementAuditor)}";
-        }
+        public string Name => "audit";
 
-        return auditor.Audit();
+        public string Description => "Audits the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if(ModInformation.IsServer)
+            {
+                return Failed("The Settlement Auditor can only be called by the client");
+            }
+            if (ContainerProvider.TryResolve<SettlementAuditor>(out var auditor) == false)
+            {
+                return Failed($"Unable to get {nameof(SettlementAuditor)}");
+            }
+
+            return Succeeded(auditor.Audit());
+
+        }
     }
 }

--- a/source/GameInterface/Services/Settlements/Commands/SettlementCommands.cs
+++ b/source/GameInterface/Services/Settlements/Commands/SettlementCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using Common.Messaging;
 using GameInterface.Services.MobileParties.Messages.Behavior;
@@ -15,12 +16,16 @@ using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.ObjectSystem;
 using static TaleWorlds.CampaignSystem.Settlements.Settlement;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Template.Commands;
 
 internal class SettlementCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
 #if DEBUG
     private static CastleTeleportSnapshot castleTeleportSnapshot;
 
@@ -39,110 +44,141 @@ internal class SettlementCommands
     }
 #endif
 
-    [CommandLineArgumentFunction("enter_random_castle", "coop.debug.settlements")]
-    public static string EnterRandomCastle(List<string> strings)
+    public sealed class EnterRandomCastleCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (strings.Count > 1)
-            return "Usage: coop.debug.settlements.enter_random_castle [castleId]";
+        public string Prefix => "coop.debug.settlements";
 
-        var castles = Campaign.Current.CampaignObjectManager.Settlements.Where(settlement => settlement.IsCastle).ToArray();
-        var castle = strings.Count == 0
-            ? castles[new Random().Next(castles.Length)]
-            : castles.FirstOrDefault(settlement => settlement.StringId == strings[0]);
-        if (castle == null)
-            return $"Castle '{strings[0]}' was not found.";
+        public string Name => "enter_random_castle";
 
-        EncounterManager.StartSettlementEncounter(MobileParty.MainParty, castle);
+        public string Description => "Enters random castle for co-op debugging.";
 
-        return $"Requested settlement encounter with {castle.Name} ({castle.StringId}).";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("castleId", "The castle id.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+            var castles = Campaign.Current.CampaignObjectManager.Settlements.Where(settlement => settlement.IsCastle).ToArray();
+            var castle = strings.Count == 0
+                ? castles[new Random().Next(castles.Length)]
+                : castles.FirstOrDefault(settlement => settlement.StringId == strings[0]);
+            if (castle == null)
+                return Failed($"Castle '{strings[0]}' was not found.");
+
+            EncounterManager.StartSettlementEncounter(MobileParty.MainParty, castle);
+
+            return Succeeded($"Requested settlement encounter with {castle.Name} ({castle.StringId}).");
+
+        }
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("teleport_main_party_to_castle", "coop.debug.settlements")]
-    public static string TeleportMainPartyToCastle(List<string> strings)
+    public sealed class TeleportMainPartyToCastleCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (strings.Count != 1)
-            return "Usage: coop.debug.settlements.teleport_main_party_to_castle <castleId>";
+        public string Prefix => "coop.debug.settlements";
 
-        var castle = Campaign.Current.CampaignObjectManager.Settlements
-            .FirstOrDefault(settlement => settlement.IsCastle && settlement.StringId == strings[0]);
-        if (castle == null)
-            return $"Castle '{strings[0]}' was not found.";
+        public string Name => "teleport_main_party_to_castle";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null)
-            return "Failed: no main party.";
-        if (mainParty.CurrentSettlement != null || mainParty.MapEvent != null || PlayerEncounter.Current != null)
-            return "Leave the active settlement or map event before teleporting.";
-        if (TryGetCurrentCastleTeleportSnapshot(mainParty, out _))
-            return "Restore the previous castle teleport before starting another one.";
+        public string Description => "Runs main party to castle for co-op debugging.";
 
-        var originalPosition = mainParty.Position;
-        castleTeleportSnapshot = new CastleTeleportSnapshot(Campaign.Current, mainParty, originalPosition);
-        try
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            mainParty.Position = castle.GatePosition;
-            MessageBroker.Instance.Publish(
-                mainParty,
-                new PartyBehaviorChangeAttempted(
+            new ExpectedArgs("castleId", "The castle id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+            var castle = Campaign.Current.CampaignObjectManager.Settlements
+                .FirstOrDefault(settlement => settlement.IsCastle && settlement.StringId == strings[0]);
+            if (castle == null)
+                return Failed($"Castle '{strings[0]}' was not found.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null)
+                return Failed("Failed: no main party.");
+            if (mainParty.CurrentSettlement != null || mainParty.MapEvent != null || PlayerEncounter.Current != null)
+                return Failed("Leave the active settlement or map event before teleporting.");
+            if (TryGetCurrentCastleTeleportSnapshot(mainParty, out _))
+                return Failed("Restore the previous castle teleport before starting another one.");
+
+            var originalPosition = mainParty.Position;
+            castleTeleportSnapshot = new CastleTeleportSnapshot(Campaign.Current, mainParty, originalPosition);
+            try
+            {
+                mainParty.Position = castle.GatePosition;
+                MessageBroker.Instance.Publish(
                     mainParty,
-                    forcePosition: true,
-                    isCurrentlyAtSea: false,
-                    resetMovementToHold: true));
-        }
-        finally
-        {
-            // The later forced-position echo proves the dedicated server applied the request.
-            mainParty.Position = originalPosition;
-        }
+                    new PartyBehaviorChangeAttempted(
+                        mainParty,
+                        forcePosition: true,
+                        isCurrentlyAtSea: false,
+                        resetMovementToHold: true));
+            }
+            finally
+            {
+                // The later forced-position echo proves the dedicated server applied the request.
+                mainParty.Position = originalPosition;
+            }
 
-        return
-            $"Requested authoritative teleport to {castle.Name} ({castle.StringId}) gate " +
-            $"at {castle.GatePosition.X:R},{castle.GatePosition.Y:R}.";
+            return Succeeded($"Requested authoritative teleport to {castle.Name} ({castle.StringId}) gate " +
+                $"at {castle.GatePosition.X:R},{castle.GatePosition.Y:R}.");
+
+        }
     }
 
-    [CommandLineArgumentFunction("restore_main_party_castle_teleport", "coop.debug.settlements")]
-    public static string RestoreMainPartyCastleTeleport(List<string> strings)
+    public sealed class RestoreMainPartyCastleTeleportCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (strings.Count != 0)
-            return "Usage: coop.debug.settlements.restore_main_party_castle_teleport";
+        public string Prefix => "coop.debug.settlements";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null)
-            return "Failed: no main party.";
-        if (!TryGetCurrentCastleTeleportSnapshot(mainParty, out var snapshot))
-            return "No castle teleport is waiting to be restored.";
-        if (mainParty.CurrentSettlement != null || mainParty.MapEvent != null || PlayerEncounter.Current != null)
-            return "Leave the active settlement or map event before restoring the teleport.";
+        public string Name => "restore_main_party_castle_teleport";
 
-        var currentPosition = mainParty.Position;
-        var restorePosition = snapshot.Position;
-        castleTeleportSnapshot = null;
-        try
+        public string Description => "Restores main party castle teleport for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            mainParty.Position = restorePosition;
-            MessageBroker.Instance.Publish(
-                mainParty,
-                new PartyBehaviorChangeAttempted(
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null)
+                return Failed("Failed: no main party.");
+            if (!TryGetCurrentCastleTeleportSnapshot(mainParty, out var snapshot))
+                return Failed("No castle teleport is waiting to be restored.");
+            if (mainParty.CurrentSettlement != null || mainParty.MapEvent != null || PlayerEncounter.Current != null)
+                return Failed("Leave the active settlement or map event before restoring the teleport.");
+
+            var currentPosition = mainParty.Position;
+            var restorePosition = snapshot.Position;
+            castleTeleportSnapshot = null;
+            try
+            {
+                mainParty.Position = restorePosition;
+                MessageBroker.Instance.Publish(
                     mainParty,
-                    forcePosition: true,
-                    isCurrentlyAtSea: restorePosition.IsOnLand == false,
-                    resetMovementToHold: true));
-        }
-        finally
-        {
-            mainParty.Position = currentPosition;
-        }
+                    new PartyBehaviorChangeAttempted(
+                        mainParty,
+                        forcePosition: true,
+                        isCurrentlyAtSea: restorePosition.IsOnLand == false,
+                        resetMovementToHold: true));
+            }
+            finally
+            {
+                mainParty.Position = currentPosition;
+            }
 
-        return
-            $"Requested authoritative castle-teleport restoration to " +
-            $"{restorePosition.X:R},{restorePosition.Y:R}.";
+            return Succeeded($"Requested authoritative castle-teleport restoration to " +
+                $"{restorePosition.X:R},{restorePosition.Y:R}.");
+
+        }
     }
 
     private static bool TryGetCurrentCastleTeleportSnapshot(
@@ -163,23 +199,36 @@ internal class SettlementCommands
     }
 #endif
 
-    [CommandLineArgumentFunction("get_town_name", "coop.debug.settlements")]
-    public static string GetTownName(List<string> strings)
+    public sealed class GetTownNameCoopCommand : ICoopCommand
     {
-        if (strings.Count != 1) return "Invalid usage, expected \"get_town_name <settlment id>\"";
+        public string Prefix => "coop.debug.settlements";
 
-        string settlementId = strings.Single();
+        public string Name => "get_town_name";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get town name";
+        public string Description => "Gets town name for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        if (objectManager.Contains(settlementId) == false) return $"{settlementId} does not exist";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
 
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"{settlementId} was in object manager but was not of type Settlement";
+            string settlementId = strings.Single();
 
-        return $"Settlement Name: {settlement.Name}";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get town name");
+
+            var objectManager = container.Resolve<IObjectManager>();
+
+            if (objectManager.Contains(settlementId) == false) return Failed($"{settlementId} does not exist");
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"{settlementId} was in object manager but was not of type Settlement");
+
+            return Succeeded($"Settlement Name: {settlement.Name}");
+
+        }
     }
 
     // coop.debug.settlements.set_enemies_spotted town_ES3 45.4
@@ -188,31 +237,45 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlement and float value</param>
     /// <returns>info that is was succesfull</returns>
-    [CommandLineArgumentFunction("set_enemies_spotted", "coop.debug.settlements")]
-    public static string SetEnemiesSpotted(List<string> args)
+    public sealed class SetEnemiesSpottedCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_enemies_spotted <settlment id> <float_value>\"";
+        public string Name => "set_enemies_spotted";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Sets enemies spotted for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
-
-        string settlementId = args[0];
-
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
-
-
-        if (float.TryParse(args[1], out var num) == false)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Error setting the value: {args[1]} to a float.";
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("value", "The value."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
+
+
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
+
+            var objectManager = container.Resolve<IObjectManager>();
+
+            string settlementId = args[0];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+
+            if (float.TryParse(args[1], out var num) == false)
+            {
+                return Failed($"Error setting the value: {args[1]} to a float.");
+            }
+
+            settlement.NearbyLandThreatIntensity = num;
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) NumberOfEnemiesSpottedAround to '{args[1]}'");
+
         }
-
-        settlement.NearbyLandThreatIntensity = num;
-
-        return $"Successfully set the Settlement ({settlementId}) NumberOfEnemiesSpottedAround to '{args[1]}'";
     }
 
 
@@ -222,28 +285,42 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlement and float value</param>
     /// <returns>info that is was succesful</returns>
-    [CommandLineArgumentFunction("set_allies_spotted", "coop.debug.settlements")]
-    public static string SetAlliesSpotted(List<string> args)
+    public sealed class SetAlliesSpottedCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_enemies_spotted <settlment id> <float_value>\"";
+        public string Name => "set_allies_spotted";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Sets allies spotted for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("value", "The value."),
+        };
 
-        string settlementId = args[0];
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
 
-        if (float.TryParse(args[1], out var num) == false)
-            return $"Error setting the value: {args[1]} to a float.";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
 
-        settlement.NearbyLandAllyIntensity = num;
+            var objectManager = container.Resolve<IObjectManager>();
 
-        return $"Successfully set the Settlement ({settlementId}) NumberOfAlliesSpottedAround to '{args[1]}'";
+            string settlementId = args[0];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+            if (float.TryParse(args[1], out var num) == false)
+                return Failed($"Error setting the value: {args[1]} to a float.");
+
+            settlement.NearbyLandAllyIntensity = num;
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) NumberOfAlliesSpottedAround to '{args[1]}'");
+
+        }
     }
 
 
@@ -253,28 +330,42 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlement and int value</param>
     /// <returns>info that is was succesful</returns>
-    [CommandLineArgumentFunction("set_bribe_paid", "coop.debug.settlements")]
-    public static string SetBribePaid(List<string> args)
+    public sealed class SetBribePaidCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_bribe_paid <settlment id> <int_value>\"";
+        public string Name => "set_bribe_paid";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Sets bribe paid for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("value", "The value."),
+        };
 
-        string settlementId = args[0];
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
 
-        if (int.TryParse(args[1], out var num) == false)
-            return $"Error setting the value: {args[1]} to a int.";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
 
-        settlement.BribePaid = num;
+            var objectManager = container.Resolve<IObjectManager>();
 
-        return $"Successfully set the Settlement ({settlementId}) BribePaid to '{args[1]}'";
+            string settlementId = args[0];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+            if (int.TryParse(args[1], out var num) == false)
+                return Failed($"Error setting the value: {args[1]} to a int.");
+
+            settlement.BribePaid = num;
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) BribePaid to '{args[1]}'");
+
+        }
     }
 
 
@@ -284,28 +375,42 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlement and float value</param>
     /// <returns>info that is was succesful</returns>
-    [CommandLineArgumentFunction("set_hit_points", "coop.debug.settlements")]
-    public static string SetHitPoints(List<string> args)
+    public sealed class SetHitPointsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_bribe_paid <settlment id> <int_value>\"";
+        public string Name => "set_hit_points";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Sets hit points for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("value", "The value."),
+        };
 
-        string settlementId = args[0];
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
 
-        if (float.TryParse(args[1], out var num) == false)
-            return $"Error setting the value: {args[1]} to a float.";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
 
-        settlement.SettlementHitPoints = num;
+            var objectManager = container.Resolve<IObjectManager>();
 
-        return $"Successfully set the Settlement ({settlementId}) SettlementHitPoints to '{args[1]}'";
+            string settlementId = args[0];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+            if (float.TryParse(args[1], out var num) == false)
+                return Failed($"Error setting the value: {args[1]} to a float.");
+
+            settlement.SettlementHitPoints = num;
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) SettlementHitPoints to '{args[1]}'");
+
+        }
     }
 
     // coop.debug.settlements.last_attacker town_ES1 CoopParty
@@ -315,32 +420,46 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlementid and last_attacker</param>
     /// <returns>info that is was succesful</returns>
-    [CommandLineArgumentFunction("last_attacker", "coop.debug.settlements")]
-    public static string SetLastAttackerParty(List<string> args)
+    public sealed class SetLastAttackerPartyCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"last_attacker <settlementId> <last_attacker_id>\"";
+        public string Name => "last_attacker";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Runs attacker for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("lastAttackerPartyId", "The last attacker party id."),
+        };
 
-        string settlementId = args[0];
-        string mobilePartyId = args[1];
-
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
-
-
-        if (objectManager.TryGetObject<MobileParty>(mobilePartyId, out var mobileParty) == false)
-            return $"Settlement: {mobilePartyId} was not found.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
 
-        settlement.LastAttackerParty = mobileParty;
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
+
+            var objectManager = container.Resolve<IObjectManager>();
+
+            string settlementId = args[0];
+            string mobilePartyId = args[1];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
 
 
-        return $"Successfully set the Settlement ({settlementId}) MobileParty to '{mobileParty.StringId}'";
+            if (objectManager.TryGetObject<MobileParty>(mobilePartyId, out var mobileParty) == false)
+                return Failed($"Settlement: {mobilePartyId} was not found.");
+
+
+            settlement.LastAttackerParty = mobileParty;
+
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) MobileParty to '{mobileParty.StringId}'");
+
+        }
     }
 
     // coop.debug.settlements.list_siege_state
@@ -348,16 +467,27 @@ internal class SettlementCommands
     // Lists all the possible siege states
     /// </summary>
     /// <returns>all the siegeStates</returns>
-    [CommandLineArgumentFunction("list_siege_state", "coop.debug.settlements")]
-    public static string ListSiegeStates(List<string> args)
+    public sealed class ListSiegeStatesCoopCommand : ICoopCommand
     {
+        public string Prefix => "coop.debug.settlements";
 
-        StringBuilder sb = new();
+        public string Name => "list_siege_state";
 
-        foreach(int i in Enum.GetValues(typeof(Settlement.SiegeState))) {
-            sb.AppendLine($"{i}: {Enum.GetName(typeof(Settlement.SiegeState), i)}");
+        public string Description => "Lists siege state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            StringBuilder sb = new();
+
+            foreach(int i in Enum.GetValues(typeof(Settlement.SiegeState))) {
+                sb.AppendLine($"{i}: {Enum.GetName(typeof(Settlement.SiegeState), i)}");
+            }
+            return Succeeded(sb.ToString());
+
         }
-        return sb.ToString();
     }
 
     // coop.debug.settlements.set_siege_state town_ES1 InTheLordsHall
@@ -366,31 +496,45 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlementid and SiegeState</param>
     /// <returns>info that is was succesful</returns>
-    [CommandLineArgumentFunction("set_siege_state", "coop.debug.settlements")]
-    public static string SetSiegeState(List<string> args)
+    public sealed class SetSiegeStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_siege_state <settlementId> <siege_state>\"";
+        public string Name => "set_siege_state";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Sets siege state for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("siegeState", "The siege state."),
+        };
 
-        string settlementId = args[0];
-        string siegeState = args[1];
-
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
-
-        if (Enum.TryParse<SiegeState>(siegeState, true, out var state) == false)
-            return $"{siegeState} was not a valid enum in {nameof(SiegeState)}";
-
-
-        settlement.CurrentSiegeState = state;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
 
-        return $"Successfully set the Settlement ({settlementId}) SiegeState to '{siegeState}'";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
+
+            var objectManager = container.Resolve<IObjectManager>();
+
+            string settlementId = args[0];
+            string siegeState = args[1];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+            if (Enum.TryParse<SiegeState>(siegeState, true, out var state) == false)
+                return Failed($"{siegeState} was not a valid enum in {nameof(SiegeState)}");
+
+
+            settlement.CurrentSiegeState = state;
+
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) SiegeState to '{siegeState}'");
+
+        }
     }
 
 
@@ -401,31 +545,45 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlementid and float of how many troops (negative or pos)</param>
     /// <returns>info that is was succesful</returns>
-    [CommandLineArgumentFunction("set_militia", "coop.debug.settlements")]
-    public static string SetMiltiia(List<string> args)
+    public sealed class SetMiltiiaCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_siege_state <settlementId> <militia_float>\"";
+        public string Name => "set_militia";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Sets militia for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("militia", "The militia."),
+        };
 
-        string settlementId = args[0];
-        string militiaFloat = args[1];
-
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
-
-
-        if (float.TryParse(militiaFloat, out var militia) == false)
-            return $"Error setting the value: {militiaFloat} to a float.";
-
-        settlement.Militia = militia;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
 
-        return $"Successfully set the Settlement ({settlementId}) Militia to '{militia}'";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
+
+            var objectManager = container.Resolve<IObjectManager>();
+
+            string settlementId = args[0];
+            string militiaFloat = args[1];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+
+            if (float.TryParse(militiaFloat, out var militia) == false)
+                return Failed($"Error setting the value: {militiaFloat} to a float.");
+
+            settlement.Militia = militia;
+
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) Militia to '{militia}'");
+
+        }
     }
 
 
@@ -435,31 +593,45 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlementid and float of how many troops (negative or pos)</param>
     /// <returns>info that is was succesful</returns>
-    [CommandLineArgumentFunction("set_garrison_pay_limit", "coop.debug.settlements")]
-    public static string SetGarrisonWageLimit(List<string> args)
+    public sealed class SetGarrisonWageLimitCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_siege_state <settlementId> <militia_float>\"";
+        public string Name => "set_garrison_pay_limit";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Sets garrison pay limit for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("payLimit", "The pay limit."),
+        };
 
-        string settlementId = args[0];
-        string garrisonInt = args[1];
-
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
-
-
-        if (int.TryParse(garrisonInt, out var wageLimit) == false)
-            return $"Error setting the value: {garrisonInt} to an int.";
-
-        settlement.SetGarrisonWagePaymentLimit(wageLimit);
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
 
-        return $"Successfully set the Settlement ({settlementId}) GarrisonWagePaymentLimit to '{wageLimit}'";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
+
+            var objectManager = container.Resolve<IObjectManager>();
+
+            string settlementId = args[0];
+            string garrisonInt = args[1];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+
+            if (int.TryParse(garrisonInt, out var wageLimit) == false)
+                return Failed($"Error setting the value: {garrisonInt} to an int.");
+
+            settlement.SetGarrisonWagePaymentLimit(wageLimit);
+
+
+            return Succeeded($"Successfully set the Settlement ({settlementId}) GarrisonWagePaymentLimit to '{wageLimit}'");
+
+        }
     }
 
 
@@ -469,75 +641,101 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args">the settlementid </param>
     /// <returns>info that is was successful</returns>
-    [CommandLineArgumentFunction("collect_cache_notables", "coop.debug.settlements")]
-    public static string CollectCacheNotables(List<string> args)
+    public sealed class CollectCacheNotablesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 1) return "Invalid usage, expected \"collect_cache_notables <settlementId>\"";
+        public string Name => "collect_cache_notables";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Collects cache notables for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        string settlementId = args[0];
-
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
-
-
-        settlement.CollectNotablesToCache();
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
 
-        return $"Successfully called settlement.CollectNotablesToCache() for {settlementId}.";
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
+
+            var objectManager = container.Resolve<IObjectManager>();
+
+            string settlementId = args[0];
+
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+
+            settlement.CollectNotablesToCache();
+
+
+            return Succeeded($"Successfully called settlement.CollectNotablesToCache() for {settlementId}.");
+
+        }
     }
 
 
 
     // Located in Modules\SandBox\ModuleData\settlements.xml
     // POROS EXAMPLE
-    // coop.debug.settlements.info town_ES3 
+    // coop.debug.settlements.info town_ES3
     /// <summary>
     /// Gives a bunch of information on a settlement.
     /// </summary>
     /// <param name="args">settlement name</param>
     /// <returns>info about the settlement</returns>
-    [CommandLineArgumentFunction("info", "coop.debug.settlements")]
-    public static string Info(List<string> args)
+    public sealed class InfoCoopCommand : ICoopCommand
     {
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count != 1) return "Invalid usage, expected \"info <settlment id>\"";
+        public string Name => "info";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get Settlement";
+        public string Description => "Shows the relevant state for co-op debugging.";
 
-        var objectManager = container.Resolve<IObjectManager>();
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        string settlementId = args.Single();
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
 
-        if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
-            return $"Settlement: {settlementId} was not found.";
 
-        StringBuilder sb = new();
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get Settlement");
 
-        string lastAttackerParty = settlement.LastAttackerParty?.ArmyName.ToString() ?? "None";
+            var objectManager = container.Resolve<IObjectManager>();
 
-        sb.AppendLine($"------------------- SETTLEMENT: {settlement.Name} -------------------");
-        sb.AppendLine($"NumberOfEnemiesSpottedAround: '{settlement.NearbyLandThreatIntensity}'");
-        sb.AppendLine($"NumberOfAlliesSpottedAround: '{settlement.NearbyLandAllyIntensity}'");
-        sb.AppendLine($"BribePaid: {settlement.BribePaid}");
-        sb.AppendLine($"SettlementHitPoints: '{settlement.SettlementHitPoints}'");
-        sb.AppendLine($"GarrisonWagePaymentLimit: '{settlement.GarrisonWagePaymentLimit}'");
-        sb.AppendLine($"LastAttackerParty: '{lastAttackerParty}'");
-        sb.AppendLine($"LastThreatTime:  '{settlement.LastThreatTime}'");
-        sb.AppendLine($"CurrentSiegeState:   '{settlement.CurrentSiegeState}'");
-        sb.AppendLine($"Militia :   '{settlement.Militia}'");
-        sb.AppendLine($"LastVisitTimeOfOwner  :   '{settlement.LastVisitTimeOfOwner}'");
-        //sb.AppendLine($"ClaimedBy   :   '{settlement.ClaimedBy}'");
-        //sb.AppendLine($"ClaimValue    :   '{settlement.ClaimValue}'");
-        //sb.AppendLine($"CanBeClaimed     :   '{Convert.ToBoolean(settlement.CanBeClaimed)}'");
-        sb.AppendLine($"------------------- SETTLEMENT: {settlement.Name} -------------------");
+            string settlementId = args.Single();
 
-        return sb.ToString();
+            if (objectManager.TryGetObject<Settlement>(settlementId, out var settlement) == false)
+                return Failed($"Settlement: {settlementId} was not found.");
+
+            StringBuilder sb = new();
+
+            string lastAttackerParty = settlement.LastAttackerParty?.ArmyName.ToString() ?? "None";
+
+            sb.AppendLine($"------------------- SETTLEMENT: {settlement.Name} -------------------");
+            sb.AppendLine($"NumberOfEnemiesSpottedAround: '{settlement.NearbyLandThreatIntensity}'");
+            sb.AppendLine($"NumberOfAlliesSpottedAround: '{settlement.NearbyLandAllyIntensity}'");
+            sb.AppendLine($"BribePaid: {settlement.BribePaid}");
+            sb.AppendLine($"SettlementHitPoints: '{settlement.SettlementHitPoints}'");
+            sb.AppendLine($"GarrisonWagePaymentLimit: '{settlement.GarrisonWagePaymentLimit}'");
+            sb.AppendLine($"LastAttackerParty: '{lastAttackerParty}'");
+            sb.AppendLine($"LastThreatTime:  '{settlement.LastThreatTime}'");
+            sb.AppendLine($"CurrentSiegeState:   '{settlement.CurrentSiegeState}'");
+            sb.AppendLine($"Militia :   '{settlement.Militia}'");
+            sb.AppendLine($"LastVisitTimeOfOwner  :   '{settlement.LastVisitTimeOfOwner}'");
+            //sb.AppendLine($"ClaimedBy   :   '{settlement.ClaimedBy}'");
+            //sb.AppendLine($"ClaimValue    :   '{settlement.ClaimValue}'");
+            //sb.AppendLine($"CanBeClaimed     :   '{Convert.ToBoolean(settlement.CanBeClaimed)}'");
+            sb.AppendLine($"------------------- SETTLEMENT: {settlement.Name} -------------------");
+
+            return Succeeded(sb.ToString());
+
+        }
     }
 
     // coop.debug.settlementcomponent.set_owner town_comp_ES3 lord_6_5_party_1
@@ -547,36 +745,50 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args"><see cref="SettlementComponent"/> id, <see cref="MobileParty"/> or <see cref="Settlement"/> id</param>
     /// <returns>info that is was successful</returns>
-    [CommandLineArgumentFunction("set_owner", "coop.debug.settlementComponent")]
-    public static string SetOwner(List<string> args)
+    public sealed class SetOwnerCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlement_component";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_owner <settlmentComponent id> <Mobile party id>\"";
+        public string Name => "set_owner";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get SettlementComponent";
-        var objectManager = container.Resolve<IObjectManager>();
-        string settlementComponentId = args[0];
-        string partyBaseId = args[1];
-        PartyBase partyBase;
-        if (objectManager.TryGetObject<SettlementComponent>(settlementComponentId, out var settlementComponent) == false)
-            return $"SettlementComponent: {settlementComponentId} was not found.";
-        if (objectManager.TryGetObject<Settlement>(partyBaseId, out var settlement))
+        public string Description => "Sets owner for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            partyBase = settlement.Party;
-        }
-        else if (objectManager.TryGetObject<MobileParty>(partyBaseId, out var mobileParty))
-        {
-            partyBase = mobileParty.Party;
-        }
-        else
-        {
-            return $"PartyBase: {partyBaseId} was not found.";
-        }
+            new ExpectedArgs("settlementComponentId", "The settlement component id."),
+            new ExpectedArgs("mobilePartyId", "The mobile party id."),
+        };
 
-        settlementComponent.Owner = partyBase;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
-        return $"Successfully set the SettlementComponent ({settlementComponentId}) Owner to '{args[1]}'";
+
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get SettlementComponent");
+            var objectManager = container.Resolve<IObjectManager>();
+            string settlementComponentId = args[0];
+            string partyBaseId = args[1];
+            PartyBase partyBase;
+            if (objectManager.TryGetObject<SettlementComponent>(settlementComponentId, out var settlementComponent) == false)
+                return Failed($"SettlementComponent: {settlementComponentId} was not found.");
+            if (objectManager.TryGetObject<Settlement>(partyBaseId, out var settlement))
+            {
+                partyBase = settlement.Party;
+            }
+            else if (objectManager.TryGetObject<MobileParty>(partyBaseId, out var mobileParty))
+            {
+                partyBase = mobileParty.Party;
+            }
+            else
+            {
+                return Failed($"PartyBase: {partyBaseId} was not found.");
+            }
+
+            settlementComponent.Owner = partyBase;
+
+            return Succeeded($"Successfully set the SettlementComponent ({settlementComponentId}) Owner to '{args[1]}'");
+
+        }
     }
 
     // coop.debug.settlements.capture_by_siege Danustica
@@ -587,68 +799,93 @@ internal class SettlementCommands
     // real siege. Server only. Settlement is resolved by name or id; the capturer (used as the new
     // owner and the garrison's destroyer) defaults to an enemy-kingdom clan leader with a party, so
     // the resulting fief owner is in a kingdom and the post-siege claimant decision is well-formed.
-    [CommandLineArgumentFunction("capture_by_siege", "coop.debug.settlements")]
-    public static string CaptureBySiege(List<string> args)
+    public sealed class CaptureBySiegeCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlements";
 
-        if (args.Count < 1)
-            return "Usage: coop.debug.settlements.capture_by_siege <Settlement name or id> [CapturerHero id]";
+        public string Name => "capture_by_siege";
 
-        var settlement = Campaign.Current.CampaignObjectManager.Settlements
-            .FirstOrDefault(s => s.StringId == args[0] || s.Name?.ToString() == args[0]);
-        if (settlement == null)
-            return $"Settlement '{args[0]}' not found";
-        if (!settlement.IsFortification)
-            return $"'{args[0]}' is not a town or castle";
+        public string Description => "Captures by siege for co-op debugging.";
 
-        Hero capturer;
-        if (args.Count >= 2)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            capturer = Campaign.Current.CampaignObjectManager.Find<Hero>(args[1]);
-            if (capturer == null)
-                return $"Hero '{args[1]}' not found";
-        }
-        else
+            new ExpectedArgs("settlementNameOrId", "The exact settlement name or id; quote names containing spaces."),
+            new ExpectedArgs("capturerHeroId", "The capturer hero id.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            // Pick an enemy-kingdom clan leader so the capture mirrors a real siege: the new owner's
-            // clan is in a kingdom, so the kingdom raises a well-formed SettlementClaimantDecision
-            // (a kingdomless owner would produce a malformed one). Prefer one already at war.
-            var candidates = Hero.AllAliveHeroes.Where(h =>
-                !h.IsHumanPlayerCharacter &&
-                h.PartyBelongedTo != null &&
-                h.Clan != null &&
-                h.Clan.Leader == h &&
-                h.Clan.Kingdom != null &&
-                h.Clan.Kingdom != settlement.MapFaction).ToList();
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
 
-            capturer = candidates.FirstOrDefault(h => h.MapFaction.IsAtWarWith(settlement.MapFaction))
-                       ?? candidates.FirstOrDefault();
-            if (capturer == null)
-                return "No eligible enemy-kingdom clan leader with a party found; pass a hero id as the 2nd arg";
+
+            var settlement = Campaign.Current.CampaignObjectManager.Settlements
+                .FirstOrDefault(s => s.StringId == args[0] || s.Name?.ToString() == args[0]);
+            if (settlement == null)
+                return Failed($"Settlement '{args[0]}' not found");
+            if (!settlement.IsFortification)
+                return Failed($"'{args[0]}' is not a town or castle");
+
+            Hero capturer;
+            if (args.Count >= 2)
+            {
+                capturer = Campaign.Current.CampaignObjectManager.Find<Hero>(args[1]);
+                if (capturer == null)
+                    return Failed($"Hero '{args[1]}' not found");
+            }
+            else
+            {
+                // Pick an enemy-kingdom clan leader so the capture mirrors a real siege: the new owner's
+                // clan is in a kingdom, so the kingdom raises a well-formed SettlementClaimantDecision
+                // (a kingdomless owner would produce a malformed one). Prefer one already at war.
+                var candidates = Hero.AllAliveHeroes.Where(h =>
+                    !h.IsHumanPlayerCharacter &&
+                    h.PartyBelongedTo != null &&
+                    h.Clan != null &&
+                    h.Clan.Leader == h &&
+                    h.Clan.Kingdom != null &&
+                    h.Clan.Kingdom != settlement.MapFaction).ToList();
+
+                capturer = candidates.FirstOrDefault(h => h.MapFaction.IsAtWarWith(settlement.MapFaction))
+                           ?? candidates.FirstOrDefault();
+                if (capturer == null)
+                    return Failed("No eligible enemy-kingdom clan leader with a party found; pass a hero id as the 2nd arg");
+            }
+
+            if (capturer.PartyBelongedTo == null)
+                return Failed($"Capturer '{capturer.Name}' has no party; BySiege uses the capturer's party as the garrison destroyer");
+
+            ChangeOwnerOfSettlementAction.ApplyBySiege(capturer, capturer, settlement);
+
+            return Succeeded($"Captured {settlement.Name} by siege; new owner {capturer.Name} ({capturer.MapFaction?.Name})" +
+                   Environment.NewLine + FormatOwnerState(settlement));
+
         }
-
-        if (capturer.PartyBelongedTo == null)
-            return $"Capturer '{capturer.Name}' has no party; BySiege uses the capturer's party as the garrison destroyer";
-
-        ChangeOwnerOfSettlementAction.ApplyBySiege(capturer, capturer, settlement);
-
-        return $"Captured {settlement.Name} by siege; new owner {capturer.Name} ({capturer.MapFaction?.Name})" +
-               Environment.NewLine + FormatOwnerState(settlement);
     }
 
-    [CommandLineArgumentFunction("owner_state", "coop.debug.settlements")]
-    public static string OwnerState(List<string> args)
+    public sealed class OwnerStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-            return "Usage: coop.debug.settlements.owner_state <Settlement name or id>";
+        public string Prefix => "coop.debug.settlements";
 
-        var settlement = Campaign.Current.CampaignObjectManager.Settlements
-            .FirstOrDefault(s => s.StringId == args[0] || s.Name?.ToString() == args[0]);
-        if (settlement == null)
-            return $"Settlement '{args[0]}' not found";
+        public string Name => "owner_state";
 
-        return FormatOwnerState(settlement);
+        public string Description => "Shows state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementNameOrId", "The exact settlement name or id; quote names containing spaces."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            var settlement = Campaign.Current.CampaignObjectManager.Settlements
+                .FirstOrDefault(s => s.StringId == args[0] || s.Name?.ToString() == args[0]);
+            if (settlement == null)
+                return Failed($"Settlement '{args[0]}' not found");
+
+            return Succeeded(FormatOwnerState(settlement));
+
+        }
     }
 
     private static string FormatOwnerState(Settlement settlement)
@@ -675,26 +912,40 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args"><see cref="SettlementComponent"/> id, amount of gold</param>
     /// <returns>info that is was successful</returns>
-    [CommandLineArgumentFunction("set_gold", "coop.debug.settlementComponent")]
-    public static string SetGold(List<string> args)
+    public sealed class SetGoldCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlement_component";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_owner <settlmentComponent id> <Gold>\"";
+        public string Name => "set_gold";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get SettlementComponent";
-        var objectManager = container.Resolve<IObjectManager>();
-        string settlementComponentId = args[0];
-        if (int.TryParse(args[1], out int gold) == false)
+        public string Description => "Sets gold for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Unable to parse gold amount";
+            new ExpectedArgs("settlementComponentId", "The settlement component id."),
+            new ExpectedArgs("gold", "The gold."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
+
+
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get SettlementComponent");
+            var objectManager = container.Resolve<IObjectManager>();
+            string settlementComponentId = args[0];
+            if (int.TryParse(args[1], out int gold) == false)
+            {
+                return Failed("Unable to parse gold amount");
+            }
+            if (objectManager.TryGetObject<SettlementComponent>(settlementComponentId, out var settlementComponent) == false)
+                return Failed($"SettlementComponent: {settlementComponentId} was not found.");
+
+            settlementComponent.Gold = gold;
+
+            return Succeeded($"Successfully set the SettlementComponent ({settlementComponentId}) Gold to '{args[1]}'");
+
         }
-        if (objectManager.TryGetObject<SettlementComponent>(settlementComponentId, out var settlementComponent) == false)
-            return $"SettlementComponent: {settlementComponentId} was not found.";
-
-        settlementComponent.Gold = gold;
-
-        return $"Successfully set the SettlementComponent ({settlementComponentId}) Gold to '{args[1]}'";
     }
 
     // coop.debug.settlementcomponent.set_is_owner_unassigned town_comp_ES3 true
@@ -704,59 +955,87 @@ internal class SettlementCommands
     /// </summary>
     /// <param name="args"><see cref="SettlementComponent"/> id, new <see cref="SettlementComponent.IsOwnerUnassigned"/> value></param>
     /// <returns>info that is was successful</returns>
-    [CommandLineArgumentFunction("set_is_owner_unassigned", "coop.debug.settlementComponent")]
-    public static string SetIsOwnerUnassigned(List<string> args)
+    public sealed class SetIsOwnerUnassignedCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "This function can only be used by the server";
+        public string Prefix => "coop.debug.settlement_component";
 
-        if (args.Count != 2) return "Invalid usage, expected \"set_owner <settlmentComponent id> <boolean>\"";
+        public string Name => "set_is_owner_unassigned";
 
-        if (ContainerProvider.TryGetContainer(out var container) == false) return "Unable to get SettlementComponent";
-        var objectManager = container.Resolve<IObjectManager>();
-        string settlementComponentId = args[0];
-        if (bool.TryParse(args[1], out bool value) == false)
+        public string Description => "Sets is owner unassigned for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Unable to parse IsOwnerUnassigned";
+            new ExpectedArgs("settlementComponentId", "The settlement component id."),
+            new ExpectedArgs("value", "The value."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("This function can only be used by the server");
+
+
+            if (ContainerProvider.TryGetContainer(out var container) == false) return Failed("Unable to get SettlementComponent");
+            var objectManager = container.Resolve<IObjectManager>();
+            string settlementComponentId = args[0];
+            if (bool.TryParse(args[1], out bool value) == false)
+            {
+                return Failed("Unable to parse IsOwnerUnassigned");
+            }
+            if (objectManager.TryGetObject<SettlementComponent>(settlementComponentId, out var settlementComponent) == false)
+                return Failed($"SettlementComponent: {settlementComponentId} was not found.");
+
+
+            settlementComponent.IsOwnerUnassigned = value;
+
+
+            return Succeeded($"Successfully set the SettlementComponent ({settlementComponentId}) IsOwnerUnassigned to '{args[1]}'");
+
         }
-        if (objectManager.TryGetObject<SettlementComponent>(settlementComponentId, out var settlementComponent) == false)
-            return $"SettlementComponent: {settlementComponentId} was not found.";
-
-
-        settlementComponent.IsOwnerUnassigned = value;
-
-
-        return $"Successfully set the SettlementComponent ({settlementComponentId}) IsOwnerUnassigned to '{args[1]}'";
     }
 
     /// <summary>
     /// Set OwnerClan of a settlement from Hero Id
     /// </summary>
-    [CommandLineArgumentFunction("set_ownerclan", "coop.debug.settlements")]
-    public static string SetOwnerClan(List<string> strings)
+    public sealed class SetOwnerClanCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.settlements";
 
-        if (strings.Count != 2) return "Invalid usage, expected \"set_ownerclan <settlementId|settlementName> <heroId>\"";
+        public string Name => "set_owner_clan";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var settlement in Settlement.All)
+        public string Description => "Sets owner clan for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (settlement.Name.ToString() == strings[0] || settlement.StringId == strings[0])
+            new ExpectedArgs("settlementNameOrId", "The exact settlement name or id; quote names containing spaces."),
+            new ExpectedArgs("heroId", "The hero id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var settlement in Settlement.All)
             {
-                var hero = Campaign.Current.CampaignObjectManager.Find<Hero>(strings[1]);
+                if (settlement.Name.ToString() == strings[0] || settlement.StringId == strings[0])
+                {
+                    var hero = Campaign.Current.CampaignObjectManager.Find<Hero>(strings[1]);
 
-                if (hero == null) return $"Unable to find hero by id: {strings[1]}";
+                    if (hero == null) return Failed($"Unable to find hero by id: {strings[1]}");
 
-                ChangeOwnerOfSettlementAction.ApplyByGift(settlement, hero);
-                stringBuilder.AppendLine($"{settlement.Name} ({settlement.StringId}) transferred to {hero.Name} ({hero.StringId}).");
+                    ChangeOwnerOfSettlementAction.ApplyByGift(settlement, hero);
+                    stringBuilder.AppendLine($"{settlement.Name} ({settlement.StringId}) transferred to {hero.Name} ({hero.StringId}).");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Settlement or hero not found.");
+
         }
-        return "Settlement or hero not found.";
     }
 }

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using Common.Messaging;
@@ -39,12 +40,16 @@ using TaleWorlds.CampaignSystem.Siege;
 using TaleWorlds.Core;
 using static TaleWorlds.CampaignSystem.Army;
 using static TaleWorlds.CampaignSystem.Siege.SiegeEvent;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.SiegeEvents.Commands;
 
 public class SiegeDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<SiegeDebugCommand>();
     private static PrisonerPromptFixture prisonerPromptFixture;
 
@@ -114,211 +119,247 @@ public class SiegeDebugCommand
         public int Tier;
     }
 
-    [CommandLineArgumentFunction("prisoner_prompt_fixture_start", "coop.debug.siege")]
-    public static string StartPrisonerPromptFixture(List<string> args)
+    public sealed class StartPrisonerPromptFixtureCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.siege.prisoner_prompt_fixture_start <controllerId> <settlementId>";
-        if (!ModInformation.IsServer) return "This command can only be used by the server";
-        if (args.Count != 2) return usage;
-        if (prisonerPromptFixture != null) return "A prisoner-prompt siege fixture is already active.";
+        public string Prefix => "coop.debug.siege";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
-            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface) ||
-            !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
-            return "Unable to resolve prisoner-prompt fixture services.";
+        public string Name => "prisoner_prompt_fixture_start";
 
-        if (!playerManager.TryGetPlayer(args[0], out var player) || !playerManager.IsConnected(player) ||
-            !objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
-            return $"No connected player has controller id {args[0]}.";
-        if (!objectManager.TryGetObject<Settlement>(args[1], out var settlement))
-            return $"Settlement with id {args[1]} not found.";
-        if (!settlement.IsFortification || settlement.OwnerClan?.Leader == null)
-            return $"{settlement.Name} must be an owned fortification.";
-        if (playerParty.MapFaction is not Kingdom attackerKingdom ||
-            settlement.MapFaction == null || settlement.MapFaction == attackerKingdom)
-            return "The player party must belong to a kingdom hostile to the target owner.";
-        if (playerParty.MapEvent != null || playerParty.BesiegerCamp != null ||
-            playerParty.CurrentSettlement != null || playerParty.Army != null || settlement.SiegeEvent != null)
-            return "The player party and target must be outside an army, settlement, siege, and map event.";
+        public string Description => "Runs prompt fixture start for co-op debugging.";
 
-        var armyLeader = MobileParty.AllLordParties
-            .Where(party => party.IsActive && !party.IsPlayerParty() && party.MapFaction == attackerKingdom &&
-                party.LeaderHero != null && party.MapEvent == null && party.CurrentSettlement == null &&
-                party.BesiegerCamp == null && party.Army == null && party.MemberRoster.TotalHealthyCount > 0)
-            .OrderByDescending(party => party.Party.CalculateCurrentStrength())
-            .FirstOrDefault();
-        if (armyLeader == null)
-            return $"No available {attackerKingdom.Name} lord party can lead the fixture army.";
-        if (!behaviorSnapshot.TryCreate(playerParty, out var playerBehavior) ||
-            !behaviorSnapshot.TryCreate(armyLeader, out var leaderBehavior))
-            return "Unable to capture the original party behavior.";
-
-        PrisonerPromptPartySnapshot[] partySnapshots;
-        PrisonerPromptHeroSnapshot[] heroSnapshots;
-        PrisonerPromptClanSnapshot[] clanSnapshots;
-        try
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            partySnapshots = CapturePrisonerPromptParties(playerParty, armyLeader, settlement);
-            heroSnapshots = CapturePrisonerPromptHeroes(partySnapshots, settlement);
-            clanSnapshots = CapturePrisonerPromptClans(heroSnapshots);
-        }
-        catch (Exception ex)
-        {
-            Logger.Error(ex, "Failed to capture prisoner-prompt siege fixture");
-            return "Unable to capture the original combat state: " + ex.Message;
-        }
-
-        var fixture = new PrisonerPromptFixture
-        {
-            ControllerId = args[0],
-            Settlement = settlement,
-            OriginalOwner = settlement.OwnerClan.Leader,
-            PlayerParty = playerParty,
-            ArmyLeader = armyLeader,
-            PlayerBehavior = playerBehavior,
-            LeaderBehavior = leaderBehavior,
-            AttackerFaction = attackerKingdom,
-            DefenderFaction = settlement.MapFaction,
-            WasAtWar = attackerKingdom.IsAtWarWith(settlement.MapFaction),
-            PartySnapshots = partySnapshots,
-            HeroSnapshots = heroSnapshots,
-            ClanSnapshots = clanSnapshots,
-            Governor = settlement.Town.Governor,
-            LastCapturedBy = settlement.Town.LastCapturedBy,
-            HadGarrison = settlement.Town.GarrisonParty != null,
-            Prosperity = settlement.Town.Prosperity,
-            Loyalty = settlement.Town.Loyalty,
-            Security = settlement.Town.Security,
-            FoodStocks = settlement.Town.FoodStocks,
+            new ExpectedArgs("controllerId", "The controller id."),
+            new ExpectedArgs("settlementId", "The settlement id."),
         };
-        prisonerPromptFixture = fixture;
 
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (!fixture.WasAtWar)
-                DeclareWarAction.ApplyByDefault(fixture.AttackerFaction, fixture.DefenderFaction);
+            if (!ModInformation.IsServer) return Failed("This command can only be used by the server");
+            if (prisonerPromptFixture != null) return Failed("A prisoner-prompt siege fixture is already active.");
 
-            armyLeader.Position = settlement.GatePosition;
-            playerParty.Position = settlement.GatePosition;
-            attackerKingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Besieger);
-            fixture.Army = armyLeader.Army;
-            if (fixture.Army == null)
-                throw new InvalidOperationException("Vanilla did not create the fixture army.");
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
+                !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface) ||
+                !ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
+                return Failed("Unable to resolve prisoner-prompt fixture services.");
 
-            playerParty.Army = fixture.Army;
-            fixture.Army.AddPartyToMergedParties(playerParty);
-            armyLeader.SetMoveBesiegeSettlement(settlement, MobileParty.NavigationType.Default);
-            siegeEventInterface.StartSiegeEvent(armyLeader, settlement);
-            if (playerParty.BesiegerCamp == null)
-                siegeEventInterface.JoinSiegeCamp(playerParty, settlement);
+            if (!playerManager.TryGetPlayer(args[0], out var player) || !playerManager.IsConnected(player) ||
+                !objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
+                return Failed($"No connected player has controller id {args[0]}.");
+            if (!objectManager.TryGetObject<Settlement>(args[1], out var settlement))
+                return Failed($"Settlement with id {args[1]} not found.");
+            if (!settlement.IsFortification || settlement.OwnerClan?.Leader == null)
+                return Failed($"{settlement.Name} must be an owned fortification.");
+            if (playerParty.MapFaction is not Kingdom attackerKingdom ||
+                settlement.MapFaction == null || settlement.MapFaction == attackerKingdom)
+                return Failed("The player party must belong to a kingdom hostile to the target owner.");
+            if (playerParty.MapEvent != null || playerParty.BesiegerCamp != null ||
+                playerParty.CurrentSettlement != null || playerParty.Army != null || settlement.SiegeEvent != null)
+                return Failed("The player party and target must be outside an army, settlement, siege, and map event.");
 
-            if (settlement.SiegeEvent == null || playerParty.Army != fixture.Army ||
-                fixture.Army.LeaderParty == playerParty)
-                throw new InvalidOperationException("The army siege fixture did not reach its required state.");
+            var armyLeader = MobileParty.AllLordParties
+                .Where(party => party.IsActive && !party.IsPlayerParty() && party.MapFaction == attackerKingdom &&
+                    party.LeaderHero != null && party.MapEvent == null && party.CurrentSettlement == null &&
+                    party.BesiegerCamp == null && party.Army == null && party.MemberRoster.TotalHealthyCount > 0)
+                .OrderByDescending(party => party.Party.CalculateCurrentStrength())
+                .FirstOrDefault();
+            if (armyLeader == null)
+                return Failed($"No available {attackerKingdom.Name} lord party can lead the fixture army.");
+            if (!behaviorSnapshot.TryCreate(playerParty, out var playerBehavior) ||
+                !behaviorSnapshot.TryCreate(armyLeader, out var leaderBehavior))
+                return Failed("Unable to capture the original party behavior.");
 
-            objectManager.TryGetId(fixture.Army, out string armyId);
-            return "Prisoner-prompt army siege fixture started." + Environment.NewLine +
+            PrisonerPromptPartySnapshot[] partySnapshots;
+            PrisonerPromptHeroSnapshot[] heroSnapshots;
+            PrisonerPromptClanSnapshot[] clanSnapshots;
+            try
+            {
+                partySnapshots = CapturePrisonerPromptParties(playerParty, armyLeader, settlement);
+                heroSnapshots = CapturePrisonerPromptHeroes(partySnapshots, settlement);
+                clanSnapshots = CapturePrisonerPromptClans(heroSnapshots);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to capture prisoner-prompt siege fixture");
+                return Failed("Unable to capture the original combat state: " + ex.Message);
+            }
+
+            var fixture = new PrisonerPromptFixture
+            {
+                ControllerId = args[0],
+                Settlement = settlement,
+                OriginalOwner = settlement.OwnerClan.Leader,
+                PlayerParty = playerParty,
+                ArmyLeader = armyLeader,
+                PlayerBehavior = playerBehavior,
+                LeaderBehavior = leaderBehavior,
+                AttackerFaction = attackerKingdom,
+                DefenderFaction = settlement.MapFaction,
+                WasAtWar = attackerKingdom.IsAtWarWith(settlement.MapFaction),
+                PartySnapshots = partySnapshots,
+                HeroSnapshots = heroSnapshots,
+                ClanSnapshots = clanSnapshots,
+                Governor = settlement.Town.Governor,
+                LastCapturedBy = settlement.Town.LastCapturedBy,
+                HadGarrison = settlement.Town.GarrisonParty != null,
+                Prosperity = settlement.Town.Prosperity,
+                Loyalty = settlement.Town.Loyalty,
+                Security = settlement.Town.Security,
+                FoodStocks = settlement.Town.FoodStocks,
+            };
+            prisonerPromptFixture = fixture;
+
+            try
+            {
+                if (!fixture.WasAtWar)
+                    DeclareWarAction.ApplyByDefault(fixture.AttackerFaction, fixture.DefenderFaction);
+
+                armyLeader.Position = settlement.GatePosition;
+                playerParty.Position = settlement.GatePosition;
+                attackerKingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Besieger);
+                fixture.Army = armyLeader.Army;
+                if (fixture.Army == null)
+                    throw new InvalidOperationException("Vanilla did not create the fixture army.");
+
+                playerParty.Army = fixture.Army;
+                fixture.Army.AddPartyToMergedParties(playerParty);
+                armyLeader.SetMoveBesiegeSettlement(settlement, MobileParty.NavigationType.Default);
+                siegeEventInterface.StartSiegeEvent(armyLeader, settlement);
+                if (playerParty.BesiegerCamp == null)
+                    siegeEventInterface.JoinSiegeCamp(playerParty, settlement);
+
+                if (settlement.SiegeEvent == null || playerParty.Army != fixture.Army ||
+                    fixture.Army.LeaderParty == playerParty)
+                    throw new InvalidOperationException("The army siege fixture did not reach its required state.");
+
+                objectManager.TryGetId(fixture.Army, out string armyId);
+                return Succeeded("Prisoner-prompt army siege fixture started." + Environment.NewLine +
+                    "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(new
+                    {
+                        success = true,
+                        controllerId = fixture.ControllerId,
+                        settlementId = settlement.StringId,
+                        armyId,
+                        leaderPartyId = armyLeader.StringId,
+                        playerPartyId = playerParty.StringId,
+                        playerIsArmyMember = playerParty.Army == fixture.Army,
+                        playerIsNonLeaderMember = fixture.Army.LeaderParty != playerParty,
+                        siegeActive = settlement.SiegeEvent != null,
+                        warDeclaredByFixture = !fixture.WasAtWar,
+                    }));
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to start prisoner-prompt siege fixture");
+                bool restored = TryRestorePrisonerPromptFixture(
+                    fixture,
+                    behaviorSnapshot,
+                    siegeEventInterface,
+                    out var restoreError);
+                if (restored)
+                    prisonerPromptFixture = null;
+
+                return Failed("Failed to start prisoner-prompt siege fixture: " + ex.Message +
+                    (restored ? string.Empty : ". Restore is still required: " + restoreError));
+            }
+
+        }
+    }
+
+    public sealed class PrisonerPromptFixtureStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "prisoner_prompt_fixture_state";
+
+        public string Description => "Runs prompt fixture state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controllerId", "The controller id."),
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer) return Failed("This command can only be used by the server");
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
+                !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.TryGetPlayer(args[0], out var player) ||
+                !objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty) ||
+                !objectManager.TryGetObject<Settlement>(args[1], out var settlement))
+                return Failed("Unable to resolve prisoner-prompt fixture state.");
+
+            var army = playerParty.Army;
+            string armyId = null;
+            if (army != null)
+                objectManager.TryGetId(army, out armyId);
+            return Succeeded("LIVE_TEST_JSON=" + JsonConvert.SerializeObject(new
+            {
+                success = true,
+                fixtureActive = prisonerPromptFixture != null,
+                controllerId = args[0],
+                settlementId = settlement.StringId,
+                settlementOwnerId = settlement.OwnerClan?.StringId,
+                playerPartyId = playerParty.StringId,
+                playerMapEventActive = playerParty.MapEvent != null,
+                playerBesieger = settlement.SiegeEvent != null &&
+                    playerParty.BesiegerCamp == settlement.SiegeEvent.BesiegerCamp,
+                armyId,
+                playerIsArmyMember = army != null,
+                playerIsNonLeaderMember = army != null && army.LeaderParty != playerParty,
+                armyLeaderPartyId = army?.LeaderParty?.StringId,
+                siegeActive = settlement.SiegeEvent != null,
+                atWar = playerParty.MapFaction?.IsAtWarWith(settlement.MapFaction) == true,
+                playerX = playerParty.Position.X,
+                playerY = playerParty.Position.Y,
+            }));
+
+        }
+    }
+
+    public sealed class RestorePrisonerPromptFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "prisoner_prompt_fixture_restore";
+
+        public string Description => "Runs prompt fixture restore for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer) return Failed("This command can only be used by the server");
+            var fixture = prisonerPromptFixture;
+            if (fixture == null) return Failed("No prisoner-prompt siege fixture is active.");
+            if (fixture.PlayerParty.MapEvent != null || fixture.ArmyLeader.MapEvent != null)
+                return Failed("The fixture battle must finish before restoration.");
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
+                !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
+                return Failed("Unable to resolve prisoner-prompt fixture restore services.");
+
+            if (!TryRestorePrisonerPromptFixture(fixture, behaviorSnapshot, siegeEventInterface, out var error))
+                return Failed("Failed to restore prisoner-prompt siege fixture: " + error);
+
+            prisonerPromptFixture = null;
+            return Succeeded("Prisoner-prompt army siege fixture restored." + Environment.NewLine +
                 "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(new
                 {
                     success = true,
+                    restored = true,
                     controllerId = fixture.ControllerId,
-                    settlementId = settlement.StringId,
-                    armyId,
-                    leaderPartyId = armyLeader.StringId,
-                    playerPartyId = playerParty.StringId,
-                    playerIsArmyMember = playerParty.Army == fixture.Army,
-                    playerIsNonLeaderMember = fixture.Army.LeaderParty != playerParty,
-                    siegeActive = settlement.SiegeEvent != null,
-                    warDeclaredByFixture = !fixture.WasAtWar,
-                });
+                    settlementId = fixture.Settlement.StringId,
+                    armyRemoved = fixture.PlayerParty.Army == null && fixture.ArmyLeader.Army == null,
+                    siegeRemoved = fixture.Settlement.SiegeEvent == null,
+                    ownerRestored = fixture.Settlement.OwnerClan == fixture.OriginalOwner.Clan,
+                    warRestored = fixture.WasAtWar ||
+                        !fixture.AttackerFaction.IsAtWarWith(fixture.DefenderFaction),
+                    combatStateRestored = IsPrisonerPromptCombatStateRestored(fixture),
+                }));
+
         }
-        catch (Exception ex)
-        {
-            Logger.Error(ex, "Failed to start prisoner-prompt siege fixture");
-            bool restored = TryRestorePrisonerPromptFixture(
-                fixture,
-                behaviorSnapshot,
-                siegeEventInterface,
-                out var restoreError);
-            if (restored)
-                prisonerPromptFixture = null;
-
-            return "Failed to start prisoner-prompt siege fixture: " + ex.Message +
-                (restored ? string.Empty : ". Restore is still required: " + restoreError);
-        }
-    }
-
-    [CommandLineArgumentFunction("prisoner_prompt_fixture_state", "coop.debug.siege")]
-    public static string PrisonerPromptFixtureState(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.siege.prisoner_prompt_fixture_state <controllerId> <settlementId>";
-        if (!ModInformation.IsServer) return "This command can only be used by the server";
-        if (args.Count != 2) return usage;
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager) ||
-            !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.TryGetPlayer(args[0], out var player) ||
-            !objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty) ||
-            !objectManager.TryGetObject<Settlement>(args[1], out var settlement))
-            return "Unable to resolve prisoner-prompt fixture state.";
-
-        var army = playerParty.Army;
-        string armyId = null;
-        if (army != null)
-            objectManager.TryGetId(army, out armyId);
-        return "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(new
-        {
-            success = true,
-            fixtureActive = prisonerPromptFixture != null,
-            controllerId = args[0],
-            settlementId = settlement.StringId,
-            settlementOwnerId = settlement.OwnerClan?.StringId,
-            playerPartyId = playerParty.StringId,
-            playerMapEventActive = playerParty.MapEvent != null,
-            playerBesieger = settlement.SiegeEvent != null &&
-                playerParty.BesiegerCamp == settlement.SiegeEvent.BesiegerCamp,
-            armyId,
-            playerIsArmyMember = army != null,
-            playerIsNonLeaderMember = army != null && army.LeaderParty != playerParty,
-            armyLeaderPartyId = army?.LeaderParty?.StringId,
-            siegeActive = settlement.SiegeEvent != null,
-            atWar = playerParty.MapFaction?.IsAtWarWith(settlement.MapFaction) == true,
-            playerX = playerParty.Position.X,
-            playerY = playerParty.Position.Y,
-        });
-    }
-
-    [CommandLineArgumentFunction("prisoner_prompt_fixture_restore", "coop.debug.siege")]
-    public static string RestorePrisonerPromptFixture(List<string> args)
-    {
-        if (!ModInformation.IsServer) return "This command can only be used by the server";
-        if (args.Count != 0) return "Usage: coop.debug.siege.prisoner_prompt_fixture_restore";
-        var fixture = prisonerPromptFixture;
-        if (fixture == null) return "No prisoner-prompt siege fixture is active.";
-        if (fixture.PlayerParty.MapEvent != null || fixture.ArmyLeader.MapEvent != null)
-            return "The fixture battle must finish before restoration.";
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
-            !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
-            return "Unable to resolve prisoner-prompt fixture restore services.";
-
-        if (!TryRestorePrisonerPromptFixture(fixture, behaviorSnapshot, siegeEventInterface, out var error))
-            return "Failed to restore prisoner-prompt siege fixture: " + error;
-
-        prisonerPromptFixture = null;
-        return "Prisoner-prompt army siege fixture restored." + Environment.NewLine +
-            "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(new
-            {
-                success = true,
-                restored = true,
-                controllerId = fixture.ControllerId,
-                settlementId = fixture.Settlement.StringId,
-                armyRemoved = fixture.PlayerParty.Army == null && fixture.ArmyLeader.Army == null,
-                siegeRemoved = fixture.Settlement.SiegeEvent == null,
-                ownerRestored = fixture.Settlement.OwnerClan == fixture.OriginalOwner.Clan,
-                warRestored = fixture.WasAtWar ||
-                    !fixture.AttackerFaction.IsAtWarWith(fixture.DefenderFaction),
-                combatStateRestored = IsPrisonerPromptCombatStateRestored(fixture),
-            });
     }
 
     private static PrisonerPromptPartySnapshot[] CapturePrisonerPromptParties(
@@ -807,398 +848,472 @@ public class SiegeDebugCommand
     /// <summary>
     /// Creates a player-led siege and sends a multi-party defending army to interrupt it. Server only.
     /// </summary>
-    [CommandLineArgumentFunction("start_army_relief", "coop.debug.siege")]
-    public static string StartArmyRelief(List<string> args)
+    public sealed class StartArmyReliefCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "start_army_relief";
+
+        public string Description => "Starts army relief for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "This command can only be used by the server";
-        }
+            new ExpectedArgs("controllerId", "The controller id."),
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("armyPartyCount", "The army party count.", isRequired: false),
+        };
 
-        if (args.Count < 2 || args.Count > 3)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Usage: coop.debug.siege.start_army_relief <controllerId> <settlementId> [armyPartyCount]";
-        }
-
-        int armyPartyCount = 3;
-        if (args.Count == 3 && (!int.TryParse(args[2], out armyPartyCount) || armyPartyCount < 2))
-        {
-            return "armyPartyCount must be at least 2";
-        }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
-            || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
-        {
-            return "Unable to resolve siege test services";
-        }
-
-        if (!playerManager.TryGetPlayer(args[0], out var player) || !playerManager.IsConnected(player))
-        {
-            return $"No connected player has controller id {args[0]}";
-        }
-
-        if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
-        {
-            return $"Unable to resolve player party {player.MobilePartyId}";
-        }
-
-        if (!objectManager.TryGetObject<Settlement>(args[1], out var settlement))
-        {
-            return $"Settlement with id {args[1]} not found";
-        }
-
-        if (!settlement.IsFortification || settlement.MapFaction is not Kingdom kingdom)
-        {
-            return $"{settlement.Name} must be a kingdom fortification";
-        }
-
-        if (settlement.SiegeEvent != null || playerParty.MapEvent != null || playerParty.BesiegerCamp != null)
-        {
-            return $"{settlement.Name} or {playerParty.Name} is already in a siege or battle";
-        }
-
-        if (playerParty.MapFaction == null)
-        {
-            return $"{playerParty.Name} has no map faction";
-        }
-
-        if (!playerParty.MapFaction.IsAtWarWith(settlement.MapFaction))
-        {
-            DeclareWarAction.ApplyByDefault(playerParty.MapFaction, settlement.MapFaction);
-        }
-
-        var defenders = MobileParty.AllLordParties
-            .Where(party => party.IsActive && !party.IsPlayerParty()
-                && party.MapFaction == settlement.MapFaction && party.LeaderHero != null
-                && party.MapEvent == null && party.CurrentSettlement == null
-                && party.BesiegerCamp == null && party.Army == null
-                && party.MemberRoster.TotalHealthyCount > 0)
-            .OrderByDescending(party => party.Party.CalculateCurrentStrength())
-            .Take(armyPartyCount)
-            .ToList();
-
-        if (defenders.Count < armyPartyCount)
-        {
-            return $"Only found {defenders.Count} available {settlement.MapFaction.Name} lord parties; need {armyPartyCount}";
-        }
-
-        siegeEventInterface.StartSiegeEvent(playerParty, settlement);
-        foreach (var otherPlayer in playerManager.Players)
-        {
-            if (otherPlayer.ControllerId == player.ControllerId || !playerManager.IsConnected(otherPlayer)) continue;
-            if (!objectManager.TryGetObjectWithLogging<MobileParty>(otherPlayer.MobilePartyId, out var otherParty)) continue;
-            if (otherParty.MapEvent != null || otherParty.BesiegerCamp != null) continue;
-            if (settlement.SiegeEvent?.CanPartyJoinSide(otherParty.Party, BattleSideEnum.Attacker) != true) continue;
-
-            siegeEventInterface.JoinSiegeCamp(otherParty, settlement);
-        }
-
-        var armyLeader = defenders[0];
-        kingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Defender);
-        var army = armyLeader.Army;
-        if (army == null)
-        {
-            return $"Failed to create a relief army led by {armyLeader.Name}";
-        }
-
-        armyLeader.Position = playerParty.Position;
-        foreach (var defender in defenders.Skip(1))
-        {
-            defender.Position = playerParty.Position;
-            defender.Army = army;
-            army.AddPartyToMergedParties(defender);
-        }
-
-        StartBattleAction.Apply(armyLeader.Party, playerParty.Party);
-
-        return $"Started {settlement.Name} siege relief: {army.Name} with {army.Parties.Count} parties is attacking " +
-            $"{playerParty.Name}; connected friendly player parties joined the siege";
-    }
-
-    [CommandLineArgumentFunction("army_relief_state", "coop.debug.siege")]
-    public static string ArmyReliefState(List<string> args)
-    {
-        if (args.Count != 2)
-        {
-            return "Usage: coop.debug.siege.army_relief_state <controllerId> <settlementId>";
-        }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
-            || !playerManager.TryGetPlayer(args[0], out var player)
-            || !objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty)
-            || !objectManager.TryGetObject<Settlement>(args[1], out var settlement))
-        {
-            return "Unable to resolve the relief fixture";
-        }
-
-        bool siegeActive = settlement.SiegeEvent != null;
-        bool playerBesieger = siegeActive && playerParty.BesiegerCamp == settlement.SiegeEvent.BesiegerCamp;
-        var mapEvent = playerParty.MapEvent;
-        var reliefArmy = mapEvent?.InvolvedParties
-            .Select(party => party.MobileParty?.Army)
-            .FirstOrDefault(army => army?.LeaderParty.MapFaction == settlement.MapFaction);
-        int involvedReliefParties = reliefArmy == null
-            ? 0
-            : mapEvent.InvolvedParties.Count(party => party.MobileParty?.Army == reliefArmy);
-        bool reliefEncounterActive = mapEvent != null && reliefArmy != null;
-        return $"siege={siegeActive} playerBesieger={playerBesieger} " +
-            $"reliefArmyParties={involvedReliefParties} reliefArmyMembers={reliefArmy?.Parties.Count ?? 0} " +
-            $"reliefEncounter={reliefEncounterActive} " +
-            $"playerMapEvent={mapEvent != null}";
-    }
-
-    [CommandLineArgumentFunction("request_besiege", "coop.debug.siege")]
-    public static string RequestBesiege(List<string> args)
-    {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.request_besiege <settlementId>";
-        }
-
-        if (ModInformation.IsServer)
-        {
-            return "This command can only be used by a client";
-        }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !objectManager.TryGetObject<Settlement>(args[0], out var settlement))
-        {
-            return $"Settlement with id {args[0]} not found";
-        }
-
-        MessageBroker.Instance.Publish(null, new BesiegeSettlementAttempted(MobileParty.MainParty, settlement));
-        return $"Requested that the local player party besiege {settlement.Name}";
-    }
-
-    [CommandLineArgumentFunction("request_assault", "coop.debug.siege")]
-    public static string RequestAssault(List<string> args)
-    {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.request_assault <settlementId>";
-        }
-
-        if (ModInformation.IsServer)
-        {
-            return "This command can only be used by a client";
-        }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !objectManager.TryGetObject<Settlement>(args[0], out var settlement))
-        {
-            return $"Settlement with id {args[0]} not found";
-        }
-
-        MessageBroker.Instance.Publish(null, new AssaultSiegeAttempted(MobileParty.MainParty, settlement));
-        return $"Requested that the local player party assault {settlement.Name}";
-    }
-
-    [CommandLineArgumentFunction("join_active_assault", "coop.debug.siege")]
-    public static string JoinActiveAssault(List<string> args)
-    {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.join_active_assault <settlementId>";
-        }
-
-        if (ModInformation.IsServer)
-        {
-            return "This command can only be used by a client";
-        }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !objectManager.TryGetObject<Settlement>(args[0], out var settlement))
-        {
-            return $"Unable to resolve the settlement encounter for {args[0]}";
-        }
-
-        var mapEvent = settlement.Party.MapEvent;
-        if (mapEvent?.IsSiegeAssault != true)
-        {
-            return $"{settlement.Name} does not have an active siege assault";
-        }
-
-        bool alreadyInAssault = PartyBase.MainParty?.MapEvent == mapEvent;
-        if (!alreadyInAssault && !mapEvent.CanPartyJoinBattle(PartyBase.MainParty, BattleSideEnum.Attacker))
-        {
-            return $"The local player party cannot join the assault at {settlement.Name}";
-        }
-
-        if (alreadyInAssault)
-        {
-            if (!ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
+            if (ModInformation.IsClient)
             {
-                return "Unable to resolve SiegeEventInterface";
+                return Failed("This command can only be used by the server");
             }
 
-            siegeEventInterface.PromptSiegeAssault(MobileParty.MainParty, settlement);
-        }
-        else
-        {
-            if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
+
+            int armyPartyCount = 3;
+            if (args.Count == 3 && (!int.TryParse(args[2], out armyPartyCount) || armyPartyCount < 2))
             {
-                return "Unable to resolve SettlementInterface";
+                return Failed("armyPartyCount must be at least 2");
             }
 
-            settlementInterface.StartSettlementEncounter(MobileParty.MainParty, settlement);
-        }
-
-        if (PlayerEncounter.Current == null)
-        {
-            return $"Unable to start the local encounter at {settlement.Name}";
-        }
-
-        if (!alreadyInAssault)
-            PlayerEncounter.JoinBattle(BattleSideEnum.Attacker);
-        else
-            GameMenu.SwitchToMenu("encounter");
-        MobileParty.MainParty.SetMoveModeHold();
-        return alreadyInAssault
-            ? $"Opened the active siege assault at {settlement.Name} for an involved player party"
-            : $"Joined the active siege assault at {settlement.Name}";
-    }
-
-    [CommandLineArgumentFunction("assault_entry_state", "coop.debug.siege")]
-    public static string AssaultEntryState(List<string> args)
-    {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.siege.assault_entry_state";
-        }
-
-        if (ModInformation.IsServer)
-        {
-            return "This command can only be used by a client";
-        }
-
-        if (Campaign.Current == null || PlayerEncounter.Current == null || MobileParty.MainParty == null)
-        {
-            return "The local player encounter is unavailable";
-        }
-
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
-
-        var behavior = new EncounterGameMenuBehavior();
-        var attackArgs = new MenuCallbackArgs((MenuContext)null, null);
-        bool attackShown = behavior.game_menu_encounter_attack_on_condition(attackArgs);
-        var simulationArgs = new MenuCallbackArgs((MenuContext)null, null);
-        bool simulationShown = behavior.game_menu_encounter_order_attack_on_condition(simulationArgs);
-        var menu = Campaign.Current?.CurrentMenuContext?.GameMenu;
-        var renderedAttack = menu?.MenuOptions
-            .FirstOrDefault(option => option.IdString == "attack");
-        var renderedSimulation = menu?.MenuOptions
-            .FirstOrDefault(option => option.IdString == "str_order_attack");
-        var settlement = MobileParty.MainParty?.BesiegedSettlement;
-        var leader = settlement?.SiegeEvent?.BesiegerCamp?.LeaderParty;
-        var mapEvent = PartyBase.MainParty?.MapEvent;
-        var tracker = mapEvent?.TroopUpgradeTracker;
-        var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out string resolvedMapEventId)
-            ? resolvedMapEventId
-            : "none";
-        var trackerId = tracker != null && objectManager.TryGetId(tracker, out string resolvedTrackerId)
-            ? resolvedTrackerId
-            : "none";
-        var involvedPartyCount = mapEvent?._sides?
-            .Where(side => side?.Parties != null)
-            .Sum(side => side.Parties.Count) ?? 0;
-        bool mainPartyAttached = PartyBase.MainParty?.MapEventSide?.MapEvent == mapEvent && mapEvent != null;
-        bool mainPartyTracked = tracker?._mapEventParties
-            .Any(party => party?.Party == PartyBase.MainParty) == true;
-
-        var structuredResult = JsonConvert.SerializeObject(new
-        {
-            menu = menu?.StringId ?? "none",
-            settlementId = settlement?.StringId ?? "none",
-            mapEventId,
-            trackerId,
-            trackerPresent = tracker != null,
-            trackedPartyCount = tracker?._mapEventParties.Count ?? 0,
-            involvedPartyCount,
-            mainPartyAttached,
-            mainPartyTracked,
-            attack = new
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
+                || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
             {
-                shown = attackShown,
-                enabled = attackArgs.IsEnabled,
-                rendered = renderedAttack != null,
-                renderedEnabled = renderedAttack?.IsEnabled ?? false,
-                tooltip = attackArgs.Tooltip?.ToString() ?? "none",
-            },
-            simulation = new
+                return Failed("Unable to resolve siege test services");
+            }
+
+            if (!playerManager.TryGetPlayer(args[0], out var player) || !playerManager.IsConnected(player))
             {
-                shown = simulationShown,
-                enabled = simulationArgs.IsEnabled,
-                rendered = renderedSimulation != null,
-                renderedEnabled = renderedSimulation?.IsEnabled ?? false,
-                tooltip = simulationArgs.Tooltip?.ToString() ?? "none",
-            },
-        });
+                return Failed($"No connected player has controller id {args[0]}");
+            }
 
-        return $"menu={menu?.StringId ?? "none"} settlement={settlement?.StringId ?? "none"} " +
-            $"leader={leader?.StringId ?? "none"} localLeader={leader == MobileParty.MainParty} " +
-            $"mapEvent={mapEventId} tracker={trackerId} tracked={tracker?._mapEventParties.Count ?? 0}/{involvedPartyCount} " +
-            $"mainPartyAttached={mainPartyAttached} mainPartyTracked={mainPartyTracked} " +
-            $"attackShown={attackShown} attackEnabled={attackArgs.IsEnabled} " +
-            $"attackRendered={renderedAttack != null} attackRenderedEnabled={renderedAttack?.IsEnabled ?? false} " +
-            $"simulationShown={simulationShown} simulationEnabled={simulationArgs.IsEnabled} " +
-            $"simulationRendered={renderedSimulation != null} simulationRenderedEnabled={renderedSimulation?.IsEnabled ?? false}" +
-            Environment.NewLine + "LIVE_TEST_JSON=" + structuredResult;
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
+            {
+                return Failed($"Unable to resolve player party {player.MobilePartyId}");
+            }
+
+            if (!objectManager.TryGetObject<Settlement>(args[1], out var settlement))
+            {
+                return Failed($"Settlement with id {args[1]} not found");
+            }
+
+            if (!settlement.IsFortification || settlement.MapFaction is not Kingdom kingdom)
+            {
+                return Failed($"{settlement.Name} must be a kingdom fortification");
+            }
+
+            if (settlement.SiegeEvent != null || playerParty.MapEvent != null || playerParty.BesiegerCamp != null)
+            {
+                return Failed($"{settlement.Name} or {playerParty.Name} is already in a siege or battle");
+            }
+
+            if (playerParty.MapFaction == null)
+            {
+                return Failed($"{playerParty.Name} has no map faction");
+            }
+
+            if (!playerParty.MapFaction.IsAtWarWith(settlement.MapFaction))
+            {
+                DeclareWarAction.ApplyByDefault(playerParty.MapFaction, settlement.MapFaction);
+            }
+
+            var defenders = MobileParty.AllLordParties
+                .Where(party => party.IsActive && !party.IsPlayerParty()
+                    && party.MapFaction == settlement.MapFaction && party.LeaderHero != null
+                    && party.MapEvent == null && party.CurrentSettlement == null
+                    && party.BesiegerCamp == null && party.Army == null
+                    && party.MemberRoster.TotalHealthyCount > 0)
+                .OrderByDescending(party => party.Party.CalculateCurrentStrength())
+                .Take(armyPartyCount)
+                .ToList();
+
+            if (defenders.Count < armyPartyCount)
+            {
+                return Failed($"Only found {defenders.Count} available {settlement.MapFaction.Name} lord parties; need {armyPartyCount}");
+            }
+
+            siegeEventInterface.StartSiegeEvent(playerParty, settlement);
+            foreach (var otherPlayer in playerManager.Players)
+            {
+                if (otherPlayer.ControllerId == player.ControllerId || !playerManager.IsConnected(otherPlayer)) continue;
+                if (!objectManager.TryGetObjectWithLogging<MobileParty>(otherPlayer.MobilePartyId, out var otherParty)) continue;
+                if (otherParty.MapEvent != null || otherParty.BesiegerCamp != null) continue;
+                if (settlement.SiegeEvent?.CanPartyJoinSide(otherParty.Party, BattleSideEnum.Attacker) != true) continue;
+
+                siegeEventInterface.JoinSiegeCamp(otherParty, settlement);
+            }
+
+            var armyLeader = defenders[0];
+            kingdom.CreateArmy(armyLeader.LeaderHero, settlement, ArmyTypes.Defender);
+            var army = armyLeader.Army;
+            if (army == null)
+            {
+                return Failed($"Failed to create a relief army led by {armyLeader.Name}");
+            }
+
+            armyLeader.Position = playerParty.Position;
+            foreach (var defender in defenders.Skip(1))
+            {
+                defender.Position = playerParty.Position;
+                defender.Army = army;
+                army.AddPartyToMergedParties(defender);
+            }
+
+            StartBattleAction.Apply(armyLeader.Party, playerParty.Party);
+
+            return Succeeded($"Started {settlement.Name} siege relief: {army.Name} with {army.Parties.Count} parties is attacking " +
+                $"{playerParty.Name}; connected friendly player parties joined the siege");
+
+        }
     }
 
-    [CommandLineArgumentFunction("leave", "coop.debug.siege")]
-    public static string Leave(List<string> args)
+    public sealed class ArmyReliefStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.siege.leave";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsServer)
-        {
-            return "This command can only be used by a client";
-        }
+        public string Name => "army_relief_state";
 
-        if (MobileParty.MainParty == null)
-        {
-            return "The local player party is unavailable";
-        }
+        public string Description => "Runs relief state for co-op debugging.";
 
-        MessageBroker.Instance.Publish(null, new BreakSiegeAttempted(MobileParty.MainParty));
-        return "Requested that the local player party leave its siege";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("controllerId", "The controller id."),
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
+                || !playerManager.TryGetPlayer(args[0], out var player)
+                || !objectManager.TryGetObject<MobileParty>(player.MobilePartyId, out var playerParty)
+                || !objectManager.TryGetObject<Settlement>(args[1], out var settlement))
+            {
+                return Failed("Unable to resolve the relief fixture");
+            }
+
+            bool siegeActive = settlement.SiegeEvent != null;
+            bool playerBesieger = siegeActive && playerParty.BesiegerCamp == settlement.SiegeEvent.BesiegerCamp;
+            var mapEvent = playerParty.MapEvent;
+            var reliefArmy = mapEvent?.InvolvedParties
+                .Select(party => party.MobileParty?.Army)
+                .FirstOrDefault(army => army?.LeaderParty.MapFaction == settlement.MapFaction);
+            int involvedReliefParties = reliefArmy == null
+                ? 0
+                : mapEvent.InvolvedParties.Count(party => party.MobileParty?.Army == reliefArmy);
+            bool reliefEncounterActive = mapEvent != null && reliefArmy != null;
+            return Succeeded($"siege={siegeActive} playerBesieger={playerBesieger} " +
+                $"reliefArmyParties={involvedReliefParties} reliefArmyMembers={reliefArmy?.Parties.Count ?? 0} " +
+                $"reliefEncounter={reliefEncounterActive} " +
+                $"playerMapEvent={mapEvent != null}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("leave_settlement", "coop.debug.siege")]
-    public static string LeaveSettlement(List<string> args)
+    public sealed class RequestBesiegeCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.siege.leave_settlement";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsServer)
-        {
-            return "This command can only be used by a client";
-        }
+        public string Name => "request_besiege";
 
-        var party = MobileParty.MainParty;
-        if (party == null)
-        {
-            return "The local player party is unavailable";
-        }
+        public string Description => "Requests besiege for co-op debugging.";
 
-        if (party.CurrentSettlement == null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "The local player party is not in a settlement encounter";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        var settlementName = party.CurrentSettlement.Name;
-        PlayerLeaveSettlementPatch.RequestLeave();
-        return $"Requested that the local player party leave {settlementName}";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (ModInformation.IsServer)
+            {
+                return Failed("This command can only be used by a client");
+            }
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            MessageBroker.Instance.Publish(null, new BesiegeSettlementAttempted(MobileParty.MainParty, settlement));
+            return Succeeded($"Requested that the local player party besiege {settlement.Name}");
+
+        }
+    }
+
+    public sealed class RequestAssaultCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "request_assault";
+
+        public string Description => "Requests assault for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (ModInformation.IsServer)
+            {
+                return Failed("This command can only be used by a client");
+            }
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            MessageBroker.Instance.Publish(null, new AssaultSiegeAttempted(MobileParty.MainParty, settlement));
+            return Succeeded($"Requested that the local player party assault {settlement.Name}");
+
+        }
+    }
+
+    public sealed class JoinActiveAssaultCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "join_active_assault";
+
+        public string Description => "Joins active assault for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (ModInformation.IsServer)
+            {
+                return Failed("This command can only be used by a client");
+            }
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Unable to resolve the settlement encounter for {args[0]}");
+            }
+
+            var mapEvent = settlement.Party.MapEvent;
+            if (mapEvent?.IsSiegeAssault != true)
+            {
+                return Failed($"{settlement.Name} does not have an active siege assault");
+            }
+
+            bool alreadyInAssault = PartyBase.MainParty?.MapEvent == mapEvent;
+            if (!alreadyInAssault && !mapEvent.CanPartyJoinBattle(PartyBase.MainParty, BattleSideEnum.Attacker))
+            {
+                return Failed($"The local player party cannot join the assault at {settlement.Name}");
+            }
+
+            if (alreadyInAssault)
+            {
+                if (!ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
+                {
+                    return Failed("Unable to resolve SiegeEventInterface");
+                }
+
+                siegeEventInterface.PromptSiegeAssault(MobileParty.MainParty, settlement);
+            }
+            else
+            {
+                if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
+                {
+                    return Failed("Unable to resolve SettlementInterface");
+                }
+
+                settlementInterface.StartSettlementEncounter(MobileParty.MainParty, settlement);
+            }
+
+            if (PlayerEncounter.Current == null)
+            {
+                return Failed($"Unable to start the local encounter at {settlement.Name}");
+            }
+
+            if (!alreadyInAssault)
+                PlayerEncounter.JoinBattle(BattleSideEnum.Attacker);
+            else
+                GameMenu.SwitchToMenu("encounter");
+            MobileParty.MainParty.SetMoveModeHold();
+            return Succeeded(alreadyInAssault
+                ? $"Opened the active siege assault at {settlement.Name} for an involved player party"
+                : $"Joined the active siege assault at {settlement.Name}");
+
+        }
+    }
+
+    public sealed class AssaultEntryStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "assault_entry_state";
+
+        public string Description => "Runs entry state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (ModInformation.IsServer)
+            {
+                return Failed("This command can only be used by a client");
+            }
+
+            if (Campaign.Current == null || PlayerEncounter.Current == null || MobileParty.MainParty == null)
+            {
+                return Failed("The local player encounter is unavailable");
+            }
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            var behavior = new EncounterGameMenuBehavior();
+            var attackArgs = new MenuCallbackArgs((MenuContext)null, null);
+            bool attackShown = behavior.game_menu_encounter_attack_on_condition(attackArgs);
+            var simulationArgs = new MenuCallbackArgs((MenuContext)null, null);
+            bool simulationShown = behavior.game_menu_encounter_order_attack_on_condition(simulationArgs);
+            var menu = Campaign.Current?.CurrentMenuContext?.GameMenu;
+            var renderedAttack = menu?.MenuOptions
+                .FirstOrDefault(option => option.IdString == "attack");
+            var renderedSimulation = menu?.MenuOptions
+                .FirstOrDefault(option => option.IdString == "str_order_attack");
+            var settlement = MobileParty.MainParty?.BesiegedSettlement;
+            var leader = settlement?.SiegeEvent?.BesiegerCamp?.LeaderParty;
+            var mapEvent = PartyBase.MainParty?.MapEvent;
+            var tracker = mapEvent?.TroopUpgradeTracker;
+            var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out string resolvedMapEventId)
+                ? resolvedMapEventId
+                : "none";
+            var trackerId = tracker != null && objectManager.TryGetId(tracker, out string resolvedTrackerId)
+                ? resolvedTrackerId
+                : "none";
+            var involvedPartyCount = mapEvent?._sides?
+                .Where(side => side?.Parties != null)
+                .Sum(side => side.Parties.Count) ?? 0;
+            bool mainPartyAttached = PartyBase.MainParty?.MapEventSide?.MapEvent == mapEvent && mapEvent != null;
+            bool mainPartyTracked = tracker?._mapEventParties
+                .Any(party => party?.Party == PartyBase.MainParty) == true;
+
+            var structuredResult = JsonConvert.SerializeObject(new
+            {
+                menu = menu?.StringId ?? "none",
+                settlementId = settlement?.StringId ?? "none",
+                mapEventId,
+                trackerId,
+                trackerPresent = tracker != null,
+                trackedPartyCount = tracker?._mapEventParties.Count ?? 0,
+                involvedPartyCount,
+                mainPartyAttached,
+                mainPartyTracked,
+                attack = new
+                {
+                    shown = attackShown,
+                    enabled = attackArgs.IsEnabled,
+                    rendered = renderedAttack != null,
+                    renderedEnabled = renderedAttack?.IsEnabled ?? false,
+                    tooltip = attackArgs.Tooltip?.ToString() ?? "none",
+                },
+                simulation = new
+                {
+                    shown = simulationShown,
+                    enabled = simulationArgs.IsEnabled,
+                    rendered = renderedSimulation != null,
+                    renderedEnabled = renderedSimulation?.IsEnabled ?? false,
+                    tooltip = simulationArgs.Tooltip?.ToString() ?? "none",
+                },
+            });
+
+            return Succeeded($"menu={menu?.StringId ?? "none"} settlement={settlement?.StringId ?? "none"} " +
+                $"leader={leader?.StringId ?? "none"} localLeader={leader == MobileParty.MainParty} " +
+                $"mapEvent={mapEventId} tracker={trackerId} tracked={tracker?._mapEventParties.Count ?? 0}/{involvedPartyCount} " +
+                $"mainPartyAttached={mainPartyAttached} mainPartyTracked={mainPartyTracked} " +
+                $"attackShown={attackShown} attackEnabled={attackArgs.IsEnabled} " +
+                $"attackRendered={renderedAttack != null} attackRenderedEnabled={renderedAttack?.IsEnabled ?? false} " +
+                $"simulationShown={simulationShown} simulationEnabled={simulationArgs.IsEnabled} " +
+                $"simulationRendered={renderedSimulation != null} simulationRenderedEnabled={renderedSimulation?.IsEnabled ?? false}" +
+                Environment.NewLine + "LIVE_TEST_JSON=" + structuredResult);
+
+        }
+    }
+
+    public sealed class LeaveCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "leave";
+
+        public string Description => "Leaves the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (ModInformation.IsServer)
+            {
+                return Failed("This command can only be used by a client");
+            }
+
+            if (MobileParty.MainParty == null)
+            {
+                return Failed("The local player party is unavailable");
+            }
+
+            MessageBroker.Instance.Publish(null, new BreakSiegeAttempted(MobileParty.MainParty));
+            return Succeeded("Requested that the local player party leave its siege");
+
+        }
+    }
+
+    public sealed class LeaveSettlementCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "leave_settlement";
+
+        public string Description => "Leaves settlement for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (ModInformation.IsServer)
+            {
+                return Failed("This command can only be used by a client");
+            }
+
+            var party = MobileParty.MainParty;
+            if (party == null)
+            {
+                return Failed("The local player party is unavailable");
+            }
+
+            if (party.CurrentSettlement == null)
+            {
+                return Failed("The local player party is not in a settlement encounter");
+            }
+
+            var settlementName = party.CurrentSettlement.Name;
+            PlayerLeaveSettlementPatch.RequestLeave();
+            return Succeeded($"Requested that the local player party leave {settlementName}");
+
+        }
     }
 
     // coop.debug.siege.start
@@ -1208,359 +1323,418 @@ public class SiegeDebugCommand
     /// </summary>
     /// <param name="args">first arg : settlementId ; optional second arg : besieger partyId</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("start", "coop.debug.siege")]
-    public static string StartSiege(List<string> args)
+    public sealed class StartSiegeCoopCommand : ICoopCommand
     {
-        if (args.Count < 1 || args.Count > 2)
-        {
-            return "Usage: coop.debug.siege.start <settlementId> [besiegerPartyId]";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
+        public string Name => "start";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Description => "Starts the relevant state for co-op debugging.";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Settlement with id {args[0]} not found";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("besiegerPartyId", "The besieger party id.", isRequired: false),
+        };
 
-        if (!settlement.IsFortification)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"{settlement.Name} is not a fortification";
-        }
 
-        if (settlement.SiegeEvent != null)
-        {
-            return $"{settlement.Name} is already under siege";
-        }
-
-        MobileParty besieger;
-        if (args.Count == 2)
-        {
-            if (!objectManager.TryGetObject(args[1], out besieger))
+            if (ModInformation.IsClient)
             {
-                return $"Party with id {args[1]} not found";
-            }
-        }
-        else
-        {
-            var connectedPlayerFactions = new List<IFaction>();
-            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
-            {
-                return "Unable to resolve PlayerManager";
+                return Failed("This command can only be used by the server");
             }
 
-            foreach (var player in playerManager.Players.Where(playerManager.IsConnected))
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
             {
-                if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            if (!settlement.IsFortification)
+            {
+                return Failed($"{settlement.Name} is not a fortification");
+            }
+
+            if (settlement.SiegeEvent != null)
+            {
+                return Failed($"{settlement.Name} is already under siege");
+            }
+
+            MobileParty besieger;
+            if (args.Count == 2)
+            {
+                if (!objectManager.TryGetObject(args[1], out besieger))
                 {
-                    return $"Unable to resolve player party {player.MobilePartyId}";
+                    return Failed($"Party with id {args[1]} not found");
+                }
+            }
+            else
+            {
+                var connectedPlayerFactions = new List<IFaction>();
+                if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+                {
+                    return Failed("Unable to resolve PlayerManager");
                 }
 
-                if (playerParty.MapFaction == null)
+                foreach (var player in playerManager.Players.Where(playerManager.IsConnected))
                 {
-                    return $"Player party {player.MobilePartyId} has no map faction";
+                    if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var playerParty))
+                    {
+                        return Failed($"Unable to resolve player party {player.MobilePartyId}");
+                    }
+
+                    if (playerParty.MapFaction == null)
+                    {
+                        return Failed($"Player party {player.MobilePartyId} has no map faction");
+                    }
+
+                    connectedPlayerFactions.Add(playerParty.MapFaction);
                 }
 
-                connectedPlayerFactions.Add(playerParty.MapFaction);
+                besieger = MobileParty.AllLordParties
+                    .Where(party => !party.IsPlayerParty()
+                        && party.MapFaction?.IsAtWarWith(settlement.MapFaction) == true
+                        && connectedPlayerFactions.All(playerFaction =>
+                            !party.MapFaction.IsAtWarWith(playerFaction))
+                        && party.LeaderHero != null && party.CurrentSettlement == null
+                        && party.MapEvent == null && party.BesiegerCamp == null && party.Army == null)
+                    .OrderByDescending(party => party.Party.CalculateCurrentStrength())
+                    .FirstOrDefault();
+                if (besieger == null)
+                {
+                    return Failed($"No hostile lord party compatible with the connected players is available to besiege " +
+                        $"{settlement.Name}; pass a partyId explicitly");
+                }
             }
 
-            besieger = MobileParty.AllLordParties
-                .Where(party => !party.IsPlayerParty()
-                    && party.MapFaction?.IsAtWarWith(settlement.MapFaction) == true
-                    && connectedPlayerFactions.All(playerFaction =>
-                        !party.MapFaction.IsAtWarWith(playerFaction))
-                    && party.LeaderHero != null && party.CurrentSettlement == null
-                    && party.MapEvent == null && party.BesiegerCamp == null && party.Army == null)
-                .OrderByDescending(party => party.Party.CalculateCurrentStrength())
-                .FirstOrDefault();
-            if (besieger == null)
+            var originalPosition = besieger.Position;
+
+            // Put the besieger at the gate and commit its AI to the siege.
+            besieger.Position = settlement.GatePosition;
+            besieger.SetMoveBesiegeSettlement(settlement, MobileParty.NavigationType.Default);
+            Campaign.Current.SiegeEventManager.StartSiegeEvent(settlement, besieger);
+
+            string structuredResult = JsonConvert.SerializeObject(new
             {
-                return $"No hostile lord party compatible with the connected players is available to besiege " +
-                    $"{settlement.Name}; pass a partyId explicitly";
-            }
+                settlementId = settlement.StringId,
+                besiegerPartyId = besieger.StringId,
+                originalX = originalPosition.X,
+                originalY = originalPosition.Y,
+                originalIsOnLand = originalPosition.IsOnLand,
+            });
+            return Succeeded($"{besieger.Name} ({besieger.StringId}) is now besieging {settlement.Name}\n" +
+                $"Restore with: coop.debug.siege.stop {settlement.StringId} " +
+                $"{originalPosition.X:R} {originalPosition.Y:R} {originalPosition.IsOnLand}\n" +
+                "LIVE_TEST_JSON=" + structuredResult);
+
         }
-
-        var originalPosition = besieger.Position;
-
-        // Put the besieger at the gate and commit its AI to the siege.
-        besieger.Position = settlement.GatePosition;
-        besieger.SetMoveBesiegeSettlement(settlement, MobileParty.NavigationType.Default);
-        Campaign.Current.SiegeEventManager.StartSiegeEvent(settlement, besieger);
-
-        string structuredResult = JsonConvert.SerializeObject(new
-        {
-            settlementId = settlement.StringId,
-            besiegerPartyId = besieger.StringId,
-            originalX = originalPosition.X,
-            originalY = originalPosition.Y,
-            originalIsOnLand = originalPosition.IsOnLand,
-        });
-        return $"{besieger.Name} ({besieger.StringId}) is now besieging {settlement.Name}\n" +
-            $"Restore with: coop.debug.siege.stop {settlement.StringId} " +
-            $"{originalPosition.X:R} {originalPosition.Y:R} {originalPosition.IsOnLand}\n" +
-            "LIVE_TEST_JSON=" + structuredResult;
     }
 
     /// <summary>
     /// Ends an AI-led siege through the normal authoritative leave path. Server only.
     /// </summary>
-    [CommandLineArgumentFunction("stop", "coop.debug.siege")]
-    public static string StopSiege(List<string> args)
+    public sealed class StopSiegeCoopCommand : ICoopCommand
     {
-        if (args.Count != 4)
-        {
-            return "Usage: coop.debug.siege.stop <settlementId> <originalX> <originalY> <originalIsOnLand>";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
+        public string Name => "stop";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Description => "Stops the relevant state for co-op debugging.";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Settlement with id {args[0]} not found";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("originalX", "The original x."),
+            new ExpectedArgs("originalY", "The original y."),
+            new ExpectedArgs("originalIsOnLand", "The original is on land."),
+        };
 
-        var camp = settlement.SiegeEvent?.BesiegerCamp;
-        var leader = camp?.LeaderParty;
-        if (leader == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"{settlement.Name} has no active siege leader";
-        }
 
-        if (!ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
-        {
-            return "Unable to resolve SiegeEventInterface";
-        }
+            if (ModInformation.IsClient)
+            {
+                return Failed("This command can only be used by the server");
+            }
 
-        var activeAssault = settlement.Party.MapEvent ?? leader.MapEvent;
-        if (activeAssault != null && !activeAssault.IsFinalized)
-            activeAssault.FinalizeEvent();
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        if (settlement.SiegeEvent == null)
-        {
-            var finalizedRestoreResult = PartyCommands.RestorePositionCommand(new List<string>
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var camp = settlement.SiegeEvent?.BesiegerCamp;
+            var leader = camp?.LeaderParty;
+            if (leader == null)
+            {
+                return Failed($"{settlement.Name} has no active siege leader");
+            }
+
+            if (!ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
+            {
+                return Failed("Unable to resolve SiegeEventInterface");
+            }
+
+            var activeAssault = settlement.Party.MapEvent ?? leader.MapEvent;
+            if (activeAssault != null && !activeAssault.IsFinalized)
+                activeAssault.FinalizeEvent();
+
+            if (settlement.SiegeEvent == null)
+            {
+                var finalizedRestoreResult = PartyCommands.RestorePositionCommand(new List<string>
+                {
+                    leader.StringId,
+                    args[1],
+                    args[2],
+                    args[3],
+                });
+                return Succeeded($"Finalized the assault and stopped the siege of {settlement.Name}\n" + finalizedRestoreResult);
+            }
+
+            var siegeParties = camp._besiegerParties.ToArray();
+            foreach (var party in siegeParties)
+            {
+                if (party != leader)
+                {
+                    siegeEventInterface.BreakSiege(party);
+                }
+            }
+
+            siegeEventInterface.BreakSiege(leader);
+            if (settlement.SiegeEvent != null)
+            {
+                return Failed($"Failed to stop the siege of {settlement.Name}; " +
+                    $"{settlement.SiegeEvent.BesiegerCamp?._besiegerParties.Count ?? 0} parties remain");
+            }
+
+            var restoreResult = PartyCommands.RestorePositionCommand(new List<string>
             {
                 leader.StringId,
                 args[1],
                 args[2],
                 args[3],
             });
-            return $"Finalized the assault and stopped the siege of {settlement.Name}\n" + finalizedRestoreResult;
-        }
+            return Succeeded($"Stopped the siege of {settlement.Name} led by {leader.Name} ({leader.StringId})\n" +
+                restoreResult);
 
-        var siegeParties = camp._besiegerParties.ToArray();
-        foreach (var party in siegeParties)
-        {
-            if (party != leader)
-            {
-                siegeEventInterface.BreakSiege(party);
-            }
         }
-
-        siegeEventInterface.BreakSiege(leader);
-        if (settlement.SiegeEvent != null)
-        {
-            return $"Failed to stop the siege of {settlement.Name}; " +
-                $"{settlement.SiegeEvent.BesiegerCamp?._besiegerParties.Count ?? 0} parties remain";
-        }
-
-        var restoreResult = PartyCommands.RestorePositionCommand(new List<string>
-        {
-            leader.StringId,
-            args[1],
-            args[2],
-            args[3],
-        });
-        return $"Stopped the siege of {settlement.Name} led by {leader.Name} ({leader.StringId})\n" +
-            restoreResult;
     }
 
     /// <summary>
     /// Joins every connected player party to an active siege on the authoritative server.
     /// </summary>
-    [CommandLineArgumentFunction("join_players", "coop.debug.siege")]
-    public static string JoinPlayers(List<string> args)
+    public sealed class JoinPlayersCoopCommand : ICoopCommand
     {
-        if (args.Count != 2 || !int.TryParse(args[1], out int expectedPlayerCount) || expectedPlayerCount < 1)
-        {
-            return "Usage: coop.debug.siege.join_players <settlementId> <expectedPlayerCount>";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
+        public string Name => "join_players";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
-            || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
-        {
-            return "Unable to resolve siege fixture services";
-        }
+        public string Description => "Joins players for co-op debugging.";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Settlement with id {args[0]} not found";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+            new ExpectedArgs("expectedPlayerCount", "The expected player count."),
+        };
 
-        var camp = settlement.SiegeEvent?.BesiegerCamp;
-        if (camp == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"{settlement.Name} is not under siege";
-        }
-
-        var connectedPlayers = playerManager.Players.Where(playerManager.IsConnected).ToArray();
-        if (connectedPlayers.Length != expectedPlayerCount)
-        {
-            return $"Expected {expectedPlayerCount} connected players, found {connectedPlayers.Length}";
-        }
-
-        var parties = new List<(string ControllerId, string PartyId, MobileParty Party)>();
-        foreach (var player in connectedPlayers)
-        {
-            if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var party))
+            if (!int.TryParse(args[1], out int expectedPlayerCount) || expectedPlayerCount < 1)
             {
-                return $"Unable to resolve player party {player.MobilePartyId}";
+                return Failed("expectedPlayerCount must be a positive integer.");
             }
 
-            if (!party.IsActive || party.MapEvent != null || party.BesiegerCamp != null || party.CurrentSettlement != null)
+            if (ModInformation.IsClient)
             {
-                return $"Player {player.ControllerId} is not clean for the fixture: " +
-                    $"active={party.IsActive} mapEvent={party.MapEvent != null} " +
-                    $"besiegerCamp={party.BesiegerCamp != null} settlement={party.CurrentSettlement?.StringId ?? "none"}";
+                return Failed("This command can only be used by the server");
             }
 
-            if (!settlement.SiegeEvent.CanPartyJoinSide(party.Party, BattleSideEnum.Attacker))
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !ContainerProvider.TryResolve<IPlayerManager>(out var playerManager)
+                || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
             {
-                return $"Player {player.ControllerId} cannot join the attacking side at {settlement.Name}";
+                return Failed("Unable to resolve siege fixture services");
             }
 
-            parties.Add((player.ControllerId, player.MobilePartyId, party));
-        }
-
-        for (int i = 0; i < parties.Count; i++)
-        {
-            for (int j = i + 1; j < parties.Count; j++)
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
             {
-                if (parties[i].Party.MapFaction.IsAtWarWith(parties[j].Party.MapFaction))
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var camp = settlement.SiegeEvent?.BesiegerCamp;
+            if (camp == null)
+            {
+                return Failed($"{settlement.Name} is not under siege");
+            }
+
+            var connectedPlayers = playerManager.Players.Where(playerManager.IsConnected).ToArray();
+            if (connectedPlayers.Length != expectedPlayerCount)
+            {
+                return Failed($"Expected {expectedPlayerCount} connected players, found {connectedPlayers.Length}");
+            }
+
+            var parties = new List<(string ControllerId, string PartyId, MobileParty Party)>();
+            foreach (var player in connectedPlayers)
+            {
+                if (!objectManager.TryGetObjectWithLogging<MobileParty>(player.MobilePartyId, out var party))
                 {
-                    return $"Players {parties[i].ControllerId} and {parties[j].ControllerId} cannot join the same siege side";
+                    return Failed($"Unable to resolve player party {player.MobilePartyId}");
+                }
+
+                if (!party.IsActive || party.MapEvent != null || party.BesiegerCamp != null || party.CurrentSettlement != null)
+                {
+                    return Failed($"Player {player.ControllerId} is not clean for the fixture: " +
+                        $"active={party.IsActive} mapEvent={party.MapEvent != null} " +
+                        $"besiegerCamp={party.BesiegerCamp != null} settlement={party.CurrentSettlement?.StringId ?? "none"}");
+                }
+
+                if (!settlement.SiegeEvent.CanPartyJoinSide(party.Party, BattleSideEnum.Attacker))
+                {
+                    return Failed($"Player {player.ControllerId} cannot join the attacking side at {settlement.Name}");
+                }
+
+                parties.Add((player.ControllerId, player.MobilePartyId, party));
+            }
+
+            for (int i = 0; i < parties.Count; i++)
+            {
+                for (int j = i + 1; j < parties.Count; j++)
+                {
+                    if (parties[i].Party.MapFaction.IsAtWarWith(parties[j].Party.MapFaction))
+                    {
+                        return Failed($"Players {parties[i].ControllerId} and {parties[j].ControllerId} cannot join the same siege side");
+                    }
                 }
             }
-        }
 
-        var joined = new List<string>();
-        foreach (var item in parties)
-        {
-            siegeEventInterface.JoinSiegeCamp(item.Party, settlement);
-            if (item.Party.BesiegerCamp != camp)
+            var joined = new List<string>();
+            foreach (var item in parties)
             {
-                return $"Failed to join player {item.ControllerId} to the siege";
+                siegeEventInterface.JoinSiegeCamp(item.Party, settlement);
+                if (item.Party.BesiegerCamp != camp)
+                {
+                    return Failed($"Failed to join player {item.ControllerId} to the siege");
+                }
+
+                joined.Add($"{item.ControllerId}:{item.PartyId}");
             }
 
-            joined.Add($"{item.ControllerId}:{item.PartyId}");
-        }
+            return Succeeded($"Joined {joined.Count} connected player parties to the siege of {settlement.Name}:\n" +
+                string.Join(Environment.NewLine, joined));
 
-        return $"Joined {joined.Count} connected player parties to the siege of {settlement.Name}:\n" +
-            string.Join(Environment.NewLine, joined);
+        }
     }
 
-    [CommandLineArgumentFunction("player_state", "coop.debug.siege")]
-    public static string PlayerState(List<string> args)
+    public sealed class PlayerStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "player_state";
+
+        public string Description => "Runs state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.siege.player_state <partyId>";
-        }
+            new ExpectedArgs("partyId", "The party id."),
+        };
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject<MobileParty>(args[0], out var party))
+            {
+                return Failed($"Party with id {args[0]} not found");
+            }
+
+            var mapEvent = party.MapEvent;
+            var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out string id) ? id : "none";
+            var camp = party.BesiegerCamp?.SiegeEvent?.BesiegedSettlement?.StringId ?? "none";
+            var army = party.Army?.LeaderParty?.StringId ?? "none";
+            var settlement = party.CurrentSettlement?.StringId ?? "none";
+            var heroHitPoints = party.LeaderHero?.HitPoints.ToString() ?? "none";
+            bool isMainParty = party == MobileParty.MainParty;
+
+            return Succeeded($"party={party.StringId} mapEvent={mapEventId} siegeAssault={mapEvent?.IsSiegeAssault == true} " +
+                $"side={party.Party.Side} besiegerCamp={camp} army={army} settlement={settlement} heroHitPoints={heroHitPoints} " +
+                $"playerSiege={isMainParty && PlayerSiege.PlayerSiegeEvent != null} encounter={isMainParty && PlayerEncounter.Current != null}");
+
         }
-
-        if (!objectManager.TryGetObject<MobileParty>(args[0], out var party))
-        {
-            return $"Party with id {args[0]} not found";
-        }
-
-        var mapEvent = party.MapEvent;
-        var mapEventId = mapEvent != null && objectManager.TryGetId(mapEvent, out string id) ? id : "none";
-        var camp = party.BesiegerCamp?.SiegeEvent?.BesiegedSettlement?.StringId ?? "none";
-        var army = party.Army?.LeaderParty?.StringId ?? "none";
-        var settlement = party.CurrentSettlement?.StringId ?? "none";
-        var heroHitPoints = party.LeaderHero?.HitPoints.ToString() ?? "none";
-        bool isMainParty = party == MobileParty.MainParty;
-
-        return $"party={party.StringId} mapEvent={mapEventId} siegeAssault={mapEvent?.IsSiegeAssault == true} " +
-            $"side={party.Party.Side} besiegerCamp={camp} army={army} settlement={settlement} heroHitPoints={heroHitPoints} " +
-            $"playerSiege={isMainParty && PlayerSiege.PlayerSiegeEvent != null} encounter={isMainParty && PlayerEncounter.Current != null}";
     }
 
-    [CommandLineArgumentFunction("prepare_ladders_only", "coop.debug.siege")]
-    public static string PrepareLaddersOnly(List<string> args)
+    public sealed class PrepareLaddersOnlyCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.prepare_ladders_only <settlementId>";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
+        public string Name => "prepare_ladders_only";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Description => "Prepares ladders only for co-op debugging.";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Settlement with id {args[0]} not found";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        var siegeEvent = settlement.SiegeEvent;
-        var attackerEngines = siegeEvent?.BesiegerCamp?.SiegeEngines;
-        var defenderEngines = settlement.SiegeEngines;
-        if (siegeEvent == null || attackerEngines == null || defenderEngines == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"{settlement.Name} is not under siege";
-        }
 
-        ClearSiegeEngines(attackerEngines);
-        ClearSiegeEngines(defenderEngines);
-        if (attackerEngines.DeployedSiegeEngines.Count > 0
-            || attackerEngines.ReservedSiegeEngines.Count > 0
-            || defenderEngines.DeployedSiegeEngines.Count > 0
-            || defenderEngines.ReservedSiegeEngines.Count > 0)
-        {
-            return $"Failed to remove the campaign siege engines from {settlement.Name}";
-        }
+            if (ModInformation.IsClient)
+            {
+                return Failed("This command can only be used by the server");
+            }
 
-        var preparations = attackerEngines.SiegePreparations;
-        if (!preparations.IsConstructed)
-        {
-            preparations.SetProgress(1f);
-            siegeEvent.CreateSiegeObject(preparations, siegeEvent.GetSiegeEventSide(BattleSideEnum.Attacker));
-        }
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        return $"Prepared a ladder-only assault at {settlement.Name} ({settlement.StringId}): " +
-            $"preparation={preparations.Progress:0.00} attackerEngines=0 defenderEngines=0";
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var siegeEvent = settlement.SiegeEvent;
+            var attackerEngines = siegeEvent?.BesiegerCamp?.SiegeEngines;
+            var defenderEngines = settlement.SiegeEngines;
+            if (siegeEvent == null || attackerEngines == null || defenderEngines == null)
+            {
+                return Failed($"{settlement.Name} is not under siege");
+            }
+
+            ClearSiegeEngines(attackerEngines);
+            ClearSiegeEngines(defenderEngines);
+            if (attackerEngines.DeployedSiegeEngines.Count > 0
+                || attackerEngines.ReservedSiegeEngines.Count > 0
+                || defenderEngines.DeployedSiegeEngines.Count > 0
+                || defenderEngines.ReservedSiegeEngines.Count > 0)
+            {
+                return Failed($"Failed to remove the campaign siege engines from {settlement.Name}");
+            }
+
+            var preparations = attackerEngines.SiegePreparations;
+            if (!preparations.IsConstructed)
+            {
+                preparations.SetProgress(1f);
+                siegeEvent.CreateSiegeObject(preparations, siegeEvent.GetSiegeEventSide(BattleSideEnum.Attacker));
+            }
+
+            return Succeeded($"Prepared a ladder-only assault at {settlement.Name} ({settlement.StringId}): " +
+                $"preparation={preparations.Progress:0.00} attackerEngines=0 defenderEngines=0");
+
+        }
     }
 
     private static void ClearSiegeEngines(SiegeEnginesContainer siegeEngines)
@@ -1591,250 +1765,290 @@ public class SiegeDebugCommand
         }
     }
 
-    [CommandLineArgumentFunction("stage_machines", "coop.debug.siege")]
-    public static string StageMachines(List<string> args)
+    public sealed class StageMachinesCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.stage_machines <settlementId>";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
+        public string Name => "stage_machines";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
-        {
-            return "Unable to resolve siege fixture services";
-        }
+        public string Description => "Stages machines for co-op debugging.";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Settlement with id {args[0]} not found";
-        }
-
-        var siegeEvent = settlement.SiegeEvent;
-        if (siegeEvent?.BesiegerCamp == null)
-        {
-            return $"{settlement.Name} is not under siege";
-        }
-
-        var attacker = siegeEvent.GetSiegeEventSide(BattleSideEnum.Attacker);
-        if (!attacker.SiegeEngines.SiegePreparations.IsConstructed)
-        {
-            attacker.SiegeEngines.SiegePreparations.SetProgress(1f);
-            siegeEvent.CreateSiegeObject(attacker.SiegeEngines.SiegePreparations, attacker);
-        }
-
-        var machines = new[]
-        {
-            (Side: BattleSideEnum.Attacker, Type: DefaultSiegeEngineTypes.Ram, Index: 0),
-            (Side: BattleSideEnum.Attacker, Type: DefaultSiegeEngineTypes.Onager, Index: 0),
-            (Side: BattleSideEnum.Defender, Type: DefaultSiegeEngineTypes.Ballista, Index: 0),
+            new ExpectedArgs("settlementId", "The settlement id."),
         };
-        var staged = new List<string>();
-        foreach (var machine in machines)
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            siegeEventInterface.DeploySiegeEngine(siegeEvent, machine.Side, machine.Type, machine.Index);
-            var side = siegeEvent.GetSiegeEventSide(machine.Side);
-            var slots = machine.Type.IsRanged
-                ? side.SiegeEngines.DeployedRangedSiegeEngines
-                : side.SiegeEngines.DeployedMeleeSiegeEngines;
-            var progress = machine.Index < slots.Length ? slots[machine.Index] : null;
-            if (progress?.SiegeEngine != machine.Type)
+
+            if (ModInformation.IsClient)
             {
-                return $"Failed to stage {machine.Type.StringId} for {machine.Side}";
+                return Failed("This command can only be used by the server");
             }
 
-            bool needsSiegeObject = !progress.IsConstructed
-                || (machine.Type.IsRanged && progress.RangedSiegeEngine == null);
-            if (!progress.IsConstructed)
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !ContainerProvider.TryResolve<ISiegeEventInterface>(out var siegeEventInterface))
             {
-                progress.SetProgress(1f);
-            }
-            if (progress.IsBeingRedeployed)
-            {
-                progress.SetRedeploymentProgress(1f);
-            }
-            if (needsSiegeObject)
-            {
-                siegeEvent.CreateSiegeObject(progress, side);
-            }
-            if (!progress.IsActive)
-            {
-                return $"Failed to activate {machine.Type.StringId} for {machine.Side}";
+                return Failed("Unable to resolve siege fixture services");
             }
 
-            staged.Add($"{machine.Side}:{machine.Type.StringId}[{machine.Index}]");
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var siegeEvent = settlement.SiegeEvent;
+            if (siegeEvent?.BesiegerCamp == null)
+            {
+                return Failed($"{settlement.Name} is not under siege");
+            }
+
+            var attacker = siegeEvent.GetSiegeEventSide(BattleSideEnum.Attacker);
+            if (!attacker.SiegeEngines.SiegePreparations.IsConstructed)
+            {
+                attacker.SiegeEngines.SiegePreparations.SetProgress(1f);
+                siegeEvent.CreateSiegeObject(attacker.SiegeEngines.SiegePreparations, attacker);
+            }
+
+            var machines = new[]
+            {
+                (Side: BattleSideEnum.Attacker, Type: DefaultSiegeEngineTypes.Ram, Index: 0),
+                (Side: BattleSideEnum.Attacker, Type: DefaultSiegeEngineTypes.Onager, Index: 0),
+                (Side: BattleSideEnum.Defender, Type: DefaultSiegeEngineTypes.Ballista, Index: 0),
+            };
+            var staged = new List<string>();
+            foreach (var machine in machines)
+            {
+                siegeEventInterface.DeploySiegeEngine(siegeEvent, machine.Side, machine.Type, machine.Index);
+                var side = siegeEvent.GetSiegeEventSide(machine.Side);
+                var slots = machine.Type.IsRanged
+                    ? side.SiegeEngines.DeployedRangedSiegeEngines
+                    : side.SiegeEngines.DeployedMeleeSiegeEngines;
+                var progress = machine.Index < slots.Length ? slots[machine.Index] : null;
+                if (progress?.SiegeEngine != machine.Type)
+                {
+                    return Failed($"Failed to stage {machine.Type.StringId} for {machine.Side}");
+                }
+
+                bool needsSiegeObject = !progress.IsConstructed
+                    || (machine.Type.IsRanged && progress.RangedSiegeEngine == null);
+                if (!progress.IsConstructed)
+                {
+                    progress.SetProgress(1f);
+                }
+                if (progress.IsBeingRedeployed)
+                {
+                    progress.SetRedeploymentProgress(1f);
+                }
+                if (needsSiegeObject)
+                {
+                    siegeEvent.CreateSiegeObject(progress, side);
+                }
+                if (!progress.IsActive)
+                {
+                    return Failed($"Failed to activate {machine.Type.StringId} for {machine.Side}");
+                }
+
+                staged.Add($"{machine.Side}:{machine.Type.StringId}[{machine.Index}]");
+            }
+
+            return Succeeded($"Staged {staged.Count} constructed siege engines at {settlement.Name}: {string.Join(", ", staged)}");
+
         }
-
-        return $"Staged {staged.Count} constructed siege engines at {settlement.Name}: {string.Join(", ", staged)}";
     }
 
     /// <summary>
     /// Starts the wall assault for an existing AI-led siege. Server only; the resulting map event uses the
     /// same authoritative action as campaign AI.
     /// </summary>
-    [CommandLineArgumentFunction("assault", "coop.debug.siege")]
-    public static string StartAssault(List<string> args)
+    public sealed class StartAssaultCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "assault";
+
+        public string Description => "Runs the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.siege.assault <settlementId>";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        if (ModInformation.IsClient)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "This command can only be used by the server";
-        }
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
-
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
-        {
-            return $"Settlement with id {args[0]} not found";
-        }
-
-        var attacker = settlement.SiegeEvent?.BesiegerCamp?.LeaderParty;
-        if (attacker == null)
-        {
-            return $"{settlement.Name} has no active siege leader";
-        }
-
-        if (attacker.IsPlayerParty())
-        {
-            return $"{settlement.Name} is player-led; this command only starts AI assaults";
-        }
-
-        if (attacker.MapEvent != null)
-        {
-            return $"{attacker.Name} is already in an active map event";
-        }
-
-        if (settlement.Party.MapEvent != null)
-        {
-            return $"{settlement.Name} already has an active map event";
-        }
-
-        StartBattleAction.ApplyStartAssaultAgainstWalls(attacker, settlement);
-
-        var mapEvent = settlement.Party.MapEvent;
-        if (mapEvent?.IsSiegeAssault != true)
-        {
-            return $"Failed to start an AI siege assault against {settlement.Name}";
-        }
-
-        var mapEventId = objectManager.TryGetId(mapEvent, out string id) ? id : mapEvent.StringId;
-        return $"Started AI siege assault by {attacker.Name} against {settlement.Name} (MapEvent {mapEventId})" +
-            Environment.NewLine + "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(new
+            if (ModInformation.IsClient)
             {
-                settlementId = settlement.StringId,
-                mapEventId,
-            });
+                return Failed("This command can only be used by the server");
+            }
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var attacker = settlement.SiegeEvent?.BesiegerCamp?.LeaderParty;
+            if (attacker == null)
+            {
+                return Failed($"{settlement.Name} has no active siege leader");
+            }
+
+            if (attacker.IsPlayerParty())
+            {
+                return Failed($"{settlement.Name} is player-led; this command only starts AI assaults");
+            }
+
+            if (attacker.MapEvent != null)
+            {
+                return Failed($"{attacker.Name} is already in an active map event");
+            }
+
+            if (settlement.Party.MapEvent != null)
+            {
+                return Failed($"{settlement.Name} already has an active map event");
+            }
+
+            StartBattleAction.ApplyStartAssaultAgainstWalls(attacker, settlement);
+
+            var mapEvent = settlement.Party.MapEvent;
+            if (mapEvent?.IsSiegeAssault != true)
+            {
+                return Failed($"Failed to start an AI siege assault against {settlement.Name}");
+            }
+
+            var mapEventId = objectManager.TryGetId(mapEvent, out string id) ? id : mapEvent.StringId;
+            return Succeeded($"Started AI siege assault by {attacker.Name} against {settlement.Name} (MapEvent {mapEventId})" +
+                Environment.NewLine + "LIVE_TEST_JSON=" + JsonConvert.SerializeObject(new
+                {
+                    settlementId = settlement.StringId,
+                    mapEventId,
+                }));
+
+        }
     }
 
     /// <summary>
     /// Reports the exact vanilla readiness inputs and the starvation terminal decision. Read-only.
     /// </summary>
-    [CommandLineArgumentFunction("terminal_status", "coop.debug.siege")]
-    public static string TerminalStatus(List<string> args)
+    public sealed class TerminalStatusCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "terminal_status";
+
+        public string Description => "Runs status for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.siege.terminal_status town_ES1";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !ContainerProvider.TryResolve<IAiSiegeAssaultReadiness>(out var readiness)
-            || !ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve AI siege terminal services";
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !ContainerProvider.TryResolve<IAiSiegeAssaultReadiness>(out var readiness)
+                || !ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
+            {
+                return Failed("Unable to resolve AI siege terminal services");
+            }
+
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var siegeEvent = settlement.SiegeEvent;
+            var camp = siegeEvent?.BesiegerCamp;
+            var leader = camp?.LeaderParty;
+            if (siegeEvent == null || camp == null || leader == null)
+            {
+                return Failed($"{settlement.Name} has no active siege leader");
+            }
+
+            var result = readiness.Evaluate(camp);
+            int starvingParties = 0;
+            int commandGroupParties = 0;
+            if (leader.Army?.LeaderParty == leader)
+            {
+                commandGroupParties = leader.Army.LeaderPartyAndAttachedPartiesCount;
+                starvingParties = leader.Party.IsStarving ? 1 : 0;
+                starvingParties += leader.AttachedParties.Count(party => party.Party.IsStarving);
+            }
+
+            bool foodProblem = commandGroupParties > 0
+                && (float)starvingParties / (float)commandGroupParties > 0.5f;
+            bool activeTransition = leader.MapEvent != null || settlement.Party.MapEvent != null;
+            var decision = terminalPolicy.GetDecision(new AiSiegeTerminalContext(
+                foodProblem,
+                camp.IsPreparationComplete,
+                leader.IsPlayerParty(),
+                isCurrentSiege: true,
+                activeTransition,
+                result.IsViable));
+
+            return Succeeded($"settlement={settlement.StringId} leader={leader.StringId} playerLed={leader.IsPlayerParty()} " +
+                $"prepared={camp.IsPreparationComplete} elapsedHours={siegeEvent.SiegeStartTime.ElapsedHoursUntilNow:0.0} " +
+                $"starving={starvingParties}/{commandGroupParties} foodProblem={foodProblem} activeTransition={activeTransition} " +
+                $"attacker={result.AttackerStrength:0.00} defender={result.DefenderStrength:0.00} " +
+                $"powerRatio={result.PowerRatioBeforeEquipment:0.000} adjustedRatio={result.PowerRatioAfterEquipment:0.000} " +
+                $"assaultChance={result.AssaultChance:0.000} viable={result.IsViable} decision={decision}");
+
         }
-
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
-        {
-            return $"Settlement with id {args[0]} not found";
-        }
-
-        var siegeEvent = settlement.SiegeEvent;
-        var camp = siegeEvent?.BesiegerCamp;
-        var leader = camp?.LeaderParty;
-        if (siegeEvent == null || camp == null || leader == null)
-        {
-            return $"{settlement.Name} has no active siege leader";
-        }
-
-        var result = readiness.Evaluate(camp);
-        int starvingParties = 0;
-        int commandGroupParties = 0;
-        if (leader.Army?.LeaderParty == leader)
-        {
-            commandGroupParties = leader.Army.LeaderPartyAndAttachedPartiesCount;
-            starvingParties = leader.Party.IsStarving ? 1 : 0;
-            starvingParties += leader.AttachedParties.Count(party => party.Party.IsStarving);
-        }
-
-        bool foodProblem = commandGroupParties > 0
-            && (float)starvingParties / (float)commandGroupParties > 0.5f;
-        bool activeTransition = leader.MapEvent != null || settlement.Party.MapEvent != null;
-        var decision = terminalPolicy.GetDecision(new AiSiegeTerminalContext(
-            foodProblem,
-            camp.IsPreparationComplete,
-            leader.IsPlayerParty(),
-            isCurrentSiege: true,
-            activeTransition,
-            result.IsViable));
-
-        return $"settlement={settlement.StringId} leader={leader.StringId} playerLed={leader.IsPlayerParty()} " +
-            $"prepared={camp.IsPreparationComplete} elapsedHours={siegeEvent.SiegeStartTime.ElapsedHoursUntilNow:0.0} " +
-            $"starving={starvingParties}/{commandGroupParties} foodProblem={foodProblem} activeTransition={activeTransition} " +
-            $"attacker={result.AttackerStrength:0.00} defender={result.DefenderStrength:0.00} " +
-            $"powerRatio={result.PowerRatioBeforeEquipment:0.000} adjustedRatio={result.PowerRatioAfterEquipment:0.000} " +
-            $"assaultChance={result.AssaultChance:0.000} viable={result.IsViable} decision={decision}";
     }
 
     /// <summary>
     /// Simulates the vanilla food-problem terminal event for an AI siege. Server only.
     /// </summary>
-    [CommandLineArgumentFunction("resolve_starvation", "coop.debug.siege")]
-    public static string ResolveStarvation(List<string> args)
+    public sealed class ResolveStarvationCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.resolve_starvation town_ES1";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (ModInformation.IsClient)
-        {
-            return "This command can only be used by the server";
-        }
+        public string Name => "resolve_starvation";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
-            || !ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
-        {
-            return "Unable to resolve AI siege terminal services";
-        }
+        public string Description => "Resolves starvation for co-op debugging.";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Settlement with id {args[0]} not found";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        var siegeEvent = settlement.SiegeEvent;
-        var leader = siegeEvent?.BesiegerCamp?.LeaderParty;
-        if (siegeEvent == null || leader == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"{settlement.Name} has no active siege leader";
-        }
 
-        var decision = terminalPolicy.ResolveFoodProblem(
-            new AiSiegeTerminalTransitionState(leader, siegeEvent));
-        return $"Simulated starvation terminal policy at {settlement.Name} ({settlement.StringId}): {decision}";
+            if (ModInformation.IsClient)
+            {
+                return Failed("This command can only be used by the server");
+            }
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager)
+                || !ContainerProvider.TryResolve<IAiSiegeTerminalPolicy>(out var terminalPolicy))
+            {
+                return Failed("Unable to resolve AI siege terminal services");
+            }
+
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var siegeEvent = settlement.SiegeEvent;
+            var leader = siegeEvent?.BesiegerCamp?.LeaderParty;
+            if (siegeEvent == null || leader == null)
+            {
+                return Failed($"{settlement.Name} has no active siege leader");
+            }
+
+            var decision = terminalPolicy.ResolveFoodProblem(
+                new AiSiegeTerminalTransitionState(leader, siegeEvent));
+            return Succeeded($"Simulated starvation terminal policy at {settlement.Name} ({settlement.StringId}): {decision}");
+
+        }
     }
 
     // coop.debug.siege.list
@@ -1843,118 +2057,149 @@ public class SiegeDebugCommand
     /// </summary>
     /// <param name="args">no args</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("list", "coop.debug.siege")]
-    public static string ListSieges(List<string> args)
+    public sealed class ListSiegesCoopCommand : ICoopCommand
     {
-        var siegeEvents = SiegeContainerLookup.ActiveSieges().ToList();
-        if (siegeEvents.Count == 0)
-        {
-            return "No active sieges";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        var sb = new StringBuilder();
-        foreach (var siegeEvent in siegeEvents)
-        {
-            var camp = siegeEvent.BesiegerCamp;
-            sb.AppendLine($"{siegeEvent.BesiegedSettlement?.Name} ({siegeEvent.BesiegedSettlement?.StringId}): " +
-                $"leader={camp?.LeaderParty?.Name} preparation={camp?.SiegeEngines?.SiegePreparations?.Progress:0.00} " +
-                $"attackerEngines={camp?.SiegeEngines?.DeployedSiegeEngines?.Count ?? 0} " +
-                $"defenderEngines={siegeEvent.BesiegedSettlement?.SiegeEngines?.DeployedSiegeEngines?.Count ?? 0} " +
-                $"strategy={camp?.SiegeStrategy?.Name}");
-        }
+        public string Name => "list";
 
-        return sb.ToString();
+        public string Description => "Lists the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var siegeEvents = SiegeContainerLookup.ActiveSieges().ToList();
+            if (siegeEvents.Count == 0)
+            {
+                return Failed("No active sieges");
+            }
+
+            var sb = new StringBuilder();
+            foreach (var siegeEvent in siegeEvents)
+            {
+                var camp = siegeEvent.BesiegerCamp;
+                sb.AppendLine($"{siegeEvent.BesiegedSettlement?.Name} ({siegeEvent.BesiegedSettlement?.StringId}): " +
+                    $"leader={camp?.LeaderParty?.Name} preparation={camp?.SiegeEngines?.SiegePreparations?.Progress:0.00} " +
+                    $"attackerEngines={camp?.SiegeEngines?.DeployedSiegeEngines?.Count ?? 0} " +
+                    $"defenderEngines={siegeEvent.BesiegedSettlement?.SiegeEngines?.DeployedSiegeEngines?.Count ?? 0} " +
+                    $"strategy={camp?.SiegeStrategy?.Name}");
+            }
+
+            return Succeeded(sb.ToString());
+
+        }
     }
 
     /// <summary>
     /// Reports whether a settlement's replicated siege graph is ready for map visuals. Read-only.
     /// </summary>
-    [CommandLineArgumentFunction("graph", "coop.debug.siege")]
-    public static string GraphState(List<string> args)
+    public sealed class GraphStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.graph <settlementId>";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Name => "graph";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
-        {
-            return $"Settlement with id {args[0]} not found";
-        }
+        public string Description => "Runs the relevant state for co-op debugging.";
 
-        var siegeEvent = settlement.SiegeEvent;
-        if (siegeEvent == null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            var cleanResult = JsonConvert.SerializeObject(new
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            var siegeEvent = settlement.SiegeEvent;
+            if (siegeEvent == null)
+            {
+                var cleanResult = JsonConvert.SerializeObject(new
+                {
+                    success = true,
+                    settlementId = settlement.StringId,
+                    siege = false,
+                    graphComplete = false,
+                });
+                return Succeeded($"{settlement.Name} ({settlement.StringId}): siege=False graphComplete=False" +
+                    Environment.NewLine + "LIVE_TEST_JSON=" + cleanResult);
+            }
+
+            var camp = siegeEvent.BesiegerCamp;
+            bool graphComplete = SiegeContainerLookup.IsGraphComplete(siegeEvent);
+            var structuredResult = JsonConvert.SerializeObject(new
             {
                 success = true,
                 settlementId = settlement.StringId,
-                siege = false,
-                graphComplete = false,
+                siege = true,
+                campPresent = camp != null,
+                leaderPresent = camp?.LeaderParty != null,
+                attackerContainerPresent = camp?.SiegeEngines != null,
+                defenderContainerPresent = settlement.SiegeEngines != null,
+                graphComplete,
             });
-            return $"{settlement.Name} ({settlement.StringId}): siege=False graphComplete=False" +
-                Environment.NewLine + "LIVE_TEST_JSON=" + cleanResult;
-        }
+            return Succeeded($"{settlement.Name} ({settlement.StringId}): siege=True " +
+                $"camp={camp != null} leader={camp?.LeaderParty != null} " +
+                $"attackerContainer={camp?.SiegeEngines != null} " +
+                $"defenderContainer={settlement.SiegeEngines != null} " +
+                $"graphComplete={graphComplete}" + Environment.NewLine +
+                "LIVE_TEST_JSON=" + structuredResult);
 
-        var camp = siegeEvent.BesiegerCamp;
-        bool graphComplete = SiegeContainerLookup.IsGraphComplete(siegeEvent);
-        var structuredResult = JsonConvert.SerializeObject(new
-        {
-            success = true,
-            settlementId = settlement.StringId,
-            siege = true,
-            campPresent = camp != null,
-            leaderPresent = camp?.LeaderParty != null,
-            attackerContainerPresent = camp?.SiegeEngines != null,
-            defenderContainerPresent = settlement.SiegeEngines != null,
-            graphComplete,
-        });
-        return $"{settlement.Name} ({settlement.StringId}): siege=True " +
-            $"camp={camp != null} leader={camp?.LeaderParty != null} " +
-            $"attackerContainer={camp?.SiegeEngines != null} " +
-            $"defenderContainer={settlement.SiegeEngines != null} " +
-            $"graphComplete={graphComplete}" + Environment.NewLine +
-            "LIVE_TEST_JSON=" + structuredResult;
+        }
     }
 
     /// <summary>
     /// Centers the client campaign camera on a settlement for visual inspection.
     /// </summary>
-    [CommandLineArgumentFunction("focus", "coop.debug.siege")]
-    public static string FocusSettlement(List<string> args)
+    public sealed class FocusSettlementCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-        {
-            return "This command can only be used by a client";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.siege.focus <settlementId>";
-        }
+        public string Name => "focus";
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Description => "Focuses the relevant state for co-op debugging.";
 
-        if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Settlement with id {args[0]} not found";
-        }
+            new ExpectedArgs("settlementId", "The settlement id."),
+        };
 
-        if (MapScreen.Instance == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "The campaign map screen is not active";
-        }
+            if (ModInformation.IsServer)
+            {
+                return Failed("This command can only be used by a client");
+            }
 
-        MapScreen.Instance.FastMoveCameraToPosition(settlement.Position);
-        return $"Centered the campaign camera on {settlement.Name} ({settlement.StringId})";
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject<Settlement>(args[0], out var settlement))
+            {
+                return Failed($"Settlement with id {args[0]} not found");
+            }
+
+            if (MapScreen.Instance == null)
+            {
+                return Failed("The campaign map screen is not active");
+            }
+
+            MapScreen.Instance.FastMoveCameraToPosition(settlement.Position);
+            return Succeeded($"Centered the campaign camera on {settlement.Name} ({settlement.StringId})");
+
+        }
     }
 
     // coop.debug.siege.dump_party <heroName|main|partyId>
@@ -1967,55 +2212,65 @@ public class SiegeDebugCommand
     /// </summary>
     /// <param name="args">first arg: heroName | main | partyId</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("dump_party", "coop.debug.siege")]
-    public static string DumpParty(List<string> args)
+    public sealed class DumpPartyCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "dump_party";
+
+        public string Description => "Dumps party for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.siege.dump_party <heroName|main|partyId>";
-        }
+            new ExpectedArgs("heroNameOrPartyId", "The exact hero name or party id; quote names containing spaces."),
+        };
 
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            string arg = args[0];
+            MobileParty party;
+            if (arg.Equals("main", StringComparison.OrdinalIgnoreCase))
+            {
+                party = MobileParty.MainParty;
+            }
+            else if (!objectManager.TryGetObject(arg, out party))
+            {
+                party = MobileParty.All.FirstOrDefault(p => p.LeaderHero?.Name != null
+                    && p.LeaderHero.Name.ToString().IndexOf(arg, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+
+            if (party == null)
+            {
+                return Failed($"No party found for '{arg}' (use \"main\", a coop id, or a leader-hero name)");
+            }
+
+            var settlement = party.CurrentSettlement ?? party.BesiegedSettlement;
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"[{(ModInformation.IsServer ? "SERVER" : "CLIENT")}] siege state: {party.Name} ({party.StringId}) coopId={IdOf(objectManager, party)}");
+            sb.AppendLine($"  Leader: {party.LeaderHero?.Name?.ToString() ?? "null"}  IsActive: {party.IsActive}");
+            var pos = party.GetPosition2D;
+            sb.AppendLine($"  Position2D: {pos.x:0.00}, {pos.y:0.00}  IsOnLand: {party.Position.IsOnLand}");
+            sb.AppendLine($"  CurrentSettlement: {Describe(party.CurrentSettlement)}");
+            sb.AppendLine($"  BesiegerCamp: {(party.BesiegerCamp != null ? "present" : "null")}");
+            sb.AppendLine($"  BesiegedSettlement: {Describe(party.BesiegedSettlement)}");
+            sb.AppendLine($"  MapEvent: {party.MapEvent?.EventType.ToString() ?? "null"}  ShortTermBehavior: {party.ShortTermBehavior}");
+
+            if (settlement != null)
+            {
+                sb.AppendLine($"  -- {settlement.Name} ({settlement.StringId}): owner={settlement.OwnerClan?.Name?.ToString() ?? "null"} " +
+                    $"underSiege={settlement.IsUnderSiege} siegeEvent={(settlement.SiegeEvent != null ? "active" : "null")}");
+            }
+
+            return Succeeded(sb.ToString());
+
         }
-
-        string arg = args[0];
-        MobileParty party;
-        if (arg.Equals("main", StringComparison.OrdinalIgnoreCase))
-        {
-            party = MobileParty.MainParty;
-        }
-        else if (!objectManager.TryGetObject(arg, out party))
-        {
-            party = MobileParty.All.FirstOrDefault(p => p.LeaderHero?.Name != null
-                && p.LeaderHero.Name.ToString().IndexOf(arg, StringComparison.OrdinalIgnoreCase) >= 0);
-        }
-
-        if (party == null)
-        {
-            return $"No party found for '{arg}' (use \"main\", a coop id, or a leader-hero name)";
-        }
-
-        var settlement = party.CurrentSettlement ?? party.BesiegedSettlement;
-
-        var sb = new StringBuilder();
-        sb.AppendLine($"[{(ModInformation.IsServer ? "SERVER" : "CLIENT")}] siege state: {party.Name} ({party.StringId}) coopId={IdOf(objectManager, party)}");
-        sb.AppendLine($"  Leader: {party.LeaderHero?.Name?.ToString() ?? "null"}  IsActive: {party.IsActive}");
-        var pos = party.GetPosition2D;
-        sb.AppendLine($"  Position2D: {pos.x:0.00}, {pos.y:0.00}  IsOnLand: {party.Position.IsOnLand}");
-        sb.AppendLine($"  CurrentSettlement: {Describe(party.CurrentSettlement)}");
-        sb.AppendLine($"  BesiegerCamp: {(party.BesiegerCamp != null ? "present" : "null")}");
-        sb.AppendLine($"  BesiegedSettlement: {Describe(party.BesiegedSettlement)}");
-        sb.AppendLine($"  MapEvent: {party.MapEvent?.EventType.ToString() ?? "null"}  ShortTermBehavior: {party.ShortTermBehavior}");
-
-        if (settlement != null)
-        {
-            sb.AppendLine($"  -- {settlement.Name} ({settlement.StringId}): owner={settlement.OwnerClan?.Name?.ToString() ?? "null"} " +
-                $"underSiege={settlement.IsUnderSiege} siegeEvent={(settlement.SiegeEvent != null ? "active" : "null")}");
-        }
-
-        return sb.ToString();
     }
 
     // coop.debug.siege.dump_engines
@@ -2027,34 +2282,45 @@ public class SiegeDebugCommand
     /// </summary>
     /// <param name="args">no args</param>
     /// <returns>Result of the operation as a string</returns>
-    [CommandLineArgumentFunction("dump_engines", "coop.debug.siege")]
-    public static string DumpEngines(List<string> args)
+    public sealed class DumpEnginesCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+        public string Prefix => "coop.debug.siege";
+
+        public string Name => "dump_engines";
+
+        public string Description => "Dumps engines for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+            if (!ContainerProvider.TryResolve<IObjectManager>(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            var siegeEvents = SiegeContainerLookup.ActiveSieges().ToList();
+            if (siegeEvents.Count == 0)
+            {
+                return Failed("No active sieges");
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"[{(ModInformation.IsServer ? "SERVER" : "CLIENT")}] siege engines:");
+
+            foreach (var siegeEvent in siegeEvents)
+            {
+                sb.AppendLine($"Siege of {siegeEvent.BesiegedSettlement?.StringId} (SiegeEvent {IdOf(objectManager, siegeEvent)})");
+                DumpSide(sb, objectManager, "ATTACKER", siegeEvent.BesiegerCamp?.SiegeEngines);
+                DumpSide(sb, objectManager, "DEFENDER", siegeEvent.BesiegedSettlement?.SiegeEngines);
+            }
+
+            var dump = sb.ToString();
+            // Into the Coop log too, so the machines' dumps can be compared from their log files.
+            Logger.Information("[EngineDump]\n{Dump}", dump);
+            return Succeeded(dump);
+
         }
-
-        var siegeEvents = SiegeContainerLookup.ActiveSieges().ToList();
-        if (siegeEvents.Count == 0)
-        {
-            return "No active sieges";
-        }
-
-        var sb = new StringBuilder();
-        sb.AppendLine($"[{(ModInformation.IsServer ? "SERVER" : "CLIENT")}] siege engines:");
-
-        foreach (var siegeEvent in siegeEvents)
-        {
-            sb.AppendLine($"Siege of {siegeEvent.BesiegedSettlement?.StringId} (SiegeEvent {IdOf(objectManager, siegeEvent)})");
-            DumpSide(sb, objectManager, "ATTACKER", siegeEvent.BesiegerCamp?.SiegeEngines);
-            DumpSide(sb, objectManager, "DEFENDER", siegeEvent.BesiegedSettlement?.SiegeEngines);
-        }
-
-        var dump = sb.ToString();
-        // Into the Coop log too, so the machines' dumps can be compared from their log files.
-        Logger.Information("[EngineDump]\n{Dump}", dump);
-        return dump;
     }
 
     private static void DumpSide(StringBuilder sb, IObjectManager objectManager, string label, SiegeEnginesContainer container)
@@ -2100,61 +2366,75 @@ public class SiegeDebugCommand
     /// prompt and the AI read — sorted so two clients' dumps diff line by line, and written to the Coop
     /// log for post-run comparison. Pass "all" to include every usable machine. Read-only.
     /// </summary>
-    [CommandLineArgumentFunction("dump_machines", "coop.debug.siege")]
-    public static string DumpMachines(List<string> args)
+    public sealed class DumpMachinesCoopCommand : ICoopCommand
     {
-        var mission = TaleWorlds.MountAndBlade.Mission.Current;
-        if (mission == null)
-        {
-            return "No mission is running";
-        }
+        public string Prefix => "coop.debug.siege";
 
-        bool includeAll = args.Count > 0 && args[0] == "all";
-        var lines = new List<string>();
-        foreach (var missionObject in mission.MissionObjects)
+        public string Name => "dump_machines";
+
+        public string Description => "Dumps machines for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (missionObject is TaleWorlds.MountAndBlade.UsableMachine machine
-                && (includeAll || machine is TaleWorlds.MountAndBlade.SiegeWeapon))
+            new ExpectedArgs("includeAll", "The include all.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var mission = TaleWorlds.MountAndBlade.Mission.Current;
+            if (mission == null)
             {
-                int deactivatedPoints = 0, usedPoints = 0;
-                foreach (var point in machine.StandingPoints)
+                return Failed("No mission is running");
+            }
+
+            bool includeAll = args.Count > 0 && args[0] == "all";
+            var lines = new List<string>();
+            foreach (var missionObject in mission.MissionObjects)
+            {
+                if (missionObject is TaleWorlds.MountAndBlade.UsableMachine machine
+                    && (includeAll || machine is TaleWorlds.MountAndBlade.SiegeWeapon))
                 {
-                    if (point.IsDeactivated) deactivatedPoints++;
-                    if (point.UserAgent != null) usedPoints++;
+                    int deactivatedPoints = 0, usedPoints = 0;
+                    foreach (var point in machine.StandingPoints)
+                    {
+                        if (point.IsDeactivated) deactivatedPoints++;
+                        if (point.UserAgent != null) usedPoints++;
+                    }
+
+                    lines.Add($"machine {machine.Id.Id:D5} {machine.GetType().Name,-16}" +
+                        $" disabled={(machine.IsDisabled ? 1 : 0)} visible={(machine.GameEntity.IsVisibleIncludeParents() ? 1 : 0)}" +
+                        $" deactivated={(machine.IsDeactivated ? 1 : 0)} aiOff={(machine.IsDisabledForAI ? 1 : 0)}" +
+                        $" simLocal={(SiegeMissionAuthorityGate.IsMachineSimulatedLocally(machine.Id.Id) ? 1 : 0)}" +
+                        $" pts={machine.StandingPoints.Count} ptsOff={deactivatedPoints} ptsUsed={usedPoints}" +
+                        DescribeMissionMachineState(machine));
                 }
+                else if (missionObject is TaleWorlds.MountAndBlade.DeploymentPoint deploymentPoint)
+                {
+                    var variants = deploymentPoint._weapons?
+                        .Where(weapon => weapon != null)
+                        .ToArray() ?? Array.Empty<TaleWorlds.MountAndBlade.SynchedMissionObject>();
+                    var deployedWeapon = deploymentPoint.DeployedWeapon;
+                    var deployedWeaponType = deployedWeapon == null
+                        ? "none"
+                        : TaleWorlds.MountAndBlade.Missions.MissionSiegeWeaponsController.GetWeaponType(deployedWeapon)?.Name
+                            ?? deployedWeapon.GetType().Name;
+                    lines.Add($"point   {deploymentPoint.Id.Id:D5} {deploymentPoint.Side,-16}" +
+                        $" disabled={(deploymentPoint.IsDisabled ? 1 : 0)} deployed={(deploymentPoint.IsDeployed ? 1 : 0)}" +
+                        $" weapon={deployedWeaponType}" +
+                        $" weaponId={(deployedWeapon != null ? deployedWeapon.Id.Id.ToString("D5") : "none")}" +
+                        $" weaponVisible={(deployedWeapon?.GameEntity.IsVisibleIncludeParents() == true ? 1 : 0)}" +
+                        $" variants={variants.Length} variantsVisible={variants.Count(weapon => weapon.GameEntity.IsVisibleIncludeParents())}");
+                }
+            }
 
-                lines.Add($"machine {machine.Id.Id:D5} {machine.GetType().Name,-16}" +
-                    $" disabled={(machine.IsDisabled ? 1 : 0)} visible={(machine.GameEntity.IsVisibleIncludeParents() ? 1 : 0)}" +
-                    $" deactivated={(machine.IsDeactivated ? 1 : 0)} aiOff={(machine.IsDisabledForAI ? 1 : 0)}" +
-                    $" simLocal={(SiegeMissionAuthorityGate.IsMachineSimulatedLocally(machine.Id.Id) ? 1 : 0)}" +
-                    $" pts={machine.StandingPoints.Count} ptsOff={deactivatedPoints} ptsUsed={usedPoints}" +
-                    DescribeMissionMachineState(machine));
-            }
-            else if (missionObject is TaleWorlds.MountAndBlade.DeploymentPoint deploymentPoint)
-            {
-                var variants = deploymentPoint._weapons?
-                    .Where(weapon => weapon != null)
-                    .ToArray() ?? Array.Empty<TaleWorlds.MountAndBlade.SynchedMissionObject>();
-                var deployedWeapon = deploymentPoint.DeployedWeapon;
-                var deployedWeaponType = deployedWeapon == null
-                    ? "none"
-                    : TaleWorlds.MountAndBlade.Missions.MissionSiegeWeaponsController.GetWeaponType(deployedWeapon)?.Name
-                        ?? deployedWeapon.GetType().Name;
-                lines.Add($"point   {deploymentPoint.Id.Id:D5} {deploymentPoint.Side,-16}" +
-                    $" disabled={(deploymentPoint.IsDisabled ? 1 : 0)} deployed={(deploymentPoint.IsDeployed ? 1 : 0)}" +
-                    $" weapon={deployedWeaponType}" +
-                    $" weaponId={(deployedWeapon != null ? deployedWeapon.Id.Id.ToString("D5") : "none")}" +
-                    $" weaponVisible={(deployedWeapon?.GameEntity.IsVisibleIncludeParents() == true ? 1 : 0)}" +
-                    $" variants={variants.Length} variantsVisible={variants.Count(weapon => weapon.GameEntity.IsVisibleIncludeParents())}");
-            }
+            lines.Sort(StringComparer.Ordinal);
+            lines.Insert(0, $"siege={mission.IsSiegeBattle} authority={SiegeMissionAuthorityGate.IsLocalAuthority} known={SiegeMissionAuthorityGate.IsAuthorityKnown} entries={lines.Count}");
+
+            var dump = string.Join(Environment.NewLine, lines);
+            Logger.Information("[MachineDump]\n{Dump}", dump);
+            return Succeeded(dump);
+
         }
-
-        lines.Sort(StringComparer.Ordinal);
-        lines.Insert(0, $"siege={mission.IsSiegeBattle} authority={SiegeMissionAuthorityGate.IsLocalAuthority} known={SiegeMissionAuthorityGate.IsAuthorityKnown} entries={lines.Count}");
-
-        var dump = string.Join(Environment.NewLine, lines);
-        Logger.Information("[MachineDump]\n{Dump}", dump);
-        return dump;
     }
 
     private static string DescribeMissionMachineState(TaleWorlds.MountAndBlade.UsableMachine machine)

--- a/source/GameInterface/Services/Tournaments/Commands/TournamentDebugCommand.cs
+++ b/source/GameInterface/Services/Tournaments/Commands/TournamentDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Messaging;
 using Common.Network;
 using GameInterface.Services.ObjectManager;
@@ -15,12 +16,16 @@ using TaleWorlds.CampaignSystem.Encounters;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.TournamentGames;
 using TaleWorlds.MountAndBlade;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Tournaments.Commands;
 
 public class TournamentDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
 #if DEBUG
     private const string DanusticaSettlementId = "town_ES1";
     private static DanusticaTournamentFixture fixture;
@@ -33,302 +38,392 @@ public class TournamentDebugCommand
     }
 #endif
 
-    [CommandLineArgumentFunction("add_tournament_to_town", "coop.debug.tournaments")]
-    public static string AddTournamentToTown(List<string> args)
+    public sealed class AddTournamentToTownCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "This function can only be used by the server";
+        public string Prefix => "coop.debug.tournaments";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.tournaments.add_tournament_to_town <town name or id>";
+        public string Name => "add_tournament_to_town";
 
-        if (Campaign.Current?.TournamentManager is not TournamentManager tournamentManager)
-            return "No campaign is currently loaded";
+        public string Description => "Adds tournament to town for co-op debugging.";
 
-        if (!TryResolveTown(args[0], out var town))
-            return $"Town '{args[0]}' not found";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("townNameOrId", "The exact town name or id; quote names containing spaces."),
+        };
 
-        if (tournamentManager.GetTournamentGame(town) != null)
-            return $"{town.Name} already has an active tournament";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("This function can only be used by the server");
 
-        bool tournamentAdded = false;
-        GameThread.RunSafe(
-            () =>
-            {
-                tournamentManager.AddTournament(new FightTournamentGame(town));
-                tournamentAdded = true;
-            },
-            blocking: true,
-            context: nameof(AddTournamentToTown));
 
-        return tournamentAdded
-            ? $"Added a tournament to {town.Name}"
-            : $"Failed to add a tournament to {town.Name}; check the log for details";
+            if (Campaign.Current?.TournamentManager is not TournamentManager tournamentManager)
+                return Failed("No campaign is currently loaded");
+
+            if (!TryResolveTown(args[0], out var town))
+                return Failed($"Town '{args[0]}' not found");
+
+            if (tournamentManager.GetTournamentGame(town) != null)
+                return Failed($"{town.Name} already has an active tournament");
+
+            bool tournamentAdded = false;
+            GameThread.RunSafe(
+                () =>
+                {
+                    tournamentManager.AddTournament(new FightTournamentGame(town));
+                    tournamentAdded = true;
+                },
+                blocking: true,
+                context: nameof(AddTournamentToTownCoopCommand));
+
+            return tournamentAdded
+                ? Succeeded($"Added a tournament to {town.Name}")
+                : Failed($"Failed to add a tournament to {town.Name}; check the log for details");
+
+        }
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("danustica_fixture_begin", "coop.debug.tournaments")]
-    public static string BeginDanusticaFixture(List<string> args)
+    public sealed class BeginDanusticaFixtureCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_fixture_begin";
-        if (fixture != null)
-            return "A Danustica tournament fixture is already pending restoration.";
-        if (!TryResolveDanusticaContext(out var town, out var townId, out var error))
-            return error;
-        if (Campaign.Current?.TournamentManager is not TournamentManager tournamentManager)
-            return "No campaign is currently loaded.";
-        if (!ContainerProvider.TryResolve<ITournamentSessionRegistry>(out var registry))
-            return "Unable to resolve the tournament session registry.";
-        if (registry.TryGetByTown(townId, out var openSession))
-        {
-            return
-                $"Danustica already has coop session {openSession.SessionId} in phase {openSession.Phase}.";
-        }
+        public string Prefix => "coop.debug.tournaments";
 
-        TournamentGame tournamentGame = tournamentManager.GetTournamentGame(town);
-        if (tournamentGame != null &&
-            !CoopTournamentCampaignBehavior.IsSupportedTournament(tournamentGame))
-        {
-            return
-                $"Danustica has unsupported tournament type {tournamentGame.GetType().Name}.";
-        }
+        public string Name => "danustica_fixture_begin";
 
-        TournamentGame createdGame = null;
-        if (tournamentGame == null)
-        {
-            createdGame = new FightTournamentGame(town);
-            tournamentManager.AddTournament(createdGame);
-            tournamentGame = createdGame;
-        }
+        public string Description => "Runs fixture begin for co-op debugging.";
 
-        fixture = new DanusticaTournamentFixture
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            Campaign = Campaign.Current,
-            Manager = tournamentManager,
-            CreatedGame = createdGame,
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+            if (fixture != null)
+                return Failed("A Danustica tournament fixture is already pending restoration.");
+            if (!TryResolveDanusticaContext(out var town, out var townId, out var error))
+                return Failed(error);
+            if (Campaign.Current?.TournamentManager is not TournamentManager tournamentManager)
+                return Failed("No campaign is currently loaded.");
+            if (!ContainerProvider.TryResolve<ITournamentSessionRegistry>(out var registry))
+                return Failed("Unable to resolve the tournament session registry.");
+            if (registry.TryGetByTown(townId, out var openSession))
+            {
+                return Failed($"Danustica already has coop session {openSession.SessionId} in phase {openSession.Phase}.");
+            }
+
+            TournamentGame tournamentGame = tournamentManager.GetTournamentGame(town);
+            if (tournamentGame != null &&
+                !CoopTournamentCampaignBehavior.IsSupportedTournament(tournamentGame))
+            {
+                return Failed($"Danustica has unsupported tournament type {tournamentGame.GetType().Name}.");
+            }
+
+            TournamentGame createdGame = null;
+            if (tournamentGame == null)
+            {
+                createdGame = new FightTournamentGame(town);
+                tournamentManager.AddTournament(createdGame);
+                tournamentGame = createdGame;
+            }
+
+            fixture = new DanusticaTournamentFixture
+            {
+                Campaign = Campaign.Current,
+                Manager = tournamentManager,
+                CreatedGame = createdGame,
+            };
+
+            return Succeeded($"DANUSTICA_TOURNAMENT_FIXTURE_STARTED townId={townId}|" +
+                $"nativeType={tournamentGame.GetType().Name}|created={createdGame != null}");
+
+        }
+    }
+
+    public sealed class DanusticaFixtureStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.tournaments";
+
+        public string Name => "danustica_fixture_state";
+
+        public string Description => "Runs fixture state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            string fixtureState;
+            if (fixture == null)
+            {
+                fixtureState = "none";
+            }
+            else if (fixture.Campaign != Campaign.Current)
+            {
+                fixtureState = "stale-campaign";
+            }
+            else
+            {
+                bool createdGameActive =
+                    fixture.CreatedGame != null &&
+                    fixture.Manager._activeTournaments.Contains(fixture.CreatedGame);
+                fixtureState =
+                    $"active|created={fixture.CreatedGame != null}|createdGameActive={createdGameActive}";
+            }
+
+            if (!TryObserveDanustica(out var observation))
+                return Failed(observation);
+
+            return Succeeded($"DANUSTICA_TOURNAMENT_FIXTURE state={fixtureState}\n" + observation);
+
+        }
+    }
+
+    public sealed class RestoreDanusticaFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.tournaments";
+
+        public string Name => "danustica_fixture_restore";
+
+        public string Description => "Runs fixture restore for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+            if (fixture == null)
+                return Failed("No Danustica tournament fixture is pending restoration.");
+
+            DanusticaTournamentFixture activeFixture = fixture;
+            if (activeFixture.Campaign != Campaign.Current)
+            {
+                fixture = null;
+                return Succeeded("The Danustica tournament fixture belonged to a previous campaign and was discarded.");
+            }
+            if (!TryResolveDanusticaContext(out _, out var townId, out var error))
+                return Failed(error);
+            if (!ContainerProvider.TryResolve<ITournamentSessionRegistry>(out var registry))
+                return Failed("Unable to resolve the tournament session registry.");
+            if (registry.TryGetByTown(townId, out var openSession))
+            {
+                return Failed($"Cannot restore while coop session {openSession.SessionId} is open in phase {openSession.Phase}.");
+            }
+
+            TournamentGame createdGame = activeFixture.CreatedGame;
+            if (createdGame != null &&
+                activeFixture.Manager._activeTournaments.Contains(createdGame))
+            {
+                activeFixture.Manager.RemoveTournament(createdGame);
+                if (activeFixture.Manager._activeTournaments.Contains(createdGame))
+                    return Failed("The fixture-created Danustica tournament could not be removed.");
+            }
+
+            fixture = null;
+            return Succeeded($"DANUSTICA_TOURNAMENT_FIXTURE_RESTORED removedCreatedTournament={createdGame != null}");
+
+        }
+    }
+
+    public sealed class AbortDanusticaFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.tournaments";
+
+        public string Name => "danustica_fixture_abort";
+
+        public string Description => "Runs fixture abort for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("Run this command on the server.");
+            if (fixture == null)
+                return Failed("No Danustica tournament fixture is pending restoration.");
+            if (fixture.Campaign != Campaign.Current)
+            {
+                fixture = null;
+                return Succeeded("The Danustica tournament fixture belonged to a previous campaign and was discarded.");
+            }
+            if (fixture.CreatedGame == null)
+                return Failed("Refusing to abort a tournament that was not created by the fixture.");
+            if (!TryResolveDanusticaContext(out _, out var townId, out var error))
+                return Failed(error);
+            if (!ContainerProvider.TryResolve<ITournamentSessionRegistry>(out var registry) ||
+                !ContainerProvider.TryResolve<INetwork>(out var network) ||
+                !ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker))
+            {
+                return Failed("Unable to resolve the tournament fixture cleanup services.");
+            }
+
+            if (!registry.TryGetByTown(townId, out var session))
+                return Failed("The fixture has no active Danustica session to abort.");
+            if (!registry.Remove(session.SessionId))
+                return Failed($"Unable to remove Danustica session {session.SessionId}.");
+
+            var removal = new NetworkTournamentSessionRemoved(session.SessionId, townId);
+            network.SendAll(removal);
+            messageBroker.Publish(
+                typeof(TournamentDebugCommand),
+                new TournamentSessionRemoved(session.SessionId, townId));
+            return Succeeded($"DANUSTICA_TOURNAMENT_FIXTURE_ABORTED sessionId={session.SessionId}|" +
+                $"phase={session.Phase}|createdTournamentPreservedForRestore=True");
+
+        }
+    }
+
+    public sealed class RequestDanusticaJoinCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.tournaments";
+
+        public string Name => "danustica_request_join";
+
+        public string Description => "Runs request join for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+            if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
+                return Failed(error);
+
+            if (!controller.TryGetTownSession(townId, out var snapshot) || snapshot.IsCompleted)
+            {
+                controller.RequestJoin(townId, null, 0);
+                return Succeeded($"DANUSTICA_TOURNAMENT_JOIN_REQUESTED townId={townId}|sessionId=none|revision=0");
+            }
+            if (snapshot.Phase != TournamentSessionPhase.Preparation)
+            {
+                return Failed($"Danustica session {snapshot.SessionId} is in phase {snapshot.Phase}, not Preparation.");
+            }
+
+            controller.RequestJoin(townId, snapshot.SessionId, snapshot.Revision);
+            return Succeeded($"DANUSTICA_TOURNAMENT_JOIN_REQUESTED townId={townId}|" +
+                $"sessionId={snapshot.SessionId}|revision={snapshot.Revision}");
+
+        }
+    }
+
+    public sealed class RequestDanusticaStartCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.tournaments";
+
+        public string Name => "danustica_request_start";
+
+        public string Description => "Runs request start for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+            if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
+                return Failed(error);
+            if (!controller.TryGetTownSession(townId, out var snapshot))
+                return Failed("The client has no Danustica tournament session snapshot.");
+            if (snapshot.Phase != TournamentSessionPhase.Preparation)
+                return Failed($"Danustica session {snapshot.SessionId} is in phase {snapshot.Phase}, not Preparation.");
+
+            controller.RequestStart(townId);
+            return Succeeded($"DANUSTICA_TOURNAMENT_START_REQUESTED sessionId={snapshot.SessionId}|revision={snapshot.Revision}");
+
+        }
+    }
+
+    public sealed class RequestDanusticaChoiceCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.tournaments";
+
+        public string Name => "danustica_request_choice";
+
+        public string Description => "Runs request choice for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("choice", "The choice."),
         };
 
-        return
-            $"DANUSTICA_TOURNAMENT_FIXTURE_STARTED townId={townId}|" +
-            $"nativeType={tournamentGame.GetType().Name}|created={createdGame != null}";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+            if (!Enum.TryParse(args[0], true, out TournamentPlayerChoice choice) ||
+                choice == TournamentPlayerChoice.None)
+            {
+                return Failed("Invalid choice. Use Join, Watch, or Skip.");
+            }
+            if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
+                return Failed(error);
+            if (!controller.TryGetTownSession(townId, out var snapshot))
+                return Failed("The client has no Danustica tournament session snapshot.");
+            if (snapshot.Phase != TournamentSessionPhase.AwaitingChoices ||
+                string.IsNullOrEmpty(snapshot.CurrentMatchId))
+            {
+                return Failed($"Danustica session {snapshot.SessionId} is not awaiting a match choice; " +
+                    $"phase={snapshot.Phase}|matchId={snapshot.CurrentMatchId ?? "none"}.");
+            }
+
+            controller.RequestChoice(snapshot, choice);
+            return Succeeded($"DANUSTICA_TOURNAMENT_CHOICE_REQUESTED sessionId={snapshot.SessionId}|" +
+                $"revision={snapshot.Revision}|matchId={snapshot.CurrentMatchId}|choice={choice}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("danustica_fixture_state", "coop.debug.tournaments")]
-    public static string DanusticaFixtureState(List<string> args)
+    public sealed class RequestDanusticaLeaveCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_fixture_state";
+        public string Prefix => "coop.debug.tournaments";
 
-        string fixtureState;
-        if (fixture == null)
-        {
-            fixtureState = "none";
-        }
-        else if (fixture.Campaign != Campaign.Current)
-        {
-            fixtureState = "stale-campaign";
-        }
-        else
-        {
-            bool createdGameActive =
-                fixture.CreatedGame != null &&
-                fixture.Manager._activeTournaments.Contains(fixture.CreatedGame);
-            fixtureState =
-                $"active|created={fixture.CreatedGame != null}|createdGameActive={createdGameActive}";
-        }
+        public string Name => "danustica_request_leave";
 
-        return $"DANUSTICA_TOURNAMENT_FIXTURE state={fixtureState}\n" + ObserveDanustica();
+        public string Description => "Runs request leave for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+            if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
+                return Failed(error);
+            if (!controller.TryGetTownSession(townId, out var snapshot))
+                return Failed("The client has no Danustica tournament session snapshot.");
+
+            controller.RequestLeaveActive(snapshot);
+            return Succeeded($"DANUSTICA_TOURNAMENT_LEAVE_REQUESTED sessionId={snapshot.SessionId}|" +
+                $"revision={snapshot.Revision}|phase={snapshot.Phase}");
+
+        }
     }
 
-    [CommandLineArgumentFunction("danustica_fixture_restore", "coop.debug.tournaments")]
-    public static string RestoreDanusticaFixture(List<string> args)
+    public sealed class ObserveDanusticaCommandCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_fixture_restore";
-        if (fixture == null)
-            return "No Danustica tournament fixture is pending restoration.";
+        public string Prefix => "coop.debug.tournaments";
 
-        DanusticaTournamentFixture activeFixture = fixture;
-        if (activeFixture.Campaign != Campaign.Current)
-        {
-            fixture = null;
-            return "The Danustica tournament fixture belonged to a previous campaign and was discarded.";
-        }
-        if (!TryResolveDanusticaContext(out _, out var townId, out var error))
-            return error;
-        if (!ContainerProvider.TryResolve<ITournamentSessionRegistry>(out var registry))
-            return "Unable to resolve the tournament session registry.";
-        if (registry.TryGetByTown(townId, out var openSession))
-        {
-            return
-                $"Cannot restore while coop session {openSession.SessionId} is open in phase {openSession.Phase}.";
-        }
+        public string Name => "danustica_observe";
 
-        TournamentGame createdGame = activeFixture.CreatedGame;
-        if (createdGame != null &&
-            activeFixture.Manager._activeTournaments.Contains(createdGame))
-        {
-            activeFixture.Manager.RemoveTournament(createdGame);
-            if (activeFixture.Manager._activeTournaments.Contains(createdGame))
-                return "The fixture-created Danustica tournament could not be removed.";
-        }
+        public string Description => "Runs observe for co-op debugging.";
 
-        fixture = null;
-        return
-            $"DANUSTICA_TOURNAMENT_FIXTURE_RESTORED removedCreatedTournament={createdGame != null}";
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!TryObserveDanustica(out var observation))
+                return Failed(observation);
+
+            return Succeeded(observation);
+
+        }
     }
 
-    [CommandLineArgumentFunction("danustica_fixture_abort", "coop.debug.tournaments")]
-    public static string AbortDanusticaFixture(List<string> args)
+    private static bool TryObserveDanustica(out string observation)
     {
-        if (ModInformation.IsClient)
-            return "Run this command on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_fixture_abort";
-        if (fixture == null)
-            return "No Danustica tournament fixture is pending restoration.";
-        if (fixture.Campaign != Campaign.Current)
-        {
-            fixture = null;
-            return "The Danustica tournament fixture belonged to a previous campaign and was discarded.";
-        }
-        if (fixture.CreatedGame == null)
-            return "Refusing to abort a tournament that was not created by the fixture.";
-        if (!TryResolveDanusticaContext(out _, out var townId, out var error))
-            return error;
-        if (!ContainerProvider.TryResolve<ITournamentSessionRegistry>(out var registry) ||
-            !ContainerProvider.TryResolve<INetwork>(out var network) ||
-            !ContainerProvider.TryResolve<IMessageBroker>(out var messageBroker))
-        {
-            return "Unable to resolve the tournament fixture cleanup services.";
-        }
-
-        if (!registry.TryGetByTown(townId, out var session))
-            return "The fixture has no active Danustica session to abort.";
-        if (!registry.Remove(session.SessionId))
-            return $"Unable to remove Danustica session {session.SessionId}.";
-
-        var removal = new NetworkTournamentSessionRemoved(session.SessionId, townId);
-        network.SendAll(removal);
-        messageBroker.Publish(
-            typeof(TournamentDebugCommand),
-            new TournamentSessionRemoved(session.SessionId, townId));
-        return
-            $"DANUSTICA_TOURNAMENT_FIXTURE_ABORTED sessionId={session.SessionId}|" +
-            $"phase={session.Phase}|createdTournamentPreservedForRestore=True";
-    }
-
-    [CommandLineArgumentFunction("danustica_request_join", "coop.debug.tournaments")]
-    public static string RequestDanusticaJoin(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_request_join";
-        if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
-            return error;
-
-        if (!controller.TryGetTownSession(townId, out var snapshot) || snapshot.IsCompleted)
-        {
-            controller.RequestJoin(townId, null, 0);
-            return $"DANUSTICA_TOURNAMENT_JOIN_REQUESTED townId={townId}|sessionId=none|revision=0";
-        }
-        if (snapshot.Phase != TournamentSessionPhase.Preparation)
-        {
-            return
-                $"Danustica session {snapshot.SessionId} is in phase {snapshot.Phase}, not Preparation.";
-        }
-
-        controller.RequestJoin(townId, snapshot.SessionId, snapshot.Revision);
-        return
-            $"DANUSTICA_TOURNAMENT_JOIN_REQUESTED townId={townId}|" +
-            $"sessionId={snapshot.SessionId}|revision={snapshot.Revision}";
-    }
-
-    [CommandLineArgumentFunction("danustica_request_start", "coop.debug.tournaments")]
-    public static string RequestDanusticaStart(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_request_start";
-        if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
-            return error;
-        if (!controller.TryGetTownSession(townId, out var snapshot))
-            return "The client has no Danustica tournament session snapshot.";
-        if (snapshot.Phase != TournamentSessionPhase.Preparation)
-            return $"Danustica session {snapshot.SessionId} is in phase {snapshot.Phase}, not Preparation.";
-
-        controller.RequestStart(townId);
-        return
-            $"DANUSTICA_TOURNAMENT_START_REQUESTED sessionId={snapshot.SessionId}|revision={snapshot.Revision}";
-    }
-
-    [CommandLineArgumentFunction("danustica_request_choice", "coop.debug.tournaments")]
-    public static string RequestDanusticaChoice(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 1 ||
-            !Enum.TryParse(args[0], true, out TournamentPlayerChoice choice) ||
-            choice == TournamentPlayerChoice.None)
-        {
-            return "Usage: coop.debug.tournaments.danustica_request_choice <Join|Watch|Skip>";
-        }
-        if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
-            return error;
-        if (!controller.TryGetTownSession(townId, out var snapshot))
-            return "The client has no Danustica tournament session snapshot.";
-        if (snapshot.Phase != TournamentSessionPhase.AwaitingChoices ||
-            string.IsNullOrEmpty(snapshot.CurrentMatchId))
-        {
-            return
-                $"Danustica session {snapshot.SessionId} is not awaiting a match choice; " +
-                $"phase={snapshot.Phase}|matchId={snapshot.CurrentMatchId ?? "none"}.";
-        }
-
-        controller.RequestChoice(snapshot, choice);
-        return
-            $"DANUSTICA_TOURNAMENT_CHOICE_REQUESTED sessionId={snapshot.SessionId}|" +
-            $"revision={snapshot.Revision}|matchId={snapshot.CurrentMatchId}|choice={choice}";
-    }
-
-    [CommandLineArgumentFunction("danustica_request_leave", "coop.debug.tournaments")]
-    public static string RequestDanusticaLeave(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_request_leave";
-        if (!TryResolveDanusticaController(out var controller, out _, out var townId, out var error))
-            return error;
-        if (!controller.TryGetTownSession(townId, out var snapshot))
-            return "The client has no Danustica tournament session snapshot.";
-
-        controller.RequestLeaveActive(snapshot);
-        return
-            $"DANUSTICA_TOURNAMENT_LEAVE_REQUESTED sessionId={snapshot.SessionId}|" +
-            $"revision={snapshot.Revision}|phase={snapshot.Phase}";
-    }
-
-    [CommandLineArgumentFunction("danustica_observe", "coop.debug.tournaments")]
-    public static string ObserveDanusticaCommand(List<string> args)
-    {
-        if (args.Count != 0)
-            return "Usage: coop.debug.tournaments.danustica_observe";
-
-        return ObserveDanustica();
-    }
-
-    private static string ObserveDanustica()
-    {
-        if (!TryResolveDanusticaContext(out var town, out var townId, out var error))
-            return error;
+        if (!TryResolveDanusticaContext(out var town, out var townId, out observation))
+            return false;
 
         TournamentGame nativeGame = Campaign.Current?.TournamentManager?.GetTournamentGame(town);
         TournamentSessionSnapshot snapshot = null;
@@ -358,7 +453,8 @@ public class TournamentDebugCommand
             $"encounterSettlement={PlayerEncounter.EncounterSettlement?.StringId ?? "none"}");
         AppendSessionState(output, snapshot, localControllerId);
         AppendMissionState(output);
-        return output.ToString().TrimEnd();
+        observation = output.ToString().TrimEnd();
+        return true;
     }
 
     private static void AppendSessionState(

--- a/source/GameInterface/Services/Towns/Commands/TownAuditorDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownAuditorDebugCommand.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Autofac;
 using Common;
 using Common.Messaging;
@@ -9,12 +10,16 @@ using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Settlements;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Towns.Commands;
 
 public class TownAuditorDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// Attempts to get the ObjectManager
     /// </summary>
@@ -34,29 +39,40 @@ public class TownAuditorDebugCommand
     /// </summary>
     /// <param name="args">actually none are being used..</param>
     /// <returns>strings of all the towns</returns>
-    [CommandLineArgumentFunction("auditor", "coop.debug.town")]
-    public static string Auditor(List<string> args)
+    public sealed class AuditorCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
+        public string Prefix => "coop.debug.town";
 
-        if (ModInformation.IsServer)
+        public string Name => "auditor";
+
+        public string Description => "Runs the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "The town Auditor debug command can only be called by a Client";
-        }
-        if (TryGetObjectManager(out var objectManager) == false)
-        {
-            return "Unable to resolve ObjectManager";
+            StringBuilder stringBuilder = new StringBuilder();
+
+            if (ModInformation.IsServer)
+            {
+                return Failed("The town Auditor debug command can only be called by a Client");
+            }
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+
+            }
+            Settlement first_settlement = Campaign.Current.CampaignObjectManager.Settlements
+                        .First();
+
+            var message = new TownAuditorSent(getAllTownInfo(objectManager, stringBuilder));
+            MessageBroker.Instance.Publish(first_settlement, message);
+
+            stringBuilder.Append("Debug command done.");
+            return Succeeded(stringBuilder.ToString());
+
 
         }
-        Settlement first_settlement = Campaign.Current.CampaignObjectManager.Settlements
-                    .First();
-
-        var message = new TownAuditorSent(getAllTownInfo(objectManager, stringBuilder));
-        MessageBroker.Instance.Publish(first_settlement, message);
-
-        stringBuilder.Append("Debug command done.");
-        return stringBuilder.ToString();
-
     }
 
     public static List<TownAuditorData> getAllTownInfo(IObjectManager objectManager, StringBuilder stringBuilder = null)
@@ -74,7 +90,7 @@ public class TownAuditorDebugCommand
             else
             {
                 Fief fief = town.Settlement.SettlementComponent as Fief;
-                
+
                 TownAuditorData auditorData = new TownAuditorData(
                     townStringId: town.StringId,
                     name: town.Name.ToString(),

--- a/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Towns.Patches;
@@ -13,12 +14,16 @@ using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Party.PartyComponents;
 using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.Core;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Villages.Commands;
 
 public class TownDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// Attempts to get the ObjectManager
     /// </summary>
@@ -38,21 +43,32 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">actually none are being used..</param>
     /// <returns>strings of all the towns</returns>
-    [CommandLineArgumentFunction("list_towns", "coop.debug.town")]
-    public static string ListTowns(List<string> args)
+    public sealed class ListTownsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
+        public string Prefix => "coop.debug.town";
 
-        List<Settlement> settlements = Campaign.Current.CampaignObjectManager.Settlements
-            .Where(settlement => settlement.IsTown).ToList();
+        public string Name => "list_towns";
 
-        settlements.ForEach((settlement) =>
+        public string Description => "Lists towns for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            Town t = settlement.Town;
-            stringBuilder.Append(string.Format("ID: '{0}'\nName: '{1}'\n", t.StringId, t.Name));
-        });
+            StringBuilder stringBuilder = new StringBuilder();
 
-        return stringBuilder.ToString();
+            List<Settlement> settlements = Campaign.Current.CampaignObjectManager.Settlements
+                .Where(settlement => settlement.IsTown).ToList();
+
+            settlements.ForEach((settlement) =>
+            {
+                Town t = settlement.Town;
+                stringBuilder.Append(string.Format("ID: '{0}'\nName: '{1}'\n", t.StringId, t.Name));
+            });
+
+            return Succeeded(stringBuilder.ToString());
+
+        }
     }
 
     // coop.debug.town.list
@@ -61,19 +77,30 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">actually none are being used..</param>
     /// <returns>strings of all the items</returns>
-    [CommandLineArgumentFunction("list_items", "coop.debug.town")]
-    public static string ListItems(List<string> args)
+    public sealed class ListItemsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
+        public string Prefix => "coop.debug.town";
 
-        List<ItemCategory> items = Campaign.Current.ObjectManager.GetObjectTypeList<ItemCategory>().ToList();
+        public string Name => "list_items";
 
-        items.ForEach((item) =>
+        public string Description => "Lists items for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            stringBuilder.Append(string.Format("ID: '{0}'\n", item.StringId));
-        });
+            StringBuilder stringBuilder = new StringBuilder();
 
-        return stringBuilder.ToString();
+            List<ItemCategory> items = Campaign.Current.ObjectManager.GetObjectTypeList<ItemCategory>().ToList();
+
+            items.ForEach((item) =>
+            {
+                stringBuilder.Append(string.Format("ID: '{0}'\n", item.StringId));
+            });
+
+            return Succeeded(stringBuilder.ToString());
+
+        }
     }
 
     /// <summary>
@@ -81,78 +108,214 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">town ID to lookup</param>
     /// <returns>Information regarding the town.</returns>
-    [CommandLineArgumentFunction("info", "coop.debug.town")]
-    public static string Info(List<string> args)
+    public sealed class InfoCoopCommand : ICoopCommand
     {
-        if (args.Count < 1)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "info";
+
+        public string Description => "Shows the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.info <townId>";
-        }
+            new ExpectedArgs("townId", "The town id."),
+        };
 
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (objectManager.TryGetObject(args[0], out Town town) == false)
-        {
-            return $"ID: '{args[0]}' not found";
-        }
-
-        Fief fief = town.Settlement.SettlementComponent as Fief;
-
-        StringBuilder sb = new();
-
-        sb.AppendFormat("ID: '{0}'\n", args[0]);
-        sb.AppendFormat("Name: '{0}'\n", town.Name);
-        sb.AppendFormat("Governor: '{0}'\n", (town.Governor != null) ? town.Governor.Name : "null");
-        sb.AppendFormat("LastCapturedBy: '{0}'\n", (town.LastCapturedBy != null) ? town.LastCapturedBy.Name : "null");
-        sb.AppendFormat("Prosperity: '{0}'\n", town.Prosperity);
-        sb.AppendFormat("Loyalty: '{0}'\n", town.Loyalty);
-        sb.AppendFormat("Security: '{0}'\n", town.Security);
-        sb.AppendFormat("InRebelliousState: '{0}'\n", town.InRebelliousState);
-        sb.AppendFormat("GarrisonAutoRecruitmentIsEnabled: '{0}'\n", town.GarrisonAutoRecruitmentIsEnabled);
-        sb.AppendFormat("Food stock '{0}' : \n", fief.FoodStocks);
-        sb.AppendFormat("TradeTaxAccumulated: '{0}'\n", town.TradeTaxAccumulated);
-        sb.AppendFormat("_tradeTax: '{0}'\n", town._tradeTax);
-        sb.AppendFormat("Sold Items: \n");
-        Town.SellLog[] logList = town._soldItems;
-        if (logList != null)
-        {
-            foreach (Town.SellLog log in logList)
+            if (TryGetObjectManager(out var objectManager) == false)
             {
-                sb.AppendFormat("SellLog: {0} {1}\n", log.Category.StringId, log.Number);
+                return Failed("Unable to resolve ObjectManager");
             }
+
+            if (objectManager.TryGetObject(args[0], out Town town) == false)
+            {
+                return Failed($"ID: '{args[0]}' not found");
+            }
+
+            Fief fief = town.Settlement.SettlementComponent as Fief;
+
+            StringBuilder sb = new();
+
+            sb.AppendFormat("ID: '{0}'\n", args[0]);
+            sb.AppendFormat("Name: '{0}'\n", town.Name);
+            sb.AppendFormat("Governor: '{0}'\n", (town.Governor != null) ? town.Governor.Name : "null");
+            sb.AppendFormat("LastCapturedBy: '{0}'\n", (town.LastCapturedBy != null) ? town.LastCapturedBy.Name : "null");
+            sb.AppendFormat("Prosperity: '{0}'\n", town.Prosperity);
+            sb.AppendFormat("Loyalty: '{0}'\n", town.Loyalty);
+            sb.AppendFormat("Security: '{0}'\n", town.Security);
+            sb.AppendFormat("InRebelliousState: '{0}'\n", town.InRebelliousState);
+            sb.AppendFormat("GarrisonAutoRecruitmentIsEnabled: '{0}'\n", town.GarrisonAutoRecruitmentIsEnabled);
+            sb.AppendFormat("Food stock '{0}' : \n", fief.FoodStocks);
+            sb.AppendFormat("TradeTaxAccumulated: '{0}'\n", town.TradeTaxAccumulated);
+            sb.AppendFormat("_tradeTax: '{0}'\n", town._tradeTax);
+            sb.AppendFormat("Sold Items: \n");
+            Town.SellLog[] logList = town._soldItems;
+            if (logList != null)
+            {
+                foreach (Town.SellLog log in logList)
+                {
+                    sb.AppendFormat("SellLog: {0} {1}\n", log.Category.StringId, log.Number);
+                }
+            }
+            return Succeeded(sb.ToString());
+
         }
-        return sb.ToString();
     }
 
-    [CommandLineArgumentFunction("garrison_backlink", "coop.debug.town")]
-    public static string GarrisonBacklink(List<string> args)
+    public sealed class GarrisonBacklinkCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.town.garrison_backlink <townId>";
-        }
+        public string Prefix => "coop.debug.town";
 
-        if (!TryGetObjectManager(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Name => "garrison_backlink";
 
-        if (!objectManager.TryGetObject(args[0], out Town town))
-        {
-            return $"ID: '{args[0]}' not found";
-        }
+        public string Description => "Runs backlink for co-op debugging.";
 
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("townId", "The town id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!TryGetObjectManager(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject(args[0], out Town town))
+            {
+                return Failed($"ID: '{args[0]}' not found");
+            }
+
+            return Succeeded(FormatGarrisonBacklink(objectManager, town, args[0]));
+
+        }
+    }
+
+    public sealed class FocusGarrisonCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "focus_garrison";
+
+        public string Description => "Focuses garrison for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("townId", "The town id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!TryGetObjectManager(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject(args[0], out Town town))
+            {
+                return Failed($"ID: '{args[0]}' not found");
+            }
+
+            var activeGarrisons = GetActiveGarrisons(town);
+            if (activeGarrisons.Count != 1)
+            {
+                return Failed($"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}");
+            }
+
+            MapScreen mapScreen = MapScreen.Instance;
+            if (mapScreen?.MapCameraView == null)
+            {
+                return Failed("Campaign map camera is unavailable");
+            }
+
+            MobileParty garrison = activeGarrisons[0];
+            var targetPosition = garrison.MapEvent?.Position ?? garrison.Position;
+            garrison.Party.SetAsCameraFollowParty();
+            mapScreen.MapCameraView.FastMoveCameraToPosition(targetPosition, mapScreen.IsInMenu);
+            mapScreen.MapCameraView.SetCameraMode(MapCameraView.CameraFollowMode.FollowParty);
+            return Succeeded($"Following {garrison.StringId} at {town.Name} on the campaign map");
+
+        }
+    }
+
+    public sealed class ApplyGarrisonLifecycleCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "apply_garrison_lifecycle";
+
+        public string Description => "Applies garrison lifecycle for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("operation", "The operation."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+            {
+                return Failed("This function can only be used by the server");
+            }
+
+
+            if (!TryGetObjectManager(out var objectManager))
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (!objectManager.TryGetObject(args[0], out Town town))
+            {
+                return Failed($"ID: '{args[0]}' not found");
+            }
+
+            var activeGarrisons = GetActiveGarrisons(town);
+            if (activeGarrisons.Count != 1)
+            {
+                return Failed($"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}");
+            }
+
+            var garrison = (GarrisonPartyComponent)activeGarrisons[0].PartyComponent;
+            switch (args[1].ToLowerInvariant())
+            {
+                case "finalize":
+                    if (!ReferenceEquals(town.GarrisonPartyComponent, garrison))
+                    {
+                        return Failed($"Refusing to finalize: {town.Name} does not point at its active garrison");
+                    }
+                    garrison.OnFinalize();
+                    break;
+                case "initialize":
+                    if (town.GarrisonPartyComponent != null &&
+                        !ReferenceEquals(town.GarrisonPartyComponent, garrison))
+                    {
+                        return Failed($"Refusing to initialize: {town.Name} points at a different garrison");
+                    }
+                    garrison.OnInitialize();
+                    break;
+                default:
+                    return Failed($"Unknown lifecycle action '{args[1]}'; expected initialize or finalize");
+            }
+
+            return Succeeded($"Applied {args[1].ToLowerInvariant()} to {activeGarrisons[0].StringId}; " +
+                   FormatGarrisonBacklink(objectManager, town, args[0]));
+
+        }
+    }
+
+    private static string FormatGarrisonBacklink(IObjectManager objectManager, Town town, string townId)
+    {
         var activeGarrisons = GetActiveGarrisons(town);
         var backlink = town.GarrisonPartyComponent;
-        string backlinkId = "null";
-        if (backlink != null)
-        {
-            backlinkId = objectManager.TryGetId(backlink, out string id) ? id : "unregistered";
-        }
-
+        string backlinkId = backlink == null
+            ? "null"
+            : objectManager.TryGetId(backlink, out string id) ? id : "unregistered";
         string activeParties = activeGarrisons.Count == 0
             ? "none"
             : string.Join(",", activeGarrisons.Select(party => party.StringId));
@@ -160,103 +323,10 @@ public class TownDebugCommand
                                      ReferenceEquals(activeGarrisons[0].PartyComponent, backlink);
 
         return $"{(ModInformation.IsServer ? "SERVER" : "CLIENT")} " +
-               $"town={args[0]} settlement={town.Settlement.StringId} " +
+               $"town={townId} settlement={town.Settlement.StringId} " +
                $"backlinkComponent={backlinkId} backlinkParty={backlink?.MobileParty?.StringId ?? "null"} " +
                $"activeGarrisonCount={activeGarrisons.Count} activeGarrisonParties={activeParties} " +
                $"backlinkMatchesActive={backlinkMatchesActive}";
-    }
-
-    [CommandLineArgumentFunction("focus_garrison", "coop.debug.town")]
-    public static string FocusGarrison(List<string> args)
-    {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.town.focus_garrison <townId>";
-        }
-
-        if (!TryGetObjectManager(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
-
-        if (!objectManager.TryGetObject(args[0], out Town town))
-        {
-            return $"ID: '{args[0]}' not found";
-        }
-
-        var activeGarrisons = GetActiveGarrisons(town);
-        if (activeGarrisons.Count != 1)
-        {
-            return $"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}";
-        }
-
-        MapScreen mapScreen = MapScreen.Instance;
-        if (mapScreen?.MapCameraView == null)
-        {
-            return "Campaign map camera is unavailable";
-        }
-
-        MobileParty garrison = activeGarrisons[0];
-        var targetPosition = garrison.MapEvent?.Position ?? garrison.Position;
-        garrison.Party.SetAsCameraFollowParty();
-        mapScreen.MapCameraView.FastMoveCameraToPosition(targetPosition, mapScreen.IsInMenu);
-        mapScreen.MapCameraView.SetCameraMode(MapCameraView.CameraFollowMode.FollowParty);
-        return $"Following {garrison.StringId} at {town.Name} on the campaign map";
-    }
-
-    [CommandLineArgumentFunction("apply_garrison_lifecycle", "coop.debug.town")]
-    public static string ApplyGarrisonLifecycle(List<string> args)
-    {
-        if (ModInformation.IsClient)
-        {
-            return "This function can only be used by the server";
-        }
-
-        if (args.Count != 2)
-        {
-            return "Usage: coop.debug.town.apply_garrison_lifecycle <townId> <initialize|finalize>";
-        }
-
-        if (!TryGetObjectManager(out var objectManager))
-        {
-            return "Unable to resolve ObjectManager";
-        }
-
-        if (!objectManager.TryGetObject(args[0], out Town town))
-        {
-            return $"ID: '{args[0]}' not found";
-        }
-
-        var activeGarrisons = GetActiveGarrisons(town);
-        if (activeGarrisons.Count != 1)
-        {
-            return $"Expected exactly one active garrison for {town.Name}, found {activeGarrisons.Count}";
-        }
-
-        var garrison = (GarrisonPartyComponent)activeGarrisons[0].PartyComponent;
-        switch (args[1].ToLowerInvariant())
-        {
-            case "finalize":
-                if (!ReferenceEquals(town.GarrisonPartyComponent, garrison))
-                {
-                    return $"Refusing to finalize: {town.Name} does not point at its active garrison";
-                }
-                garrison.OnFinalize();
-                break;
-            case "initialize":
-                if (town.GarrisonPartyComponent != null &&
-                    !ReferenceEquals(town.GarrisonPartyComponent, garrison))
-                {
-                    return $"Refusing to initialize: {town.Name} points at a different garrison";
-                }
-                garrison.OnInitialize();
-                break;
-            default:
-                return $"Unknown lifecycle action '{args[1]}'; expected initialize or finalize";
-        }
-
-        return $"Applied {args[1].ToLowerInvariant()} to {activeGarrisons[0].StringId}; " +
-               GarrisonBacklink(new List<string> { args[0] });
     }
 
     private static List<MobileParty> GetActiveGarrisons(Town town)
@@ -274,21 +344,34 @@ public class TownDebugCommand
     /// building's level/progress, so server and client screenshots can be compared to confirm the building
     /// collection still replicates.
     /// </summary>
-    [CommandLineArgumentFunction("list_buildings", "coop.debug.town")]
-    public static string ListBuildings(List<string> args)
+    public sealed class ListBuildingsCoopCommand : ICoopCommand
     {
-        if (args.Count != 1) return "Usage: coop.debug.town.list_buildings <townId>";
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager";
-        if (objectManager.TryGetObject(args[0], out Town town) == false) return $"ID: '{args[0]}' not found";
+        public string Prefix => "coop.debug.town";
 
-        StringBuilder sb = new();
-        sb.AppendFormat("Buildings for '{0}' ({1}):\n", town.Name, town.Buildings.Count);
-        foreach (var building in town.Buildings)
-            sb.AppendFormat("  {0} level={1} progress={2}\n", building.BuildingType?.StringId, building.CurrentLevel, building.BuildingProgress);
-        sb.AppendFormat("BuildingsInProgress queue ({0}):\n", town.BuildingsInProgress.Count);
-        foreach (var building in town.BuildingsInProgress)
-            sb.AppendFormat("  {0} level={1}\n", building.BuildingType?.StringId, building.CurrentLevel);
-        return sb.ToString();
+        public string Name => "list_buildings";
+
+        public string Description => "Lists buildings for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("townId", "The town id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager");
+            if (objectManager.TryGetObject(args[0], out Town town) == false) return Failed($"ID: '{args[0]}' not found");
+
+            StringBuilder sb = new();
+            sb.AppendFormat("Buildings for '{0}' ({1}):\n", town.Name, town.Buildings.Count);
+            foreach (var building in town.Buildings)
+                sb.AppendFormat("  {0} level={1} progress={2}\n", building.BuildingType?.StringId, building.CurrentLevel, building.BuildingProgress);
+            sb.AppendFormat("BuildingsInProgress queue ({0}):\n", town.BuildingsInProgress.Count);
+            foreach (var building in town.BuildingsInProgress)
+                sb.AppendFormat("  {0} level={1}\n", building.BuildingType?.StringId, building.CurrentLevel);
+            return Succeeded(sb.ToString());
+
+        }
     }
 
     // coop.debug.town.list_workshops <townId>
@@ -296,18 +379,31 @@ public class TownDebugCommand
     /// Lists a town's Workshops (the synced collection-PROPERTY array) with each workshop's type and owner,
     /// so server and client screenshots can be compared to confirm the workshop collection still replicates.
     /// </summary>
-    [CommandLineArgumentFunction("list_workshops", "coop.debug.town")]
-    public static string ListWorkshops(List<string> args)
+    public sealed class ListWorkshopsCoopCommand : ICoopCommand
     {
-        if (args.Count != 1) return "Usage: coop.debug.town.list_workshops <townId>";
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager";
-        if (objectManager.TryGetObject(args[0], out Town town) == false) return $"ID: '{args[0]}' not found";
+        public string Prefix => "coop.debug.town";
 
-        StringBuilder sb = new();
-        sb.AppendFormat("Workshops for '{0}' ({1}):\n", town.Name, town.Workshops.Length);
-        foreach (var workshop in town.Workshops)
-            sb.AppendFormat("  {0} owner={1}\n", workshop.WorkshopType?.StringId, workshop.Owner?.Name);
-        return sb.ToString();
+        public string Name => "list_workshops";
+
+        public string Description => "Lists workshops for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("townId", "The town id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager");
+            if (objectManager.TryGetObject(args[0], out Town town) == false) return Failed($"ID: '{args[0]}' not found");
+
+            StringBuilder sb = new();
+            sb.AppendFormat("Workshops for '{0}' ({1}):\n", town.Name, town.Workshops.Length);
+            foreach (var workshop in town.Workshops)
+                sb.AppendFormat("  {0} owner={1}\n", workshop.WorkshopType?.StringId, workshop.Owner?.Name);
+            return Succeeded(sb.ToString());
+
+        }
     }
 
     // coop.debug.town.set_foodStocks
@@ -316,36 +412,47 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">first arg : townId ; second arg : stock value</param>
     /// <returns></returns>
-    [CommandLineArgumentFunction("set_foodStocks", "coop.debug.town")]
-    public static string SetFoodStocks(List<string> args)
+    public sealed class SetFoodStocksCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_food_stocks";
+
+        public string Description => "Sets food stocks for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_foodStocks <townId> <foodStocks> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("foodStocks", "The food stocks."),
+        };
 
-        string townId = args[0];
-        string foodStocksString = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"Town with ID: '{townId}' not found";
-        }
-        
-        Fief fief = town.Settlement.SettlementComponent as Fief;
 
-        if (float.TryParse(foodStocksString, out float foodStocks) == false)
-        {
-            return $"Argument2: {foodStocksString} is not a float.";
+            string townId = args[0];
+            string foodStocksString = args[1];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"Town with ID: '{townId}' not found");
+            }
+
+            Fief fief = town.Settlement.SettlementComponent as Fief;
+
+            if (float.TryParse(foodStocksString, out float foodStocks) == false)
+            {
+                return Failed($"Argument2: {foodStocksString} is not a float.");
+            }
+
+            fief.FoodStocks = foodStocks;
+
+            return Succeeded($"Town food stocks has changed to: {fief.FoodStocks}");
+
         }
-
-        fief.FoodStocks = foodStocks;
-
-        return $"Town food stocks has changed to: {fief.FoodStocks}";
     }
 
     // coop.debug.town.set_governor town_comp_V1 lord_1_1
@@ -354,35 +461,46 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the heroID to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_governor", "coop.debug.town")]
-    public static string SetTownGovernor(List<string> args)
+    public sealed class SetTownGovernorCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_governor";
+
+        public string Description => "Sets governor for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_governor <townId> <heroId> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("heroId", "The hero id."),
+        };
 
-        string townId = args[0];
-        string heroId = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            string townId = args[0];
+            string heroId = args[1];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"Town with ID: '{townId}' not found");
+            }
+
+            if (objectManager.TryGetObject(heroId, out Hero hero) == false)
+            {
+                return Failed($"Hero with ID: '{heroId}' not found");
+            }
+
+            town.Governor = hero;
+
+            return Succeeded($"Town governor has changed to: {town.Governor?.Name} hero with ID: {town.Governor?.StringId}");
+
         }
-
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"Town with ID: '{townId}' not found";
-        }
-
-        if (objectManager.TryGetObject(heroId, out Hero hero) == false)
-        {
-            return $"Hero with ID: '{heroId}' not found";
-        }
-
-        town.Governor = hero;
-
-        return $"Town governor has changed to: {town.Governor?.Name} hero with ID: {town.Governor?.StringId}";
     }
 
     // coop.debug.town.set_last_captured_by town_comp_V1 clan_sturgia_2
@@ -391,35 +509,46 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the clanID to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_last_captured_by", "coop.debug.town")]
-    public static string SetTownLastCapturedBy(List<string> args)
+    public sealed class SetTownLastCapturedByCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_last_captured_by";
+
+        public string Description => "Sets last captured by for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_last_captured_by <townId> <clanId> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("clanId", "The clan id."),
+        };
 
-        string townId = args[0];
-        string clanId = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            string townId = args[0];
+            string clanId = args[1];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (objectManager.TryGetObject(clanId, out Clan clan) == false)
+            {
+                return Failed($"{nameof(Clan)} with ID: '{clanId}' not found");
+            }
+
+            town.LastCapturedBy = clan;
+
+            return Succeeded($"{nameof(Town.LastCapturedBy)} has changed to: {town.LastCapturedBy.Name} clan with ID: {town.LastCapturedBy.StringId}");
+
         }
-
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
-
-        if (objectManager.TryGetObject(clanId, out Clan clan) == false)
-        {
-            return $"{nameof(Clan)} with ID: '{clanId}' not found";
-        }
-
-        town.LastCapturedBy = clan;
-
-        return $"{nameof(Town.LastCapturedBy)} has changed to: {town.LastCapturedBy.Name} clan with ID: {town.LastCapturedBy.StringId}";
     }
 
     // coop.debug.town.add_item_to_sold_items town_comp_V1 noble_horse 100
@@ -428,60 +557,72 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the itemID to add and a number to add.</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("add_item_to_sold_items", "coop.debug.town")]
-    public static string AddToTownSoldItems(List<string> args)
+    public sealed class AddToTownSoldItemsCoopCommand : ICoopCommand
     {
-        if (args.Count != 3)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "add_item_to_sold_items";
+
+        public string Description => "Adds item to sold items for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.add_item_to_sold_items <townId> <itemId> <numberOfItems>";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("itemId", "The item id."),
+            new ExpectedArgs("numberOfItems", "The number of items."),
+        };
 
-        string townId = args[0];
-        string itemId = args[1];
-        string count = args[2];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
+
+            string townId = args[0];
+            string itemId = args[1];
+            string count = args[2];
+
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (objectManager.TryGetObject(itemId, out ItemCategory item) == false)
+            {
+                return Failed($"{nameof(ItemCategory)} with ID: '{itemId}' not found");
+            }
+
+            if (int.TryParse(count, out int numberOfItems) == false)
+            {
+                return Failed($"Argument3: {count} is not an integer.");
+            }
+
+
+            List<Town.SellLog> newSoldItems = new List<Town.SellLog>(town._soldItems);
+            int idx = newSoldItems.FindIndex(log => log.Category == item);
+            if (idx != -1)
+            {
+                newSoldItems[idx] = new Town.SellLog(item, newSoldItems[idx].Number + numberOfItems);
+            }
+            else
+            {
+                newSoldItems.Add(new Town.SellLog(item, numberOfItems));
+            }
+            town.SetSoldItems(newSoldItems);
+
+            // Check if item was added
+            if (town.SoldItems.Count(soldItem => soldItem.Category == item) <= 0)
+            {
+                return Failed($"Unable to find {item} in {nameof(Town.SoldItems)}");
+            }
+
+            var newItem = town.SoldItems.First(soldItem => soldItem.Category == item);
+
+            return Succeeded($"Added {newItem.Number} number of {newItem.Category.StringId} to Town SoldItems");
+
         }
-
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
-
-        if (objectManager.TryGetObject(itemId, out ItemCategory item) == false)
-        {
-            return $"{nameof(ItemCategory)} with ID: '{itemId}' not found";
-        }
-
-        if (int.TryParse(count, out int numberOfItems) == false)
-        {
-            return $"Argument3: {count} is not an integer.";
-        }
-
-
-        List<Town.SellLog> newSoldItems = new List<Town.SellLog>(town._soldItems);
-        int idx = newSoldItems.FindIndex(log => log.Category == item);
-        if (idx != -1)
-        {
-            newSoldItems[idx] = new Town.SellLog(item, newSoldItems[idx].Number + numberOfItems);
-        }
-        else
-        {
-            newSoldItems.Add(new Town.SellLog(item, numberOfItems));
-        }
-        town.SetSoldItems(newSoldItems);
-
-        // Check if item was added
-        if (town.SoldItems.Count(soldItem => soldItem.Category == item) <= 0)
-        {
-            return $"Unable to find {item} in {nameof(Town.SoldItems)}";
-        }
-
-        var newItem = town.SoldItems.First(soldItem => soldItem.Category == item);
-
-        return $"Added {newItem.Number} number of {newItem.Category.StringId} to Town SoldItems";
     }
 
     // coop.debug.town.set_prosperity town_comp_V1 100
@@ -490,34 +631,45 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the prosperity to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_prosperity", "coop.debug.town")]
-    public static string SetTownProsperity(List<string> args)
+    public sealed class SetTownProsperityCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_prosperity";
+
+        public string Description => "Sets prosperity for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_prosperity <townId> <prosperity> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("prosperity", "The prosperity."),
+        };
 
-        string townId = args[0];
-        string prosperityValue = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
+            string townId = args[0];
+            string prosperityValue = args[1];
 
-        if (int.TryParse(prosperityValue, out int prosperity) == false)
-        {
-            return $"Argument2: {prosperityValue} is not an integer.";
-        }
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        town.Prosperity = prosperity;
-        return $"Town Prosperity has changed to: {town.Prosperity}.";
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (int.TryParse(prosperityValue, out int prosperity) == false)
+            {
+                return Failed($"Argument2: {prosperityValue} is not an integer.");
+            }
+
+            town.Prosperity = prosperity;
+            return Succeeded($"Town Prosperity has changed to: {town.Prosperity}.");
+
+        }
     }
 
     // coop.debug.town.set_loyalty town_comp_V1 100
@@ -526,34 +678,45 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the loyalty to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_loyalty", "coop.debug.town")]
-    public static string SetTownLoyalty(List<string> args)
+    public sealed class SetTownLoyaltyCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_loyalty";
+
+        public string Description => "Sets loyalty for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_loyalty <townId> <loyalty> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("loyalty", "The loyalty."),
+        };
 
-        string townId = args[0];
-        string loyaltyValue = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
+            string townId = args[0];
+            string loyaltyValue = args[1];
 
-        if (float.TryParse(loyaltyValue, out float loyalty) == false)
-        {
-            return $"Argument2: {loyaltyValue} is not a float.";
-        }
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        town.Loyalty = loyalty;
-        return $"Town Loyalty has changed to: {town.Loyalty}.";
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (float.TryParse(loyaltyValue, out float loyalty) == false)
+            {
+                return Failed($"Argument2: {loyaltyValue} is not a float.");
+            }
+
+            town.Loyalty = loyalty;
+            return Succeeded($"Town Loyalty has changed to: {town.Loyalty}.");
+
+        }
     }
 
     // coop.debug.town.set_security town_comp_V1 100
@@ -562,34 +725,45 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the security to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_security", "coop.debug.town")]
-    public static string SetTownSecurity(List<string> args)
+    public sealed class SetTownSecurityCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_security";
+
+        public string Description => "Sets security for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_loyalty <townId> <security> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("security", "The security."),
+        };
 
-        string townId = args[0];
-        string securityValue = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
+            string townId = args[0];
+            string securityValue = args[1];
 
-        if (float.TryParse(securityValue, out float security) == false)
-        {
-            return $"Argument2: {securityValue} is not a float.";
-        }
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        town.Security = security;
-        return $"Town Security has changed to: {town.Security}.";
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (float.TryParse(securityValue, out float security) == false)
+            {
+                return Failed($"Argument2: {securityValue} is not a float.");
+            }
+
+            town.Security = security;
+            return Succeeded($"Town Security has changed to: {town.Security}.");
+
+        }
     }
 
 
@@ -599,53 +773,77 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the rebellious state to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_in_rebellious_state", "coop.debug.town")]
-    public static string SetTownInRebelliousState(List<string> args)
+    public sealed class SetTownInRebelliousStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_in_rebellious_state";
+
+        public string Description => "Sets in rebellious state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_in_rebellious_state <townId> <in_rebellious_state> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("inRebelliousState", "The in rebellious state."),
+        };
 
-        string townId = args[0];
-        string rebellionStateValue = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
+            string townId = args[0];
+            string rebellionStateValue = args[1];
 
-        if (bool.TryParse(rebellionStateValue, out bool inRebelliousState) == false)
-        {
-            return $"Argument2: {rebellionStateValue} is not a boolean.";
-        }
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        RebellionsCampaignBehaviorPatches.PublishTownInRebelliousStateChanged(town, inRebelliousState);
-        return $"Town InRebelliousState has changed to: {town.InRebelliousState}.";
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (bool.TryParse(rebellionStateValue, out bool inRebelliousState) == false)
+            {
+                return Failed($"Argument2: {rebellionStateValue} is not a boolean.");
+            }
+
+            RebellionsCampaignBehaviorPatches.PublishTownInRebelliousStateChanged(town, inRebelliousState);
+            return Succeeded($"Town InRebelliousState has changed to: {town.InRebelliousState}.");
+
+        }
     }
 
-    [CommandLineArgumentFunction("start_rebellion", "coop.debug.town")]
-    public static string StartRebellion(List<string> args)
+    public sealed class StartRebellionCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Run coop.debug.town.start_rebellion on the server.";
-        if (args.Count != 1) return "Usage: coop.debug.town.start_rebellion <townId>";
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager";
-        if (objectManager.TryGetObject(args[0], out Town town) == false)
-            return $"{nameof(Town)} with ID: '{args[0]}' not found";
-        if (town.OwnerClan.IsRebelClan) return $"{town.Name} is already owned by a rebel clan.";
-        if (town.Settlement.Party.MapEvent != null) return $"{town.Name} is in a map event.";
-        if (town.Settlement.Party.SiegeEvent != null) return $"{town.Name} is under siege.";
+        public string Prefix => "coop.debug.town";
 
-        RebellionsCampaignBehavior behavior = Campaign.Current.GetCampaignBehavior<RebellionsCampaignBehavior>();
-        if (behavior == null) return "Unable to resolve RebellionsCampaignBehavior";
+        public string Name => "start_rebellion";
 
-        behavior.StartRebellionEvent(town.Settlement);
-        return $"Started the vanilla rebellion in {town.Name}. New owner: {town.OwnerClan.Name} (rebel={town.OwnerClan.IsRebelClan}).";
+        public string Description => "Starts rebellion for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("townId", "The town id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient) return Failed("Run coop.debug.town.start_rebellion on the server.");
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager");
+            if (objectManager.TryGetObject(args[0], out Town town) == false)
+                return Failed($"{nameof(Town)} with ID: '{args[0]}' not found");
+            if (town.OwnerClan.IsRebelClan) return Failed($"{town.Name} is already owned by a rebel clan.");
+            if (town.Settlement.Party.MapEvent != null) return Failed($"{town.Name} is in a map event.");
+            if (town.Settlement.Party.SiegeEvent != null) return Failed($"{town.Name} is under siege.");
+
+            RebellionsCampaignBehavior behavior = Campaign.Current.GetCampaignBehavior<RebellionsCampaignBehavior>();
+            if (behavior == null) return Failed("Unable to resolve RebellionsCampaignBehavior");
+
+            behavior.StartRebellionEvent(town.Settlement);
+            return Succeeded($"Started the vanilla rebellion in {town.Name}. New owner: {town.OwnerClan.Name} (rebel={town.OwnerClan.IsRebelClan}).");
+
+        }
     }
 
     // coop.debug.town.set_garrison_auto_recruitment town_comp_V1 false
@@ -654,34 +852,45 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">townID and the GarrisonAutoRecruitmentIsEnabled property value to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_garrison_auto_recruitment", "coop.debug.town")]
-    public static string SetTownGarrisonAutoRecruitmentIsEnabled(List<string> args)
+    public sealed class SetTownGarrisonAutoRecruitmentIsEnabledCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_garrison_auto_recruitment";
+
+        public string Description => "Sets garrison auto recruitment for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_garrison_auto_recruitment <townId> <garrison_auto_recruitment_enabled> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("enabled", "The enabled."),
+        };
 
-        string townId = args[0];
-        string garrisonRecruitmentValue = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
+            string townId = args[0];
+            string garrisonRecruitmentValue = args[1];
 
-        if (bool.TryParse(garrisonRecruitmentValue, out bool garrisonAutoRecruitmentIsEnabled) == false)
-        {
-            return $"Argument2: {garrisonRecruitmentValue} is not a boolean.";
-        }
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        UpdateClanSettlementAutoRecruitmentPatches.PublishTownGarrisonAutoRecruitmentIsEnabledChanged(town, garrisonAutoRecruitmentIsEnabled);
-        return $"Town GarrisonAutoRecruitmentIsEnabled has changed to: {town.GarrisonAutoRecruitmentIsEnabled}.";
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (bool.TryParse(garrisonRecruitmentValue, out bool garrisonAutoRecruitmentIsEnabled) == false)
+            {
+                return Failed($"Argument2: {garrisonRecruitmentValue} is not a boolean.");
+            }
+
+            UpdateClanSettlementAutoRecruitmentPatches.PublishTownGarrisonAutoRecruitmentIsEnabledChanged(town, garrisonAutoRecruitmentIsEnabled);
+            return Succeeded($"Town GarrisonAutoRecruitmentIsEnabled has changed to: {town.GarrisonAutoRecruitmentIsEnabled}.");
+
+        }
     }
 
     // coop.debug.town.set_trade_tax_acc town_comp_V1 100
@@ -690,34 +899,45 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">the town and tradetaxaccumulated value float</param>
     /// <returns>string output if success</returns>
-    [CommandLineArgumentFunction("set_trade_tax_acc", "coop.debug.town")]
-    public static string SetTradeTaxAccumulated(List<string> args)
+    public sealed class SetTradeTaxAccumulatedCoopCommand : ICoopCommand
     {
-        if (args.Count != 2)
+        public string Prefix => "coop.debug.town";
+
+        public string Name => "set_trade_tax_acc";
+
+        public string Description => "Sets trade tax acc for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.town.set_trade_tax_acc <townId> <0.0> ";
-        }
+            new ExpectedArgs("townId", "The town id."),
+            new ExpectedArgs("tradeTax", "The trade tax."),
+        };
 
-        string townId = args[0];
-        string tradeTaxAccumulatedValue = args[1];
-
-        if (TryGetObjectManager(out var objectManager) == false)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return "Unable to resolve ObjectManager";
-        }
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
-        {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
-        }
+            string townId = args[0];
+            string tradeTaxAccumulatedValue = args[1];
 
-        if (int.TryParse(tradeTaxAccumulatedValue, out int tradeTaxAccumulated) == false)
-        {
-            return $"Argument2: {tradeTaxAccumulatedValue} is not an integer.";
-        }
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
 
-        town.TradeTaxAccumulated = tradeTaxAccumulated;
-        return $"Town TradeTaxAccumulated has changed to: {town.TradeTaxAccumulated}.";
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+
+            if (int.TryParse(tradeTaxAccumulatedValue, out int tradeTaxAccumulated) == false)
+            {
+                return Failed($"Argument2: {tradeTaxAccumulatedValue} is not an integer.");
+            }
+
+            town.TradeTaxAccumulated = tradeTaxAccumulated;
+            return Succeeded($"Town TradeTaxAccumulated has changed to: {town.TradeTaxAccumulated}.");
+
+        }
     }
 
     // coop.debug.town.set_trade_tax_acc town_comp_V1 100
@@ -726,25 +946,35 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">the town and tradetaxaccumulated value float</param>
     /// <returns>string output if success</returns>
-    [CommandLineArgumentFunction("change_current_building", "coop.debug.town")]
-    public static string ChangeCurrentBuilding(List<string> args)
+    public sealed class ChangeCurrentBuildingCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.town.change_current_building <townId>";
-        }
-        string townId = args[0];
-        if (TryGetObjectManager(out var objectManager) == false)
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Prefix => "coop.debug.town";
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
+        public string Name => "change_current_building";
+
+        public string Description => "Changes current building for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
+            new ExpectedArgs("townId", "The town id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string townId = args[0];
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+            //BuildingHelper.ChangeCurrentBuilding(town.Buildings.Last().BuildingType, town);
+            return Succeeded("success");
+
         }
-        //BuildingHelper.ChangeCurrentBuilding(town.Buildings.Last().BuildingType, town);
-        return "success";
     }
 
     // coop.debug.town.set_trade_tax_acc town_comp_V1 100
@@ -753,57 +983,80 @@ public class TownDebugCommand
     /// </summary>
     /// <param name="args">the town and tradetaxaccumulated value float</param>
     /// <returns>string output if success</returns>
-    [CommandLineArgumentFunction("change_current_building_queue", "coop.debug.town")]
-    public static string ChangeCurrentBuildingQueue(List<string> args)
+    public sealed class ChangeCurrentBuildingQueueCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.town.change_current_building_queue <townId>";
-        }
-        string townId = args[0];
-        if (TryGetObjectManager(out var objectManager) == false)
-        {
-            return "Unable to resolve ObjectManager";
-        }
+        public string Prefix => "coop.debug.town";
 
-        if (objectManager.TryGetObject(townId, out Town town) == false)
+        public string Name => "change_current_building_queue";
+
+        public string Description => "Changes current building queue for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"{nameof(Town)} with ID: '{townId}' not found";
+            new ExpectedArgs("townId", "The town id."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string townId = args[0];
+            if (TryGetObjectManager(out var objectManager) == false)
+            {
+                return Failed("Unable to resolve ObjectManager");
+            }
+
+            if (objectManager.TryGetObject(townId, out Town town) == false)
+            {
+                return Failed($"{nameof(Town)} with ID: '{townId}' not found");
+            }
+            BuildingHelper.ChangeCurrentBuildingQueue(town.Buildings, town);
+            return Succeeded("success");
+
         }
-        BuildingHelper.ChangeCurrentBuildingQueue(town.Buildings, town);
-        return "success";
     }
 
     /// <summary>
     /// View town management data of a specified town
     /// </summary>
-    [CommandLineArgumentFunction("managementdata", "coop.debug.town")]
-    public static string ViewManagementData(List<string> strings)
+    public sealed class ViewManagementDataCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0) return "Town name argument required.";
+        public string Prefix => "coop.debug.town";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var town in Town.AllTowns)
+        public string Name => "management_data";
+
+        public string Description => "Runs data for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (town.Name.ToString() == strings[0])
+            new ExpectedArgs("townName", "The exact town name; quote values containing spaces."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var town in Town.AllTowns)
             {
-                stringBuilder.AppendLine(town.Name.ToString() + ":");
-                stringBuilder.AppendLine("Reserves: " + town.BoostBuildingProcess.ToString());
-                stringBuilder.AppendLine("Governor Name: " + town.Governor?.Name?.ToString());
-                stringBuilder.AppendLine("Current default building: " + town.CurrentDefaultBuilding?.Name?.ToString());
-                stringBuilder.AppendLine("Current building queue:");
-                foreach (var building in town.BuildingsInProgress)
+                if (town.Name.ToString() == strings[0])
                 {
-                    stringBuilder.AppendLine(building.Name.ToString());
+                    stringBuilder.AppendLine(town.Name.ToString() + ":");
+                    stringBuilder.AppendLine("Reserves: " + town.BoostBuildingProcess.ToString());
+                    stringBuilder.AppendLine("Governor Name: " + town.Governor?.Name?.ToString());
+                    stringBuilder.AppendLine("Current default building: " + town.CurrentDefaultBuilding?.Name?.ToString());
+                    stringBuilder.AppendLine("Current building queue:");
+                    foreach (var building in town.BuildingsInProgress)
+                    {
+                        stringBuilder.AppendLine(building.Name.ToString());
+                    }
                 }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Town not found.");
+
         }
-        return "Town not found.";
     }
 }

--- a/source/GameInterface/Services/Villages/Commands/RaidDebugCommands.cs
+++ b/source/GameInterface/Services/Villages/Commands/RaidDebugCommands.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Autofac;
 using Common;
 using Common.Network;
@@ -5,37 +6,51 @@ using GameInterface.Services.MapEvents;
 using GameInterface.Services.MapEvents.Handlers;
 using GameInterface.Services.MapEvents.Messages;
 using System.Collections.Generic;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Villages.Commands;
 
 public class RaidDebugCommands
 {
-    [CommandLineArgumentFunction("allow_raid_ai_intervention", "coop.debug.mapevent")]
-    public static string AllowRaidAiIntervention(List<string> args)
-    {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.mapevent.allow_raid_ai_intervention <on|off|toggle|status>";
-        }
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 
-        var value = args[0].ToLowerInvariant();
-        switch (value)
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class AllowRaidAiInterventionCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.mapevent";
+
+        public string Name => "allow_raid_ai_intervention";
+
+        public string Description => "Controls raid ai intervention for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "on":
-            case "true":
-            case "1":
-                return ApplyRaidAiInterventionConfig(true);
-            case "off":
-            case "false":
-            case "0":
-                return ApplyRaidAiInterventionConfig(false);
-            case "toggle":
-                return ApplyRaidAiInterventionConfig(!MapEventConfig.AllowRaidAiIntervention);
-            case "status":
-                return RaidAiInterventionConfigHandler.StatusText;
-            default:
-                return "Usage: coop.debug.mapevent.allow_raid_ai_intervention <on|off|toggle|status>";
+            new ExpectedArgs("mode", "The mode."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            var value = args[0].ToLowerInvariant();
+            switch (value)
+            {
+                case "on":
+                case "true":
+                case "1":
+                    return Succeeded(ApplyRaidAiInterventionConfig(true));
+                case "off":
+                case "false":
+                case "0":
+                    return Succeeded(ApplyRaidAiInterventionConfig(false));
+                case "toggle":
+                    return Succeeded(ApplyRaidAiInterventionConfig(!MapEventConfig.AllowRaidAiIntervention));
+                case "status":
+                    return Succeeded(RaidAiInterventionConfigHandler.StatusText);
+                default:
+                    return Failed("Invalid action. Use on, off, toggle, or status.");
+            }
+
         }
     }
 

--- a/source/GameInterface/Services/Villages/Commands/VillageDebugCommand.cs
+++ b/source/GameInterface/Services/Villages/Commands/VillageDebugCommand.cs
@@ -1,16 +1,21 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Settlements;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Villages.Commands;
 
 internal class VillageDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// Finds a specific village in game.
     /// </summary>
@@ -30,21 +35,32 @@ internal class VillageDebugCommand
     /// </summary>
     /// <param name="args">actually none are being used..</param>
     /// <returns>strings of all the villages</returns>
-    [CommandLineArgumentFunction("list", "coop.debug.village")]
-    public static string ListVillages(List<string> args)
+    public sealed class ListVillagesCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
+        public string Prefix => "coop.debug.village";
 
-        List<Settlement> settlements = Campaign.Current.CampaignObjectManager.Settlements
-            .Where(settlement => settlement.IsVillage).ToList();
+        public string Name => "list";
 
-        settlements.ForEach((settlement) =>
+        public string Description => "Lists the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            Village v = settlement.Village;
-            stringBuilder.Append(string.Format("ID: '{0}'\nName: '{1}'\n", v.StringId, v.Name));
-        });
+            StringBuilder stringBuilder = new StringBuilder();
 
-        return stringBuilder.ToString();
+            List<Settlement> settlements = Campaign.Current.CampaignObjectManager.Settlements
+                .Where(settlement => settlement.IsVillage).ToList();
+
+            settlements.ForEach((settlement) =>
+            {
+                Village v = settlement.Village;
+                stringBuilder.Append(string.Format("ID: '{0}'\nName: '{1}'\n", v.StringId, v.Name));
+            });
+
+            return Succeeded(stringBuilder.ToString());
+
+        }
     }
 
     /// coop.debug.village.info castle_village_comp_K7_2
@@ -54,33 +70,43 @@ internal class VillageDebugCommand
     /// </summary>
     /// <param name="args">vilage ID to lookup</param>
     /// <returns>Information regarding the village.</returns>
-    [CommandLineArgumentFunction("info", "coop.debug.village")]
-    public static string Info(List<string> args)
+    public sealed class InfoCoopCommand : ICoopCommand
     {
-        if (args.Count < 1)
+        public string Prefix => "coop.debug.village";
+
+        public string Name => "info";
+
+        public string Description => "Shows the relevant state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.village.info <villageId>";
-        }
+            new ExpectedArgs("villageId", "The village id."),
+        };
 
-        Village village = findVillage(args[0]);
-
-        if (village == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return string.Format("ID: '{0}' not found", args[0]);
+
+            Village village = findVillage(args[0]);
+
+            if (village == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+
+            StringBuilder sb = new();
+
+            sb.AppendFormat("ID: '{0}'\n", args[0]);
+            sb.AppendFormat("Name: '{0}'\n", village.Name);
+            sb.AppendFormat("Owner: '{0}'\n", village.Owner.Name);
+            sb.AppendFormat("State: '{0}'\n", village.VillageState.ToString());
+            sb.AppendFormat("Hearth: '{0}'\n", village.Hearth);
+            sb.AppendFormat("TradeTaxAccumulated: '{0}'\n", village.TradeTaxAccumulated);
+            sb.AppendFormat("LastDemandStatisifiedTime: '{0}'\n", village.LastDemandSatisfiedTime);
+
+            return Succeeded(sb.ToString());
+
         }
-
-
-        StringBuilder sb = new();
-
-        sb.AppendFormat("ID: '{0}'\n", args[0]);
-        sb.AppendFormat("Name: '{0}'\n", village.Name);
-        sb.AppendFormat("Owner: '{0}'\n", village.Owner.Name);
-        sb.AppendFormat("State: '{0}'\n", village.VillageState.ToString());
-        sb.AppendFormat("Hearth: '{0}'\n", village.Hearth);
-        sb.AppendFormat("TradeTaxAccumulated: '{0}'\n", village.TradeTaxAccumulated);
-        sb.AppendFormat("LastDemandStatisifiedTime: '{0}'\n", village.LastDemandSatisfiedTime);
-
-        return sb.ToString();
     }
 
     // coop.debug.village.set_state castle_village_comp_K7_2 BeingRaided
@@ -89,32 +115,43 @@ internal class VillageDebugCommand
     /// </summary>
     /// <param name="args">villageID and the state to set</param>
     /// <returns>information if it changed</returns>
-    [CommandLineArgumentFunction("set_state", "coop.debug.village")]
-    public static string SetVillageState(List<string> args)
+    public sealed class SetVillageStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Usage: This command can only be used by the server for debugging purposes.";
+        public string Prefix => "coop.debug.village";
 
-        if (args.Count < 2)
+        public string Name => "set_state";
+
+        public string Description => "Sets state for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.village.set_state <villageId> <BeingRaided | ForcedForVolunteers | ForcedForSupplies | Looted> ";
-        }
+            new ExpectedArgs("villageId", "The village id."),
+            new ExpectedArgs("state", "The state."),
+        };
 
-        Village village = findVillage(args[0]);
-
-        if (village == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return string.Format("ID: '{0}' not found", args[0]);
+            if (ModInformation.IsClient)
+                return Failed("This command can only be used by the server for debugging purposes.");
+
+
+            Village village = findVillage(args[0]);
+
+            if (village == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+
+            if(!Enum.TryParse(args[1], out Village.VillageStates villageState))
+            {
+                return Failed(string.Format("InvalidVillageState: '{0}' not found", args[0]));
+            }
+            village.VillageState = villageState;
+
+            return Succeeded(string.Format("VillageState has changed to: {0}", villageState));
+
         }
-
-
-        if(!Enum.TryParse(args[1], out Village.VillageStates villageState))
-        {
-            return string.Format("InvalidVillageState: '{0}' not found", args[0]);
-        }
-        village.VillageState = villageState;
-
-        return string.Format("VillageState has changed to: {0}", villageState);
     }
 
 
@@ -124,36 +161,47 @@ internal class VillageDebugCommand
     /// </summary>
     /// <param name="args">the village and hearth value float</param>
     /// <returns>string output if success</returns>
-    [CommandLineArgumentFunction("set_hearth", "coop.debug.village")]
-    public static string SetVillageHearth(List<string> args)
+    public sealed class SetVillageHearthCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Usage: This command can only be used by the server for debugging purposes.";
+        public string Prefix => "coop.debug.village";
 
-        if (args.Count < 2)
+        public string Name => "set_hearth";
+
+        public string Description => "Sets hearth for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.village.set_hearth <villageId> <0.0> ";
+            new ExpectedArgs("villageId", "The village id."),
+            new ExpectedArgs("hearth", "The hearth."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("This command can only be used by the server for debugging purposes.");
+
+
+            Village village = findVillage(args[0]);
+
+            if (village == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            float hearth = 0.0f;
+            try
+            {
+                hearth = float.Parse(args[1]);
+            }catch(Exception)
+            {
+                return Failed(string.Format("Failed to parse the value: {0}", hearth));
+            }
+
+            village.Hearth = hearth;
+
+            return Succeeded(string.Format("Hearth has changed to to: {0}", hearth));
+
         }
-
-        Village village = findVillage(args[0]);
-
-        if (village == null)
-        {
-            return string.Format("ID: '{0}' not found", args[0]);
-        }
-
-        float hearth = 0.0f;
-        try
-        {
-            hearth = float.Parse(args[1]);
-        }catch(Exception)
-        {
-            return string.Format("Failed to parse the value: {0}", hearth);
-        }
-
-        village.Hearth = hearth;
-
-        return string.Format("Hearth has changed to to: {0}", hearth);
     }
 
     // coop.debug.village.set_trade_tax_acc castle_village_comp_K7_2 500
@@ -162,37 +210,48 @@ internal class VillageDebugCommand
     /// </summary>
     /// <param name="args">the village and tradetaxaccumulated value float</param>
     /// <returns>string output if success</returns>
-    [CommandLineArgumentFunction("set_trade_tax_acc", "coop.debug.village")]
-    public static string SetTradeTaxAccumulated(List<string> args)
+    public sealed class SetTradeTaxAccumulatedCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Usage: This command can only be used by the server for debugging purposes.";
+        public string Prefix => "coop.debug.village";
 
-        if (args.Count < 2)
+        public string Name => "set_trade_tax_acc";
+
+        public string Description => "Sets trade tax acc for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.village.set_trade_tax_acc <villageId> <0.0> ";
-        }
+            new ExpectedArgs("villageId", "The village id."),
+            new ExpectedArgs("tradeTax", "The trade tax."),
+        };
 
-        Village village = findVillage(args[0]);
-
-        if (village == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return string.Format("ID: '{0}' not found", args[0]);
-        }
+            if (ModInformation.IsClient)
+                return Failed("This command can only be used by the server for debugging purposes.");
 
-        int tradeTaxAccumulated = 0;
-        try
-        {
-            tradeTaxAccumulated = int.Parse(args[1]);
-        }
-        catch (Exception)
-        {
-            return string.Format("Failed to parse the value: {0}", tradeTaxAccumulated);
-        }
 
-        village.TradeTaxAccumulated = tradeTaxAccumulated;
+            Village village = findVillage(args[0]);
 
-        return string.Format("Hearth has changed to to: {0}", tradeTaxAccumulated);
+            if (village == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            int tradeTaxAccumulated = 0;
+            try
+            {
+                tradeTaxAccumulated = int.Parse(args[1]);
+            }
+            catch (Exception)
+            {
+                return Failed(string.Format("Failed to parse the value: {0}", tradeTaxAccumulated));
+            }
+
+            village.TradeTaxAccumulated = tradeTaxAccumulated;
+
+            return Succeeded(string.Format("Hearth has changed to to: {0}", tradeTaxAccumulated));
+
+        }
     }
 
 
@@ -202,36 +261,47 @@ internal class VillageDebugCommand
     /// </summary>
     /// <param name="args">the village and village last demand time value</param>
     /// <returns>string output if success</returns>
-    [CommandLineArgumentFunction("set_demand_time", "coop.debug.village")]
-    public static string SetLastDemandTimeSatisified(List<string> args)
+    public sealed class SetLastDemandTimeSatisifiedCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "Usage: This command can only be used by the server for debugging purposes.";
+        public string Prefix => "coop.debug.village";
 
-        if (args.Count < 2)
+        public string Name => "set_demand_time";
+
+        public string Description => "Sets demand time for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "Usage: coop.debug.village.set_demand_time <villageId> <0.0> ";
-        }
+            new ExpectedArgs("villageId", "The village id."),
+            new ExpectedArgs("demandTime", "The demand time."),
+        };
 
-        Village village = findVillage(args[0]);
-
-        if (village == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return string.Format("ID: '{0}' not found", args[0]);
-        }
+            if (ModInformation.IsClient)
+                return Failed("This command can only be used by the server for debugging purposes.");
 
-        float lastDemandTime = 0.0f;
-        try
-        {
-            lastDemandTime = float.Parse(args[1]);
-        }
-        catch (Exception)
-        {
-            return string.Format("Failed to parse the value: {0}", lastDemandTime);
-        }
 
-        village.LastDemandSatisfiedTime = lastDemandTime;
+            Village village = findVillage(args[0]);
 
-        return string.Format("Hearth has changed to to: {0}", lastDemandTime);
+            if (village == null)
+            {
+                return Failed(string.Format("ID: '{0}' not found", args[0]));
+            }
+
+            float lastDemandTime = 0.0f;
+            try
+            {
+                lastDemandTime = float.Parse(args[1]);
+            }
+            catch (Exception)
+            {
+                return Failed(string.Format("Failed to parse the value: {0}", lastDemandTime));
+            }
+
+            village.LastDemandSatisfiedTime = lastDemandTime;
+
+            return Succeeded(string.Format("Hearth has changed to to: {0}", lastDemandTime));
+
+        }
     }
 }

--- a/source/GameInterface/Services/Villages/Commands/VillagerPartiesCommands.cs
+++ b/source/GameInterface/Services/Villages/Commands/VillagerPartiesCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using GameInterface.CoopSessionData;
 using Serilog;
@@ -6,67 +7,93 @@ using System.Collections.Generic;
 using System.Text;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Villages.Commands;
 
 internal class VillagerPartiesCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<VillagerPartiesCommands>();
 
     /// <summary>
     /// View interacted villagers for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_interacted_villagers", "coop.debug.villagers")]
-    public static string ViewInteractedVillagersCommand(List<string> strings)
+    public sealed class ViewInteractedVillagersCommandCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.villagers";
+
+        public string Name => "view_interacted_villagers";
+
+        public string Description => "Shows interacted villagers for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerInteractedVillager in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerInteractedVillagers)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerInteractedVillager.Key == null || playerInteractedVillager.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerInteractedVillager.Key}");
-                foreach (var interactedVillager in playerInteractedVillager.Value)
+                foreach (var playerInteractedVillager in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerInteractedVillagers)
                 {
-                    stringBuilder.AppendLine($"{interactedVillager.Key} ({interactedVillager.Value})");
+                    if (playerInteractedVillager.Key == null || playerInteractedVillager.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerInteractedVillager.Key}");
+                    foreach (var interactedVillager in playerInteractedVillager.Value)
+                    {
+                        stringBuilder.AppendLine($"{interactedVillager.Key} ({interactedVillager.Value})");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var interactedVillager in Campaign.Current.GetCampaignBehavior<VillagerCampaignBehavior>()._interactedVillagers)
+            else
             {
-                stringBuilder.AppendLine($"{interactedVillager.Key.StringId} ({(int)interactedVillager.Value})");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var interactedVillager in Campaign.Current.GetCampaignBehavior<VillagerCampaignBehavior>()._interactedVillagers)
+                {
+                    stringBuilder.AppendLine($"{interactedVillager.Key.StringId} ({(int)interactedVillager.Value})");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve interacted villagers");
+
         }
-        return "Failed to retrieve interacted villagers";
     }
 
-    [CommandLineArgumentFunction("view_looted_villagers", "coop.debug.villagers")]
-    public static string ViewLootedVillagers(List<string> strings)
+    public sealed class ViewLootedVillagersCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var lootedVillager in Campaign.Current.GetCampaignBehavior<VillagerCampaignBehavior>()._lootedVillagers)
-        {
-            stringBuilder.AppendLine($"{lootedVillager.Key.StringId} ({lootedVillager.Value.NumTicks})");
-        }
+        public string Prefix => "coop.debug.villagers";
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
+        public string Name => "view_looted_villagers";
+
+        public string Description => "Shows looted villagers for co-op debugging.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            return result;
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var lootedVillager in Campaign.Current.GetCampaignBehavior<VillagerCampaignBehavior>()._lootedVillagers)
+            {
+                stringBuilder.AppendLine($"{lootedVillager.Key.StringId} ({lootedVillager.Value.NumTicks})");
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve looted villagers");
+
         }
-        return "Failed to retrieve looted villagers";
     }
 }

--- a/source/GameInterface/Services/Workshops/Commands/WorkshopDebugCommand.cs
+++ b/source/GameInterface/Services/Workshops/Commands/WorkshopDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using GameInterface.CoopSessionData;
 using GameInterface.Services.Actions.Patches;
@@ -11,12 +12,16 @@ using TaleWorlds.CampaignSystem.Settlements;
 using TaleWorlds.CampaignSystem.Settlements.Workshops;
 using TaleWorlds.Localization;
 using TaleWorlds.SaveSystem;
-using static TaleWorlds.Library.CommandLineFunctionality;
-
 namespace GameInterface.Services.Workshops.Commands
 {
     public class WorkshopDebugCommand
     {
+        private static CoopCommandResult Succeeded(string output) =>
+            new CoopCommandResult(true, output);
+
+        private static CoopCommandResult Failed(string output) =>
+            new CoopCommandResult(false, output, "command_failed");
+
         private static bool TryGetObjectManager(out IObjectManager objectManager)
         {
             objectManager = null;
@@ -57,246 +62,320 @@ namespace GameInterface.Services.Workshops.Commands
                 0);
         }
 
-        [CommandLineArgumentFunction("set_workshop_custom_name", "coop.debug.workshop")]
-        public static string SetWorkshopCustomName(List<string> args)
+        public sealed class SetWorkshopCustomNameCoopCommand : ICoopCommand
         {
-            if (args.Count != 3)
+            public string Prefix => "coop.debug.workshop";
+
+            public string Name => "set_workshop_custom_name";
+
+            public string Description => "Sets workshop custom name for co-op debugging.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.workshop.set_custom_name <settlementName> <workshopType> <newCustomName>";
-            }
+                new ExpectedArgs("settlementId", "The settlement id."),
+                new ExpectedArgs("workshopType", "The workshop type."),
+                new ExpectedArgs("newCustomName", "The exact new custom name; quote values containing spaces."),
+            };
 
-            string settlementName = args[0];
-            string workshopType = args[1];
-            string newCustomName = args[2];
-
-            Settlement settlement = Settlement.Find(settlementName);
-            if (settlement == null)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                return $"Settlement with name: '{settlementName}' not found";
+
+                string settlementId = args[0];
+                string workshopType = args[1];
+                string newCustomName = args[2];
+
+                Settlement settlement = Settlement.Find(settlementId);
+                if (settlement == null)
+                {
+                    return Failed($"Settlement with id: '{settlementId}' not found");
+                }
+
+                WorkshopType type = WorkshopType.Find(workshopType); // Ensure this method or logic to find WorkshopType exists
+                if (type == null)
+                {
+                    return Failed($"Workshop type: '{workshopType}' not found");
+                }
+
+                Workshop workshop = GetWorkshopBySettlementAndType(settlement, type);
+                if (workshop == null)
+                {
+                    return Failed($"Workshop of type '{workshopType}' not found in settlement '{settlementId}'");
+                }
+
+                // Change the custom name
+                workshop.SetCustomName(new TextObject(value: newCustomName));
+
+                return Succeeded($"Workshop custom name has been changed to: {workshop._customName}");
+
             }
-
-            WorkshopType type = WorkshopType.Find(workshopType); // Ensure this method or logic to find WorkshopType exists
-            if (type == null)
-            {
-                return $"Workshop type: '{workshopType}' not found";
-            }
-
-            Workshop workshop = GetWorkshopBySettlementAndType(settlement, type);
-            if (workshop == null)
-            {
-                return $"Workshop of type '{workshopType}' not found in settlement '{settlementName}'";
-            }
-
-            // Change the custom name
-            workshop.SetCustomName(new TextObject(value: newCustomName));
-
-            return $"Workshop custom name has been changed to: {workshop._customName}";
         }
 
-        [CommandLineArgumentFunction("set_workshop_owner", "coop.debug.workshop")]
-        public static string SetWorkshopOwner(List<string> args)
+        public sealed class SetWorkshopOwnerCoopCommand : ICoopCommand
         {
-            // Expect three arguments: settlement name, workshop type, and new owner (hero ID or name)
-            if (args.Count != 3)
+            public string Prefix => "coop.debug.workshop";
+
+            public string Name => "set_workshop_owner";
+
+            public string Description => "Sets workshop owner for co-op debugging.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.workshop.set_workshop_owner <settlementName> <workshopType> <newOwnerId>";
-            }
+                new ExpectedArgs("settlementId", "The settlement id."),
+                new ExpectedArgs("workshopType", "The workshop type."),
+                new ExpectedArgs("newOwnerId", "The new owner id."),
+            };
 
-            string settlementName = args[0];
-            string workshopType = args[1];
-            string newOwnerId = args[2];
-
-            // Find the settlement
-            Settlement settlement = Settlement.Find(settlementName);
-            if (settlement == null)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                return $"Settlement with name: '{settlementName}' not found";
+                // Expect three arguments: settlement id, workshop type, and new owner (hero ID or name)
+
+                string settlementId = args[0];
+                string workshopType = args[1];
+                string newOwnerId = args[2];
+
+                // Find the settlement
+                Settlement settlement = Settlement.Find(settlementId);
+                if (settlement == null)
+                {
+                    return Failed($"Settlement with id: '{settlementId}' not found");
+                }
+
+                // Find the workshop type (ensure the workshop type is valid)
+                WorkshopType type = WorkshopType.Find(workshopType); // Ensure this method exists in your codebase or mod
+                if (type == null)
+                {
+                    return Failed($"Workshop type: '{workshopType}' not found");
+                }
+
+                // Find the workshop by settlement and type
+                Workshop workshop = GetWorkshopBySettlementAndType(settlement, type);
+                if (workshop == null)
+                {
+                    return Failed($"Workshop of type '{workshopType}' not found in settlement '{settlementId}'");
+                }
+
+                // Find the new owner (Hero) by ID or name
+                if (!TryGetObjectManager(out var objectManager))
+                {
+                    return Failed("Unable to resolve ObjectManager");
+                }
+
+                Hero newOwner = ResolveHero(newOwnerId, objectManager);
+                if (newOwner == null)
+                {
+                    return Failed($"Hero with ID or Name: '{newOwnerId}' not found (use the registry id from coop.debug.alley.my_hero_id on the owning client)");
+                }
+
+                // Use the same action path as normal workshop purchases so ownership-dependent
+                // campaign behavior and client warehouse data are updated too.
+                ApplyOwnerChange(workshop, newOwner);
+
+                return Succeeded($"Workshop owner has been changed to: {newOwner.Name} with the type {workshop.WorkshopType} and with a capital of {workshop.Capital}");
+
             }
-
-            // Find the workshop type (ensure the workshop type is valid)
-            WorkshopType type = WorkshopType.Find(workshopType); // Ensure this method exists in your codebase or mod
-            if (type == null)
-            {
-                return $"Workshop type: '{workshopType}' not found";
-            }
-
-            // Find the workshop by settlement and type
-            Workshop workshop = GetWorkshopBySettlementAndType(settlement, type);
-            if (workshop == null)
-            {
-                return $"Workshop of type '{workshopType}' not found in settlement '{settlementName}'";
-            }
-
-            // Find the new owner (Hero) by ID or name
-            if (!TryGetObjectManager(out var objectManager))
-            {
-                return "Unable to resolve ObjectManager";
-            }
-
-            Hero newOwner = ResolveHero(newOwnerId, objectManager);
-            if (newOwner == null)
-            {
-                return $"Hero with ID or Name: '{newOwnerId}' not found (use the registry id from coop.debug.alley.my_hero_id on the owning client)";
-            }
-
-            // Use the same action path as normal workshop purchases so ownership-dependent
-            // campaign behavior and client warehouse data are updated too.
-            ApplyOwnerChange(workshop, newOwner);
-
-            return $"Workshop owner has been changed to: {newOwner.Name} with the type {workshop.WorkshopType} and with a capital of {workshop.Capital}";
         }
 
         /// <summary>
         /// View workshop owners in a settlement
         /// </summary>
-        [CommandLineArgumentFunction("owners_in_settlement", "coop.debug.workshop")]
-        public static string OwnersInSettlementCommand(List<string> strings)
+        public sealed class OwnersInSettlementCommandCoopCommand : ICoopCommand
         {
-            if (strings.Count == 0) return "Usage: coop.debug.workshop.owners_in_settlement <settlementId>";
+            public string Prefix => "coop.debug.workshop";
 
-            StringBuilder stringBuilder = new StringBuilder();
-            Settlement settlement = Settlement.Find(strings[0]);
-            if (settlement == null)
-            {
-                return $"Settlement with id: '{strings[0]}' not found";
-            }
+            public string Name => "owners_in_settlement";
 
-            stringBuilder.AppendLine($"{settlement.Name}");
-            foreach (var workshop in settlement.Town.Workshops)
-            {
-                stringBuilder.AppendLine($"{workshop.Name}: {workshop.Owner.Name} ({workshop.Owner.StringId})");
-            }
+            public string Description => "Runs in settlement for co-op debugging.";
 
-            string result = stringBuilder.ToString();
-            if (result.Length > 0)
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return result;
+                new ExpectedArgs("settlementId", "The settlement id."),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+            {
+
+                StringBuilder stringBuilder = new StringBuilder();
+                Settlement settlement = Settlement.Find(strings[0]);
+                if (settlement == null)
+                {
+                    return Failed($"Settlement with id: '{strings[0]}' not found");
+                }
+
+                stringBuilder.AppendLine($"{settlement.Name}");
+                foreach (var workshop in settlement.Town.Workshops)
+                {
+                    stringBuilder.AppendLine($"{workshop.Name}: {workshop.Owner.Name} ({workshop.Owner.StringId})");
+                }
+
+                string result = stringBuilder.ToString();
+                if (result.Length > 0)
+                {
+                    return Succeeded(result);
+                }
+                return Failed("No workshop owners were found");
+
             }
-            return "No workshop owners were found";
         }
 
         /// <summary>
         /// View workshops a hero owns
         /// </summary>
-        [CommandLineArgumentFunction("hero_owned_workshops", "coop.debug.workshop")]
-        public static string HeroOwnedWorkshopsCommand(List<string> strings)
+        public sealed class HeroOwnedWorkshopsCommandCoopCommand : ICoopCommand
         {
-            if (strings.Count == 0) return "Usage: coop.debug.workshop.hero_owned_workshops <heroId>";
+            public string Prefix => "coop.debug.workshop";
 
-            StringBuilder stringBuilder = new StringBuilder();
-            Hero hero = Hero.Find(strings[0]);
-            if (hero == null)
-            {
-                return $"Hero with id: '{strings[0]}' not found";
-            }
+            public string Name => "hero_owned_workshops";
 
-            stringBuilder.AppendLine($"{hero.Name}");
-            foreach (var workshop in hero.OwnedWorkshops)
-            {
-                stringBuilder.AppendLine($"{workshop.Name} ({workshop.Settlement.Name})");
-            }
+            public string Description => "Runs owned workshops for co-op debugging.";
 
-            string result = stringBuilder.ToString();
-            if (result.Length > 0)
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return result;
+                new ExpectedArgs("heroId", "The hero id."),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+            {
+
+                StringBuilder stringBuilder = new StringBuilder();
+                Hero hero = Hero.Find(strings[0]);
+                if (hero == null)
+                {
+                    return Failed($"Hero with id: '{strings[0]}' not found");
+                }
+
+                stringBuilder.AppendLine($"{hero.Name}");
+                foreach (var workshop in hero.OwnedWorkshops)
+                {
+                    stringBuilder.AppendLine($"{workshop.Name} ({workshop.Settlement.Name})");
+                }
+
+                string result = stringBuilder.ToString();
+                if (result.Length > 0)
+                {
+                    return Succeeded(result);
+                }
+                return Failed("No owned workshops were found");
+
             }
-            return "No owned workshops were found";
         }
 
         /// <summary>
         /// View warehouse rosters for all players on server and for current player on client
         /// </summary>
-        [CommandLineArgumentFunction("view_warehouse_rosters", "coop.debug.workshop")]
-        public static string ViewWarehouseRostersCommand(List<string> strings)
+        public sealed class ViewWarehouseRostersCommandCoopCommand : ICoopCommand
         {
-            StringBuilder stringBuilder = new StringBuilder();
-            if (ModInformation.IsServer)
+            public string Prefix => "coop.debug.workshop";
+
+            public string Name => "view_warehouse_rosters";
+
+            public string Description => "Shows warehouse rosters for co-op debugging.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
             {
-                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-                foreach (var playerWarehouseData in coopSessionProvider.CoopSession.WorkshopPlayerData.PlayerWarehouseRosterPerSettlement)
+                StringBuilder stringBuilder = new StringBuilder();
+                if (ModInformation.IsServer)
                 {
-                    if (playerWarehouseData.Key == null || playerWarehouseData.Value == null) continue;
+                    if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                    stringBuilder.AppendLine($"{playerWarehouseData.Key}");
-                    foreach (var warehouseData in playerWarehouseData.Value)
+                    foreach (var playerWarehouseData in coopSessionProvider.CoopSession.WorkshopPlayerData.PlayerWarehouseRosterPerSettlement)
                     {
-                        if (warehouseData.Key == null || warehouseData.Value == null) continue;
+                        if (playerWarehouseData.Key == null || playerWarehouseData.Value == null) continue;
 
-                        stringBuilder.AppendLine($"{warehouseData.Key}");
-                        foreach (var item in warehouseData.Value)
+                        stringBuilder.AppendLine($"{playerWarehouseData.Key}");
+                        foreach (var warehouseData in playerWarehouseData.Value)
                         {
-                            if (item.ItemObjectData.ItemObjectId == null) continue;
-                            stringBuilder.AppendLine($"{item.ItemObjectData.ItemObjectId} ({item.Amount})");
+                            if (warehouseData.Key == null || warehouseData.Value == null) continue;
+
+                            stringBuilder.AppendLine($"{warehouseData.Key}");
+                            foreach (var item in warehouseData.Value)
+                            {
+                                if (item.ItemObjectData.ItemObjectId == null) continue;
+                                stringBuilder.AppendLine($"{item.ItemObjectData.ItemObjectId} ({item.Amount})");
+                            }
                         }
                     }
                 }
-            }
-            else
-            {
-                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-                foreach (var warehouseRoster in Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>()._warehouseRosterPerSettlement)
+                else
                 {
-                    if (warehouseRoster.Key == null || warehouseRoster.Value == null) continue;
-
-                    stringBuilder.AppendLine($"{warehouseRoster.Key.Name}");
-                    foreach (var item in warehouseRoster.Value)
+                    stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                    foreach (var warehouseRoster in Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>()._warehouseRosterPerSettlement)
                     {
-                        stringBuilder.AppendLine($"{item.EquipmentElement.Item.Name} ({item.Amount})");
-                    }
-                } 
-            }
+                        if (warehouseRoster.Key == null || warehouseRoster.Value == null) continue;
 
-            string result = stringBuilder.ToString();
-            if (result.Length > 0)
-            {
-                return result;
+                        stringBuilder.AppendLine($"{warehouseRoster.Key.Name}");
+                        foreach (var item in warehouseRoster.Value)
+                        {
+                            stringBuilder.AppendLine($"{item.EquipmentElement.Item.Name} ({item.Amount})");
+                        }
+                    }
+                }
+
+                string result = stringBuilder.ToString();
+                if (result.Length > 0)
+                {
+                    return Succeeded(result);
+                }
+                return Failed("Failed to retrieve warehouse rosters");
+
             }
-            return "Failed to retrieve warehouse rosters";
         }
 
         /// <summary>
         /// View information about workshops in a settlement
         /// </summary>
-        [CommandLineArgumentFunction("workshop_info", "coop.debug.workshop")]
-        public static string ViewWorkshopInfoCommand(List<string> strings)
+        public sealed class ViewWorkshopInfoCommandCoopCommand : ICoopCommand
         {
-            if (strings.Count == 0) return "Usage: coop.debug.workshop.workshop_info <settlementId>";
+            public string Prefix => "coop.debug.workshop";
 
-            StringBuilder stringBuilder = new StringBuilder();
-            Settlement settlement = Settlement.Find(strings[0]);
-            if (settlement == null)
+            public string Name => "workshop_info";
+
+            public string Description => "Runs info for co-op debugging.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return $"Settlement with id: '{strings[0]}' not found";
-            }
+                new ExpectedArgs("settlementId", "The settlement id."),
+            };
 
-            stringBuilder.AppendLine($"{settlement.Name}");
-            foreach (var workshop in settlement.Town.Workshops)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
             {
-                stringBuilder.AppendLine($"Name: {workshop.Name}");
-                stringBuilder.AppendLine($"Owner: {workshop.Owner.StringId} ({workshop.Owner.Name})");
-                stringBuilder.AppendLine($"Type: {workshop.WorkshopType}");
 
-                var workshopData = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>().GetDataOfWorkshop(workshop);
-                if (workshopData == null)
+                StringBuilder stringBuilder = new StringBuilder();
+                Settlement settlement = Settlement.Find(strings[0]);
+                if (settlement == null)
                 {
-                    stringBuilder.AppendLine($"{workshop.Name} had no workshop data.");
-                    continue;
+                    return Failed($"Settlement with id: '{strings[0]}' not found");
                 }
-                stringBuilder.AppendLine($"WorkshopData:");
-                stringBuilder.AppendLine($"IsGettingInputsFromWarehouse: {workshopData.IsGettingInputsFromWarehouse}");
-                stringBuilder.AppendLine($"ProductionProgressForWarehouse: {workshopData.ProductionProgressForWarehouse}");
-                stringBuilder.AppendLine($"ProductionProgressForTown: {workshopData.ProductionProgressForTown}");
-                stringBuilder.AppendLine($"StockProductionInWarehouseRatio: {workshopData.StockProductionInWarehouseRatio}");
-            }
 
-            string result = stringBuilder.ToString();
-            if (result.Length > 0)
-            {
-                return result;
+                stringBuilder.AppendLine($"{settlement.Name}");
+                foreach (var workshop in settlement.Town.Workshops)
+                {
+                    stringBuilder.AppendLine($"Name: {workshop.Name}");
+                    stringBuilder.AppendLine($"Owner: {workshop.Owner.StringId} ({workshop.Owner.Name})");
+                    stringBuilder.AppendLine($"Type: {workshop.WorkshopType}");
+
+                    var workshopData = Campaign.Current.GetCampaignBehavior<WorkshopsCampaignBehavior>().GetDataOfWorkshop(workshop);
+                    if (workshopData == null)
+                    {
+                        stringBuilder.AppendLine($"{workshop.Name} had no workshop data.");
+                        continue;
+                    }
+                    stringBuilder.AppendLine($"WorkshopData:");
+                    stringBuilder.AppendLine($"IsGettingInputsFromWarehouse: {workshopData.IsGettingInputsFromWarehouse}");
+                    stringBuilder.AppendLine($"ProductionProgressForWarehouse: {workshopData.ProductionProgressForWarehouse}");
+                    stringBuilder.AppendLine($"ProductionProgressForTown: {workshopData.ProductionProgressForTown}");
+                    stringBuilder.AppendLine($"StockProductionInWarehouseRatio: {workshopData.StockProductionInWarehouseRatio}");
+                }
+
+                string result = stringBuilder.ToString();
+                if (result.Length > 0)
+                {
+                    return Succeeded(result);
+                }
+                return Failed("No workshop owners were found");
+
             }
-            return "No workshop owners were found";
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

World-map and settlement debug commands still use attributed static methods with command-specific argument handling.

## What is the new behavior?

Migrates all 134 commands within their original files. Each replacement directly implements `ICoopCommand`, contains its command behavior, returns explicit results, and uses registry-generated argument validation.

Resolves #3408
Resolves #3410
Resolves #3424
Resolves #3426
Resolves #3432
Resolves #3433
Resolves #3437
Resolves #3438
Resolves #3440
Resolves #3441

## Bot Changelog Entry

## Other information

Supersedes #3485.

Tests:

- Release `CoopTests.slnf` build
- Release `CoopUnitTests.slnf` tests
- World/settlement command and container tests
