### PR TITLE
Migrate system and developer commands in place

### DIFF
--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -11,6 +12,9 @@ using Coop.Core.Client.Services.Session;
 using Coop.Core.Client.States;
 using Coop.Core.Common;
 using Coop.Core.Common.Configuration;
+#if DEBUG
+using Coop.Core.Common.Commands;
+#endif
 using Coop.Core.Common.Session;
 using Coop.Steam;
 using GameInterface.Policies;
@@ -30,6 +34,12 @@ public class ClientModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<MissionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinDebugCommands.JoinStateCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.ArmInactivePartyDeficitCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.DisconnectCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+#endif
 
         builder.RegisterType<ClientContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ClientLogic>().As<ILogic>().As<IClientLogic>().InstancePerLifetimeScope();

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -1,4 +1,6 @@
 ﻿#if DEBUG
+using System;
+using Common.Commands;
 using Common;
 using Coop.Core.Client;
 using Coop.Core.Client.States;
@@ -19,154 +21,193 @@ namespace Coop.Core.Common.Commands;
 /// <summary>
 /// Stages and observes campaign-join scenarios in DEBUG builds.
 /// </summary>
-internal static class JoinDebugCommands
+public static class JoinDebugCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    private static Func<bool> startClientSession;
     private static int forceNextInactivePartyDeficit;
     private static string desiredInactivePartyId;
     private static string lastForcedPartyId = "none";
     private static MobileParty stagedInactiveParty;
     private static bool stagedInactivePartyWasActive;
 
-    [CommandLineArgumentFunction("join_state", "coop.debug.connection")]
-    public static string JoinState(List<string> args)
+    public sealed class JoinStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.join_state";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        if (ModInformation.IsServer)
+        public string Name => "join_state";
+
+        public string Description => "Reports the current campaign join state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (!ContainerProvider.TryResolve<IConnectionCollection>(out var connections))
+            if (ModInformation.IsServer)
             {
-                return "Failed to get connection collection";
+                if (!ContainerProvider.TryResolve<IConnectionCollection>(out var connections))
+                {
+                    return Failed("Failed to get connection collection");
+                }
+
+                string connectionState = string.Join(" | ", connections.Select(connection =>
+                {
+                    string state = connection.State?.GetType().Name ?? "none";
+                    string details = connection.State is ServerLoadingState loading
+                        ? loading.DebugJoinState
+                        : "joinCatchUpPending=false";
+                    return $"peer={connection.Peer.Id} state={state} {details}";
+                }));
+                return Succeeded($"{GetPartyCounts()} | {connectionState}");
             }
 
-            string connectionState = string.Join(" | ", connections.Select(connection =>
+            if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
             {
-                string state = connection.State?.GetType().Name ?? "none";
-                string details = connection.State is ServerLoadingState loading
-                    ? loading.DebugJoinState
-                    : "joinCatchUpPending=false";
-                return $"peer={connection.Peer.Id} state={state} {details}";
-            }));
-            return $"{GetPartyCounts()} | {connectionState}";
-        }
+                return Failed("Failed to get client logic");
+            }
 
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
-        {
-            return "Failed to get client logic";
+            return Succeeded(clientLogic.State is CampaignState campaignState
+                ? $"{campaignState.DebugJoinState} {GetPartyCounts()} " +
+                  $"forcedInactiveParty={lastForcedPartyId}"
+                : $"state={clientLogic.State?.GetType().Name ?? "none"} {GetPartyCounts()} " +
+                  $"forcedInactiveParty={lastForcedPartyId}");
         }
-
-        return clientLogic.State is CampaignState campaignState
-            ? $"{campaignState.DebugJoinState} {GetPartyCounts()} " +
-              $"forcedInactiveParty={lastForcedPartyId}"
-            : $"state={clientLogic.State?.GetType().Name ?? "none"} {GetPartyCounts()} " +
-              $"forcedInactiveParty={lastForcedPartyId}";
     }
 
-    [CommandLineArgumentFunction("arm_inactive_party_deficit", "coop.debug.connection")]
-    public static string ArmInactivePartyDeficit(List<string> args)
+    public sealed class ArmInactivePartyDeficitCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-        {
-            return "Usage: coop.debug.connection.arm_inactive_party_deficit <partyStringId>";
-        }
-        if (ModInformation.IsServer)
-        {
-            return "The inactive-party deficit fixture is client-only.";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        desiredInactivePartyId = args[0];
-        lastForcedPartyId = "armed";
-        Interlocked.Exchange(ref forceNextInactivePartyDeficit, 1);
-        return $"The next complete join baseline will remove inactive party '{args[0]}' " +
-               "from the client campaign collection before validation.";
+        public string Name => "arm_inactive_party_deficit";
+
+        public string Description => "Arms the next client join baseline to omit an inactive party.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_string_id", "The inactive party StringId."),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+            {
+                return Failed("The inactive-party deficit fixture is client-only.");
+            }
+
+            desiredInactivePartyId = args[0];
+            lastForcedPartyId = "armed";
+            Interlocked.Exchange(ref forceNextInactivePartyDeficit, 1);
+            return Succeeded($"The next complete join baseline will remove inactive party '{args[0]}' " +
+                   "from the client campaign collection before validation.");
+        }
     }
 
-    [CommandLineArgumentFunction("stage_inactive_party", "coop.debug.connection")]
-    public static string StageInactiveParty(List<string> args)
+    public sealed class StageInactivePartyCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.stage_inactive_party";
-        }
-        if (!ModInformation.IsServer)
-        {
-            return "stage_inactive_party must be run on the server.";
-        }
-        if (stagedInactiveParty != null)
-        {
-            return GetStagedPartyResult(stagedInactiveParty);
-        }
+        public string Prefix => "coop.debug.connection";
 
-        var parties = Campaign.Current?.CampaignObjectManager?.MobileParties;
-        stagedInactiveParty = parties?.FirstOrDefault(party =>
-                party?.IsActive == true &&
-                party.Ai != null &&
-                !party.IsPlayerParty() &&
-                party.Army == null &&
-                party.AttachedTo == null &&
-                party.MapEvent == null &&
-                party.CurrentSettlement == null &&
-                party.BesiegedSettlement == null &&
-                party.BesiegerCamp == null &&
-                !party.IsTransitionInProgress &&
-                !party.StartTransitionNextFrameToExitFromPort &&
-                !party.IsInRaftState &&
-                !IsReferencedByActiveParty(party, parties));
-        if (stagedInactiveParty == null)
-        {
-            return "No isolated active non-player field party was available for the fixture.";
-        }
+        public string Name => "stage_inactive_party";
 
-        stagedInactivePartyWasActive = stagedInactiveParty.IsActive;
-        stagedInactiveParty.IsActive = false;
-        return GetStagedPartyResult(stagedInactiveParty);
+        public string Description => "Stages an isolated server party as inactive for join testing.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+            {
+                return Failed("stage_inactive_party must be run on the server.");
+            }
+            if (stagedInactiveParty != null)
+            {
+                return Succeeded(GetStagedPartyResult(stagedInactiveParty));
+            }
+
+            var parties = Campaign.Current?.CampaignObjectManager?.MobileParties;
+            stagedInactiveParty = parties?.FirstOrDefault(party =>
+                    party?.IsActive == true &&
+                    party.Ai != null &&
+                    !party.IsPlayerParty() &&
+                    party.Army == null &&
+                    party.AttachedTo == null &&
+                    party.MapEvent == null &&
+                    party.CurrentSettlement == null &&
+                    party.BesiegedSettlement == null &&
+                    party.BesiegerCamp == null &&
+                    !party.IsTransitionInProgress &&
+                    !party.StartTransitionNextFrameToExitFromPort &&
+                    !party.IsInRaftState &&
+                    !IsReferencedByActiveParty(party, parties));
+            if (stagedInactiveParty == null)
+            {
+                return Failed("No isolated active non-player field party was available for the fixture.");
+            }
+
+            stagedInactivePartyWasActive = stagedInactiveParty.IsActive;
+            stagedInactiveParty.IsActive = false;
+            return Succeeded(GetStagedPartyResult(stagedInactiveParty));
+        }
     }
 
-    [CommandLineArgumentFunction("restore_inactive_party", "coop.debug.connection")]
-    public static string RestoreInactiveParty(List<string> args)
+    public sealed class RestoreInactivePartyCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.restore_inactive_party";
-        }
-        if (!ModInformation.IsServer)
-        {
-            return "restore_inactive_party must be run on the server.";
-        }
-        if (stagedInactiveParty == null)
-        {
-            return "No inactive-party fixture is staged.";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        string partyId = stagedInactiveParty.StringId;
-        stagedInactiveParty.IsActive = stagedInactivePartyWasActive;
-        bool restoredActive = stagedInactiveParty.IsActive;
-        stagedInactiveParty = null;
-        stagedInactivePartyWasActive = false;
-        return $"restoredParty={partyId} active={restoredActive}";
+        public string Name => "restore_inactive_party";
+
+        public string Description => "Restores the staged inactive server party.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsServer)
+            {
+                return Failed("restore_inactive_party must be run on the server.");
+            }
+            if (stagedInactiveParty == null)
+            {
+                return Failed("No inactive-party fixture is staged.");
+            }
+
+            string partyId = stagedInactiveParty.StringId;
+            stagedInactiveParty.IsActive = stagedInactivePartyWasActive;
+            bool restoredActive = stagedInactiveParty.IsActive;
+            stagedInactiveParty = null;
+            stagedInactivePartyWasActive = false;
+            return Succeeded($"restoredParty={partyId} active={restoredActive}");
+        }
     }
 
-    [CommandLineArgumentFunction("disconnect", "coop.debug.connection")]
-    public static string Disconnect(List<string> args)
+    public sealed class DisconnectCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-        {
-            return "Usage: coop.debug.connection.disconnect";
-        }
-        if (ModInformation.IsServer)
-        {
-            return "disconnect must be run on a client.";
-        }
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
-        {
-            return "No active client session was found.";
-        }
+        public string Prefix => "coop.debug.connection";
 
-        clientLogic.Disconnect();
-        return "Client session is returning to the main menu.";
+        public string Name => "disconnect";
+
+        public string Description => "Disconnects the active client session.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+            {
+                return Failed("disconnect must be run on a client.");
+            }
+            if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+            {
+                return Failed("No active client session was found.");
+            }
+
+            clientLogic.Disconnect();
+            return Succeeded("Client session is returning to the main menu.");
+        }
     }
 
     [CommandLineArgumentFunction("reconnect", "coop.debug.connection")]
@@ -180,13 +221,31 @@ internal static class JoinDebugCommands
         {
             return "reconnect must be run on a client.";
         }
-        if (!ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
+        if (ContainerProvider.TryResolve<IClientLogic>(out var clientLogic))
         {
-            return "No client session was found.";
+            clientLogic.Connect();
+            return "Client session is reconnecting to the configured server.";
         }
 
-        clientLogic.Connect();
-        return "Client session is reconnecting to the configured server.";
+        Func<bool> starter = Volatile.Read(ref startClientSession);
+        if (starter == null)
+            return "The process client-session starter is unavailable.";
+        if (!starter())
+            throw new InvalidOperationException("Client co-op connection start was refused.");
+
+        return "Client co-op session restarted after teardown.";
+    }
+
+    public static void ConfigureClientSessionStarter(Func<bool> starter)
+    {
+        if (starter == null) throw new ArgumentNullException(nameof(starter));
+
+        Volatile.Write(ref startClientSession, starter);
+    }
+
+    internal static void ResetClientSessionStarter()
+    {
+        Volatile.Write(ref startClientSession, null);
     }
 
     internal static void ForceArmedInactivePartyDeficit()

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Common.Commands;
 using Common.LogicStates;
 using Common.Messaging;
 using Common.Network;
@@ -9,6 +10,9 @@ using Coop.Core.Client.Services.Kingdoms;
 using Coop.Core.Client.Services.MobileParties;
 using Coop.Core.Common;
 using Coop.Core.Common.Configuration;
+#if DEBUG
+using Coop.Core.Common.Commands;
+#endif
 using Coop.Core.Common.Session;
 using Coop.Core.Server.Connections;
 using Coop.Core.Server.Policies;
@@ -40,6 +44,12 @@ public class ServerModule : CommonModule
         base.Load(builder);
 
         builder.RegisterModule<ConnectionModule>();
+
+#if DEBUG
+        builder.RegisterType<JoinDebugCommands.JoinStateCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.StageInactivePartyCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+        builder.RegisterType<JoinDebugCommands.RestoreInactivePartyCoopCommand>().As<ICoopCommand>().InstancePerDependency();
+#endif
 
         // The mission/P2P stack is composed into the server container too (it is also in ClientModule) so the
         // server-authoritative battle classes — notably BattleHostHandler, which elects the battle host — run

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -45,6 +45,12 @@ namespace Coop.Tests.Autofac
                 .ToArray();
 #if DEBUG
             Assert.Equal(26, missionCommands.Length);
+            Assert.Equal(
+                new[] { "arm_inactive_party_deficit", "disconnect", "join_state" },
+                registeredCommands
+                    .Where(command => command.Prefix == "coop.debug.connection")
+                    .Select(command => command.Name)
+                    .OrderBy(name => name));
 #else
             Assert.Equal(15, missionCommands.Length);
 #endif
@@ -66,6 +72,16 @@ namespace Coop.Tests.Autofac
 
             var logic = container.Resolve<ILogic>();
             Assert.NotNull(logic);
+
+#if DEBUG
+            ICoopCommand[] registeredCommands = container.Resolve<IEnumerable<ICoopCommand>>().ToArray();
+            Assert.Equal(
+                new[] { "join_state", "restore_inactive_party", "stage_inactive_party" },
+                registeredCommands
+                    .Where(command => command.Prefix == "coop.debug.connection")
+                    .Select(command => command.Name)
+                    .OrderBy(name => name));
+#endif
         }
 
         [Theory]

--- a/source/Coop.Tests/Common/Commands/ConnectionDirectCommandTests.cs
+++ b/source/Coop.Tests/Common/Commands/ConnectionDirectCommandTests.cs
@@ -1,0 +1,94 @@
+﻿#if DEBUG
+using Common;
+using Common.Commands;
+using Coop.Core.Common.Commands;
+using GameInterface;
+using System;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace Coop.Tests.Commands;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class ConnectionDirectCommandTests
+{
+    [Fact]
+    public void SessionCommands_AreDirectCommandsInTheOwningType()
+    {
+        Type[] commandTypes = typeof(JoinDebugCommands).GetNestedTypes(BindingFlags.Public)
+            .Where(type => typeof(ICoopCommand).IsAssignableFrom(type))
+            .ToArray();
+
+        Assert.Equal(5, commandTypes.Length);
+        Assert.All(commandTypes, type =>
+        {
+            Assert.Equal(typeof(object), type.BaseType);
+            Assert.Equal(new[] { typeof(ICoopCommand) }, type.GetInterfaces());
+            Assert.EndsWith("CoopCommand", type.Name);
+        });
+    }
+
+    [Fact]
+    public void Reconnect_RemainsAProcessLifetimeAttributedCommand()
+    {
+        MethodInfo method = typeof(JoinDebugCommands).GetMethod(
+            nameof(JoinDebugCommands.Reconnect),
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        Assert.True(method.IsDefined(
+            typeof(CommandLineFunctionality.CommandLineArgumentFunction),
+            inherit: false));
+    }
+
+    [Fact]
+    public void ReconnectWithoutSession_RestartsThroughProcessLifetimeStarter()
+    {
+        bool wasServer = ModInformation.IsServer;
+        bool started = false;
+        try
+        {
+            ModInformation.IsServer = false;
+            ContainerProvider.Clear();
+            JoinDebugCommands.ConfigureClientSessionStarter(() =>
+            {
+                started = true;
+                return true;
+            });
+
+            string output = JoinDebugCommands.Reconnect(new System.Collections.Generic.List<string>());
+
+            Assert.True(started);
+            Assert.Equal("Client co-op session restarted after teardown.", output);
+        }
+        finally
+        {
+            JoinDebugCommands.ResetClientSessionStarter();
+            ModInformation.IsServer = wasServer;
+        }
+    }
+
+    [Fact]
+    public void DisconnectServerRejection_IsExplicitFailure()
+    {
+        bool wasServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            var command = new JoinDebugCommands.DisconnectCoopCommand();
+
+            CoopCommandResult result = command.ProcessCommand(
+                new CoopCommandArgsFactory().FromValues(Array.Empty<string>()));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+    }
+}
+#endif

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -483,6 +483,11 @@ namespace Coop
                 CrashDiagnostics.SetPhase,
                 activeLogFilePath);
 
+#if DEBUG
+            global::Coop.Core.Common.Commands.JoinDebugCommands.ConfigureClientSessionStarter(
+                () => Coop.StartAsClient());
+#endif
+
             Updateables.Add(GameThread.Instance);
 
 #if DEBUG

--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -4,6 +4,7 @@ using Common.LiveTesting;
 using Common.Logging;
 using Common.LogicStates;
 using Coop.Core.Client;
+using Coop.Core.Common.Commands;
 using Coop.Core.Server;
 using GameInterface;
 using GameInterface.Services.LiveTesting;
@@ -190,9 +191,18 @@ namespace Coop.LiveTesting
             {
                 if (!ContainerProvider.TryResolve<ILiveTestCommandDispatcher>(out var dispatcher))
                 {
+                    string output = null;
                     if (string.Equals(command, "coop.debug.connection.start", StringComparison.Ordinal))
                     {
-                        string output = Coop.JoinFixtureCommands.Start(arguments);
+                        output = Coop.JoinFixtureCommands.Start(arguments);
+                    }
+                    else if (string.Equals(command, "coop.debug.connection.reconnect", StringComparison.Ordinal))
+                    {
+                        output = JoinDebugCommands.Reconnect(arguments);
+                    }
+
+                    if (output != null)
+                    {
                         bool hasFallbackStructuredResult = TryParseStructuredResult(
                             output,
                             out var fallbackStructuredResult);

--- a/source/E2E.Tests/Services/Issues/IssuesDebugCommandTests.cs
+++ b/source/E2E.Tests/Services/Issues/IssuesDebugCommandTests.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Common.Util;
 using E2E.Tests.Environment;
 using E2E.Tests.Environment.Instance;
@@ -41,7 +42,7 @@ public class IssuesDebugCommandTests : IDisposable
             Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
             setupHero.StayingInSettlement = settlement;
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" });
+            var giveResult = Give(new List<string> { heroId, "BettingFraud" });
             Assert.True(giveResult.Contains("Gave quest type 'BettingFraud'"), giveResult);
 
             Assert.True(Server.ObjectManager.TryGetObject<Hero>(heroId, out var hero));
@@ -49,7 +50,7 @@ public class IssuesDebugCommandTests : IDisposable
             Assert.NotNull(issue.IssueQuest);
             Assert.True(Campaign.Current.IssueManager.Issues.ContainsKey(hero));
 
-            var completeResult = IssuesDebugCommand.Complete(new List<string> { heroId });
+            var completeResult = Complete(new List<string> { heroId });
             Assert.Contains("Completed quest for hero", completeResult);
 
             Assert.Null(hero.Issue);
@@ -69,9 +70,9 @@ public class IssuesDebugCommandTests : IDisposable
             Assert.True(Server.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
             setupHero.StayingInSettlement = settlement;
 
-            Assert.Contains("Gave quest type", IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" }));
+            Assert.Contains("Gave quest type", Give(new List<string> { heroId, "BettingFraud" }));
 
-            var secondResult = IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" });
+            var secondResult = Give(new List<string> { heroId, "BettingFraud" });
 
             Assert.Contains("already has an active issue", secondResult);
         });
@@ -95,14 +96,14 @@ public class IssuesDebugCommandTests : IDisposable
             village.Hearth = 650f;
             hero.StayingInSettlement = settlement;
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "VillageNeedsTools" });
+            var giveResult = Give(new List<string> { heroId, "VillageNeedsTools" });
             Assert.True(giveResult.Contains("Gave quest type 'VillageNeedsTools'"), giveResult);
 
             var issue = Assert.IsType<VillageNeedsToolsIssueBehavior.VillageNeedsToolsIssue>(hero.Issue);
             Assert.NotNull(issue.IssueQuest);
             Assert.Same(DefaultItems.Tools, issue._requestedItem);
 
-            var completeResult = IssuesDebugCommand.Complete(new List<string> { heroId, "cancel" });
+            var completeResult = Complete(new List<string> { heroId, "cancel" });
             Assert.Contains("outcome 'cancel'", completeResult);
 
             Assert.Null(hero.Issue);
@@ -129,13 +130,13 @@ public class IssuesDebugCommandTests : IDisposable
             boundTown.Culture = ObjectHelper.SkipConstructor<CultureObject>();
             hero.StayingInSettlement = settlement;
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "RuralNotableInnAndOut" });
+            var giveResult = Give(new List<string> { heroId, "RuralNotableInnAndOut" });
             Assert.Contains("Gave quest type 'RuralNotableInnAndOut'", giveResult);
 
             var issue = Assert.IsType<RuralNotableInnAndOutIssueBehavior.RuralNotableInnAndOutIssue>(hero.Issue);
             Assert.NotNull(issue.IssueQuest);
 
-            var completeResult = IssuesDebugCommand.Complete(new List<string> { heroId, "fail" });
+            var completeResult = Complete(new List<string> { heroId, "fail" });
             Assert.Contains("outcome 'fail'", completeResult);
 
             Assert.Null(hero.Issue);
@@ -155,7 +156,7 @@ public class IssuesDebugCommandTests : IDisposable
 
             Assert.Null(hero.CurrentSettlement);
 
-            var giveResult = IssuesDebugCommand.Give(new List<string> { heroId, "NotableWantsDaughterFound" });
+            var giveResult = Give(new List<string> { heroId, "NotableWantsDaughterFound" });
 
             Assert.Contains("NotableWantsDaughterFound", giveResult);
             Assert.Contains("StartIssueQuest threw", giveResult);
@@ -165,7 +166,7 @@ public class IssuesDebugCommandTests : IDisposable
 
             hero.StayingInSettlement = settlement;
 
-            var retryResult = IssuesDebugCommand.Give(new List<string> { heroId, "BettingFraud" });
+            var retryResult = Give(new List<string> { heroId, "BettingFraud" });
             Assert.Contains("Gave quest type 'BettingFraud'", retryResult);
         });
     }
@@ -173,11 +174,30 @@ public class IssuesDebugCommandTests : IDisposable
     [Fact]
     public void ListTypes_ReportsAllFortyThreeVanillaIssueTypes_WithExactlyOneNotWired()
     {
-        var result = IssuesDebugCommand.ListTypes(new List<string>());
+        var result = ListTypes(new List<string>());
         var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         Assert.Equal(43, lines.Length);
         Assert.Single(lines, line => line.Contains("[not wired"));
         Assert.Contains(lines, line => line.StartsWith("ProdigalSon ") && line.Contains("[not wired"));
     }
+
+    private static string Give(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesGiveCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
+    private static string Complete(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesCompleteCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
+    private static string ListTypes(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesListTypesCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
 }

--- a/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
+++ b/source/E2E.Tests/Services/MobileParties/UnstuckCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using Common.Util;
+﻿using Common.Commands;
+using Common.Util;
 using E2E.Tests.Environment.Instance;
 using E2E.Tests.Services.MapEvents;
 using E2E.Tests.Util;
@@ -49,7 +50,7 @@ public class UnstuckCommandTests : MapEventTestBase
         string output = null;
         Server.Call(() =>
         {
-            output = UnstuckCommand.Unstuck(new List<string>());
+            output = ExecuteUnstuck();
         });
 
         Assert.Equal("Command can only be run on a client.", output);
@@ -64,7 +65,7 @@ public class UnstuckCommandTests : MapEventTestBase
         string output = null;
         Client.Call(() =>
         {
-            output = UnstuckCommand.Unstuck(new List<string>());
+            output = ExecuteUnstuck();
         });
 
         Assert.Contains("Unstuck request sent", output);
@@ -378,4 +379,11 @@ public class UnstuckCommandTests : MapEventTestBase
 
         return new PlayerIds(heroId, characterId, partyId);
     }
+
+    private static string ExecuteUnstuck()
+    {
+        var command = new UnstuckCommand.UnstuckCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(Array.Empty<string>())).Output;
+    }
+
 }

--- a/source/GameInterface.Tests/Services/GameDebug/GameThreadDebugCommandTests.cs
+++ b/source/GameInterface.Tests/Services/GameDebug/GameThreadDebugCommandTests.cs
@@ -1,4 +1,5 @@
 ﻿using Common;
+using Common.Commands;
 using GameInterface.Services.GameDebug.Commands;
 using GameInterface.Tests;
 using System;
@@ -24,7 +25,7 @@ public class GameThreadDebugCommandTests : IDisposable
 
         Assert.Equal(
             "gamethread.stall must be run on the server",
-            GameThreadDebugCommand.Stall(new List<string> { "1" }));
+            Stall(new List<string> { "1" }));
     }
 
     [Theory]
@@ -36,8 +37,8 @@ public class GameThreadDebugCommandTests : IDisposable
         ModInformation.IsServer = true;
 
         Assert.StartsWith(
-            "Usage:",
-            GameThreadDebugCommand.Stall(new List<string> { duration }));
+            "Stall duration must be",
+            Stall(new List<string> { duration }));
     }
 
     [Fact]
@@ -47,6 +48,11 @@ public class GameThreadDebugCommandTests : IDisposable
 
         Assert.Equal(
             "Stalled the server game thread for 1 ms",
-            GameThreadDebugCommand.Stall(new List<string> { "1" }));
+            Stall(new List<string> { "1" }));
+    }
+    private static string Stall(List<string> args)
+    {
+        var command = new GameThreadDebugCommand.GameThreadStallCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
     }
 }

--- a/source/GameInterface.Tests/Services/GameDebug/Metrics/PartySyncPerformanceLogsTests.cs
+++ b/source/GameInterface.Tests/Services/GameDebug/Metrics/PartySyncPerformanceLogsTests.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common;
+using Common.Commands;
 using Common.Messaging;
 using Common.Network;
 using Common.Tests.Utils;
@@ -53,7 +54,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         logger.Setup(l => l.Enable(TimeSpan.FromSeconds(60), "test_log")).Returns("enabled");
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "60", "test_log" });
+        var result = ExecuteCommand(new List<string> { "on", "60", "test_log" });
 
         Assert.Equal("enabled", result);
         logger.Verify(l => l.Enable(TimeSpan.FromSeconds(60), "test_log"), Times.Once);
@@ -64,7 +65,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         logger.Setup(l => l.Disable()).Returns("disabled");
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "off" });
+        var result = ExecuteCommand(new List<string> { "off" });
 
         Assert.Equal("disabled", result);
         logger.Verify(l => l.Disable(), Times.Once);
@@ -75,7 +76,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         logger.Setup(l => l.Status()).Returns("status");
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "status" });
+        var result = ExecuteCommand(new List<string> { "status" });
 
         Assert.Equal("status", result);
         logger.Verify(l => l.Status(), Times.Once);
@@ -84,16 +85,16 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     [Fact]
     public void On_MissingArgs_ReturnsUsage()
     {
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "60" });
+        var result = ExecuteCommand(new List<string> { "on", "60" });
 
-        Assert.Contains("Usage:", result);
+        Assert.Contains("requires seconds and a file name", result);
         logger.Verify(l => l.Enable(It.IsAny<TimeSpan>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
     public void On_NonPositiveSeconds_ReturnsError()
     {
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "0", "test_log" });
+        var result = ExecuteCommand(new List<string> { "on", "0", "test_log" });
 
         Assert.Equal("Seconds must be a positive number", result);
         logger.Verify(l => l.Enable(It.IsAny<TimeSpan>(), It.IsAny<string>()), Times.Never);
@@ -106,7 +107,7 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
         using var realContainer = CreateLoggerContainer(fileWriter);
         ContainerProvider.SetContainer(realContainer);
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "on", "60", "test_log" });
+        var result = ExecuteCommand(new List<string> { "on", "60", "test_log" });
 
         Assert.Contains("test_log.csv", result);
         var write = Assert.Single(fileWriter.Writes);
@@ -118,10 +119,16 @@ public class PartySyncPerformanceLogsCommandTests : IDisposable
     {
         ModInformation.IsServer = true;
 
-        var result = PartySyncPerformanceLogsCommand.PartySyncPerformanceLogs(new List<string> { "status" });
+        var result = ExecuteCommand(new List<string> { "status" });
 
         Assert.Equal("party_sync_performance_logs can only be called by a client", result);
         logger.Verify(l => l.Status(), Times.Never);
+    }
+
+    private static string ExecuteCommand(List<string> args)
+    {
+        var command = new PartySyncPerformanceLogsCommand.MetricsPartySyncPerformanceLogsCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
     }
 
     private static IContainer CreateLoggerContainer(FakeFileWriter fileWriter)

--- a/source/GameInterface.Tests/Services/Issues/IssuesDebugCommandTests.cs
+++ b/source/GameInterface.Tests/Services/Issues/IssuesDebugCommandTests.cs
@@ -1,5 +1,6 @@
-using Autofac;
+﻿using Autofac;
 using Common;
+using Common.Commands;
 using Common.Util;
 using GameInterface.Services.Issues.Commands;
 using GameInterface.Services.ObjectManager;
@@ -44,7 +45,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "some_hero", "BettingFraud" });
+            var result = Give(new List<string> { "some_hero", "BettingFraud" });
 
             Assert.Equal(
                 "The 'coop.debug.issues.give' command cannot be used on the client. It is intended for server use only.",
@@ -65,7 +66,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "no_such_hero", "BettingFraud" });
+            var result = Give(new List<string> { "no_such_hero", "BettingFraud" });
 
             Assert.Contains("No Hero found with id", result);
         }
@@ -86,7 +87,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "hero_1", "NotARealQuestType" });
+            var result = Give(new List<string> { "hero_1", "NotARealQuestType" });
 
             Assert.Contains("Unknown quest type key 'NotARealQuestType'", result);
             Assert.Contains("list_types", result);
@@ -108,7 +109,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "hero_1", "ProdigalSon" });
+            var result = Give(new List<string> { "hero_1", "ProdigalSon" });
 
             Assert.Contains("is a known vanilla Issue type but is not wired for give", result);
         }
@@ -131,7 +132,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Give(new List<string> { "hero_1", "BettingFraud" });
+            var result = Give(new List<string> { "hero_1", "BettingFraud" });
 
             Assert.Contains("already has an active issue", result);
         }
@@ -149,7 +150,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "some_hero" });
+            var result = Complete(new List<string> { "some_hero" });
 
             Assert.Equal(
                 "The 'coop.debug.issues.complete' command cannot be used on the client. It is intended for server use only.",
@@ -170,7 +171,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "no_such_hero" });
+            var result = Complete(new List<string> { "no_such_hero" });
 
             Assert.Contains("No Hero found with id", result);
         }
@@ -191,7 +192,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "hero_1" });
+            var result = Complete(new List<string> { "hero_1" });
 
             Assert.Contains("has no active issue", result);
         }
@@ -214,7 +215,7 @@ public class IssuesDebugCommandTests : System.IDisposable
 
         try
         {
-            var result = IssuesDebugCommand.Complete(new List<string> { "hero_1" });
+            var result = Complete(new List<string> { "hero_1" });
 
             Assert.Contains("no live quest yet", result);
             Assert.Contains("coop.debug.issues.give", result);
@@ -224,4 +225,17 @@ public class IssuesDebugCommandTests : System.IDisposable
             ModInformation.IsServer = wasServer;
         }
     }
+
+    private static string Give(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesGiveCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
+    private static string Complete(List<string> args)
+    {
+        var command = new IssuesDebugCommand.IssuesCompleteCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
 }

--- a/source/GameInterface.Tests/Services/UI/TacticalUnitSymbolsConfigTests.cs
+++ b/source/GameInterface.Tests/Services/UI/TacticalUnitSymbolsConfigTests.cs
@@ -1,5 +1,6 @@
-using Autofac;
+﻿using Autofac;
 using Common;
+using Common.Commands;
 using Common.Messaging;
 using Common.Network;
 using Coop.Tests.Mocks;
@@ -32,7 +33,7 @@ public class TacticalUnitSymbolsConfigTests
 
         try
         {
-            var result = TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string> { "on" });
+            var result = ExecuteTacticalSymbols(new List<string> { "on" });
 
             Assert.Equal(
                 "The 'coop.debug.ui.tactical_symbols' command cannot be used on the client. It is intended for server use only.",
@@ -54,7 +55,7 @@ public class TacticalUnitSymbolsConfigTests
 
         try
         {
-            var result = TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string> { "status" });
+            var result = ExecuteTacticalSymbols(new List<string> { "status" });
 
             Assert.Equal("Tactical unit symbols are hidden.", result);
         }
@@ -88,7 +89,7 @@ public class TacticalUnitSymbolsConfigTests
             using var container = builder.Build();
             ContainerProvider.SetContainer(container);
 
-            var result = TacticalUnitSymbolsDebugCommand.TacticalSymbols(new List<string> { "on" });
+            var result = ExecuteTacticalSymbols(new List<string> { "on" });
 
             Assert.Equal("Tactical unit symbols are visible.", result);
             Assert.False(TacticalUnitSymbolsSettings.HideTacticalUnitSymbols);
@@ -149,4 +150,11 @@ public class TacticalUnitSymbolsConfigTests
             TacticalUnitSymbolsSettings.SetHideTacticalUnitSymbols(previous);
         }
     }
+
+    private static string ExecuteTacticalSymbols(List<string> args)
+    {
+        var command = new TacticalUnitSymbolsDebugCommand.UiTacticalSymbolsCoopCommand();
+        return command.ProcessCommand(new CoopCommandArgsFactory().FromValues(args)).Output;
+    }
+
 }

--- a/source/GameInterface.Tests/Utils/Commands/SystemDeveloperDirectCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/SystemDeveloperDirectCommandTests.cs
@@ -1,0 +1,235 @@
+﻿using Common;
+using Common.Commands;
+using GameInterface.Services.CampaignService.Commands;
+using GameInterface.Services.GameDebug.Commands;
+using GameInterface.Services.UI.Commands;
+using Serilog;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class SystemDeveloperDirectCommandTests
+{
+    private static readonly HashSet<string> OwningTypes = new HashSet<string>
+    {
+        "CampaignOptionsCommands",
+        "ModOptionsCommands",
+        "CaravansCommands",
+        "CharacterDeveloperCommands",
+        "CharacterObjectCommands",
+        "CameraReset",
+        "GameThreadDebugCommand",
+        "PartySyncPerformanceLogsCommand",
+        "UiDebugCommands",
+        "UnstuckCommand",
+        "HeroDeveloperCommands",
+        "InventoryCommands",
+        "TradeSkillCommands",
+        "IssuesDebugCommand",
+        "ItemObjectCommands",
+        "ItemRosterDebugCommands",
+        "AiLordPeaceReleaseFixtureCommands",
+        "PlayerCaptivityCommands",
+        "SaveDebugCommand",
+        "SmithingCommands",
+        "TemplateCommands",
+        "TimeCommands",
+        "SteamDebugCommand",
+        "TacticalUnitSymbolsDebugCommand",
+    };
+
+    [Fact]
+    public void MigratedCommands_AreDirectCommandsInTheirOwningTypes()
+    {
+        Type[] commandTypes = GetCommandTypes();
+
+#if DEBUG
+        Assert.Equal(103, commandTypes.Length);
+#else
+        Assert.Equal(92, commandTypes.Length);
+#endif
+        Assert.All(commandTypes, type =>
+        {
+            Assert.Equal(typeof(object), type.BaseType);
+            Assert.Equal(new[] { typeof(ICoopCommand) }, type.GetInterfaces());
+            Assert.EndsWith("CoopCommand", type.Name);
+        });
+    }
+
+    [Fact]
+    public void MigratedCommands_HaveUniqueNormalizedMetadata()
+    {
+        ICoopCommand[] commands = CreateCommands();
+        var registry = new CoopCommandRegistry(commands, new LoggerConfiguration().CreateLogger());
+
+        Assert.Equal(commands.Length, registry.Commands.Count);
+        Assert.All(commands, command =>
+        {
+            Assert.Matches("^coop(?:\\.[a-z0-9_]+)*$", command.Prefix);
+            Assert.Matches("^[a-z0-9]+(?:_[a-z0-9]+)*$", command.Name);
+            Assert.False(string.IsNullOrWhiteSpace(command.Description));
+            Assert.NotNull(command.ExpectedArgs);
+        });
+    }
+
+    [Fact]
+    public void ProcessLifetimeCommands_KeepAttributedEntryPoints()
+    {
+        AssertAttributed(typeof(SteamDebugCommand), nameof(SteamDebugCommand.Status));
+        AssertAttributed(typeof(SteamDebugCommand), nameof(SteamDebugCommand.Join));
+        AssertAttributed(typeof(BugReportLogSharingCommand), nameof(BugReportLogSharingCommand.Configure));
+
+        string[] migratedSteamCommands = CreateCommands()
+            .Where(command => command.GetType().DeclaringType == typeof(SteamDebugCommand))
+            .Select(command => command.Name)
+            .OrderBy(name => name)
+            .ToArray();
+        Assert.Equal(new[] { "host_lobby", "invite" }, migratedSteamCommands);
+    }
+
+    [Fact]
+    public void ProcessCommand_ReadsCountOnlyForOptionalOrConditionalArguments()
+    {
+        string[] countReaders = GetCommandTypes()
+            .Where(type => CallsArgumentCount(type.GetMethod(nameof(ICoopCommand.ProcessCommand))))
+            .Select(type => ((ICoopCommand)Activator.CreateInstance(type)).Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+#if DEBUG
+        Assert.Equal(
+            new[]
+            {
+                "advance_time",
+                "complete",
+                "force_autosave",
+                "instrument",
+                "is_ironman_mode",
+                "set_time_mode",
+            },
+            countReaders);
+#else
+        Assert.Equal(
+            new[]
+            {
+                "advance_time",
+                "complete",
+                "force_autosave",
+                "instrument",
+                "is_ironman_mode",
+            },
+            countReaders);
+#endif
+    }
+
+    [Fact]
+    public void Registry_RejectsInvalidArgumentCountBeforeCommandLogic()
+    {
+        ICoopCommand command = Assert.Single(
+            CreateCommands(),
+            candidate => candidate.Name == "add_attribute_points");
+        var registry = new CoopCommandRegistry(new[] { command }, new LoggerConfiguration().CreateLogger());
+
+        CoopCommandResult result = registry.ProcessCommand(
+            $"{command.Prefix}.{command.Name}",
+            new TestArgs(new[] { "Hero", "With", "Spaces", "2" }));
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("invalid_arguments", result.ErrorCode);
+    }
+
+    [Fact]
+    public void CampaignOptionClientRejection_IsExplicitFailure()
+    {
+        bool wasServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = false;
+            ICoopCommand command = new CampaignOptionsCommands.CampaignOptionsAutoAllocateClanMemberPerksCoopCommand();
+
+            CoopCommandResult result = command.ProcessCommand(new TestArgs(new[] { "true" }));
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_failed", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = wasServer;
+        }
+    }
+
+    private static void AssertAttributed(Type owner, string methodName)
+    {
+        MethodInfo method = owner.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(method);
+        Assert.True(method.IsDefined(
+            typeof(CommandLineFunctionality.CommandLineArgumentFunction),
+            inherit: false));
+    }
+
+    private static bool CallsArgumentCount(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody().GetILAsByteArray();
+        for (int index = 0; index <= il.Length - sizeof(int); index++)
+        {
+            try
+            {
+                MethodBase referencedMethod = method.Module.ResolveMethod(BitConverter.ToInt32(il, index));
+                if (referencedMethod.Name == "get_Count" &&
+                    (referencedMethod.DeclaringType == typeof(ICoopCommandArgs) ||
+                     referencedMethod.DeclaringType == typeof(IReadOnlyCollection<string>)))
+                {
+                    return true;
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private static Type[] GetCommandTypes()
+    {
+        return typeof(GameInterfaceModule).Assembly.GetTypes()
+            .Where(type => type.IsClass &&
+                           !type.IsAbstract &&
+                           type.DeclaringType != null &&
+                           OwningTypes.Contains(type.DeclaringType.Name) &&
+                           typeof(ICoopCommand).IsAssignableFrom(type))
+            .ToArray();
+    }
+
+    private static ICoopCommand[] CreateCommands()
+    {
+        return GetCommandTypes()
+            .Select(type => (ICoopCommand)Activator.CreateInstance(type))
+            .ToArray();
+    }
+
+    private sealed class TestArgs : ICoopCommandArgs
+    {
+        private readonly IReadOnlyList<string> values;
+
+        public TestArgs(IReadOnlyList<string> values)
+        {
+            this.values = values;
+        }
+
+        public int Count => values.Count;
+
+        public string this[int index] => values[index];
+
+        public IEnumerator<string> GetEnumerator() => values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.CampaignService.Messages;
 using Newtonsoft.Json.Linq;
@@ -17,198 +18,364 @@ namespace GameInterface.Services.CampaignService.Commands;
 /// </summary>
 internal class CampaignOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.campaignoptions")]
-    public static string ListOptionsCommand(List<string> strings)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class CampaignOptionsListCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new();
+        public string Prefix => "coop.debug.campaign_options";
 
-        stringBuilder.AppendLine($"PlayerReceivedDamageDifficulty: {(Difficulty)PlayerReceivedDamageDifficulty}");
+        public string Name => "list";
 
-        // Different order to match vanilla campaign options menu
-        stringBuilder.AppendLine($"PlayerTroopsReceivedDamage: {PlayerTroopsReceivedDamage}");
-        stringBuilder.AppendLine($"RecruitmentDifficulty: {RecruitmentDifficulty}");
-        stringBuilder.AppendLine($"PlayerMapMovementSpeed: {PlayerMapMovementSpeed}");
-        stringBuilder.AppendLine($"PersuasionSuccessChance: {PersuasionSuccessChance}");
-        stringBuilder.AppendLine($"CombatAIDifficulty: {CombatAIDifficulty}");
-        stringBuilder.AppendLine($"ClanMemberDeathChance: {ClanMemberDeathChance}");
-        stringBuilder.AppendLine($"BattleDeath: {BattleDeath}");
-        stringBuilder.AppendLine($"StealthAndDisguiseDifficulty: {StealthAndDisguiseDifficulty}");
-        stringBuilder.AppendLine($"AutoAllocateClanMemberPerks: {AutoAllocateClanMemberPerks}");
-        stringBuilder.AppendLine($"IsIronmanMode: {IsIronmanMode}");
+        public string Description => "Reports list.";
 
-        return stringBuilder.ToString();
-    }
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-    [CommandLineArgumentFunction("AutoAllocateClanMemberPerks", "coop.debug.campaignoptions")]
-    public static string AutoAllocateClanMemberPerksCommand(List<string> strings)
-    {
-        return HandleBooleanOptionCommand(
-            strings,
-            nameof(AutoAllocateClanMemberPerks),
-            () => AutoAllocateClanMemberPerks,
-            value => AutoAllocateClanMemberPerks = value);
-    }
-
-    [CommandLineArgumentFunction("PlayerTroopsReceivedDamage", "coop.debug.campaignoptions")]
-    public static string PlayerTroopsReceivedDamageCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(PlayerTroopsReceivedDamage),
-            () => PlayerTroopsReceivedDamage,
-            value => PlayerTroopsReceivedDamage = value);
-    }
-
-    [CommandLineArgumentFunction("RecruitmentDifficulty", "coop.debug.campaignoptions")]
-    public static string RecruitmentDifficultyCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(RecruitmentDifficulty),
-            () => RecruitmentDifficulty,
-            value => RecruitmentDifficulty = value);
-    }
-
-    [CommandLineArgumentFunction("PlayerMapMovementSpeed", "coop.debug.campaignoptions")]
-    public static string PlayerMapMovementSpeedCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(PlayerMapMovementSpeed),
-            () => PlayerMapMovementSpeed,
-            value => PlayerMapMovementSpeed = value);
-    }
-
-    [CommandLineArgumentFunction("StealthAndDisguiseDifficulty", "coop.debug.campaignoptions")]
-    public static string StealthAndDisguiseDifficultyCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(StealthAndDisguiseDifficulty),
-            () => StealthAndDisguiseDifficulty,
-            value => StealthAndDisguiseDifficulty = value);
-    }
-
-    [CommandLineArgumentFunction("CombatAIDifficulty", "coop.debug.campaignoptions")]
-    public static string CombatAIDifficultyCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(CombatAIDifficulty),
-            () => CombatAIDifficulty,
-            value => CombatAIDifficulty = value);
-    }
-
-    [CommandLineArgumentFunction("IsLifeDeathCycleDisabled", "coop.debug.campaignoptions")]
-    public static string IsLifeDeathCycleDisabledCommand(List<string> strings)
-    {
-        return HandleBooleanOptionCommand(
-            strings,
-            nameof(IsLifeDeathCycleDisabled),
-            () => IsLifeDeathCycleDisabled,
-            value => IsLifeDeathCycleDisabled = value);
-    }
-
-    [CommandLineArgumentFunction("PersuasionSuccessChance", "coop.debug.campaignoptions")]
-    public static string PersuasionSuccessChanceCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(PersuasionSuccessChance),
-            () => PersuasionSuccessChance,
-            value => PersuasionSuccessChance = value);
-    }
-
-    [CommandLineArgumentFunction("ClanMemberDeathChance", "coop.debug.campaignoptions")]
-    public static string ClanMemberDeathChanceCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(ClanMemberDeathChance),
-            () => ClanMemberDeathChance,
-            value => ClanMemberDeathChance = value);
-    }
-
-    [CommandLineArgumentFunction("IsIronmanMode", "coop.debug.campaignoptions")]
-    public static string IsIronmanModeCommand(List<string> strings)
-    {
-        if (strings.Count == 0)
-            return $"{nameof(IsIronmanMode)} is {(IsIronmanMode ? "enabled" : "disabled")}.";
-
-        if (ModInformation.IsClient)
-            return "Managing campaign options is disabled on clients; the host does this.";
-
-        return "This option can only be set at game start.";
-    }
-
-    [CommandLineArgumentFunction("BattleDeath", "coop.debug.campaignoptions")]
-    public static string BattleDeathCommand(List<string> strings)
-    {
-        return HandleDifficultyOptionCommand(
-            strings,
-            nameof(BattleDeath),
-            () => BattleDeath,
-            value => BattleDeath = value);
-    }
-
-    [CommandLineArgumentFunction("PlayerReceivedDamageDifficulty", "coop.debug.campaignoptions")]
-    public static string SetPlayerReceivedDamageDifficulty(List<string> strings)
-    {
-        Difficulty oldValue = (Difficulty)PlayerReceivedDamageDifficulty;
-
-        var result = HandleDifficultyOptionCommand(
-            strings,
-            nameof(PlayerReceivedDamageDifficulty),
-            () => (Difficulty)PlayerReceivedDamageDifficulty,
-            value => PlayerReceivedDamageDifficulty = (int)value);
-
-        // Player received damage is not a campaign option. Need to update for clients separately
-        if (oldValue != (Difficulty)PlayerReceivedDamageDifficulty)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            UpdateOtherOptions();
-        }
+            StringBuilder stringBuilder = new();
 
-        return result;
+            stringBuilder.AppendLine($"PlayerReceivedDamageDifficulty: {(Difficulty)PlayerReceivedDamageDifficulty}");
+
+            // Different order to match vanilla campaign options menu
+            stringBuilder.AppendLine($"PlayerTroopsReceivedDamage: {PlayerTroopsReceivedDamage}");
+            stringBuilder.AppendLine($"RecruitmentDifficulty: {RecruitmentDifficulty}");
+            stringBuilder.AppendLine($"PlayerMapMovementSpeed: {PlayerMapMovementSpeed}");
+            stringBuilder.AppendLine($"PersuasionSuccessChance: {PersuasionSuccessChance}");
+            stringBuilder.AppendLine($"CombatAIDifficulty: {CombatAIDifficulty}");
+            stringBuilder.AppendLine($"ClanMemberDeathChance: {ClanMemberDeathChance}");
+            stringBuilder.AppendLine($"BattleDeath: {BattleDeath}");
+            stringBuilder.AppendLine($"StealthAndDisguiseDifficulty: {StealthAndDisguiseDifficulty}");
+            stringBuilder.AppendLine($"AutoAllocateClanMemberPerks: {AutoAllocateClanMemberPerks}");
+            stringBuilder.AppendLine($"IsIronmanMode: {IsIronmanMode}");
+
+            return Succeeded(stringBuilder.ToString());
+        }
     }
 
-    private static string HandleBooleanOptionCommand(List<string> strings, string optionName, Func<bool> getter, Action<bool> setter)
+    public sealed class CampaignOptionsAutoAllocateClanMemberPerksCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "auto_allocate_clan_member_perks";
+
+        public string Description => "Runs the auto allocate clan member perks debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleBooleanOptionCommand(
+                strings,
+                nameof(AutoAllocateClanMemberPerks),
+                () => AutoAllocateClanMemberPerks,
+                value => AutoAllocateClanMemberPerks = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPlayerTroopsReceivedDamageCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "player_troops_received_damage";
+
+        public string Description => "Runs the player troops received damage debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(PlayerTroopsReceivedDamage),
+                () => PlayerTroopsReceivedDamage,
+                value => PlayerTroopsReceivedDamage = value);
+        }
+    }
+
+    public sealed class CampaignOptionsRecruitmentDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "recruitment_difficulty";
+
+        public string Description => "Runs the recruitment difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(RecruitmentDifficulty),
+                () => RecruitmentDifficulty,
+                value => RecruitmentDifficulty = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPlayerMapMovementSpeedCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "player_map_movement_speed";
+
+        public string Description => "Runs the player map movement speed debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(PlayerMapMovementSpeed),
+                () => PlayerMapMovementSpeed,
+                value => PlayerMapMovementSpeed = value);
+        }
+    }
+
+    public sealed class CampaignOptionsStealthAndDisguiseDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "stealth_and_disguise_difficulty";
+
+        public string Description => "Runs the stealth and disguise difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(StealthAndDisguiseDifficulty),
+                () => StealthAndDisguiseDifficulty,
+                value => StealthAndDisguiseDifficulty = value);
+        }
+    }
+
+    public sealed class CampaignOptionsCombatAiDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "combat_ai_difficulty";
+
+        public string Description => "Runs the combat ai difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(CombatAIDifficulty),
+                () => CombatAIDifficulty,
+                value => CombatAIDifficulty = value);
+        }
+    }
+
+    public sealed class CampaignOptionsIsLifeDeathCycleDisabledCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "is_life_death_cycle_disabled";
+
+        public string Description => "Runs the is life death cycle disabled debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleBooleanOptionCommand(
+                strings,
+                nameof(IsLifeDeathCycleDisabled),
+                () => IsLifeDeathCycleDisabled,
+                value => IsLifeDeathCycleDisabled = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPersuasionSuccessChanceCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "persuasion_success_chance";
+
+        public string Description => "Runs the persuasion success chance debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(PersuasionSuccessChance),
+                () => PersuasionSuccessChance,
+                value => PersuasionSuccessChance = value);
+        }
+    }
+
+    public sealed class CampaignOptionsClanMemberDeathChanceCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "clan_member_death_chance";
+
+        public string Description => "Runs the clan member death chance debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(ClanMemberDeathChance),
+                () => ClanMemberDeathChance,
+                value => ClanMemberDeathChance = value);
+        }
+    }
+
+    public sealed class CampaignOptionsIsIronmanModeCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "is_ironman_mode";
+
+        public string Description => "Runs the is ironman mode debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (strings.Count == 0)
+                return Succeeded($"{nameof(IsIronmanMode)} is {(IsIronmanMode ? "enabled" : "disabled")}.");
+
+            if (ModInformation.IsClient)
+                return Failed("Managing campaign options is disabled on clients; the host does this.");
+
+            return Failed("This option can only be set at game start.");
+        }
+    }
+
+    public sealed class CampaignOptionsBattleDeathCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "battle_death";
+
+        public string Description => "Runs the battle death debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return HandleDifficultyOptionCommand(
+                strings,
+                nameof(BattleDeath),
+                () => BattleDeath,
+                value => BattleDeath = value);
+        }
+    }
+
+    public sealed class CampaignOptionsPlayerReceivedDamageDifficultyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.campaign_options";
+
+        public string Name => "player_received_damage_difficulty";
+
+        public string Description => "Runs the player received damage difficulty debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("value", "The option value.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            Difficulty oldValue = (Difficulty)PlayerReceivedDamageDifficulty;
+
+            var result = HandleDifficultyOptionCommand(
+                strings,
+                nameof(PlayerReceivedDamageDifficulty),
+                () => (Difficulty)PlayerReceivedDamageDifficulty,
+                value => PlayerReceivedDamageDifficulty = (int)value);
+
+            // Player received damage is not a campaign option. Need to update for clients separately
+            if (oldValue != (Difficulty)PlayerReceivedDamageDifficulty)
+            {
+                UpdateOtherOptions();
+            }
+
+            return result;
+        }
+    }
+
+    private static CoopCommandResult HandleBooleanOptionCommand(IReadOnlyList<string> strings, string optionName, Func<bool> getter, Action<bool> setter)
     {
         if (strings.Count == 0)
-            return $"{optionName} is currently {(getter() ? "enabled" : "disabled")}.";
+            return Succeeded($"{optionName} is currently {(getter() ? "enabled" : "disabled")}.");
 
         if (ModInformation.IsClient)
-            return "Managing campaign options is disabled on clients; the host does this.";
-
-        if (strings.Count != 1)
-            return $"Usage: coop.debug.campaignoptions.{optionName} <true|false|1|0>";
+            return Failed("Managing campaign options is disabled on clients; the host does this.");
 
         if (!TryParseBool(strings[0], out var value))
-            return $"Invalid value '{strings[0]}'. Valid values: true, false, 1, 0.";
+            return Failed($"Invalid value '{strings[0]}'. Valid values: true, false, 1, 0.");
 
         setter(value);
         UpdateCampaignOptions();
 
-        return $"{optionName} {(value ? "enabled" : "disabled")}.";
+        return Succeeded($"{optionName} {(value ? "enabled" : "disabled")}.");
     }
 
-    private static string HandleDifficultyOptionCommand(List<string> strings, string optionName, Func<Difficulty> getter, Action<Difficulty> setter)
+    private static CoopCommandResult HandleDifficultyOptionCommand(IReadOnlyList<string> strings, string optionName, Func<Difficulty> getter, Action<Difficulty> setter)
     {
         if (strings.Count == 0)
-            return $"{optionName} is currently {getter()}.";
+            return Succeeded($"{optionName} is currently {getter()}.");
 
         if (ModInformation.IsClient)
-            return "Managing campaign options is disabled on clients; the host does this.";
-
-        if (strings.Count != 1)
-            return $"Usage: coop.debug.campaignoptions.{optionName} <veryeasy|easy|realistic|0|1|2>";
+            return Failed("Managing campaign options is disabled on clients; the host does this.");
 
         if (!TryParseDifficulty(strings[0], out var value))
-            return $"Invalid value '{strings[0]}'. Valid values: veryeasy, easy, realistic, 0, 1, 2.";
+            return Failed($"Invalid value '{strings[0]}'. Valid values: veryeasy, easy, realistic, 0, 1, 2.");
 
         setter(value);
         UpdateCampaignOptions();
 
-        return $"{optionName} set to {value}.";
+        return Succeeded($"{optionName} set to {value}.");
     }
 
     private static bool TryParseBool(string input, out bool value)

--- a/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
@@ -1,4 +1,6 @@
-﻿using GameInterface.Configuration;
+﻿using System;
+using Common.Commands;
+using GameInterface.Configuration;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
@@ -8,21 +10,37 @@ namespace GameInterface.Services.CampaignService.Commands;
 
 internal class ModOptionsCommands
 {
-    [CommandLineArgumentFunction("list", "coop.debug.modconfig")]
-    public static string ListOptionsCommand(List<string> strings)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class ModConfigListCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new();
+        public string Prefix => "coop.debug.mod_config";
 
-        var modOptions = ModConfigProvider.ModOptions;
+        public string Name => "list";
 
-        foreach (PropertyInfo property in typeof(ModOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        public string Description => "Reports list.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            string name = property.Name;
-            string value = property.GetValue(modOptions)?.ToString() ?? "null";
+            StringBuilder stringBuilder = new();
 
-            stringBuilder.AppendLine($"{name}: {value}");
+            var modOptions = ModConfigProvider.ModOptions;
+
+            foreach (PropertyInfo property in typeof(ModOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                string name = property.Name;
+                string value = property.GetValue(modOptions)?.ToString() ?? "null";
+
+                stringBuilder.AppendLine($"{name}: {value}");
+            }
+
+            return Succeeded(stringBuilder.ToString());
         }
-
-        return stringBuilder.ToString();
     }
 }

--- a/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
+++ b/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System;
+using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using GameInterface.CoopSessionData;
@@ -15,6 +17,12 @@ namespace GameInterface.Services.Caravans.Commands;
 
 internal class CaravansCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<CaravansCommands>();
 
     /// <summary>
@@ -31,164 +39,214 @@ internal class CaravansCommands
     /// <summary>
     /// View prohibited kingdoms for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_prohibited_kingdoms", "coop.debug.caravans")]
-    public static string ViewProhibitedKingdomsCommand(List<string> strings)
+    public sealed class CaravansViewProhibitedKingdomsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.caravans";
+
+        public string Name => "view_prohibited_kingdoms";
+
+        public string Description => "Reports view prohibited kingdoms.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerProhibitedKingdom in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerProhibitedKingdomsForPlayerCaravans)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerProhibitedKingdom.Key == null || playerProhibitedKingdom.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerProhibitedKingdom.Key}");
-                foreach (var prohibitedKingdom in playerProhibitedKingdom.Value)
+                foreach (var playerProhibitedKingdom in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerProhibitedKingdomsForPlayerCaravans)
                 {
-                    stringBuilder.AppendLine($"{prohibitedKingdom}");
+                    if (playerProhibitedKingdom.Key == null || playerProhibitedKingdom.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerProhibitedKingdom.Key}");
+                    foreach (var prohibitedKingdom in playerProhibitedKingdom.Value)
+                    {
+                        stringBuilder.AppendLine($"{prohibitedKingdom}");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var prohibitedKingdom in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._prohibitedKingdomsForPlayerCaravans)
+            else
             {
-                stringBuilder.AppendLine($"{prohibitedKingdom.StringId}");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var prohibitedKingdom in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._prohibitedKingdomsForPlayerCaravans)
+                {
+                    stringBuilder.AppendLine($"{prohibitedKingdom.StringId}");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve prohibited kingdoms");
         }
-        return "Failed to retrieve prohibited kingdoms";
     }
 
     /// <summary>
     /// View interacted caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_interacted_caravans", "coop.debug.caravans")]
-    public static string ViewInteractedCaravansCommand(List<string> strings)
+    public sealed class CaravansViewInteractedCaravansCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.caravans";
+
+        public string Name => "view_interacted_caravans";
+
+        public string Description => "Reports view interacted caravans.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerInteractedCaravan in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerInteractedCaravans)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerInteractedCaravan.Key == null || playerInteractedCaravan.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerInteractedCaravan.Key}");
-                foreach (var interactedCaravan in playerInteractedCaravan.Value)
+                foreach (var playerInteractedCaravan in coopSessionProvider.CoopSession.InteractionsPlayerData.PlayerInteractedCaravans)
                 {
-                    stringBuilder.AppendLine($"{interactedCaravan.Key} ({interactedCaravan.Value})");
+                    if (playerInteractedCaravan.Key == null || playerInteractedCaravan.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerInteractedCaravan.Key}");
+                    foreach (var interactedCaravan in playerInteractedCaravan.Value)
+                    {
+                        stringBuilder.AppendLine($"{interactedCaravan.Key} ({interactedCaravan.Value})");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var interactedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._interactedCaravans)
+            else
             {
-                stringBuilder.AppendLine($"{interactedCaravan.Key.StringId} ({(int)interactedCaravan.Value})");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var interactedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._interactedCaravans)
+                {
+                    stringBuilder.AppendLine($"{interactedCaravan.Key.StringId} ({(int)interactedCaravan.Value})");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve interacted caravans");
         }
-        return "Failed to retrieve interacted caravans";
     }
 
     /// <summary>
     /// View player trade rumor taken caravans for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_taken_trade_rumors", "coop.debug.caravans")]
-    public static string ViewTakenTradeRumorsCommand(List<string> strings)
+    public sealed class CaravansViewTakenTradeRumorsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.caravans";
+
+        public string Name => "view_taken_trade_rumors";
+
+        public string Description => "Reports view taken trade rumors.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerTakenTradeRumorCaravan in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerTradeRumorTakenCaravans)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerTakenTradeRumorCaravan.Key == null || playerTakenTradeRumorCaravan.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerTakenTradeRumorCaravan.Key}");
-                foreach (var takenTradeRumorCaravan in playerTakenTradeRumorCaravan.Value)
+                foreach (var playerTakenTradeRumorCaravan in coopSessionProvider.CoopSession.CaravansPlayerData.PlayerTradeRumorTakenCaravans)
                 {
-                    stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key} ({takenTradeRumorCaravan.Value})");
+                    if (playerTakenTradeRumorCaravan.Key == null || playerTakenTradeRumorCaravan.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerTakenTradeRumorCaravan.Key}");
+                    foreach (var takenTradeRumorCaravan in playerTakenTradeRumorCaravan.Value)
+                    {
+                        stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key} ({takenTradeRumorCaravan.Value})");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var takenTradeRumorCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeRumorTakenCaravans)
+            else
             {
-                stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key.StringId} ({takenTradeRumorCaravan.Value.NumTicks})");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var takenTradeRumorCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeRumorTakenCaravans)
+                {
+                    stringBuilder.AppendLine($"{takenTradeRumorCaravan.Key.StringId} ({takenTradeRumorCaravan.Value.NumTicks})");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve trade rumor taken caravans");
         }
-        return "Failed to retrieve trade rumor taken caravans";
     }
 
-    [CommandLineArgumentFunction("view_trade_action_logs", "coop.debug.caravans")]
-    public static string ViewTradeActionLogs(List<string> strings)
+    public sealed class CaravansViewTradeActionLogsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var caravanTradeActionLogs in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeActionLogs)
-        {
-            // Do not output data for caravans in a settlement, logs only refresh for clients when caravans leave a settlement
-            if (caravanTradeActionLogs.Key.CurrentSettlement != null) continue;
+        public string Prefix => "coop.debug.caravans";
 
-            stringBuilder.AppendLine($"{caravanTradeActionLogs.Key.StringId}:");
-            foreach (var tradeActionLog in caravanTradeActionLogs.Value)
+        public string Name => "view_trade_action_logs";
+
+        public string Description => "Reports view trade action logs.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var caravanTradeActionLogs in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._tradeActionLogs)
             {
-                stringBuilder.AppendLine($"- " +
-                    $"{tradeActionLog.BoughtSettlement?.StringId}, " +
-                    $"{tradeActionLog.SoldSettlement?.StringId}, " +
-                    $"{tradeActionLog.BuyPrice}, " +
-                    $"{tradeActionLog.SellPrice}, " +
-                    $"{tradeActionLog.ItemRosterElement.EquipmentElement.Item.StringId}, " +
-                    $"{tradeActionLog.BoughtTime.NumTicks}");
-            }
-        }
+                // Do not output data for caravans in a settlement, logs only refresh for clients when caravans leave a settlement
+                if (caravanTradeActionLogs.Key.CurrentSettlement != null) continue;
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+                stringBuilder.AppendLine($"{caravanTradeActionLogs.Key.StringId}:");
+                foreach (var tradeActionLog in caravanTradeActionLogs.Value)
+                {
+                    stringBuilder.AppendLine($"- " +
+                        $"{tradeActionLog.BoughtSettlement?.StringId}, " +
+                        $"{tradeActionLog.SoldSettlement?.StringId}, " +
+                        $"{tradeActionLog.BuyPrice}, " +
+                        $"{tradeActionLog.SellPrice}, " +
+                        $"{tradeActionLog.ItemRosterElement.EquipmentElement.Item.StringId}, " +
+                        $"{tradeActionLog.BoughtTime.NumTicks}");
+                }
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve trade action logs");
         }
-        return "Failed to retrieve trade action logs";
     }
 
-    [CommandLineArgumentFunction("view_looted_caravans", "coop.debug.caravans")]
-    public static string ViewLootedCaravans(List<string> strings)
+    public sealed class CaravansViewLootedCaravansCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var lootedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._lootedCaravans)
-        {
-            stringBuilder.AppendLine($"{lootedCaravan.Key.StringId} ({lootedCaravan.Value.NumTicks})");
-        }
+        public string Prefix => "coop.debug.caravans";
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
+        public string Name => "view_looted_caravans";
+
+        public string Description => "Reports view looted caravans.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            return result;
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var lootedCaravan in Campaign.Current.GetCampaignBehavior<CaravansCampaignBehavior>()._lootedCaravans)
+            {
+                stringBuilder.AppendLine($"{lootedCaravan.Key.StringId} ({lootedCaravan.Value.NumTicks})");
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve looted caravans");
         }
-        return "Failed to retrieve looted caravans";
     }
 }

--- a/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common.Logging;
+﻿using Common.Commands;
+using Common.Logging;
 using GameInterface.Services.CharacterDevelopers.Handlers;
 using Serilog;
 using System.Collections.Generic;
@@ -12,74 +13,89 @@ namespace GameInterface.Services.CharacterDevelopers.Commands;
 
 internal class CharacterDeveloperCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<CharacterDeveloperHandler>();
 
     /// <summary>
     /// Output attributes, focuses, skills and perks of a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("stats", "coop.debug.herodeveloper")]
-    public static string HeroStatsCommand(List<string> strings)
+    public sealed class HeroDeveloperStatsCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.hero_developer";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "stats";
+
+        public string Description => "Reports stats.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                string heroData = hero.Name + ":\n";
-
-                heroData += " Level: " + hero.Level + "\n";
-
-                heroData += " Total XP: " + hero.HeroDeveloper.TotalXp + "\n";
-
-                heroData += " Unspent Focus Points: " + hero.HeroDeveloper.UnspentFocusPoints + "\n";
-
-                heroData += " Unspent Attribute Points: " + hero.HeroDeveloper.UnspentAttributePoints + "\n";
-
-                heroData += " Attributes: {";
-                foreach (CharacterAttribute attribute in hero._characterAttributes._attributes.Keys)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    heroData += attribute.Name + ": " + hero.GetAttributeValue(attribute) + ",";
-                }
+                    string heroData = hero.Name + ":\n";
 
-                heroData += "\n Skill XPs: {";
-                foreach (var skillXp in hero.HeroDeveloper._skillXps)
-                {
-                    heroData += skillXp.Key.Name + ": " + skillXp.Value + ",";
-                }
+                    heroData += " Level: " + hero.Level + "\n";
 
-                heroData += "}\n Focuses: {";
-                foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
-                {
-                    heroData += skill.Name + ": " + hero.HeroDeveloper.GetFocus(skill) + ",";
-                }
+                    heroData += " Total XP: " + hero.HeroDeveloper.TotalXp + "\n";
 
-                heroData += "}\n Skills: {";
-                foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
-                {
-                    heroData += skill.Name + ": " + hero.GetSkillValue(skill) + ",";
-                }
+                    heroData += " Unspent Focus Points: " + hero.HeroDeveloper.UnspentFocusPoints + "\n";
 
-                heroData += "}\n Perks: {";
-                foreach (PerkObject perk in hero._heroPerks._attributes.Keys)
-                {
-                    heroData += perk.Name + ",";
-                }
-                heroData += "}";
+                    heroData += " Unspent Attribute Points: " + hero.HeroDeveloper.UnspentAttributePoints + "\n";
 
-                stringBuilder.AppendLine(heroData);
+                    heroData += " Attributes: {";
+                    foreach (CharacterAttribute attribute in hero._characterAttributes._attributes.Keys)
+                    {
+                        heroData += attribute.Name + ": " + hero.GetAttributeValue(attribute) + ",";
+                    }
+
+                    heroData += "\n Skill XPs: {";
+                    foreach (var skillXp in hero.HeroDeveloper._skillXps)
+                    {
+                        heroData += skillXp.Key.Name + ": " + skillXp.Value + ",";
+                    }
+
+                    heroData += "}\n Focuses: {";
+                    foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
+                    {
+                        heroData += skill.Name + ": " + hero.HeroDeveloper.GetFocus(skill) + ",";
+                    }
+
+                    heroData += "}\n Skills: {";
+                    foreach (SkillObject skill in hero._heroSkills._attributes.Keys)
+                    {
+                        heroData += skill.Name + ": " + hero.GetSkillValue(skill) + ",";
+                    }
+
+                    heroData += "}\n Perks: {";
+                    foreach (PerkObject perk in hero._heroPerks._attributes.Keys)
+                    {
+                        heroData += perk.Name + ",";
+                    }
+                    heroData += "}";
+
+                    stringBuilder.AppendLine(heroData);
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 }

--- a/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
+++ b/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
@@ -1,4 +1,5 @@
-﻿using GameInterface.Services.ObjectManager;
+﻿using Common.Commands;
+using GameInterface.Services.ObjectManager;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,53 +11,81 @@ using static TaleWorlds.Library.CommandLineFunctionality;
 namespace GameInterface.Services.CharacterObjects.Commands;
 internal class CharacterObjectCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     // coop.debug.characterObjects.info <charId>
     /// <summary>
     /// Reflection-dumps every field of a CharacterObject (walking up to its BasicCharacterObject base, where
     /// the synced _characterTraits / _occupation / _persona fields live) so a server screenshot and a client
     /// screenshot can be compared field-for-field to confirm CharacterObject syncs still replicate.
     /// </summary>
-    [CommandLineArgumentFunction("info", "coop.debug.characterObjects")]
-    public static string Info(List<string> args)
+    public sealed class CharacterObjectsInfoCoopCommand : ICoopCommand
     {
-        if (args.Count != 1) return "Usage: coop.debug.characterObjects.info <charId>";
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false) return "Unable to resolve object manager";
-        if (objectManager.TryGetObject<CharacterObject>(args[0], out var character) == false) return $"Unable to find character with id: {args[0]}";
+        public string Prefix => "coop.debug.character_objects";
 
-        var stringBuilder = new StringBuilder();
-        for (Type type = typeof(CharacterObject); type != null && type != typeof(object); type = type.BaseType)
+        public string Name => "info";
+
+        public string Description => "Reports info.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            foreach (var field in type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            new ExpectedArgs("character_id", "The registered character id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false) return Failed("Unable to resolve object manager");
+            if (objectManager.TryGetObject<CharacterObject>(args[0], out var character) == false) return Failed($"Unable to find character with id: {args[0]}");
+
+            var stringBuilder = new StringBuilder();
+            for (Type type = typeof(CharacterObject); type != null && type != typeof(object); type = type.BaseType)
             {
-                stringBuilder.AppendLine($"{type.Name}.{field.Name} = {field.GetValue(character)}");
+                foreach (var field in type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    stringBuilder.AppendLine($"{type.Name}.{field.Name} = {field.GetValue(character)}");
+                }
             }
+            return Succeeded(stringBuilder.ToString());
         }
-        return stringBuilder.ToString();
     }
 
     // coop.debug.characterObjects.list
-    [CommandLineArgumentFunction("list", "coop.debug.characterObjects")]
-    public static string ListCharacterObjects(List<string> args)
+    public sealed class CharacterObjectsListCoopCommand : ICoopCommand
     {
-        var characters = MBObjectManager.Instance.GetObjectTypeList<CharacterObject>();
+        public string Prefix => "coop.debug.character_objects";
 
-        if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
-        {
-            return "Unable to resolve object manager";
-        }
+        public string Name => "list";
 
-        var stringBuilder = new StringBuilder();
-        foreach (var character in characters)
+        public string Description => "Reports list.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            if (objectManager.TryGetId(character, out var id) == false)
+            var characters = MBObjectManager.Instance.GetObjectTypeList<CharacterObject>();
+
+            if (ContainerProvider.TryResolve<IObjectManager>(out var objectManager) == false)
             {
-                stringBuilder.Append($"Unable to get id for {character.StringId}");
-                continue;
+                return Failed("Unable to resolve object manager");
             }
 
-            stringBuilder.AppendLine(id);
-        }
+            var stringBuilder = new StringBuilder();
+            foreach (var character in characters)
+            {
+                if (objectManager.TryGetId(character, out var id) == false)
+                {
+                    stringBuilder.Append($"Unable to get id for {character.StringId}");
+                    continue;
+                }
 
-        return stringBuilder.ToString();
+                stringBuilder.AppendLine(id);
+            }
+
+            return Succeeded(stringBuilder.ToString());
+        }
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
@@ -1,4 +1,6 @@
-﻿using SandBox.View.Map;
+﻿using System;
+using Common.Commands;
+using SandBox.View.Map;
 using System.Collections.Generic;
 using TaleWorlds.Core;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -7,43 +9,72 @@ namespace GameInterface.Services.GameDebug.Commands;
 
 internal class CameraReset
 {
-    [CommandLineArgumentFunction("fix_camera", "coop.debug")]
-    public static string ChangeClanLeader(List<string> strings)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class FixCameraCoopCommand : ICoopCommand
     {
-        Game.Current.GameStateManager.UnregisterActiveStateDisableRequest(MapScreen.Instance);
-        return "Camera reset";
+        public string Prefix => "coop.debug";
+
+        public string Name => "fix_camera";
+
+        public string Description => "Runs the fix camera debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            Game.Current.GameStateManager.UnregisterActiveStateDisableRequest(MapScreen.Instance);
+            return Succeeded("Camera reset");
+        }
     }
 
-    [CommandLineArgumentFunction("focus_main_party", "coop.debug.map_camera")]
-    public static string FocusMainParty(List<string> strings)
+    public sealed class MapCameraFocusMainPartyCoopCommand : ICoopCommand
     {
-        if (strings.Count != 0)
-        {
-            return "Usage: coop.debug.map_camera.focus_main_party";
-        }
+        public string Prefix => "coop.debug.map_camera";
 
-        MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
-        if (cameraView == null)
-        {
-            return "Campaign map camera is unavailable";
-        }
+        public string Name => "focus_main_party";
 
-        cameraView.TeleportCameraToMainParty();
-        return GetCameraState(cameraView);
+        public string Description => "Runs the focus main party debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
+            if (cameraView == null)
+            {
+                return Failed("Campaign map camera is unavailable");
+            }
+
+            cameraView.TeleportCameraToMainParty();
+            return Succeeded(GetCameraState(cameraView));
+        }
     }
 
-    [CommandLineArgumentFunction("state", "coop.debug.map_camera")]
-    public static string GetState(List<string> strings)
+    public sealed class MapCameraStateCoopCommand : ICoopCommand
     {
-        if (strings.Count != 0)
-        {
-            return "Usage: coop.debug.map_camera.state";
-        }
+        public string Prefix => "coop.debug.map_camera";
 
-        MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
-        return cameraView == null
-            ? "Campaign map camera is unavailable"
-            : GetCameraState(cameraView);
+        public string Name => "state";
+
+        public string Description => "Reports state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            MapCameraView cameraView = MapScreen.Instance?.MapCameraView;
+            if (cameraView == null)
+                return Failed("Campaign map camera is unavailable");
+
+            return Succeeded(GetCameraState(cameraView));
+        }
     }
 
     private static string GetCameraState(MapCameraView cameraView)

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using System.Collections.Generic;
 using System.Threading;
 using static TaleWorlds.Library.CommandLineFunctionality;
@@ -12,58 +13,89 @@ namespace GameInterface.Services.GameDebug.Commands;
 /// </summary>
 public class GameThreadDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     // coop.debug.gamethread.instrument [on|off|toggle|status]
     /// <summary>
     /// Turns the game-thread drain instrumentation on or off, or reports its current state. With no
     /// argument it flips the current setting.
     /// </summary>
-    [CommandLineArgumentFunction("instrument", "coop.debug.gamethread")]
-    public static string Instrument(List<string> args)
+    public sealed class GameThreadInstrumentCoopCommand : ICoopCommand
     {
-        var arg = args.Count > 0 ? args[0].ToLowerInvariant() : "toggle";
+        public string Prefix => "coop.debug.game_thread";
 
-        switch (arg)
+        public string Name => "instrument";
+
+        public string Description => "Runs the instrument debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "on":
-            case "true":
-            case "1":
-                GameThread.Instrument = true;
-                break;
-            case "off":
-            case "false":
-            case "0":
-                GameThread.Instrument = false;
-                break;
-            case "toggle":
-                GameThread.Instrument = !GameThread.Instrument;
-                break;
-            case "status":
-                break;
-            default:
-                return "Usage: coop.debug.gamethread.instrument [on|off|toggle|status]";
-        }
+            new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: false),
+        };
 
-        return $"GameThread drain instrumentation is {(GameThread.Instrument ? "ON" : "OFF")}. " +
-               "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.";
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var arg = args.Count > 0 ? args[0].ToLowerInvariant() : "toggle";
+
+            switch (arg)
+            {
+                case "on":
+                case "true":
+                case "1":
+                    GameThread.Instrument = true;
+                    break;
+                case "off":
+                case "false":
+                case "0":
+                    GameThread.Instrument = false;
+                    break;
+                case "toggle":
+                    GameThread.Instrument = !GameThread.Instrument;
+                    break;
+                case "status":
+                    break;
+                default:
+                    return Failed($"Invalid mode '{args[0]}'. Expected on, off, toggle, or status.");
+            }
+
+            return Succeeded($"GameThread drain instrumentation is {(GameThread.Instrument ? "ON" : "OFF")}. " +
+                   "When ON, a per-second [GameThread] summary (drain ms, worst frame, backlog, top handlers) is written to the log.");
+        }
     }
 
-    [CommandLineArgumentFunction("stall", "coop.debug.gamethread")]
-    public static string Stall(List<string> args)
+    public sealed class GameThreadStallCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-        {
-            return "gamethread.stall must be run on the server";
-        }
+        public string Prefix => "coop.debug.game_thread";
 
-        if (args.Count != 1 ||
-            int.TryParse(args[0], out int milliseconds) == false ||
-            milliseconds < 1 ||
-            milliseconds > 5000)
-        {
-            return "Usage: coop.debug.gamethread.stall <milliseconds from 1 to 5000>";
-        }
+        public string Name => "stall";
 
-        Thread.Sleep(milliseconds);
-        return $"Stalled the server game thread for {milliseconds} ms";
+        public string Description => "Runs the stall debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("milliseconds", "The stall duration from 1 through 5000 milliseconds.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+            {
+                return Failed("gamethread.stall must be run on the server");
+            }
+
+            if (int.TryParse(args[0], out int milliseconds) == false ||
+                milliseconds < 1 ||
+                milliseconds > 5000)
+            {
+                return Failed("Stall duration must be an integer from 1 through 5000 milliseconds.");
+            }
+
+            Thread.Sleep(milliseconds);
+            return Succeeded($"Stalled the server game thread for {milliseconds} ms");
+        }
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
@@ -1,62 +1,84 @@
+﻿using Common.Commands;
 using Common;
 using GameInterface.Services.GameDebug.Metrics;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.GameDebug.Commands;
 
 public class PartySyncPerformanceLogsCommand
 {
-    private const string Usage = "Usage: coop.debug.metrics.party_sync_performance_logs on <seconds> <filename> | off | status";
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 
-    [CommandLineArgumentFunction("party_sync_performance_logs", "coop.debug.metrics")]
-    public static string PartySyncPerformanceLogs(List<string> args)
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class MetricsPartySyncPerformanceLogsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-        {
-            return "party_sync_performance_logs can only be called by a client";
-        }
+        public string Prefix => "coop.debug.metrics";
 
-        if (ContainerProvider.TryResolve<IPartySyncPerformanceLogger>(out var logger) == false)
-        {
-            return $"Unable to get {nameof(IPartySyncPerformanceLogger)}";
-        }
+        public string Name => "party_sync_performance_logs";
 
-        if (args.Count == 0)
-        {
-            return Usage;
-        }
+        public string Description => "Runs the party sync performance logs debug operation.";
 
-        var mode = args[0].ToLowerInvariant();
-
-        switch (mode)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "on":
-                return Enable(logger, args);
-            case "off":
-                return logger.Disable();
-            case "status":
-                return logger.Status();
-            default:
-                return Usage;
+            new ExpectedArgs("mode", "on, off, or status.", isRequired: true),
+            new ExpectedArgs("seconds", "The logging duration in seconds when enabling.", isRequired: false),
+            new ExpectedArgs("file_name", "The output file name when enabling.", isRequired: false),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+            {
+                return Failed("party_sync_performance_logs can only be called by a client");
+            }
+
+            if (ContainerProvider.TryResolve<IPartySyncPerformanceLogger>(out var logger) == false)
+            {
+                return Failed($"Unable to get {nameof(IPartySyncPerformanceLogger)}");
+            }
+
+            var mode = args[0].ToLowerInvariant();
+
+            switch (mode)
+            {
+                case "on":
+                    return Enable(logger, args);
+                case "off":
+                    return Succeeded(logger.Disable());
+                case "status":
+                    return Succeeded(logger.Status());
+                default:
+                    return Failed($"Invalid mode '{args[0]}'. Expected on, off, or status.");
+            }
         }
     }
 
-    private static string Enable(IPartySyncPerformanceLogger logger, List<string> args)
+    private static CoopCommandResult Enable(IPartySyncPerformanceLogger logger, IReadOnlyList<string> args)
     {
         if (args.Count != 3)
-        {
-            return Usage;
-        }
+            return Failed("Enabling performance logs requires seconds and a file name.");
 
         if (!double.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) ||
             seconds <= 0d)
         {
-            return "Seconds must be a positive number";
+            return Failed("Seconds must be a positive number");
         }
 
-        return logger.Enable(TimeSpan.FromSeconds(seconds), args[2]);
+        string fileName = args[2];
+        if (string.IsNullOrWhiteSpace(fileName))
+            return Failed("File name must not be empty.");
+        if (Path.GetFileName(fileName) != fileName || fileName.Contains(".."))
+            return Failed("File name must not include a path.");
+        if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            return Failed("File name contains invalid characters.");
+
+        return Succeeded(logger.Enable(TimeSpan.FromSeconds(seconds), fileName));
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using Common.Util;
 using GameInterface.Services.Settlements.Interfaces;
@@ -27,80 +28,103 @@ namespace GameInterface.Services.GameDebug.Commands;
 /// </summary>
 internal class UiDebugCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     public static readonly ILogger Logger = LogManager.GetLogger<UiDebugCommands>();
 
-    private const string CloseScreenUsage =
-@"Usage:
-  coop.debug.ui.close_screen
-
-Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle encounter screen left open.";
-
-    [CommandLineArgumentFunction("close_screen", "coop.debug.ui")]
-    public static string CloseScreen(List<string> args)
+    public sealed class UiCloseScreenCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext("close_screen", CloseScreenUsage, args);
-        if (!ctx.RequireArgCount(0, out var error))
-            return error;
+        public string Prefix => "coop.debug.ui";
 
-        if (Campaign.Current == null)
-            return "Failed: no active campaign.";
+        public string Name => "close_screen";
 
-        try
+        public string Description => "Runs the close screen debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            GameMenu.ExitToLast();
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException("Close screen", ex);
-        }
+            if (Campaign.Current == null)
+                return Failed("Failed: no active campaign.");
 
-        return "Called GameMenu.ExitToLast().";
-    }
-
-    [CommandLineArgumentFunction("prepare_evidence_map", "coop.debug.ui")]
-    public static string PrepareEvidenceMap(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.prepare_evidence_map";
-
-        MapScreen mapScreen = MapScreen.Instance;
-        if (mapScreen == null)
-            return "Campaign map screen is unavailable.";
-
-        try
-        {
-            // Hide only the client presentation; keep the saved encounter and map event unchanged.
-            if (mapScreen.IsInMenu)
+            try
             {
-                mapScreen._latestMenuContext = null;
-                mapScreen.ExitMenuContext();
+                GameMenu.ExitToLast();
             }
-            mapScreen.RemoveEncounterOverlay();
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException("Prepare evidence map", ex);
-        }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Close screen", ex));
+            }
 
-        return GetEvidenceMapState(mapScreen);
+            return Succeeded("Called GameMenu.ExitToLast().");
+        }
     }
 
-    [CommandLineArgumentFunction("evidence_map_state", "coop.debug.ui")]
-    public static string EvidenceMapState(List<string> args)
+    public sealed class UiPrepareEvidenceMapCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.ui";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.evidence_map_state";
+        public string Name => "prepare_evidence_map";
 
-        MapScreen mapScreen = MapScreen.Instance;
-        return mapScreen == null
-            ? "Campaign map screen is unavailable."
-            : GetEvidenceMapState(mapScreen);
+        public string Description => "Runs the prepare evidence map debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            MapScreen mapScreen = MapScreen.Instance;
+            if (mapScreen == null)
+                return Failed("Campaign map screen is unavailable.");
+
+            try
+            {
+                // Hide only the client presentation; keep the saved encounter and map event unchanged.
+                if (mapScreen.IsInMenu)
+                {
+                    mapScreen._latestMenuContext = null;
+                    mapScreen.ExitMenuContext();
+                }
+                mapScreen.RemoveEncounterOverlay();
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Prepare evidence map", ex));
+            }
+
+            return Succeeded(GetEvidenceMapState(mapScreen));
+        }
+    }
+
+    public sealed class UiEvidenceMapStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.ui";
+
+        public string Name => "evidence_map_state";
+
+        public string Description => "Reports evidence map state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            MapScreen mapScreen = MapScreen.Instance;
+            if (mapScreen == null)
+                return Failed("Campaign map screen is unavailable.");
+
+            return Succeeded(GetEvidenceMapState(mapScreen));
+        }
     }
 
     private static string GetEvidenceMapState(MapScreen mapScreen)
@@ -128,194 +152,264 @@ Exits the current game menu (GameMenu.ExitToLast). Use to dismiss a post-battle 
                $"loading={LoadingWindow.IsLoadingWindowActive}";
     }
 
-    [CommandLineArgumentFunction("leave_settlement_encounter", "coop.debug.ui")]
-    public static string LeaveSettlementEncounter(List<string> args)
+    public sealed class UiLeaveSettlementEncounterCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.ui";
 
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.leave_settlement_encounter";
+        public string Name => "leave_settlement_encounter";
 
-        if (Campaign.Current == null)
-            return "Failed: no active campaign.";
+        public string Description => "Runs the leave settlement encounter debug operation.";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null)
-            return "Failed: no main party.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
-        if (PlayerEncounter.Battle != null || mainParty.MapEvent != null)
-            return "Cannot leave the settlement encounter after a battle has started.";
-
-        if (PlayerEncounter.Current == null || PlayerEncounter.EncounterSettlement == null)
-            return "No active settlement encounter to leave.";
-
-        if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
-            return "Unable to resolve the settlement interface.";
-
-        try
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            using (new AllowedThread())
-                settlementInterface.EndSettlementEncounter();
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException("Leave settlement encounter", ex);
-        }
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
 
-        return "Cleared the local settlement encounter and returned to the campaign map.";
+
+            if (Campaign.Current == null)
+                return Failed("Failed: no active campaign.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null)
+                return Failed("Failed: no main party.");
+
+            if (PlayerEncounter.Battle != null || mainParty.MapEvent != null)
+                return Failed("Cannot leave the settlement encounter after a battle has started.");
+
+            if (PlayerEncounter.Current == null || PlayerEncounter.EncounterSettlement == null)
+                return Failed("No active settlement encounter to leave.");
+
+            if (!ContainerProvider.TryResolve<ISettlementInterface>(out var settlementInterface))
+                return Failed("Unable to resolve the settlement interface.");
+
+            try
+            {
+                using (new AllowedThread())
+                    settlementInterface.EndSettlementEncounter();
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Leave settlement encounter", ex));
+            }
+
+            return Succeeded("Cleared the local settlement encounter and returned to the campaign map.");
+        }
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("map_click_offset", "coop.debug.ui")]
-    public static string MapClickOffset(List<string> args)
+    public sealed class UiMapClickOffsetCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 2 ||
-            !float.TryParse(args[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetX) ||
-            !float.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetY))
-            return "Usage: coop.debug.ui.map_click_offset <offsetX> <offsetY>";
+        public string Prefix => "coop.debug.ui";
 
-        var mapScreen = MapScreen.Instance;
-        var mainParty = MobileParty.MainParty;
-        if (mapScreen == null || mainParty == null)
-            return "Failed: campaign map or main party is unavailable.";
-        if (PlayerEncounter.Current != null || mainParty.CurrentSettlement != null)
-            return "Leave the active settlement encounter before clicking the campaign map.";
-        if (mainParty.MapEvent != null)
-            return "Cannot click-to-move while the main party is in a map event.";
+        public string Name => "map_click_offset";
 
-        var current = mainParty.Position;
-        var offsets = new[]
+        public string Description => "Runs the map click offset debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            new Vec2(offsetX, offsetY),
-            new Vec2(-offsetY, offsetX),
-            new Vec2(-offsetX, -offsetY),
-            new Vec2(offsetY, -offsetX),
+            new ExpectedArgs("offset_x", "The horizontal map offset.", isRequired: true),
+            new ExpectedArgs("offset_y", "The vertical map offset.", isRequired: true),
         };
-        CampaignVec2 target = default;
-        bool targetFound = false;
-        foreach (var offset in offsets)
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var candidate = new CampaignVec2(
-                new Vec2(current.X + offset.x, current.Y + offset.y),
-                current.IsOnLand);
-            if (!candidate.Face.IsValid() ||
-                !mapScreen.MapScene.DoesPathExistBetweenFaces(
-                    candidate.Face.FaceIndex,
-                    mainParty.CurrentNavigationFace.FaceIndex,
-                    false))
-                continue;
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+            if (!float.TryParse(args[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetX) ||
+                !float.TryParse(args[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var offsetY))
+                return Failed("Offsets must be valid numbers.");
 
-            target = candidate;
-            targetFound = true;
-            break;
+            var mapScreen = MapScreen.Instance;
+            var mainParty = MobileParty.MainParty;
+            if (mapScreen == null || mainParty == null)
+                return Failed("Failed: campaign map or main party is unavailable.");
+            if (PlayerEncounter.Current != null || mainParty.CurrentSettlement != null)
+                return Failed("Leave the active settlement encounter before clicking the campaign map.");
+            if (mainParty.MapEvent != null)
+                return Failed("Cannot click-to-move while the main party is in a map event.");
+
+            var current = mainParty.Position;
+            var offsets = new[]
+            {
+                new Vec2(offsetX, offsetY),
+                new Vec2(-offsetY, offsetX),
+                new Vec2(-offsetX, -offsetY),
+                new Vec2(offsetY, -offsetX),
+            };
+            CampaignVec2 target = default;
+            bool targetFound = false;
+            foreach (var offset in offsets)
+            {
+                var candidate = new CampaignVec2(
+                    new Vec2(current.X + offset.x, current.Y + offset.y),
+                    current.IsOnLand);
+                if (!candidate.Face.IsValid() ||
+                    !mapScreen.MapScene.DoesPathExistBetweenFaces(
+                        candidate.Face.FaceIndex,
+                        mainParty.CurrentNavigationFace.FaceIndex,
+                        false))
+                    continue;
+
+                target = candidate;
+                targetFound = true;
+                break;
+            }
+            if (!targetFound)
+                return Failed("No nearby navigable map-click target was found.");
+
+            mapScreen.HandleLeftMouseButtonClick(null, target, target.Face, false);
+
+            return Succeeded($"Issued a real campaign-map click from {current.X:R},{current.Y:R} " +
+                $"to {target.X:R},{target.Y:R}; time={Campaign.Current.TimeControlMode}; " +
+                $"behavior={mainParty.DefaultBehavior}; target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}.");
         }
-        if (!targetFound)
-            return "No nearby navigable map-click target was found.";
-
-        mapScreen.HandleLeftMouseButtonClick(null, target, target.Face, false);
-
-        return
-            $"Issued a real campaign-map click from {current.X:R},{current.Y:R} " +
-            $"to {target.X:R},{target.Y:R}; time={Campaign.Current.TimeControlMode}; " +
-            $"behavior={mainParty.DefaultBehavior}; target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}.";
     }
 
-    [CommandLineArgumentFunction("map_movement_state", "coop.debug.ui")]
-    public static string MapMovementState(List<string> args)
+    public sealed class UiMapMovementStateCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.map_movement_state";
+        public string Prefix => "coop.debug.ui";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null || Campaign.Current == null)
-            return "Failed: no active campaign or main party.";
+        public string Name => "map_movement_state";
 
-        return
-            $"position={mainParty.Position.X:R},{mainParty.Position.Y:R}|" +
-            $"target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}|" +
-            $"behavior={mainParty.DefaultBehavior}|" +
-            $"settlement={mainParty.CurrentSettlement?.StringId ?? "none"}|" +
-            $"encounter={PlayerEncounter.EncounterSettlement?.StringId ?? "none"}|" +
-            $"time={Campaign.Current.TimeControlMode}";
+        public string Description => "Reports map movement state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null || Campaign.Current == null)
+                return Failed("Failed: no active campaign or main party.");
+
+            return Succeeded($"position={mainParty.Position.X:R},{mainParty.Position.Y:R}|" +
+                $"target={mainParty.TargetPosition.X:R},{mainParty.TargetPosition.Y:R}|" +
+                $"behavior={mainParty.DefaultBehavior}|" +
+                $"settlement={mainParty.CurrentSettlement?.StringId ?? "none"}|" +
+                $"encounter={PlayerEncounter.EncounterSettlement?.StringId ?? "none"}|" +
+                $"time={Campaign.Current.TimeControlMode}");
+        }
     }
 #endif
 
-    [CommandLineArgumentFunction("switch_menu", "coop.debug.ui")]
-    public static string SwitchMenu(List<string> args)
+    public sealed class UiSwitchMenuCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Run this command on a client.";
+        public string Prefix => "coop.debug.ui";
 
-        if (args.Count != 1)
-            return "Usage: coop.debug.ui.switch_menu <menuId>";
+        public string Name => "switch_menu";
 
-        if (Campaign.Current == null)
-            return "Failed: no active campaign.";
+        public string Description => "Runs the switch menu debug operation.";
 
-        try
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            GameMenu.SwitchToMenu(args[0]);
-        }
-        catch (Exception ex)
+            new ExpectedArgs("menu_id", "The game menu id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return CommandHelpers.FormatException("Switch menu", ex);
+            if (ModInformation.IsServer)
+                return Failed("Run this command on a client.");
+
+
+            if (Campaign.Current == null)
+                return Failed("Failed: no active campaign.");
+
+            try
+            {
+                GameMenu.SwitchToMenu(args[0]);
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException("Switch menu", ex));
+            }
+
+            return Succeeded($"Switched to game menu {args[0]}.");
         }
-
-        return $"Switched to game menu {args[0]}.";
     }
 
-    [CommandLineArgumentFunction("pop_state", "coop.debug.ui")]
-    public static string PopState(List<string> args)
+    public sealed class UiPopStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.pop_state";
+        public string Prefix => "coop.debug.ui";
 
-        TaleWorlds.Core.GameState activeState = Game.Current?.GameStateManager?.ActiveState;
-        if (activeState == null)
-            return "Failed: no active game state.";
+        public string Name => "pop_state";
 
-        if (activeState is MapState)
-            return "Active state is already MapState.";
+        public string Description => "Reports pop state.";
 
-        Game.Current.GameStateManager.PopState();
-        return $"Queued pop for {activeState.GetType().Name}.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            TaleWorlds.Core.GameState activeState = Game.Current?.GameStateManager?.ActiveState;
+            if (activeState == null)
+                return Failed("Failed: no active game state.");
+
+            if (activeState is MapState)
+                return Failed("Active state is already MapState.");
+
+            Game.Current.GameStateManager.PopState();
+            return Succeeded($"Queued pop for {activeState.GetType().Name}.");
+        }
     }
 
-    [CommandLineArgumentFunction("active_state", "coop.debug.ui")]
-    public static string ActiveState(List<string> args)
+    public sealed class UiActiveStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.active_state";
+        public string Prefix => "coop.debug.ui";
 
-        return Game.Current?.GameStateManager?.ActiveState?.GetType().Name ?? "none";
+        public string Name => "active_state";
+
+        public string Description => "Reports active state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            return Succeeded(Game.Current?.GameStateManager?.ActiveState?.GetType().Name ?? "none");
+        }
     }
 
-    [CommandLineArgumentFunction("loading_window_state", "coop.debug.ui")]
-    public static string LoadingWindowState(List<string> args)
+    public sealed class UiLoadingWindowStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.loading_window_state";
+        public string Prefix => "coop.debug.ui";
 
-        return $"Loading window: {(LoadingWindow.IsLoadingWindowActive ? "ACTIVE" : "INACTIVE")}.";
+        public string Name => "loading_window_state";
+
+        public string Description => "Reports loading window state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            return Succeeded($"Loading window: {(LoadingWindow.IsLoadingWindowActive ? "ACTIVE" : "INACTIVE")}.");
+        }
     }
 
-    [CommandLineArgumentFunction("saving_overlay_state", "coop.debug.ui")]
-    public static string SavingOverlayState(List<string> args)
+    public sealed class UiSavingOverlayStateCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.ui.saving_overlay_state";
+        public string Prefix => "coop.debug.ui";
 
-        var dataSource = MapScreen.Instance?
-            .GetMapView<GauntletMapSaveView>()?
-            ._dataSource;
-        if (dataSource == null)
-            return "Saving overlay: UNAVAILABLE.";
+        public string Name => "saving_overlay_state";
 
-        return $"Saving overlay: {(dataSource.IsActive ? "ACTIVE" : "INACTIVE")}.";
+        public string Description => "Reports saving overlay state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            var dataSource = MapScreen.Instance?
+                .GetMapView<GauntletMapSaveView>()?
+                ._dataSource;
+            if (dataSource == null)
+                return Failed("Saving overlay: UNAVAILABLE.");
+
+            return Succeeded($"Saving overlay: {(dataSource.IsActive ? "ACTIVE" : "INACTIVE")}.");
+        }
     }
 }

--- a/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
@@ -1,4 +1,6 @@
-﻿using Common;
+﻿using System;
+using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.MobileParties.Messages.Unstuck;
 using System.Collections.Generic;
@@ -10,23 +12,39 @@ namespace GameInterface.Services.GameDebug.Commands;
 
 public class UnstuckCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     // coop.debug.mobileparty.unstuck
     /// <summary>
     /// Requests a server-authoritative unstuck of the local player party. Client only.
     /// </summary>
-    [CommandLineArgumentFunction("unstuck", "coop")]
-    public static string Unstuck(List<string> args)
+    public sealed class UnstuckCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsClient) return "Command can only be run on a client.";
-        if (Campaign.Current == null) return "No campaign is loaded.";
+        public string Prefix => "coop";
 
-        var mainParty = MobileParty.MainParty;
-        if (mainParty == null) return "No main party on this client.";
+        public string Name => "unstuck";
 
-        MessageBroker.Instance.Publish(mainParty, new PlayerUnstuckRequested(mainParty));
+        public string Description => "Runs the unstuck debug operation.";
 
-        return "Unstuck request sent to the server. Captivity, map event, army, siege camp, and " +
-               "settlement exits apply on the server; the local encounter and menu state clear when its reply arrives. " +
-               "Consenting clients may also send their current co-op log for a diagnostic report.";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient) return Failed("Command can only be run on a client.");
+            if (Campaign.Current == null) return Failed("No campaign is loaded.");
+
+            var mainParty = MobileParty.MainParty;
+            if (mainParty == null) return Failed("No main party on this client.");
+
+            MessageBroker.Instance.Publish(mainParty, new PlayerUnstuckRequested(mainParty));
+
+            return Succeeded("Unstuck request sent to the server. Captivity, map event, army, siege camp, and " +
+                   "settlement exits apply on the server; the local encounter and menu state clear when its reply arrives. " +
+                   "Consenting clients may also send their current co-op log for a diagnostic report.");
+        }
     }
 }

--- a/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using Serilog;
 using System.Collections.Generic;
@@ -13,38 +14,58 @@ namespace GameInterface.Services.HeroDevelopers.Commands;
 
 internal class HeroDeveloperCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<HeroDeveloperCommands>();
 
     /// <summary>
     /// Add skill xp to a hero with a skill object name.
-    /// Examples: 
+    /// Examples:
     /// coop.debug.herodeveloper.addskillxp RandomPlayer OneHanded 3000
     /// </summary>
-    [CommandLineArgumentFunction("addskillxp", "coop.debug.herodeveloper")]
-    public static string AddSkillXpCommand(List<string> strings)
+    public sealed class HeroDeveloperAddSkillXpCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 3) return "Usage: addskillxp heroName skillName xp";
+        public string Name => "add_skill_xp";
 
-        SkillObject skillObject = GetSkillByName(strings[1]);
-        if (skillObject == null) return "Unable to find SkillObject by provided name.";
+        public string Description => "Runs the add skill xp debug operation.";
 
-        if (!int.TryParse(strings[2], out int xpGain)) return "An integer amount of xp is required.";
-
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+            new ExpectedArgs("skill_name", "The skill object name.", isRequired: true),
+            new ExpectedArgs("xp_amount", "The amount of skill experience.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            SkillObject skillObject = GetSkillByName(strings[1]);
+            if (skillObject == null) return Failed("Unable to find SkillObject by provided name.");
+
+            if (!int.TryParse(strings[2], out int xpGain)) return Failed("An integer amount of xp is required.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                hero.AddSkillXp(skillObject, xpGain);
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    hero.AddSkillXp(skillObject, xpGain);
 
-                stringBuilder.AppendLine($"{strings[0]} was given {xpGain} xp for {skillObject.Name}");
+                    stringBuilder.AppendLine($"{strings[0]} was given {xpGain} xp for {skillObject.Name}");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     /// <summary>
@@ -52,29 +73,42 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addattributepoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addattributepoints", "coop.debug.herodeveloper")]
-    public static string AddAttributePointsCommand(List<string> strings)
+    public sealed class HeroDeveloperAddAttributePointsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 2) return "Usage: addattributepoints heroName numPoints";
+        public string Name => "add_attribute_points";
 
-        if (!int.TryParse(strings[1], out int numPoints)) return "An integer amount of attribute points is required.";
+        public string Description => "Runs the add attribute points debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+            new ExpectedArgs("point_count", "The number of attribute points.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            if (!int.TryParse(strings[1], out int numPoints)) return Failed("An integer amount of attribute points is required.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                // Use same implementation as vanilla command
-                hero.HeroDeveloper.UnspentAttributePoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentAttributePoints + numPoints, 0, 10000);
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    // Use same implementation as vanilla command
+                    hero.HeroDeveloper.UnspentAttributePoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentAttributePoints + numPoints, 0, 10000);
 
-                stringBuilder.AppendLine($"{strings[0]} was given {numPoints} attribute points.");
+                    stringBuilder.AppendLine($"{strings[0]} was given {numPoints} attribute points.");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     /// <summary>
@@ -82,29 +116,42 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.addfocuspoints RandomPlayer 10
     /// </summary>
-    [CommandLineArgumentFunction("addfocuspoints", "coop.debug.herodeveloper")]
-    public static string AddFocusPointsCommand(List<string> strings)
+    public sealed class HeroDeveloperAddFocusPointsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 2) return "Usage: addfocuspoints heroName numPoints";
+        public string Name => "add_focus_points";
 
-        if (!int.TryParse(strings[1], out int numPoints)) return "An integer amount of focus points is required.";
+        public string Description => "Runs the add focus points debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+            new ExpectedArgs("point_count", "The number of focus points.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            if (!int.TryParse(strings[1], out int numPoints)) return Failed("An integer amount of focus points is required.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                // Use same implementation as vanilla command
-                hero.HeroDeveloper.UnspentFocusPoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentFocusPoints + numPoints, 0, 10000);
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    // Use same implementation as vanilla command
+                    hero.HeroDeveloper.UnspentFocusPoints = MBMath.ClampInt(hero.HeroDeveloper.UnspentFocusPoints + numPoints, 0, 10000);
 
-                stringBuilder.AppendLine($"{strings[0]} was given {numPoints} focus points.");
+                    stringBuilder.AppendLine($"{strings[0]} was given {numPoints} focus points.");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     /// <summary>
@@ -112,26 +159,38 @@ internal class HeroDeveloperCommands
     /// Example:
     /// coop.debug.herodeveloper.resetskills
     /// </summary>
-    [CommandLineArgumentFunction("resetskills", "coop.debug.herodeveloper")]
-    public static string ResetSkillsCommand(List<string> strings)
+    public sealed class HeroDeveloperResetSkillsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.hero_developer";
 
-        if (strings.Count != 1) return "Usage: resetskills heroName";
+        public string Name => "reset_skills";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Description => "Runs the reset skills debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+            new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                hero.HeroDeveloper.ResetCharacterStats();
+                if (hero.Name.ToString() == strings[0] || hero.StringId == strings[0])
+                {
+                    hero.HeroDeveloper.ResetCharacterStats();
 
-                stringBuilder.AppendLine($"{strings[0]}'s skills were reset.");
+                    stringBuilder.AppendLine($"{strings[0]}'s skills were reset.");
+                }
             }
-        }
 
-        if (stringBuilder.Length > 0) return stringBuilder.ToString();
-        else return $"Unable to find hero with name or id of {strings[0]}";
+            if (stringBuilder.Length > 0) return Succeeded(stringBuilder.ToString());
+            else return Failed($"Unable to find hero with name or id of {strings[0]}");
+        }
     }
 
     private static SkillObject GetSkillByName(string skillName)

--- a/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
+++ b/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using GameInterface.Services.ObjectManager;
@@ -13,6 +14,12 @@ namespace GameInterface.Services.Inventory.Commands;
 
 internal class InventoryCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<InventoryCommands>();
 
     /// <summary>
@@ -29,204 +36,250 @@ internal class InventoryCommands
     /// <summary>
     /// View item ids in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemids", "coop.debug.inventory")]
-    public static string ViewItemIdsCommand(List<string> strings)
+    public sealed class InventoryItemIdsCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.inventory";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "item_ids";
+
+        public string Description => "Runs the item ids debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                stringBuilder.AppendLine(hero.Name.ToString());
-                foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement._amount);
+                    stringBuilder.AppendLine(hero.Name.ToString());
+                    foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                    {
+                        stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement._amount);
+                    }
                 }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// View item values in player inventories
     /// </summary>
-    [CommandLineArgumentFunction("itemvalues", "coop.debug.inventory")]
-    public static string ViewItemValuesCommand(List<string> strings)
+    public sealed class InventoryItemValuesCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.inventory";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "item_values";
+
+        public string Description => "Runs the item values debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                stringBuilder.AppendLine(hero.Name.ToString());
-                foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement.EquipmentElement.Item.Value + "(" + rosterElement.EquipmentElement.ItemValue + ")");
+                    stringBuilder.AppendLine(hero.Name.ToString());
+                    foreach (var rosterElement in hero.PartyBelongedTo.ItemRoster)
+                    {
+                        stringBuilder.AppendLine(rosterElement.EquipmentElement.Item.StringId + ": " + rosterElement.EquipmentElement.Item.Value + "(" + rosterElement.EquipmentElement.ItemValue + ")");
+                    }
                 }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Output equipment ids of battle, civilian and stealth equipment for a specific hero
     /// </summary>
-    [CommandLineArgumentFunction("heroequipment", "coop.debug.inventory")]
-    public static string HeroEquipmentCommand(List<string> strings)
+    public sealed class InventoryHeroEquipmentCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Prefix => "coop.debug.inventory";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Name => "hero_equipment";
+
+        public string Description => "Runs the hero equipment debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                stringBuilder.AppendLine(hero.Name.ToString());
+                if (hero.Name.ToString() == strings[0])
+                {
+                    stringBuilder.AppendLine(hero.Name.ToString());
 
-                stringBuilder.AppendLine("BattleEquipment");
-                foreach (var equipmentElement in hero.BattleEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                    stringBuilder.AppendLine("BattleEquipment");
+                    foreach (var equipmentElement in hero.BattleEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
 
-                stringBuilder.AppendLine("CivilianEquipment");
-                foreach (var equipmentElement in hero.CivilianEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                    stringBuilder.AppendLine("CivilianEquipment");
+                    foreach (var equipmentElement in hero.CivilianEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
 
-                stringBuilder.AppendLine("StealthEquipment");
-                foreach (var equipmentElement in hero.StealthEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                    stringBuilder.AppendLine("StealthEquipment");
+                    foreach (var equipmentElement in hero.StealthEquipment._itemSlots) stringBuilder.AppendLine(equipmentElement.Item?.StringId ?? "[EMPTY]");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Give debug animals to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("giveanimals", "coop.debug.inventory")]
-    public static string GiveAnimalsCommand(List<string> strings)
+    public sealed class InventoryGiveAnimalsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.inventory";
 
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Name => "give_animals";
 
-        if (TryGetObjectManager(out var objectManager) == false)
-        {
-            return "Unable to resolve ObjectManager.";
-        }
+        public string Description => "Runs the give animals debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false)
             {
-                var itemsToAdd = new Dictionary<string, int>()
-                {
-                    { "sheep", 5 },
-                    { "cow", 5 },
-                    { "hog", 5 },
-                    { "goose", 5 },
-                    { "chicken", 5 }
-                };
-
-                foreach (var itemId in itemsToAdd.Keys)
-                {
-                    if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
-                    {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
-                    }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
-                    }
-                }
-
-                stringBuilder.AppendLine(strings[0] + " was given animals.");
+                return Failed("Unable to resolve ObjectManager.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
+            {
+                if (hero.Name.ToString() == strings[0])
+                {
+                    var itemsToAdd = new Dictionary<string, int>()
+                    {
+                        { "sheep", 5 },
+                        { "cow", 5 },
+                        { "hog", 5 },
+                        { "goose", 5 },
+                        { "chicken", 5 }
+                    };
+
+                    foreach (var itemId in itemsToAdd.Keys)
+                    {
+                        if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
+                        }
+                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given animals.");
+                }
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Give war horses to a hero with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givewarhorses", "coop.debug.inventory")]
-    public static string GiveWarhorsesCommand(List<string> strings)
+    public sealed class InventoryGiveWarhorsesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.inventory";
 
-        if (strings.Count == 0) return "Hero name argument required.";
-        
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Name => "give_warhorses";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public string Description => "Runs the give warhorses debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                var itemsToAdd = new Dictionary<string, int>()
+                if (hero.Name.ToString() == strings[0])
                 {
-                    { "t2_empire_horse", 3 },
-                    { "t2_khuzait_horse", 2 }
-                };
+                    var itemsToAdd = new Dictionary<string, int>()
+                    {
+                        { "t2_empire_horse", 3 },
+                        { "t2_khuzait_horse", 2 }
+                    };
 
-                foreach (var itemId in itemsToAdd.Keys)
-                {
-                    if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                    foreach (var itemId in itemsToAdd.Keys)
                     {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
+                        }
                     }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
-                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given war horses.");
                 }
-
-                stringBuilder.AppendLine(strings[0] + " was given war horses.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 }

--- a/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
+++ b/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
@@ -1,4 +1,6 @@
-﻿using Common;
+﻿using System;
+using Common.Commands;
+using Common;
 using GameInterface.CoopSessionData;
 using System.Collections.Generic;
 using System.Text;
@@ -11,125 +13,161 @@ namespace GameInterface.Services.Inventory.TradeSkills.Commands;
 
 internal class TradeSkillCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// View trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_data", "coop.debug.inventory")]
-    public static string ViewPlayerTradeDataCommand(List<string> strings)
+    public sealed class InventoryViewPlayerTradeDataCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.inventory";
+
+        public string Name => "view_player_trade_data";
+
+        public string Description => "Reports view player trade data.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerTradeData in coopSessionProvider.CoopSession.TradePlayerData.PlayerItemsTradeData)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerTradeData.Key == null || playerTradeData.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerTradeData.Key}");
-                foreach (var itemIdTradeData in playerTradeData.Value)
+                foreach (var playerTradeData in coopSessionProvider.CoopSession.TradePlayerData.PlayerItemsTradeData)
                 {
-                    stringBuilder.AppendLine($"{itemIdTradeData.Key} (Total Purchased: {itemIdTradeData.Value.Item2}, Average price: {itemIdTradeData.Value.Item1})");
+                    if (playerTradeData.Key == null || playerTradeData.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerTradeData.Key}");
+                    foreach (var itemIdTradeData in playerTradeData.Value)
+                    {
+                        stringBuilder.AppendLine($"{itemIdTradeData.Key} (Total Purchased: {itemIdTradeData.Value.Item2}, Average price: {itemIdTradeData.Value.Item1})");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var itemTradeData in Campaign.Current.GetCampaignBehavior<TradeSkillCampaignBehavior>().ItemsTradeData)
+            else
             {
-                stringBuilder.AppendLine($"{itemTradeData.Key.StringId} (Total Purchased: {itemTradeData.Value.NumItemsPurchased}, Average price: {itemTradeData.Value.AveragePrice})");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var itemTradeData in Campaign.Current.GetCampaignBehavior<TradeSkillCampaignBehavior>().ItemsTradeData)
+                {
+                    stringBuilder.AppendLine($"{itemTradeData.Key.StringId} (Total Purchased: {itemTradeData.Value.NumItemsPurchased}, Average price: {itemTradeData.Value.AveragePrice})");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve player trade data");
         }
-        return "Failed to retrieve player trade data";
     }
 
     /// <summary>
     /// View trade rumors for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_player_trade_rumors", "coop.debug.inventory")]
-    public static string ViewPlayerTradeRumorsCommand(List<string> strings)
+    public sealed class InventoryViewPlayerTradeRumorsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.inventory";
+
+        public string Name => "view_player_trade_rumors";
+
+        public string Description => "Reports view player trade rumors.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerTradeRumors in coopSessionProvider.CoopSession.TradePlayerData.PlayerTradeRumors)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerTradeRumors.Key == null || playerTradeRumors.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerTradeRumors.Key}");
-                foreach (var rumorData in playerTradeRumors.Value)
+                foreach (var playerTradeRumors in coopSessionProvider.CoopSession.TradePlayerData.PlayerTradeRumors)
                 {
-                    stringBuilder.AppendLine($"{rumorData.ItemObjectId} at {rumorData.SettlementId} (expiring in {new CampaignTime(rumorData.RumorEndTime).RemainingHoursFromNow} hours) rumored to:");
-                    stringBuilder.AppendLine($"     Buy at: {rumorData.BuyPrice}");
-                    stringBuilder.AppendLine($"     Sell at: {rumorData.SellPrice}");
+                    if (playerTradeRumors.Key == null || playerTradeRumors.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerTradeRumors.Key}");
+                    foreach (var rumorData in playerTradeRumors.Value)
+                    {
+                        stringBuilder.AppendLine($"{rumorData.ItemObjectId} at {rumorData.SettlementId} (expiring in {new CampaignTime(rumorData.RumorEndTime).RemainingHoursFromNow} hours) rumored to:");
+                        stringBuilder.AppendLine($"     Buy at: {rumorData.BuyPrice}");
+                        stringBuilder.AppendLine($"     Sell at: {rumorData.SellPrice}");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var tradeRumor in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._tradeRumors)
+            else
             {
-                stringBuilder.AppendLine($"{tradeRumor.ItemCategory.StringId} at {tradeRumor.Settlement.StringId} (expiring in {tradeRumor.RumorEndTime.RemainingHoursFromNow} hours) rumored to:");
-                stringBuilder.AppendLine($"     Buy at: {tradeRumor.BuyPrice}");
-                stringBuilder.AppendLine($"     Sell at: {tradeRumor.SellPrice}");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var tradeRumor in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._tradeRumors)
+                {
+                    stringBuilder.AppendLine($"{tradeRumor.ItemCategory.StringId} at {tradeRumor.Settlement.StringId} (expiring in {tradeRumor.RumorEndTime.RemainingHoursFromNow} hours) rumored to:");
+                    stringBuilder.AppendLine($"     Buy at: {tradeRumor.BuyPrice}");
+                    stringBuilder.AppendLine($"     Sell at: {tradeRumor.SellPrice}");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve player rumors data");
         }
-        return "Failed to retrieve player rumors data";
     }
 
     /// <summary>
     /// View entered settlements trade data for all players on server and for current player on client
     /// </summary>
-    [CommandLineArgumentFunction("view_entered_settlements", "coop.debug.inventory")]
-    public static string ViewPlayerEnteredSettlementsCommand(List<string> strings)
+    public sealed class InventoryViewEnteredSettlementsCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Prefix => "coop.debug.inventory";
+
+        public string Name => "view_entered_settlements";
+
+        public string Description => "Reports view entered settlements.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
-
-            foreach (var playerEnteredSettlement in coopSessionProvider.CoopSession.TradePlayerData.PlayerEnteredSettlements)
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                if (playerEnteredSettlement.Key == null || playerEnteredSettlement.Value == null) continue;
+                if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
 
-                stringBuilder.AppendLine($"{playerEnteredSettlement.Key}");
-                foreach (var enteredSettlementData in playerEnteredSettlement.Value)
+                foreach (var playerEnteredSettlement in coopSessionProvider.CoopSession.TradePlayerData.PlayerEnteredSettlements)
                 {
-                    stringBuilder.AppendLine($"{enteredSettlementData.Key} {new CampaignTime(enteredSettlementData.Value).ElapsedHoursUntilNow} hours ago.");
+                    if (playerEnteredSettlement.Key == null || playerEnteredSettlement.Value == null) continue;
+
+                    stringBuilder.AppendLine($"{playerEnteredSettlement.Key}");
+                    foreach (var enteredSettlementData in playerEnteredSettlement.Value)
+                    {
+                        stringBuilder.AppendLine($"{enteredSettlementData.Key} {new CampaignTime(enteredSettlementData.Value).ElapsedHoursUntilNow} hours ago.");
+                    }
                 }
             }
-        }
-        else
-        {
-            stringBuilder.AppendLine($"{Hero.MainHero.Name}");
-            foreach (var enteredSettlement in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._enteredSettlements)
+            else
             {
-                stringBuilder.AppendLine($"{enteredSettlement.Key.StringId} {enteredSettlement.Value.ElapsedHoursUntilNow} hours ago.");
+                stringBuilder.AppendLine($"{Hero.MainHero.Name}");
+                foreach (var enteredSettlement in Campaign.Current.GetCampaignBehavior<TradeRumorsCampaignBehavior>()._enteredSettlements)
+                {
+                    stringBuilder.AppendLine($"{enteredSettlement.Key.StringId} {enteredSettlement.Value.ElapsedHoursUntilNow} hours ago.");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Failed to retrieve player trade data");
         }
-        return "Failed to retrieve player trade data";
     }
 
     /// <summary>

--- a/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
+++ b/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using GameInterface.Services.Issues.Generic;
 using GameInterface.Utils.Commands;
 using System;
@@ -12,54 +13,71 @@ namespace GameInterface.Services.Issues.Commands;
 
 public static class IssuesDebugCommand
 {
-    [CommandLineArgumentFunction("give", "coop.debug.issues")]
-    public static string Give(List<string> args)
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class IssuesGiveCoopCommand : ICoopCommand
     {
-        if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.give")) return error;
+        public string Prefix => "coop.debug.issues";
 
-        const string usage = "Usage: coop.debug.issues.give <heroId> <questTypeKey> (see coop.debug.issues.list_types)";
+        public string Name => "give";
 
-        if (!CommandHelpers.HasArgCount(args, 2, usage, out error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return error;
+        public string Description => "Runs the give debug operation.";
 
-        var key = args[1];
-        if (!IssueGiveCatalog.TryGet(key, out var entry))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return $"Unknown quest type key '{key}'. Use coop.debug.issues.list_types to see all valid keys.";
-        }
+            new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+            new ExpectedArgs("quest_type_key", "The issue type key.", isRequired: true),
+        };
 
-        if (entry.Resolve == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Quest type '{key}' is a known vanilla Issue type but is not wired for give: {entry.NotWiredReason}";
-        }
+            if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.give")) return Failed(error);
 
-        if (hero.Issue != null)
-        {
-            return $"Hero '{hero.Name}' (StringId '{hero.StringId}') already has an active issue " +
-                $"({hero.Issue.GetType().Name}, StringId '{hero.Issue.StringId}'). Complete or clear it first.";
-        }
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return Failed(error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return Failed(error);
 
-        (PotentialIssueData.StartIssueDelegate factory, string resolveError) = entry.Resolve(hero);
-        if (factory == null)
-        {
-            return $"Could not give '{key}' to hero '{hero.Name}': {resolveError}";
-        }
+            var key = args[1];
+            if (!IssueGiveCatalog.TryGet(key, out var entry))
+            {
+                return Failed($"Unknown quest type key '{key}'. Use coop.debug.issues.list_types to see all valid keys.");
+            }
 
-        try
-        {
-            var pid = new PotentialIssueData(factory, entry.IssueType, IssueBase.IssueFrequency.Common);
-            Campaign.Current.IssueManager.CreateNewIssue(in pid, hero);
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException($"coop.debug.issues.give ({key}): CreateNewIssue", ex);
-        }
+            if (entry.Resolve == null)
+            {
+                return Failed($"Quest type '{key}' is a known vanilla Issue type but is not wired for give: {entry.NotWiredReason}");
+            }
 
-        return StartQuestOrRollback(hero, key);
+            if (hero.Issue != null)
+            {
+                return Failed($"Hero '{hero.Name}' (StringId '{hero.StringId}') already has an active issue " +
+                    $"({hero.Issue.GetType().Name}, StringId '{hero.Issue.StringId}'). Complete or clear it first.");
+            }
+
+            (PotentialIssueData.StartIssueDelegate factory, string resolveError) = entry.Resolve(hero);
+            if (factory == null)
+            {
+                return Failed($"Could not give '{key}' to hero '{hero.Name}': {resolveError}");
+            }
+
+            try
+            {
+                var pid = new PotentialIssueData(factory, entry.IssueType, IssueBase.IssueFrequency.Common);
+                Campaign.Current.IssueManager.CreateNewIssue(in pid, hero);
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException($"coop.debug.issues.give ({key}): CreateNewIssue", ex));
+            }
+
+            return StartQuestOrRollback(hero, key);
+        }
     }
 
-    private static string StartQuestOrRollback(Hero hero, string key)
+    private static CoopCommandResult StartQuestOrRollback(Hero hero, string key)
     {
         bool started;
         try
@@ -80,104 +98,121 @@ public static class IssuesDebugCommand
                 }
                 catch (Exception cleanupEx)
                 {
-                    return CommandHelpers.FormatException(
+                    return Failed(CommandHelpers.FormatException(
                         $"coop.debug.issues.give ({key}): StartIssueQuest threw ({ex.GetType().Name}: {ex.Message}), " +
                         $"then the DeactivateIssue rollback ALSO threw - hero '{hero.Name}' (StringId '{hero.StringId}') " +
-                        "may still have a stuck issue attached", cleanupEx);
+                        "may still have a stuck issue attached", cleanupEx));
                 }
             }
 
-            return CommandHelpers.FormatException(
+            return Failed(CommandHelpers.FormatException(
                 $"coop.debug.issues.give ({key}): StartIssueQuest threw during quest construction. The issue has " +
                 $"been rolled back via DeactivateIssue - hero '{hero.Name}' (StringId '{hero.StringId}') has no " +
-                "issue attached and is safe to retry give with any quest type", ex);
+                "issue attached and is safe to retry give with any quest type", ex));
         }
 
         if (!started)
         {
-            return $"Issue '{key}' was created for hero '{hero.Name}' but StartIssueQuest returned false " +
-                "(its IssueStayAliveConditions failed immediately) - the game has already cleaned the issue up.";
+            return Failed($"Issue '{key}' was created for hero '{hero.Name}' but StartIssueQuest returned false " +
+                "(its IssueStayAliveConditions failed immediately) - the game has already cleaned the issue up.");
         }
 
-        return $"Gave quest type '{key}' to hero '{hero.Name}' (StringId '{hero.StringId}'). " +
-            $"Issue StringId: '{hero.Issue?.StringId}'. Quest StringId: '{hero.Issue?.IssueQuest?.StringId ?? "none"}'.";
+        return Succeeded($"Gave quest type '{key}' to hero '{hero.Name}' (StringId '{hero.StringId}'). " +
+            $"Issue StringId: '{hero.Issue?.StringId}'. Quest StringId: '{hero.Issue?.IssueQuest?.StringId ?? "none"}'.");
     }
 
-    [CommandLineArgumentFunction("complete", "coop.debug.issues")]
-    public static string Complete(List<string> args)
+    public sealed class IssuesCompleteCoopCommand : ICoopCommand
     {
-        if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.complete")) return error;
+        public string Prefix => "coop.debug.issues";
 
-        const string usage = "Usage: coop.debug.issues.complete <heroId> [success|cancel|fail|timeout|betrayal]";
+        public string Name => "complete";
 
-        if (args == null || args.Count < 1 || args.Count > 2)
+        public string Description => "Runs the complete debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return usage;
-        }
+            new ExpectedArgs("hero_id", "The registered issue owner hero id.", isRequired: true),
+            new ExpectedArgs("outcome", "success, cancel, fail, timeout, or betrayal.", isRequired: false),
+        };
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return error;
-
-        if (hero.Issue == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return $"Hero '{hero.Name}' (StringId '{hero.StringId}') has no active issue.";
-        }
+            if (!CommandHelpers.IsServerOnlyCommand(out var error, "coop.debug.issues.complete")) return Failed(error);
 
-        var quest = hero.Issue.IssueQuest;
-        if (quest == null)
-        {
-            return $"Hero '{hero.Name}' has an active issue ({hero.Issue.GetType().Name}) but no live quest yet. " +
-                "Use coop.debug.issues.give (or the natural accept flow) to start the quest before completing it.";
-        }
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error)) return Failed(error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error)) return Failed(error);
 
-        var outcome = args.Count == 2 ? args[1].Trim().ToLowerInvariant() : "success";
-
-        try
-        {
-            using (new IssueFinalizeAuthorityGuard())
+            if (hero.Issue == null)
             {
-                switch (outcome)
+                return Failed($"Hero '{hero.Name}' (StringId '{hero.StringId}') has no active issue.");
+            }
+
+            var quest = hero.Issue.IssueQuest;
+            if (quest == null)
+            {
+                return Failed($"Hero '{hero.Name}' has an active issue ({hero.Issue.GetType().Name}) but no live quest yet. " +
+                    "Use coop.debug.issues.give (or the natural accept flow) to start the quest before completing it.");
+            }
+
+            var outcome = args.Count == 2 ? args[1].Trim().ToLowerInvariant() : "success";
+
+            try
+            {
+                using (new IssueFinalizeAuthorityGuard())
                 {
-                    case "success":
-                        quest.CompleteQuestWithSuccess();
-                        break;
-                    case "cancel":
-                        quest.CompleteQuestWithCancel();
-                        break;
-                    case "fail":
-                        quest.CompleteQuestWithFail();
-                        break;
-                    case "timeout":
-                        quest.CompleteQuestWithTimeOut();
-                        break;
-                    case "betrayal":
-                        quest.CompleteQuestWithBetrayal();
-                        break;
-                    default:
-                        return $"Unknown outcome '{outcome}'. {usage}";
+                    switch (outcome)
+                    {
+                        case "success":
+                            quest.CompleteQuestWithSuccess();
+                            break;
+                        case "cancel":
+                            quest.CompleteQuestWithCancel();
+                            break;
+                        case "fail":
+                            quest.CompleteQuestWithFail();
+                            break;
+                        case "timeout":
+                            quest.CompleteQuestWithTimeOut();
+                            break;
+                        case "betrayal":
+                            quest.CompleteQuestWithBetrayal();
+                            break;
+                        default:
+                            return Failed($"Unknown outcome '{outcome}'. Expected success, cancel, fail, timeout, or betrayal.");
+                    }
                 }
             }
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException($"coop.debug.issues.complete ({outcome})", ex);
-        }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException($"coop.debug.issues.complete ({outcome})", ex));
+            }
 
-        return $"Completed quest for hero '{hero.Name}' (StringId '{hero.StringId}') with outcome '{outcome}'.";
+            return Succeeded($"Completed quest for hero '{hero.Name}' (StringId '{hero.StringId}') with outcome '{outcome}'.");
+        }
     }
 
-    [CommandLineArgumentFunction("list_types", "coop.debug.issues")]
-    public static string ListTypes(List<string> args)
+    public sealed class IssuesListTypesCoopCommand : ICoopCommand
     {
-        var sb = new StringBuilder();
+        public string Prefix => "coop.debug.issues";
 
-        foreach (var entry in IssueGiveCatalog.Entries.Values.OrderBy(e => e.Key, StringComparer.Ordinal))
+        public string Name => "list_types";
+
+        public string Description => "Reports list types.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            sb.AppendLine(entry.Resolve != null
-                ? $"{entry.Key} [wired]"
-                : $"{entry.Key} [not wired: {entry.NotWiredReason}]");
-        }
+            var sb = new StringBuilder();
 
-        return sb.ToString();
+            foreach (var entry in IssueGiveCatalog.Entries.Values.OrderBy(e => e.Key, StringComparer.Ordinal))
+            {
+                sb.AppendLine(entry.Resolve != null
+                    ? $"{entry.Key} [wired]"
+                    : $"{entry.Key} [not wired: {entry.NotWiredReason}]");
+            }
+
+            return Succeeded(sb.ToString());
+        }
     }
 }

--- a/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
+++ b/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using Common.Commands;
+using Autofac;
 using GameInterface.Services.ObjectManager;
 using System.Collections.Generic;
 using System.Text;
@@ -9,6 +10,12 @@ namespace GameInterface.Services.ItemObjects.Commands
 {
     internal class ItemObjectCommands
     {
+        private static CoopCommandResult Succeeded(string output) =>
+            new CoopCommandResult(true, output);
+
+        private static CoopCommandResult Failed(string output) =>
+            new CoopCommandResult(false, output, "command_failed");
+
         private static bool TryGetObjectManager(out IObjectManager objectManager)
         {
             objectManager = null;
@@ -20,42 +27,51 @@ namespace GameInterface.Services.ItemObjects.Commands
         /// <summary>
         /// View select properties of an item object retrieved by string id
         /// </summary>
-        [CommandLineArgumentFunction("data", "coop.debug.itemobject")]
-        public static string ViewCraftedItemData(List<string> strings)
+        public sealed class ItemObjectDataCoopCommand : ICoopCommand
         {
-            if (strings.Count == 0)
+            public string Prefix => "coop.debug.item_object";
+
+            public string Name => "data";
+
+            public string Description => "Reports data.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Hero name argument required.";
-            }
+                new ExpectedArgs("item_id", "The registered item object id.", isRequired: true),
+            };
 
-            if (TryGetObjectManager(out var objectManager) == false)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
             {
-                return "Unable to resolve ObjectManager.";
+
+                if (TryGetObjectManager(out var objectManager) == false)
+                {
+                    return Failed("Unable to resolve ObjectManager.");
+                }
+
+                string itemId = strings[0];
+
+                StringBuilder stringBuilder = new StringBuilder();
+
+                if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                {
+                    return Failed("Failed to retrieve object for ItemObject id: " + itemId);
+                }
+
+                // Add properties as necessary
+                stringBuilder.AppendLine(itemObject.StringId + ": " + itemObject.Name);
+                stringBuilder.AppendLine("Value: " + itemObject.Value);
+                stringBuilder.AppendLine("Difficulty: " + itemObject.Difficulty);
+                stringBuilder.AppendLine("Tier: " + itemObject.Tier);
+                stringBuilder.AppendLine("Tierf: " + itemObject.Tierf);
+                stringBuilder.AppendLine("Appearance: " + itemObject.Appearance);
+
+                string result = stringBuilder.ToString();
+                if (result.Length > 0)
+                {
+                    return Succeeded(result);
+                }
+                return Failed("Item object not found.");
             }
-
-            string itemId = strings[0];
-
-            StringBuilder stringBuilder = new StringBuilder();
-
-            if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
-            {
-                return "Failed to retrieve object for ItemObject id: " + itemId;
-            }
-
-            // Add properties as necessary
-            stringBuilder.AppendLine(itemObject.StringId + ": " + itemObject.Name);
-            stringBuilder.AppendLine("Value: " + itemObject.Value);
-            stringBuilder.AppendLine("Difficulty: " + itemObject.Difficulty);
-            stringBuilder.AppendLine("Tier: " + itemObject.Tier);
-            stringBuilder.AppendLine("Tierf: " + itemObject.Tierf);
-            stringBuilder.AppendLine("Appearance: " + itemObject.Appearance);
-
-            string result = stringBuilder.ToString();
-            if (result.Length > 0)
-            {
-                return result;
-            }
-            return "Item object not found.";
         }
     }
 }

--- a/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
+++ b/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -17,109 +18,152 @@ namespace GameInterface.Services.ItemRosters.Commands
 {
     internal class ItemRosterDebugCommands
     {
-        [CommandLineArgumentFunction("add_random_item", "coop.debug.itemrosters")]
-        public static string AddRandomItem(List<string> args)
+        private static CoopCommandResult Succeeded(string output) =>
+            new CoopCommandResult(true, output);
+
+        private static CoopCommandResult Failed(string output) =>
+            new CoopCommandResult(false, output, "command_failed");
+
+        public sealed class ItemRostersAddRandomItemCoopCommand : ICoopCommand
         {
-            if (args.Count < 1)
+            public string Prefix => "coop.debug.item_rosters";
+
+            public string Name => "add_random_item";
+
+            public string Description => "Runs the add random item debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.itemrosters.add_random_item <party base id> (i.e. town_V1)";
-            }
+                new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+            };
 
-            var settlementId = args[0];
-            var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
-
-            if (settlement == null) return $"Unable to find settlement with id: {settlementId}";
-
-            Random random = new();
-
-            var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
-
-            var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
-
-            settlement.ItemRoster.AddToCounts(new EquipmentElement(randomItem), 1);
-
-            return $"Added {randomItem.Name} to {settlement.Name}'s ItemRoster";
-        }
-
-        [CommandLineArgumentFunction("add_item_burst", "coop.debug.itemrosters")]
-        public static string AddItemBurst(List<string> args)
-        {
-            if (ModInformation.IsClient)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                return "Run this on the server; it is authoritative and replicates to clients.";
-            }
 
-            if (args.Count < 2)
-            {
-                return "Usage: coop.debug.itemrosters.add_item_burst <settlement id> <count> (i.e. town_ES1 20)";
-            }
+                var settlementId = args[0];
+                var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
 
-            var settlementId = args[0];
-            var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
+                if (settlement == null) return Failed($"Unable to find settlement with id: {settlementId}");
 
-            if (settlement == null) return $"Unable to find settlement with id: {settlementId}";
+                Random random = new();
 
-            if (!int.TryParse(args[1], out var count) || count < 1)
-            {
-                return $"Invalid count: '{args[1]}'. Provide a positive integer.";
-            }
+                var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
 
-            var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
+                var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
 
-            if (itemEnumerable.Count == 0) return "No items are loaded.";
-
-            Random random = new();
-
-            var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
-
-            // Add the same item count times in one tick so the coalescer collapses them into a single
-            // update carrying the final count.
-            for (int i = 0; i < count; i++)
-            {
                 settlement.ItemRoster.AddToCounts(new EquipmentElement(randomItem), 1);
-            }
 
-            return $"Added {count}x {randomItem.Name} to {settlement.Name}'s ItemRoster in one tick";
+                return Succeeded($"Added {randomItem.Name} to {settlement.Name}'s ItemRoster");
+            }
         }
 
-        [CommandLineArgumentFunction("info", "coop.debug.itemrosters")]
-        public static string Info(List<string> args)
+        public sealed class ItemRostersAddItemBurstCoopCommand : ICoopCommand
         {
-            if (args.Count < 1)
-            {
-                return "Usage: coop.debug.itemrosters.info <party base id> (i.e. town_V1)";
-            }
+            public string Prefix => "coop.debug.item_rosters";
 
-            var roster = FindItemRoster(args[0], out string owner);
-            
-            if (roster == null)
-            {
-                return string.Format("ID: '{0}' not found", args[0]);
-            }
+            public string Name => "add_item_burst";
 
-            return string.Format("ItemRoster info for '{0}':\n  Items: {1}\n  Count: {2}\n  SHA1: {3:X}\n",
-                owner, roster.Count, roster.Sum((i) => { return i.Amount; }), ItemRosterHash(roster));
+            public string Description => "Runs the add item burst debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
+                new ExpectedArgs("count", "The positive number of items to add.", isRequired: true),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+                if (ModInformation.IsClient)
+                {
+                    return Failed("Run this on the server; it is authoritative and replicates to clients.");
+                }
+
+
+                var settlementId = args[0];
+                var settlement = MBObjectManager.Instance.GetObject<Settlement>(settlementId);
+
+                if (settlement == null) return Failed($"Unable to find settlement with id: {settlementId}");
+
+                if (!int.TryParse(args[1], out var count) || count < 1)
+                {
+                    return Failed($"Invalid count: '{args[1]}'. Provide a positive integer.");
+                }
+
+                var itemEnumerable = MBObjectManager.Instance.GetObjectTypeList<ItemObject>();
+
+                if (itemEnumerable.Count == 0) return Failed("No items are loaded.");
+
+                Random random = new();
+
+                var randomItem = itemEnumerable.Skip(random.Next(itemEnumerable.Count)).First();
+
+                // Add the same item count times in one tick so the coalescer collapses them into a single
+                // update carrying the final count.
+                for (int i = 0; i < count; i++)
+                {
+                    settlement.ItemRoster.AddToCounts(new EquipmentElement(randomItem), 1);
+                }
+
+                return Succeeded($"Added {count}x {randomItem.Name} to {settlement.Name}'s ItemRoster in one tick");
+            }
         }
 
-        [CommandLineArgumentFunction("export", "coop.debug.itemrosters")]
-        public static string Export(List<string> args)
+        public sealed class ItemRostersInfoCoopCommand : ICoopCommand
         {
-            if (args.Count < 1)
+            public string Prefix => "coop.debug.item_rosters";
+
+            public string Name => "info";
+
+            public string Description => "Reports info.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.itemrosters.export <party base id> (i.e. town_V1)";
-            }
+                new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+            };
 
-            var roster = FindItemRoster(args[0], out string owner);
-
-            if (roster == null)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                return string.Format("ID: '{0}' not found", args[0]);
+
+                var roster = FindItemRoster(args[0], out string owner);
+
+                if (roster == null)
+                {
+                    return Failed(string.Format("ID: '{0}' not found", args[0]));
+                }
+
+                return Succeeded(string.Format("ItemRoster info for '{0}':\n  Items: {1}\n  Count: {2}\n  SHA1: {3:X}\n",
+                    owner, roster.Count, roster.Sum((i) => { return i.Amount; }), ItemRosterHash(roster)));
             }
+        }
 
-            var name = "!" + (ModInformation.IsServer ? "server-itemroster-export-" : "client-itemroster-export-") + $"{owner}.txt";
-            File.WriteAllText(name, ItemRosterContent(roster));
+        public sealed class ItemRostersExportCoopCommand : ICoopCommand
+        {
+            public string Prefix => "coop.debug.item_rosters";
 
-            return $"Exported '{owner}' into '{name}'.\n Check bannerlord bin directory.";
+            public string Name => "export";
+
+            public string Description => "Runs the export debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+
+                var roster = FindItemRoster(args[0], out string owner);
+
+                if (roster == null)
+                {
+                    return Failed(string.Format("ID: '{0}' not found", args[0]));
+                }
+
+                var name = "!" + (ModInformation.IsServer ? "server-itemroster-export-" : "client-itemroster-export-") + $"{owner}.txt";
+                File.WriteAllText(name, ItemRosterContent(roster));
+
+                return Succeeded($"Exported '{owner}' into '{name}'.\n Check bannerlord bin directory.");
+            }
         }
 
         private static ItemRoster FindItemRoster(string id, out string name)
@@ -127,7 +171,7 @@ namespace GameInterface.Services.ItemRosters.Commands
             if (MBObjectManager.Instance.ContainsObject<Settlement>(id))
             {
                 var obj = MBObjectManager.Instance.GetObject<Settlement>(id);
-                
+
                 name = obj.Town.Name.ToString();
                 return obj.ItemRoster;
             }

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
@@ -1,4 +1,5 @@
 ﻿#if DEBUG
+using Common.Commands;
 using Common;
 using Common.Messaging;
 using GameInterface.Services.Heroes.Extensions;
@@ -26,254 +27,347 @@ namespace GameInterface.Services.PlayerCaptivityService.Commands;
 /// </summary>
 internal static class AiLordPeaceReleaseFixtureCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static AiLordPeaceReleaseFixture fixture;
     private static StanceLinkSnapshot clientDiplomaticSnapshot;
 
-    [CommandLineArgumentFunction("observe_ai_lord_pair", "coop.debug.player_captivity")]
-    public static string ObserveAiLordPair(List<string> args)
+    public sealed class PlayerCaptivityObserveAiLordPairCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.player_captivity.observe_ai_lord_pair <prisonerHeroId> <captorHeroId>";
-        var context = new CommandContext("observe_ai_lord_pair", usage, args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!context.RequireArgCount(2, out var error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to observe AI lords: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
-            return "Failed to observe AI lords: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
-            return "Failed to observe AI lords: " + error;
+        public string Name => "observe_ai_lord_pair";
 
-        var heroParty = prisoner.PartyBelongedTo;
-        var captorParty = prisoner.PartyBelongedToAsPrisoner?.MobileParty;
-        var captorHeroParty = captorHero.PartyBelongedTo;
-        var prisonerFaction = prisoner.MapFaction;
-        var captorFaction = captorHero.MapFaction;
-        var output = new StringBuilder();
-        output.AppendLine("PrisonerHeroId=" + prisoner.StringId);
-        output.AppendLine("CaptorHeroId=" + captorHero.StringId);
-        output.AppendLine("PrisonerFactionId=" + (prisonerFaction?.StringId ?? "none"));
-        output.AppendLine("CaptorFactionId=" + (captorFaction?.StringId ?? "none"));
-        output.AppendLine("AtWar=" + (prisonerFaction != null && captorFaction != null
-            ? prisonerFaction.IsAtWarWith(captorFaction).ToString()
-            : "none"));
-        output.AppendLine("HeroState=" + prisoner.HeroState);
-        output.AppendLine("IsPrisoner=" + prisoner.IsPrisoner);
-        output.AppendLine("CaptorPartyId=" + (captorParty?.StringId ?? "none"));
-        output.AppendLine("CaptorPrisonerCount=" + (captorParty?.PrisonRoster.GetTroopCount(prisoner.CharacterObject) ?? 0));
-        output.AppendLine("HeroPartyId=" + (heroParty?.StringId ?? "none"));
-        output.AppendLine("HeroPartyActive=" + (heroParty?.IsActive.ToString() ?? "none"));
-        output.AppendLine("HeroPartyLeaderId=" + (heroParty?.LeaderHero?.StringId ?? "none"));
-        output.AppendLine("HeroPartyPosition=" + (heroParty == null ? "none" : FormatPosition(heroParty.Position)));
-        output.AppendLine("CaptorHeroPartyId=" + (captorHeroParty?.StringId ?? "none"));
-        output.AppendLine("CaptorHeroPartyActive=" + (captorHeroParty?.IsActive.ToString() ?? "none"));
-        output.AppendLine("CaptorHeroPartyPosition=" + (captorHeroParty == null ? "none" : FormatPosition(captorHeroParty.Position)));
-        output.Append("DiplomaticStateFingerprint=" + GetDiplomaticStateFingerprint(prisonerFaction, captorFaction));
-        return output.ToString();
-    }
+        public string Description => "Runs the observe ai lord pair debug operation.";
 
-    [CommandLineArgumentFunction("focus_hero_party", "coop.debug.player_captivity")]
-    public static string FocusHeroParty(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.focus_hero_party <heroId>";
-        var context = new CommandContext("focus_hero_party", usage, args);
-
-        if (!context.RequireArgCount(1, out var error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to focus hero party: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
-            return "Failed to focus hero party: " + error;
-
-        var party = hero.PartyBelongedTo ?? hero.PartyBelongedToAsPrisoner?.MobileParty;
-        if (party?.IsActive != true)
-            return $"Failed to focus hero party: '{hero.StringId}' has no active member or captor party.";
-
-        party.Party.SetAsCameraFollowParty();
-        return $"Following party '{party.StringId}' for hero '{hero.StringId}' on the campaign map.";
-    }
-
-    [CommandLineArgumentFunction("snapshot_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
-    public static string SnapshotAiLordDiplomacyFixture(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.snapshot_ai_lord_diplomacy_fixture <prisonerHeroId> <captorHeroId>";
-        var context = new CommandContext("snapshot_ai_lord_diplomacy_fixture", usage, args);
-
-        if (!ModInformation.IsClient) return "snapshot_ai_lord_diplomacy_fixture must be run on a client.";
-        if (!context.RequireArgCount(2, out var error)) return error;
-        if (clientDiplomaticSnapshot != null) return "A client AI-lord diplomatic fixture is already active.";
-        if (!TryGetHeroFactions(args, out var prisonerFaction, out var captorFaction, out error))
-            return "Failed to snapshot AI-lord diplomacy: " + error;
-
-        clientDiplomaticSnapshot = StanceLinkSnapshot.Capture(prisonerFaction, captorFaction);
-        return "Client AI-lord diplomatic fixture captured.\nOriginalDiplomaticStateFingerprint=" +
-            clientDiplomaticSnapshot.OriginalFingerprint;
-    }
-
-    [CommandLineArgumentFunction("restore_ai_lord_diplomacy_fixture", "coop.debug.player_captivity")]
-    public static string RestoreAiLordDiplomacyFixture(List<string> args)
-    {
-        if (!ModInformation.IsClient)
-            return "restore_ai_lord_diplomacy_fixture must be run on a client.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.player_captivity.restore_ai_lord_diplomacy_fixture";
-        if (clientDiplomaticSnapshot == null)
-            return "No client AI-lord diplomatic fixture is active.";
-
-        var pendingSnapshot = clientDiplomaticSnapshot;
-        pendingSnapshot.Restore(false);
-        var verification = pendingSnapshot.VerifyRestored();
-        if (verification != null)
-            return "Failed to restore client AI-lord diplomatic fixture: " + verification;
-
-        clientDiplomaticSnapshot = null;
-        return "Client AI-lord diplomatic fixture restored.";
-    }
-
-    [CommandLineArgumentFunction("capture_ai_lord_fixture", "coop.debug.player_captivity")]
-    public static string CaptureAiLordFixture(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.capture_ai_lord_fixture <prisonerHeroId> <captorHeroId>";
-        var context = new CommandContext("capture_ai_lord_fixture", usage, args);
-
-        if (!context.RequireServer(out var error)) return error;
-        if (!context.RequireArgCount(2, out error)) return error;
-        if (fixture != null) return "An AI-lord captivity fixture is already active.";
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to create AI-lord fixture: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
-            return "Failed to create AI-lord fixture: " + error;
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
-            return "Failed to create AI-lord fixture: " + error;
-
-        if (prisoner.IsPrisoner)
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' is already a prisoner.";
-        if (!prisoner.IsLord || prisoner.IsPlayerHero())
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' is not an AI lord.";
-
-        var prisonerParty = prisoner.PartyBelongedTo;
-        var captorParty = captorHero.PartyBelongedTo;
-        if (prisonerParty?.IsActive != true)
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' has no active party.";
-        if (captorParty?.IsActive != true)
-            return $"Failed to create AI-lord fixture: '{captorHero.StringId}' has no active party.";
-        if (prisonerParty == captorParty)
-            return "Failed to create AI-lord fixture: prisoner and captor belong to the same party.";
-
-        var prisonerFaction = prisoner.MapFaction;
-        var captorFaction = captorHero.MapFaction;
-        if (prisonerFaction == null || captorFaction == null || prisonerFaction == captorFaction)
-            return "Failed to create AI-lord fixture: prisoner and captor need distinct map factions.";
-
-        var prisonerIndex = prisonerParty.MemberRoster.FindIndexOfTroop(prisoner.CharacterObject);
-        if (prisonerIndex < 0)
-            return $"Failed to create AI-lord fixture: '{prisoner.StringId}' is absent from its party roster.";
-
-        if (!prisonerFaction.IsAtWarWith(captorFaction))
-            return "Failed to create AI-lord fixture: the prisoner and captor factions must already be at war.";
-
-        var pendingFixture = new AiLordPeaceReleaseFixture(
-            prisoner,
-            captorHero,
-            prisonerParty,
-            captorParty,
-            prisonerParty.MemberRoster.GetElementCopyAtIndex(prisonerIndex),
-            prisoner.HeroState,
-            prisonerParty.LeaderHero,
-            prisonerParty.CurrentSettlement,
-            prisonerParty.Position,
-            prisonerParty.IsActive,
-            captorParty.CurrentSettlement,
-            captorParty.Position,
-            captorParty.IsActive,
-            prisonerFaction,
-            captorFaction,
-            StanceLinkSnapshot.Capture(prisonerFaction, captorFaction));
-
-        fixture = pendingFixture;
-        try
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            TakePrisonerAction.Apply(captorParty.Party, prisoner);
-            if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner != captorParty.Party)
-            {
-                Restore(pendingFixture);
-                var verification = VerifyRestored(pendingFixture);
-                if (verification != null)
-                    return "Failed to create AI-lord fixture: the capture action did not establish captivity; rollback failed: " + verification;
+            new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+            new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+        };
 
-                fixture = null;
-                return "Failed to create AI-lord fixture: the capture action did not establish captivity; the baseline was restored.";
-            }
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("observe_ai_lord_pair", "Argument must not be empty.", new List<string>(args));
 
-            return "AI-lord captivity fixture created.\n" + Observe(fixture);
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to observe AI lords: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
+                return Failed("Failed to observe AI lords: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
+                return Failed("Failed to observe AI lords: " + error);
+
+            var heroParty = prisoner.PartyBelongedTo;
+            var captorParty = prisoner.PartyBelongedToAsPrisoner?.MobileParty;
+            var captorHeroParty = captorHero.PartyBelongedTo;
+            var prisonerFaction = prisoner.MapFaction;
+            var captorFaction = captorHero.MapFaction;
+            var output = new StringBuilder();
+            output.AppendLine("PrisonerHeroId=" + prisoner.StringId);
+            output.AppendLine("CaptorHeroId=" + captorHero.StringId);
+            output.AppendLine("PrisonerFactionId=" + (prisonerFaction?.StringId ?? "none"));
+            output.AppendLine("CaptorFactionId=" + (captorFaction?.StringId ?? "none"));
+            output.AppendLine("AtWar=" + (prisonerFaction != null && captorFaction != null
+                ? prisonerFaction.IsAtWarWith(captorFaction).ToString()
+                : "none"));
+            output.AppendLine("HeroState=" + prisoner.HeroState);
+            output.AppendLine("IsPrisoner=" + prisoner.IsPrisoner);
+            output.AppendLine("CaptorPartyId=" + (captorParty?.StringId ?? "none"));
+            output.AppendLine("CaptorPrisonerCount=" + (captorParty?.PrisonRoster.GetTroopCount(prisoner.CharacterObject) ?? 0));
+            output.AppendLine("HeroPartyId=" + (heroParty?.StringId ?? "none"));
+            output.AppendLine("HeroPartyActive=" + (heroParty?.IsActive.ToString() ?? "none"));
+            output.AppendLine("HeroPartyLeaderId=" + (heroParty?.LeaderHero?.StringId ?? "none"));
+            output.AppendLine("HeroPartyPosition=" + (heroParty == null ? "none" : FormatPosition(heroParty.Position)));
+            output.AppendLine("CaptorHeroPartyId=" + (captorHeroParty?.StringId ?? "none"));
+            output.AppendLine("CaptorHeroPartyActive=" + (captorHeroParty?.IsActive.ToString() ?? "none"));
+            output.AppendLine("CaptorHeroPartyPosition=" + (captorHeroParty == null ? "none" : FormatPosition(captorHeroParty.Position)));
+            output.Append("DiplomaticStateFingerprint=" + GetDiplomaticStateFingerprint(prisonerFaction, captorFaction));
+            return Succeeded(output.ToString());
         }
-        catch (Exception captureException)
+    }
+
+    public sealed class PlayerCaptivityFocusHeroPartyCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "focus_hero_party";
+
+        public string Description => "Runs the focus hero party debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
+            new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("focus_hero_party", "Argument must not be empty.", new List<string>(args));
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to focus hero party: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
+                return Failed("Failed to focus hero party: " + error);
+
+            var party = hero.PartyBelongedTo ?? hero.PartyBelongedToAsPrisoner?.MobileParty;
+            if (party?.IsActive != true)
+                return Failed($"Failed to focus hero party: '{hero.StringId}' has no active member or captor party.");
+
+            party.Party.SetAsCameraFollowParty();
+            return Succeeded($"Following party '{party.StringId}' for hero '{hero.StringId}' on the campaign map.");
+        }
+    }
+
+    public sealed class PlayerCaptivitySnapshotAiLordDiplomacyFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "snapshot_ai_lord_diplomacy_fixture";
+
+        public string Description => "Runs the snapshot ai lord diplomacy fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+            new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("snapshot_ai_lord_diplomacy_fixture", "Argument must not be empty.", new List<string>(args));
+
+            if (!ModInformation.IsClient) return Failed("snapshot_ai_lord_diplomacy_fixture must be run on a client.");
+            if (clientDiplomaticSnapshot != null) return Failed("A client AI-lord diplomatic fixture is already active.");
+            if (!TryGetHeroFactions(args, out var prisonerFaction, out var captorFaction, out error))
+                return Failed("Failed to snapshot AI-lord diplomacy: " + error);
+
+            clientDiplomaticSnapshot = StanceLinkSnapshot.Capture(prisonerFaction, captorFaction);
+            return Succeeded("Client AI-lord diplomatic fixture captured.\nOriginalDiplomaticStateFingerprint=" +
+                clientDiplomaticSnapshot.OriginalFingerprint);
+        }
+    }
+
+    public sealed class PlayerCaptivityRestoreAiLordDiplomacyFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_ai_lord_diplomacy_fixture";
+
+        public string Description => "Runs the restore ai lord diplomacy fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ModInformation.IsClient)
+                return Failed("restore_ai_lord_diplomacy_fixture must be run on a client.");
+            if (clientDiplomaticSnapshot == null)
+                return Failed("No client AI-lord diplomatic fixture is active.");
+
+            var pendingSnapshot = clientDiplomaticSnapshot;
+            pendingSnapshot.Restore(false);
+            var verification = pendingSnapshot.VerifyRestored();
+            if (verification != null)
+                return Failed("Failed to restore client AI-lord diplomatic fixture: " + verification);
+
+            clientDiplomaticSnapshot = null;
+            return Succeeded("Client AI-lord diplomatic fixture restored.");
+        }
+    }
+
+    public sealed class PlayerCaptivityCaptureAiLordFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "capture_ai_lord_fixture";
+
+        public string Description => "Runs the capture ai lord fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
+            new ExpectedArgs("captor_hero_id", "The registered captor hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var context = new CommandContext("capture_ai_lord_fixture", "Argument must not be empty.", new List<string>(args));
+
+            if (!context.RequireServer(out var error)) return Failed(error);
+            if (fixture != null) return Failed("An AI-lord captivity fixture is already active.");
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to create AI-lord fixture: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var prisoner, out error))
+                return Failed("Failed to create AI-lord fixture: " + error);
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[1], out var captorHero, out error))
+                return Failed("Failed to create AI-lord fixture: " + error);
+
+            if (prisoner.IsPrisoner)
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' is already a prisoner.");
+            if (!prisoner.IsLord || prisoner.IsPlayerHero())
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' is not an AI lord.");
+
+            var prisonerParty = prisoner.PartyBelongedTo;
+            var captorParty = captorHero.PartyBelongedTo;
+            if (prisonerParty?.IsActive != true)
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' has no active party.");
+            if (captorParty?.IsActive != true)
+                return Failed($"Failed to create AI-lord fixture: '{captorHero.StringId}' has no active party.");
+            if (prisonerParty == captorParty)
+                return Failed("Failed to create AI-lord fixture: prisoner and captor belong to the same party.");
+
+            var prisonerFaction = prisoner.MapFaction;
+            var captorFaction = captorHero.MapFaction;
+            if (prisonerFaction == null || captorFaction == null || prisonerFaction == captorFaction)
+                return Failed("Failed to create AI-lord fixture: prisoner and captor need distinct map factions.");
+
+            var prisonerIndex = prisonerParty.MemberRoster.FindIndexOfTroop(prisoner.CharacterObject);
+            if (prisonerIndex < 0)
+                return Failed($"Failed to create AI-lord fixture: '{prisoner.StringId}' is absent from its party roster.");
+
+            if (!prisonerFaction.IsAtWarWith(captorFaction))
+                return Failed("Failed to create AI-lord fixture: the prisoner and captor factions must already be at war.");
+
+            var pendingFixture = new AiLordPeaceReleaseFixture(
+                prisoner,
+                captorHero,
+                prisonerParty,
+                captorParty,
+                prisonerParty.MemberRoster.GetElementCopyAtIndex(prisonerIndex),
+                prisoner.HeroState,
+                prisonerParty.LeaderHero,
+                prisonerParty.CurrentSettlement,
+                prisonerParty.Position,
+                prisonerParty.IsActive,
+                captorParty.CurrentSettlement,
+                captorParty.Position,
+                captorParty.IsActive,
+                prisonerFaction,
+                captorFaction,
+                StanceLinkSnapshot.Capture(prisonerFaction, captorFaction));
+
+            fixture = pendingFixture;
             try
             {
-                Restore(pendingFixture);
-                var verification = VerifyRestored(pendingFixture);
-                if (verification != null)
-                    throw new InvalidOperationException(verification);
+                TakePrisonerAction.Apply(captorParty.Party, prisoner);
+                if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner != captorParty.Party)
+                {
+                    Restore(pendingFixture);
+                    var verification = VerifyRestored(pendingFixture);
+                    if (verification != null)
+                        return Failed("Failed to create AI-lord fixture: the capture action did not establish captivity; rollback failed: " + verification);
 
-                fixture = null;
+                    fixture = null;
+                    return Failed("Failed to create AI-lord fixture: the capture action did not establish captivity; the baseline was restored.");
+                }
+
+                return Succeeded("AI-lord captivity fixture created.\n" + Observe(fixture));
             }
-            catch (Exception restoreException)
+            catch (Exception captureException)
             {
-                throw new AggregateException(
-                    "AI-lord fixture capture failed and rollback failed; the retained fixture can be restored manually.",
-                    captureException,
-                    restoreException);
-            }
+                try
+                {
+                    Restore(pendingFixture);
+                    var verification = VerifyRestored(pendingFixture);
+                    if (verification != null)
+                        throw new InvalidOperationException(verification);
 
-            throw;
+                    fixture = null;
+                }
+                catch (Exception restoreException)
+                {
+                    throw new AggregateException(
+                        "AI-lord fixture capture failed and rollback failed; the retained fixture can be restored manually.",
+                        captureException,
+                        restoreException);
+                }
+
+                throw;
+            }
         }
     }
 
-    [CommandLineArgumentFunction("observe_ai_lord_fixture", "coop.debug.player_captivity")]
-    public static string ObserveAiLordFixture(List<string> args)
+    public sealed class PlayerCaptivityObserveAiLordFixtureCoopCommand : ICoopCommand
     {
-        if (args.Count != 0)
-            return "Usage: coop.debug.player_captivity.observe_ai_lord_fixture";
+        public string Prefix => "coop.debug.player_captivity";
 
-        return fixture == null
-            ? "No AI-lord captivity fixture is active."
-            : Observe(fixture);
+        public string Name => "observe_ai_lord_fixture";
+
+        public string Description => "Runs the observe ai lord fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (fixture == null)
+                return Failed("No AI-lord captivity fixture is active.");
+
+            return Succeeded(Observe(fixture));
+        }
     }
 
-    [CommandLineArgumentFunction("focus_party", "coop.debug.player_captivity")]
-    public static string FocusParty(List<string> args)
+    public sealed class PlayerCaptivityFocusPartyCoopCommand : ICoopCommand
     {
-        const string usage = "Usage: coop.debug.player_captivity.focus_party <mobilePartyId>";
-        var context = new CommandContext("focus_party", usage, args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!context.RequireArgCount(1, out var error)) return error;
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to focus party: " + error;
-        if (!objectManager.TryGetObject(args[0], out MobileParty party) &&
-            !CommandHelpers.TryGetMobileParty(args[0], out party, out error))
-            return "Failed to focus party: " + error;
+        public string Name => "focus_party";
 
-        party.Party.SetAsCameraFollowParty();
-        return $"Following party '{party.StringId}' on the campaign map.";
+        public string Description => "Runs the focus party debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("mobile_party_id", "The registered mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var context = new CommandContext("focus_party", "Argument must not be empty.", new List<string>(args));
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to focus party: " + error);
+            if (!objectManager.TryGetObject(args[0], out MobileParty party) &&
+                !CommandHelpers.TryGetMobileParty(args[0], out party, out error))
+                return Failed("Failed to focus party: " + error);
+
+            party.Party.SetAsCameraFollowParty();
+            return Succeeded($"Following party '{party.StringId}' on the campaign map.");
+        }
     }
 
-    [CommandLineArgumentFunction("restore_ai_lord_fixture", "coop.debug.player_captivity")]
-    public static string RestoreAiLordFixture(List<string> args)
+    public sealed class PlayerCaptivityRestoreAiLordFixtureCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient)
-            return "restore_ai_lord_fixture must be run on the server.";
-        if (args.Count != 0)
-            return "Usage: coop.debug.player_captivity.restore_ai_lord_fixture";
-        if (fixture == null)
-            return "No AI-lord captivity fixture is active.";
+        public string Prefix => "coop.debug.player_captivity";
 
-        var pendingFixture = fixture;
-        Restore(pendingFixture);
-        var verification = VerifyRestored(pendingFixture);
-        if (verification != null)
-            return "Failed to restore AI-lord captivity fixture: " + verification;
+        public string Name => "restore_ai_lord_fixture";
 
-        fixture = null;
-        return "AI-lord captivity fixture restored.";
+        public string Description => "Runs the restore ai lord fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (ModInformation.IsClient)
+                return Failed("restore_ai_lord_fixture must be run on the server.");
+            if (fixture == null)
+                return Failed("No AI-lord captivity fixture is active.");
+
+            var pendingFixture = fixture;
+            Restore(pendingFixture);
+            var verification = VerifyRestored(pendingFixture);
+            if (verification != null)
+                return Failed("Failed to restore AI-lord captivity fixture: " + verification);
+
+            fixture = null;
+            return Succeeded("AI-lord captivity fixture restored.");
+        }
     }
 
     private static string Observe(AiLordPeaceReleaseFixture activeFixture)

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Logging;
 using Common.Messaging;
 using Common.Network;
@@ -36,875 +37,1018 @@ namespace GameInterface.Services.PlayerCaptivityService.Commands;
 
 internal class PlayerCaptivityCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     public static readonly ILogger Logger = LogManager.GetLogger<PlayerCaptivityCommands>();
     private static CaptivityRosterFixture pendingRosterFixture;
 
     private static LiveTestFixtureSnapshot liveTestFixtureSnapshot;
 
-    private const string RandomCapturePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.random_capture_player <heroId>
-
-Example:
-  coop.debug.player_captivity.random_capture_player Player
-
-Captures the given hero and assigns a random mobile party as the captor.";
-
-    [CommandLineArgumentFunction("random_capture_player", "coop.debug.player_captivity")]
-    public static string RandomCapturePlayer(List<string> args)
+        public sealed class PlayerCaptivityRandomCapturePlayerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "random_capture_player",
-            RandomCapturePlayerUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireServer(out var error))
-            return error;
+        public string Name => "random_capture_player";
 
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
+        public string Description => "Runs the random capture player debug operation.";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!TryGetRandomCaptor(out var newCaptor, out error))
-            return "Failed to capture hero: " + error;
-
-        return CaptureHero(hero, newCaptor);
-    }
-
-    private const string CapturePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.capture_player <heroId> <mobilePartyId>
-
-Example:
-  coop.debug.player_captivity.capture_player lord_1_29 MobileParty_looters_248
-
-Captures the given hero and assigns the given mobile party as the captor. The party argument accepts
-a co-op registry id or a local StringId.";
-
-    [CommandLineArgumentFunction("capture_player", "coop.debug.player_captivity")]
-    public static string CapturePlayer(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "capture_player",
-            CapturePlayerUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(2, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to capture hero: " + error;
-
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty newCaptor)
-            && !CommandHelpers.TryGetMobileParty(captorPartyId, out newCaptor, out error))
-            return "Failed to capture hero: " + error;
-
-        return CaptureHero(hero, newCaptor);
-    }
-
-    private const string CapturePlayerFixtureUsage =
-@"Usage:
-  coop.debug.player_captivity.capture_player_fixture <heroId> <mobilePartyId>
-
-Example:
-  coop.debug.player_captivity.capture_player_fixture Hero_Player2863 MobileParty_Player
-
-Captures a registered co-op player through the real captivity path and records the transferred regular
-troops for separate fixture cleanup. This is intended for automated tests.";
-
-    [CommandLineArgumentFunction("capture_player_fixture", "coop.debug.player_captivity")]
-    public static string CapturePlayerFixture(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "capture_player_fixture",
-            CapturePlayerFixtureUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(2, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to capture hero fixture: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to capture hero fixture: " + error;
-
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty)
-            && !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
-            return "Failed to capture hero fixture: " + error;
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
-            return "Failed to capture hero fixture: could not resolve PlayerManager.";
-
-        var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == heroId);
-        if (player == null)
-            return $"Failed to capture hero fixture: hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.";
-
-        if (!objectManager.TryGetObject(player.MobilePartyId, out MobileParty playerParty))
-            return $"Failed to capture hero fixture: player party '{player.MobilePartyId}' is not registered.";
-
-        if (hero.IsPrisoner)
-            return CaptureHero(hero, captorParty);
-
-        if (hero.PartyBelongedTo != playerParty)
-            return "Failed to capture hero fixture: the hero does not belong to the registered player party.";
-
-        if (captorParty == playerParty)
-            return "Failed to capture hero fixture: the player party cannot capture its own hero.";
-
-        if (!playerParty.IsActive)
-            return "Failed to capture hero fixture: the player party is not active.";
-
-        if (pendingRosterFixture != null)
-            return "Failed to capture hero fixture: another roster fixture is pending cleanup.";
-
-        var regularTroops = SnapshotRegularTroops(playerParty.MemberRoster);
-        if (HasOtherHero(playerParty.MemberRoster, hero))
-            return "Failed to capture hero fixture: the player party contains another hero.";
-
-        pendingRosterFixture = new CaptivityRosterFixture(hero, playerParty, captorParty, regularTroops);
-        var captureResult = CaptureHero(hero, captorParty);
-        if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != captorParty.Party)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "random_capture_player",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!TryGetRandomCaptor(out var newCaptor, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            return CaptureHero(hero, newCaptor);
+        }
+    }
+
+        public sealed class PlayerCaptivityCapturePlayerCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "capture_player";
+
+        public string Description => "Runs the capture player debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "capture_player",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty newCaptor)
+                && !CommandHelpers.TryGetMobileParty(captorPartyId, out newCaptor, out error))
+                return Failed("Failed to capture hero: " + error);
+
+            return CaptureHero(hero, newCaptor);
+        }
+    }
+
+        public sealed class PlayerCaptivityCapturePlayerFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "capture_player_fixture";
+
+        public string Description => "Runs the capture player fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "capture_player_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!ctx.TryGetArg(1, "mobilePartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to capture hero fixture: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to capture hero fixture: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty)
+                && !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
+                return Failed("Failed to capture hero fixture: " + error);
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+                return Failed("Failed to capture hero fixture: could not resolve PlayerManager.");
+
+            var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == heroId);
+            if (player == null)
+                return Failed($"Failed to capture hero fixture: hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.");
+
+            if (!objectManager.TryGetObject(player.MobilePartyId, out MobileParty playerParty))
+                return Failed($"Failed to capture hero fixture: player party '{player.MobilePartyId}' is not registered.");
+
+            if (hero.IsPrisoner)
+                return CaptureHero(hero, captorParty);
+
+            if (hero.PartyBelongedTo != playerParty)
+                return Failed("Failed to capture hero fixture: the hero does not belong to the registered player party.");
+
+            if (captorParty == playerParty)
+                return Failed("Failed to capture hero fixture: the player party cannot capture its own hero.");
+
+            if (!playerParty.IsActive)
+                return Failed("Failed to capture hero fixture: the player party is not active.");
+
+            if (pendingRosterFixture != null)
+                return Failed("Failed to capture hero fixture: another roster fixture is pending cleanup.");
+
+            var regularTroops = SnapshotRegularTroops(playerParty.MemberRoster);
+            if (HasOtherHero(playerParty.MemberRoster, hero))
+                return Failed("Failed to capture hero fixture: the player party contains another hero.");
+
+            pendingRosterFixture = new CaptivityRosterFixture(hero, playerParty, captorParty, regularTroops);
+            CoopCommandResult captureResult = CaptureHero(hero, captorParty);
+            if (!captureResult.Succeeded)
+            {
+                pendingRosterFixture = null;
+                return captureResult;
+            }
+
+            if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner != captorParty.Party)
+            {
+                pendingRosterFixture = null;
+                return Failed(captureResult.Output + "\nFailed to capture the player through the expected captivity path.");
+            }
+
+            if (playerParty.IsActive)
+            {
+                pendingRosterFixture = null;
+                return Failed(captureResult.Output + "\nFailed to record fixture regular troops: the captivity handler did not park the player party.");
+            }
+
+            return Succeeded(captureResult.Output + "\nFixture regular troops recorded for cleanup: " +
+                regularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture));
+        }
+    }
+
+        public sealed class PlayerCaptivityRestoreRosterFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_roster_fixture";
+
+        public string Description => "Runs the restore roster fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "restore_roster_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to restore roster fixture: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to restore roster fixture: " + error);
+
+            var fixture = pendingRosterFixture;
+            if (fixture == null)
+                return Failed("No roster fixture is pending cleanup.");
+
+            if (fixture.PlayerHero != hero)
+                return Failed($"Failed to restore roster fixture: the pending fixture belongs to '{GetHeroDisplayName(fixture.PlayerHero)}'.");
+
+            if (hero.IsPrisoner)
+                return Failed("Failed to restore roster fixture: the player hero is still a prisoner.");
+
+            var playerHeroIndex = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(fixture.PlayerHero.CharacterObject);
+            if (fixture.PlayerParty.MemberRoster.TotalManCount != 1 ||
+                playerHeroIndex < 0 ||
+                fixture.PlayerParty.MemberRoster.GetTroopCount(fixture.PlayerHero.CharacterObject) != 1)
+                return Failed("Failed to restore roster fixture: the player party is not the released hero's party of one.");
+
+            foreach (var troop in fixture.RegularTroops)
+            {
+                var captorIndex = fixture.CaptorParty.PrisonRoster.FindIndexOfTroop(troop.Character);
+                var availableTotal = captorIndex < 0
+                    ? 0
+                    : fixture.CaptorParty.PrisonRoster.GetTroopCount(troop.Character);
+                var availableWounded = captorIndex < 0
+                    ? 0
+                    : fixture.CaptorParty.PrisonRoster.GetElementWoundedNumber(captorIndex);
+                var availableHealthy = availableTotal - availableWounded;
+                var recordedHealthy = troop.Number - troop.WoundedNumber;
+                if (availableWounded < troop.WoundedNumber || availableHealthy < recordedHealthy)
+                    return Failed($"Failed to restore roster fixture: captor no longer holds the recorded '{troop.Character.StringId}' troops.");
+            }
+
+            foreach (var troop in fixture.RegularTroops)
+            {
+                fixture.CaptorParty.PrisonRoster.AddToCounts(
+                    troop.Character,
+                    -troop.Number,
+                    false,
+                    -troop.WoundedNumber,
+                    0,
+                    true);
+                fixture.PlayerParty.MemberRoster.AddToCounts(
+                    troop.Character,
+                    troop.Number,
+                    false,
+                    troop.WoundedNumber,
+                    troop.Xp,
+                    true);
+            }
+
             pendingRosterFixture = null;
-            return captureResult;
-        }
-
-        if (playerParty.IsActive)
-        {
-            pendingRosterFixture = null;
-            return captureResult + "\nFailed to record fixture regular troops: the captivity handler did not park the player party.";
-        }
-
-        return captureResult + "\nFixture regular troops recorded for cleanup: " +
-            regularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture);
-    }
-
-    private const string RestoreRosterFixtureUsage =
-@"Usage:
-  coop.debug.player_captivity.restore_roster_fixture <heroId>
-
-Example:
-  coop.debug.player_captivity.restore_roster_fixture Hero_Player2863
-
-Restores the regular troops recorded by capture_player_fixture after the player has left captivity.";
-
-    [CommandLineArgumentFunction("restore_roster_fixture", "coop.debug.player_captivity")]
-    public static string RestoreRosterFixture(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "restore_roster_fixture",
-            RestoreRosterFixtureUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to restore roster fixture: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to restore roster fixture: " + error;
-
-        var fixture = pendingRosterFixture;
-        if (fixture == null)
-            return "No roster fixture is pending cleanup.";
-
-        if (fixture.PlayerHero != hero)
-            return $"Failed to restore roster fixture: the pending fixture belongs to '{GetHeroDisplayName(fixture.PlayerHero)}'.";
-
-        if (hero.IsPrisoner)
-            return "Failed to restore roster fixture: the player hero is still a prisoner.";
-
-        var playerHeroIndex = fixture.PlayerParty.MemberRoster.FindIndexOfTroop(fixture.PlayerHero.CharacterObject);
-        if (fixture.PlayerParty.MemberRoster.TotalManCount != 1 ||
-            playerHeroIndex < 0 ||
-            fixture.PlayerParty.MemberRoster.GetTroopCount(fixture.PlayerHero.CharacterObject) != 1)
-            return "Failed to restore roster fixture: the player party is not the released hero's party of one.";
-
-        foreach (var troop in fixture.RegularTroops)
-        {
-            var captorIndex = fixture.CaptorParty.PrisonRoster.FindIndexOfTroop(troop.Character);
-            var availableTotal = captorIndex < 0
-                ? 0
-                : fixture.CaptorParty.PrisonRoster.GetTroopCount(troop.Character);
-            var availableWounded = captorIndex < 0
-                ? 0
-                : fixture.CaptorParty.PrisonRoster.GetElementWoundedNumber(captorIndex);
-            var availableHealthy = availableTotal - availableWounded;
-            var recordedHealthy = troop.Number - troop.WoundedNumber;
-            if (availableWounded < troop.WoundedNumber || availableHealthy < recordedHealthy)
-                return $"Failed to restore roster fixture: captor no longer holds the recorded '{troop.Character.StringId}' troops.";
-        }
-
-        foreach (var troop in fixture.RegularTroops)
-        {
-            fixture.CaptorParty.PrisonRoster.AddToCounts(
-                troop.Character,
-                -troop.Number,
-                false,
-                -troop.WoundedNumber,
-                0,
-                true);
-            fixture.PlayerParty.MemberRoster.AddToCounts(
-                troop.Character,
-                troop.Number,
-                false,
-                troop.WoundedNumber,
-                troop.Xp,
-                true);
-        }
-
-        pendingRosterFixture = null;
-        return "Restored fixture regular troops: " +
-            fixture.RegularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture);
-    }
-
-    private const string ReleasePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.release_player <heroId>
-
-Example:
-  coop.debug.player_captivity.release_player Player
-
-Releases the given player hero from captivity.";
-
-    [CommandLineArgumentFunction("release_player", "coop.debug.player_captivity")]
-    public static string ReleasePlayer(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "release_player",
-            ReleasePlayerUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to release hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to release hero: " + error;
-
-        if (!hero.IsPrisoner)
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
-
-        var captorId = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "unknown";
-
-        try
-        {
-            EndCaptivityAction.ApplyByEscape(hero);
-
-            return
-                "Hero released successfully.\n" +
-                $"Hero: {GetHeroDisplayName(hero)}\n" +
-                $"Former captor StringId: {captorId}";
-        }
-        catch (Exception ex)
-        {
-            return CommandHelpers.FormatException(
-                $"Failed to release hero '{GetHeroDisplayName(hero)}'",
-                ex);
+            return Succeeded("Restored fixture regular troops: " +
+                fixture.RegularTroops.Sum(troop => troop.Number).ToString(CultureInfo.InvariantCulture));
         }
     }
 
-    private const string PrepareVisualTestFixtureUsage =
-@"Usage:
-  coop.debug.player_captivity.prepare_visual_test_fixture <heroId> <captorPartyId>
-
-Snapshots the player's party, removes its non-hero members, and moves it beside the captor. Server only.";
-
-    [CommandLineArgumentFunction("prepare_visual_test_fixture", "coop.debug.player_captivity")]
-    public static string PrepareVisualTestFixture(List<string> args)
+        public sealed class PlayerCaptivityReleasePlayerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "prepare_visual_test_fixture",
-            PrepareVisualTestFixtureUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireServer(out var error))
-            return error;
+        public string Name => "release_player";
 
-        if (!ctx.RequireArgCount(2, out error))
-            return error;
+        public string Description => "Runs the release player debug operation.";
 
-        if (liveTestFixtureSnapshot != null)
-            return "A visual test fixture is already prepared.";
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
-            !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to prepare visual test fixture: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to prepare visual test fixture: " + error;
-
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty) &&
-            !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
-            return "Failed to prepare visual test fixture: " + error;
-
-        var playerParty = hero.PartyBelongedTo;
-        if (playerParty == null || playerParty == captorParty)
-            return "Failed to prepare visual test fixture: player and captor parties must be distinct.";
-
-        if (hero.IsPrisoner || playerParty.PrisonRoster.TotalManCount != 0)
-            return "Failed to prepare visual test fixture: player must be free and their prison roster empty.";
-
-        if (!playerParty.IsActive ||
-            playerParty.LeaderHero != hero ||
-            playerParty.MemberRoster.GetTroopCount(hero.CharacterObject) != 1)
-            return "Failed to prepare visual test fixture: player must lead an active party containing them exactly once.";
-
-        if (playerParty.IsCurrentlyAtSea != captorParty.IsCurrentlyAtSea ||
-            playerParty.Position.IsOnLand != captorParty.Position.IsOnLand)
-            return "Failed to prepare visual test fixture: player and captor parties must use the same navigation layer.";
-
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
-            !behaviorSnapshot.TryCreate(playerParty, out var behavior))
-            return "Failed to prepare visual test fixture: unable to snapshot player party behavior.";
-
-        var snapshot = new LiveTestFixtureSnapshot(
-            playerParty,
-            hero.CharacterObject,
-            playerParty.MemberRoster.GetTroopRoster().ToArray(),
-            behavior);
-        liveTestFixtureSnapshot = snapshot;
-
-        foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            playerParty.MemberRoster.AddToCounts(
-                element.Character,
-                -element.Number,
-                false,
-                -element.WoundedNumber,
-                -element.Xp);
-        }
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        playerParty.Position = new CampaignVec2(
-            new TaleWorlds.Library.Vec2(captorParty.Position.X + 1f, captorParty.Position.Y),
-            captorParty.Position.IsOnLand);
-        playerParty.SetMoveModeHold();
-        playerParty.ResetNavigationToHold();
-        MessageBroker.Instance.Publish(
-            typeof(PlayerCaptivityCommands),
-            new PartyBehaviorChangeAttempted(
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "release_player",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to release hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to release hero: " + error);
+
+            if (!hero.IsPrisoner)
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.");
+
+            var captorId = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "unknown";
+
+            try
+            {
+                EndCaptivityAction.ApplyByEscape(hero);
+
+                return Succeeded("Hero released successfully.\n" +
+                    $"Hero: {GetHeroDisplayName(hero)}\n" +
+                    $"Former captor StringId: {captorId}");
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException(
+                    $"Failed to release hero '{GetHeroDisplayName(hero)}'",
+                    ex));
+            }
+        }
+    }
+
+        public sealed class PlayerCaptivityPrepareVisualTestFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "prepare_visual_test_fixture";
+
+        public string Description => "Runs the prepare visual test fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "prepare_visual_test_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (liveTestFixtureSnapshot != null)
+                return Failed("A visual test fixture is already prepared.");
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
+                !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to prepare visual test fixture: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to prepare visual test fixture: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty captorParty) &&
+                !CommandHelpers.TryGetMobileParty(captorPartyId, out captorParty, out error))
+                return Failed("Failed to prepare visual test fixture: " + error);
+
+            var playerParty = hero.PartyBelongedTo;
+            if (playerParty == null || playerParty == captorParty)
+                return Failed("Failed to prepare visual test fixture: player and captor parties must be distinct.");
+
+            if (hero.IsPrisoner || playerParty.PrisonRoster.TotalManCount != 0)
+                return Failed("Failed to prepare visual test fixture: player must be free and their prison roster empty.");
+
+            if (!playerParty.IsActive ||
+                playerParty.LeaderHero != hero ||
+                playerParty.MemberRoster.GetTroopCount(hero.CharacterObject) != 1)
+                return Failed("Failed to prepare visual test fixture: player must lead an active party containing them exactly once.");
+
+            if (playerParty.IsCurrentlyAtSea != captorParty.IsCurrentlyAtSea ||
+                playerParty.Position.IsOnLand != captorParty.Position.IsOnLand)
+                return Failed("Failed to prepare visual test fixture: player and captor parties must use the same navigation layer.");
+
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot) ||
+                !behaviorSnapshot.TryCreate(playerParty, out var behavior))
+                return Failed("Failed to prepare visual test fixture: unable to snapshot player party behavior.");
+
+            var snapshot = new LiveTestFixtureSnapshot(
                 playerParty,
-                forcePosition: true,
-                isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
-                resetMovementToHold: true));
+                hero.CharacterObject,
+                playerParty.MemberRoster.GetTroopRoster().ToArray(),
+                behavior);
+            liveTestFixtureSnapshot = snapshot;
 
-        return
-            "Visual test fixture prepared.\n" +
-            $"Player party: {playerParty.StringId}\n" +
-            $"Original member count: {snapshot.MemberRoster.Sum(element => element.Number)}\n" +
-            $"Prepared position: {playerParty.Position.X:R},{playerParty.Position.Y:R}";
-    }
+            foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
+            {
+                playerParty.MemberRoster.AddToCounts(
+                    element.Character,
+                    -element.Number,
+                    false,
+                    -element.WoundedNumber,
+                    -element.Xp);
+            }
 
-    [CommandLineArgumentFunction("restore_visual_test_fixture", "coop.debug.player_captivity")]
-    public static string RestoreVisualTestFixture(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "restore_visual_test_fixture",
-            "Usage: coop.debug.player_captivity.restore_visual_test_fixture",
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(0, out error))
-            return error;
-
-        var snapshot = liveTestFixtureSnapshot;
-        if (snapshot == null)
-            return "No visual test fixture is prepared.";
-
-        if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
-            return "Failed to restore visual test fixture: unable to resolve party behavior snapshot service.";
-
-        var playerParty = snapshot.PlayerParty;
-        var playerHero = snapshot.PlayerCharacter.HeroObject;
-        if (playerHero == null ||
-            playerHero.IsPrisoner ||
-            !playerParty.IsActive ||
-            playerHero.PartyBelongedTo != playerParty ||
-            playerParty.LeaderHero != playerHero)
-            return "Failed to restore visual test fixture: player must be free in their active party.";
-
-        if (!behaviorSnapshot.CanApply(playerParty, snapshot.Behavior))
-            return "Failed to restore visual test fixture: unable to resolve the party behavior snapshot.";
-
-        foreach (var element in playerParty.MemberRoster.GetTroopRoster()
-                     .Where(element => element.Character != snapshot.PlayerCharacter)
-                     .ToArray())
-        {
-            playerParty.MemberRoster.AddToCounts(
-                element.Character,
-                -element.Number,
-                false,
-                -element.WoundedNumber,
-                -element.Xp);
-        }
-
-        foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
-            playerParty.MemberRoster.Add(element);
-
-        playerParty.Position = snapshot.Behavior.PartyPosition;
-        playerParty.IsCurrentlyAtSea = snapshot.Behavior.IsCurrentlyAtSea;
-        if (!behaviorSnapshot.TryApply(playerParty, snapshot.Behavior, out _))
-            return "Failed to restore visual test fixture: unable to apply the party behavior snapshot.";
-
-        MessageBroker.Instance.Publish(
-            typeof(PlayerCaptivityCommands),
-            new PartyBehaviorChangeAttempted(
-                playerParty,
-                forcePosition: true,
-                isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
-                resetMovementToHold: false));
-
-        liveTestFixtureSnapshot = null;
-        return
-            "Visual test fixture restored.\n" +
-            $"Player party: {playerParty.StringId}\n" +
-            $"Member count: {playerParty.MemberRoster.TotalManCount}\n" +
-            $"Position: {playerParty.Position.X:R},{playerParty.Position.Y:R}\n" +
-            $"Move mode: {playerParty.PartyMoveMode}";
-    }
-
-    private const string LiberatePrisonerUsage =
-@"Usage:
-  coop.debug.player_captivity.liberate_prisoner <heroId>
-
-Example:
-  coop.debug.player_captivity.liberate_prisoner lord_1_29
-
-Runs the client-side rescued-prisoner liberation consequence for the given hero.";
-
-    [CommandLineArgumentFunction("liberate_prisoner", "coop.debug.player_captivity")]
-    public static string LiberatePrisoner(List<string> args)
-    {
-        if (ModInformation.IsServer)
-            return "Run coop.debug.player_captivity.liberate_prisoner on a client.";
-
-        var ctx = new CommandContext(
-            "liberate_prisoner",
-            LiberatePrisonerUsage,
-            args);
-
-        if (!ctx.RequireArgCount(1, out var error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to liberate hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to liberate hero: " + error;
-
-        if (!hero.IsPrisoner)
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
-
-        var behavior = Campaign.Current?.GetCampaignBehavior<LordConversationsCampaignBehavior>();
-        if (behavior == null)
-            return $"Unable to find {nameof(LordConversationsCampaignBehavior)}.";
-
-        try
-        {
+            playerParty.Position = new CampaignVec2(
+                new TaleWorlds.Library.Vec2(captorParty.Position.X + 1f, captorParty.Position.Y),
+                captorParty.Position.IsOnLand);
+            playerParty.SetMoveModeHold();
+            playerParty.ResetNavigationToHold();
             MessageBroker.Instance.Publish(
-                behavior,
-                new LiberateLordPrisoner(Hero.MainHero, hero));
-            EndCaptivityAction.ApplyByReleasedAfterBattle(hero);
-            return $"Liberated '{GetHeroDisplayName(hero)}' after battle.";
+                typeof(PlayerCaptivityCommands),
+                new PartyBehaviorChangeAttempted(
+                    playerParty,
+                    forcePosition: true,
+                    isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
+                    resetMovementToHold: true));
+
+            return Succeeded("Visual test fixture prepared.\n" +
+                $"Player party: {playerParty.StringId}\n" +
+                $"Original member count: {snapshot.MemberRoster.Sum(element => element.Number)}\n" +
+                $"Prepared position: {playerParty.Position.X:R},{playerParty.Position.Y:R}");
         }
-        catch (Exception ex)
+    }
+
+    public sealed class PlayerCaptivityRestoreVisualTestFixtureCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_visual_test_fixture";
+
+        public string Description => "Runs the restore visual test fixture debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            return CommandHelpers.FormatException(
-                $"Failed to liberate hero '{GetHeroDisplayName(hero)}'",
-                ex);
+            var ctx = new CommandContext(
+                "restore_visual_test_fixture",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            var snapshot = liveTestFixtureSnapshot;
+            if (snapshot == null)
+                return Failed("No visual test fixture is prepared.");
+
+            if (!ContainerProvider.TryResolve<IMobilePartyBehaviorSnapshot>(out var behaviorSnapshot))
+                return Failed("Failed to restore visual test fixture: unable to resolve party behavior snapshot service.");
+
+            var playerParty = snapshot.PlayerParty;
+            var playerHero = snapshot.PlayerCharacter.HeroObject;
+            if (playerHero == null ||
+                playerHero.IsPrisoner ||
+                !playerParty.IsActive ||
+                playerHero.PartyBelongedTo != playerParty ||
+                playerParty.LeaderHero != playerHero)
+                return Failed("Failed to restore visual test fixture: player must be free in their active party.");
+
+            if (!behaviorSnapshot.CanApply(playerParty, snapshot.Behavior))
+                return Failed("Failed to restore visual test fixture: unable to resolve the party behavior snapshot.");
+
+            foreach (var element in playerParty.MemberRoster.GetTroopRoster()
+                         .Where(element => element.Character != snapshot.PlayerCharacter)
+                         .ToArray())
+            {
+                playerParty.MemberRoster.AddToCounts(
+                    element.Character,
+                    -element.Number,
+                    false,
+                    -element.WoundedNumber,
+                    -element.Xp);
+            }
+
+            foreach (var element in snapshot.MemberRoster.Where(element => element.Character != snapshot.PlayerCharacter))
+                playerParty.MemberRoster.Add(element);
+
+            playerParty.Position = snapshot.Behavior.PartyPosition;
+            playerParty.IsCurrentlyAtSea = snapshot.Behavior.IsCurrentlyAtSea;
+            if (!behaviorSnapshot.TryApply(playerParty, snapshot.Behavior, out _))
+                return Failed("Failed to restore visual test fixture: unable to apply the party behavior snapshot.");
+
+            MessageBroker.Instance.Publish(
+                typeof(PlayerCaptivityCommands),
+                new PartyBehaviorChangeAttempted(
+                    playerParty,
+                    forcePosition: true,
+                    isCurrentlyAtSea: playerParty.IsCurrentlyAtSea,
+                    resetMovementToHold: false));
+
+            liveTestFixtureSnapshot = null;
+            return Succeeded("Visual test fixture restored.\n" +
+                $"Player party: {playerParty.StringId}\n" +
+                $"Member count: {playerParty.MemberRoster.TotalManCount}\n" +
+                $"Position: {playerParty.Position.X:R},{playerParty.Position.Y:R}\n" +
+                $"Move mode: {playerParty.PartyMoveMode}");
         }
     }
 
-    private const string PrisonerStatusUsage =
-@"Usage:
-  coop.debug.player_captivity.status <heroId>
-
-Example:
-  coop.debug.player_captivity.status lord_1_29
-
-Reports the hero's current captivity state on this process.";
-
-    [CommandLineArgumentFunction("status", "coop.debug.player_captivity")]
-    public static string PrisonerStatus(List<string> args)
+        public sealed class PlayerCaptivityLiberatePrisonerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "status",
-            PrisonerStatusUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireArgCount(1, out var error))
-            return error;
+        public string Name => "liberate_prisoner";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
+        public string Description => "Runs the liberate prisoner debug operation.";
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to inspect hero: " + error;
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to inspect hero: " + error;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            if (ModInformation.IsServer)
+                return Failed("Run coop.debug.player_captivity.liberate_prisoner on a client.");
 
-        var captor = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none";
-        return
-            $"Hero: {GetHeroDisplayName(hero)} ({hero.StringId})\n" +
-            $"IsPrisoner: {hero.IsPrisoner}\n" +
-            $"Captor: {captor}";
+            var ctx = new CommandContext(
+                "liberate_prisoner",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to liberate hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to liberate hero: " + error);
+
+            if (!hero.IsPrisoner)
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.");
+
+            var behavior = Campaign.Current?.GetCampaignBehavior<LordConversationsCampaignBehavior>();
+            if (behavior == null)
+                return Failed($"Unable to find {nameof(LordConversationsCampaignBehavior)}.");
+
+            try
+            {
+                MessageBroker.Instance.Publish(
+                    behavior,
+                    new LiberateLordPrisoner(Hero.MainHero, hero));
+                EndCaptivityAction.ApplyByReleasedAfterBattle(hero);
+                return Succeeded($"Liberated '{GetHeroDisplayName(hero)}' after battle.");
+            }
+            catch (Exception ex)
+            {
+                return Failed(CommandHelpers.FormatException(
+                    $"Failed to liberate hero '{GetHeroDisplayName(hero)}'",
+                    ex));
+            }
+        }
     }
 
-    private const string DiscardPlayerFromPartyScreenUsage =
-@"Usage:
-  coop.debug.player_captivity.discard_player_from_party_screen <heroId> <captorPartyId>
-
-Moves a captured player into the active normal Party screen's left dismissal roster and presses Done.
-Run this on the client that controls the captor after opening the Party screen.";
-
-    [CommandLineArgumentFunction("discard_player_from_party_screen", "coop.debug.player_captivity")]
-    public static string DiscardPlayerFromPartyScreen(List<string> args)
+        public sealed class PlayerCaptivityStatusCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext(
-            "discard_player_from_party_screen",
-            DiscardPlayerFromPartyScreenUsage,
-            args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ModInformation.IsClient)
-            return "Run this command on the client that controls the captor party.";
+        public string Name => "status";
 
-        if (!ctx.RequireArgCount(2, out var error))
-            return error;
+        public string Description => "Reports status.";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
-            !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
-            return error;
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to discard player prisoner: " + error;
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var ctx = new CommandContext(
+                "status",
+                "Argument must not be empty.",
+                new List<string>(args));
 
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var prisoner, out error))
-            return "Failed to discard player prisoner: " + error;
 
-        if (!objectManager.TryGetObject(captorPartyId, out MobileParty captor) &&
-            !CommandHelpers.TryGetMobileParty(captorPartyId, out captor, out error))
-            return "Failed to discard player prisoner: " + error;
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
 
-        if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner?.MobileParty != captor)
-            return $"Hero '{GetHeroDisplayName(prisoner)}' is not a prisoner of '{captor.StringId}'.";
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to inspect hero: " + error);
 
-        if (captor.LeaderHero == null)
-            return $"Captor party '{captor.StringId}' has no leader hero.";
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to inspect hero: " + error);
 
-        if (MobileParty.MainParty != captor)
-            return "Run this command on the client that controls the captor party.";
+            var captor = hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none";
+            return Succeeded($"Hero: {GetHeroDisplayName(hero)} ({hero.StringId})\n" +
+                $"IsPrisoner: {hero.IsPrisoner}\n" +
+                $"Captor: {captor}");
+        }
+    }
 
-        if (Game.Current?.GameStateManager?.ActiveState is not PartyState partyState ||
-            partyState.PartyScreenLogic == null)
-            return "Open the normal Party screen before running this command.";
+        public sealed class PlayerCaptivityDiscardPlayerFromPartyScreenCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (partyState.PartyScreenMode != PartyScreenHelper.PartyScreenMode.Normal)
-            return $"The active Party screen is '{partyState.PartyScreenMode}', not Normal.";
+        public string Name => "discard_player_from_party_screen";
 
-        var partyScreenLogic = partyState.PartyScreenLogic;
-        var leftPrisonerRoster =
-            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left];
-        if (partyScreenLogic.LeftOwnerParty != null ||
-            leftPrisonerRoster.OwnerParty != null ||
-            objectManager.TryGetId(leftPrisonerRoster, out _) ||
-            partyScreenLogic.RightOwnerParty?.MobileParty != captor ||
-            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right] != captor.PrisonRoster)
-            return "The active Party screen is not the captor's prisoner-dismissal screen.";
+        public string Description => "Runs the discard player from party screen debug operation.";
 
-        var rightPrisonerRoster =
-            partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right];
-        var rightIndex = rightPrisonerRoster.FindIndexOfTroop(prisoner.CharacterObject);
-        if (rightIndex < 0)
-            return $"The active Party screen does not contain '{GetHeroDisplayName(prisoner)}' as a prisoner.";
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+            new ExpectedArgs("captor_party_id", "The registered captor mobile party id.", isRequired: true),
+        };
 
-        var prisonerElement = rightPrisonerRoster.GetElementCopyAtIndex(rightIndex);
-        if (!partyScreenLogic.IsTroopTransferable(
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            string error;
+            var ctx = new CommandContext(
+                "discard_player_from_party_screen",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ModInformation.IsClient)
+                return Failed("Run this command on the client that controls the captor party.");
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error) ||
+                !ctx.TryGetArg(1, "captorPartyId", out var captorPartyId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to discard player prisoner: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var prisoner, out error))
+                return Failed("Failed to discard player prisoner: " + error);
+
+            if (!objectManager.TryGetObject(captorPartyId, out MobileParty captor) &&
+                !CommandHelpers.TryGetMobileParty(captorPartyId, out captor, out error))
+                return Failed("Failed to discard player prisoner: " + error);
+
+            if (!prisoner.IsPrisoner || prisoner.PartyBelongedToAsPrisoner?.MobileParty != captor)
+                return Failed($"Hero '{GetHeroDisplayName(prisoner)}' is not a prisoner of '{captor.StringId}'.");
+
+            if (captor.LeaderHero == null)
+                return Failed($"Captor party '{captor.StringId}' has no leader hero.");
+
+            if (MobileParty.MainParty != captor)
+                return Failed("Run this command on the client that controls the captor party.");
+
+            if (Game.Current?.GameStateManager?.ActiveState is not PartyState partyState ||
+                partyState.PartyScreenLogic == null)
+                return Failed("Open the normal Party screen before running this command.");
+
+            if (partyState.PartyScreenMode != PartyScreenHelper.PartyScreenMode.Normal)
+                return Failed($"The active Party screen is '{partyState.PartyScreenMode}', not Normal.");
+
+            var partyScreenLogic = partyState.PartyScreenLogic;
+            var leftPrisonerRoster =
+                partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Left];
+            if (partyScreenLogic.LeftOwnerParty != null ||
+                leftPrisonerRoster.OwnerParty != null ||
+                objectManager.TryGetId(leftPrisonerRoster, out _) ||
+                partyScreenLogic.RightOwnerParty?.MobileParty != captor ||
+                partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right] != captor.PrisonRoster)
+                return Failed("The active Party screen is not the captor's prisoner-dismissal screen.");
+
+            var rightPrisonerRoster =
+                partyScreenLogic.PrisonerRosters[(int)PartyScreenLogic.PartyRosterSide.Right];
+            var rightIndex = rightPrisonerRoster.FindIndexOfTroop(prisoner.CharacterObject);
+            if (rightIndex < 0)
+                return Failed($"The active Party screen does not contain '{GetHeroDisplayName(prisoner)}' as a prisoner.");
+
+            var prisonerElement = rightPrisonerRoster.GetElementCopyAtIndex(rightIndex);
+            if (!partyScreenLogic.IsTroopTransferable(
+                    PartyScreenLogic.TroopType.Prisoner,
+                    prisoner.CharacterObject,
+                    (int)PartyScreenLogic.PartyRosterSide.Right))
+                return Failed($"The active Party screen does not allow '{GetHeroDisplayName(prisoner)}' to be transferred.");
+
+            var targetIndex = partyScreenLogic.GetIndexToInsertTroop(
+                PartyScreenLogic.PartyRosterSide.Left,
+                PartyScreenLogic.TroopType.Prisoner,
+                prisonerElement);
+            var command = new PartyScreenLogic.PartyCommand();
+            command.FillForTransferTroop(
+                PartyScreenLogic.PartyRosterSide.Right,
                 PartyScreenLogic.TroopType.Prisoner,
                 prisoner.CharacterObject,
-                (int)PartyScreenLogic.PartyRosterSide.Right))
-            return $"The active Party screen does not allow '{GetHeroDisplayName(prisoner)}' to be transferred.";
+                prisonerElement.Number,
+                prisonerElement.WoundedNumber,
+                targetIndex);
 
-        var targetIndex = partyScreenLogic.GetIndexToInsertTroop(
-            PartyScreenLogic.PartyRosterSide.Left,
-            PartyScreenLogic.TroopType.Prisoner,
-            prisonerElement);
-        var command = new PartyScreenLogic.PartyCommand();
-        command.FillForTransferTroop(
-            PartyScreenLogic.PartyRosterSide.Right,
-            PartyScreenLogic.TroopType.Prisoner,
-            prisoner.CharacterObject,
-            prisonerElement.Number,
-            prisonerElement.WoundedNumber,
-            targetIndex);
+            // PartyCharacterVM.ApplyTransfer is patched with this same scope. Drive PartyScreenLogic directly
+            // so the automation exercises the real transfer history, both Done handlers, network messages,
+            // rollback, and state close without synthesizing either wire payload.
+            using (new AllowedThread())
+            {
+                partyScreenLogic.AddCommand(command);
+                partyScreenLogic.RemoveZeroCounts();
+            }
 
-        // PartyCharacterVM.ApplyTransfer is patched with this same scope. Drive PartyScreenLogic directly
-        // so the automation exercises the real transfer history, both Done handlers, network messages,
-        // rollback, and state close without synthesizing either wire payload.
-        using (new AllowedThread())
-        {
-            partyScreenLogic.AddCommand(command);
-            partyScreenLogic.RemoveZeroCounts();
+            var movedCount = leftPrisonerRoster.GetTroopCount(prisoner.CharacterObject);
+            if (movedCount != prisonerElement.Number ||
+                rightPrisonerRoster.GetTroopCount(prisoner.CharacterObject) != 0)
+                return Failed("PartyScreenLogic did not move the complete prisoner stack to the dismissal roster.");
+
+            PartyScreenHelper.CloseScreen(isForced: false);
+            var screenClosed = Game.Current.GameStateManager.ActiveState != partyState;
+
+            return Succeeded("Player prisoner discarded through the active Party screen.\n" +
+                $"Hero: {GetHeroDisplayName(prisoner)}\n" +
+                $"Captor StringId: {captor.StringId}\n" +
+                $"TransferredCount: {movedCount}\n" +
+                $"ActionPath: {nameof(PartyScreenLogic)}.{nameof(PartyScreenLogic.AddCommand)} -> " +
+                $"{nameof(PartyScreenHelper)}.{nameof(PartyScreenHelper.CloseScreen)}\n" +
+                $"ScreenClosed: {screenClosed}");
         }
-
-        var movedCount = leftPrisonerRoster.GetTroopCount(prisoner.CharacterObject);
-        if (movedCount != prisonerElement.Number ||
-            rightPrisonerRoster.GetTroopCount(prisoner.CharacterObject) != 0)
-            return "PartyScreenLogic did not move the complete prisoner stack to the dismissal roster.";
-
-        PartyScreenHelper.CloseScreen(isForced: false);
-        var screenClosed = Game.Current.GameStateManager.ActiveState != partyState;
-
-        return
-            "Player prisoner discarded through the active Party screen.\n" +
-            $"Hero: {GetHeroDisplayName(prisoner)}\n" +
-            $"Captor StringId: {captor.StringId}\n" +
-            $"TransferredCount: {movedCount}\n" +
-            $"ActionPath: {nameof(PartyScreenLogic)}.{nameof(PartyScreenLogic.AddCommand)} -> " +
-            $"{nameof(PartyScreenHelper)}.{nameof(PartyScreenHelper.CloseScreen)}\n" +
-            $"ScreenClosed: {screenClosed}";
     }
 
-    private const string ObservePlayerUsage =
-@"Usage:
-  coop.debug.player_captivity.observe_player <heroId>
-
-Reports captivity and registered party state without mutating it.";
-
-    [CommandLineArgumentFunction("observe_player", "coop.debug.player_captivity")]
-    public static string ObservePlayer(List<string> args)
+        public sealed class PlayerCaptivityObservePlayerCoopCommand : ICoopCommand
     {
-        var ctx = new CommandContext("observe_player", ObservePlayerUsage, args);
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!ctx.RequireArgCount(1, out var error))
-            return error;
+        public string Name => "observe_player";
 
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
+        public string Description => "Runs the observe player debug operation.";
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to observe player: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to observe player: " + error;
-
-        if (!objectManager.TryGetId(hero, out var registeredHeroId))
-            return "Failed to observe player: hero is not registered.";
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
-            return "Failed to observe player: unable to resolve player manager.";
-
-        var player = playerManager.Players.FirstOrDefault(candidate => candidate.HeroId == registeredHeroId);
-        var partyId = player?.MobilePartyId;
-        MobileParty registeredParty = null;
-        if (!string.IsNullOrEmpty(partyId))
-            objectManager.TryGetObject(partyId, out registeredParty);
-        var captorParty = hero.PartyBelongedToAsPrisoner?.MobileParty;
-
-        var output = new StringBuilder();
-        output.AppendLine($"HeroId: {registeredHeroId}");
-        output.AppendLine($"IsPrisoner: {hero.IsPrisoner}");
-        output.AppendLine($"HeroPartyId: {hero.PartyBelongedTo?.StringId ?? "<none>"}");
-        output.AppendLine($"CaptorPartyId: {captorParty?.StringId ?? "<none>"}");
-        output.AppendLine($"RegisteredPartyId: {partyId ?? "<none>"}");
-        output.AppendLine($"PartyResolved: {registeredParty != null}");
-
-        if (registeredParty != null)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            output.AppendLine($"PartyActive: {registeredParty.IsActive}");
-            output.AppendLine($"PartyVisible: {registeredParty.IsVisible}");
-            output.AppendLine($"PartyVisualPresent: {registeredParty.Party.GetPartyVisual() != null}");
-            output.AppendLine($"PartyLeaderId: {registeredParty.LeaderHero?.StringId ?? "<none>"}");
-            output.AppendLine($"HeroMemberCount: {registeredParty.MemberRoster.GetTroopCount(hero.CharacterObject)}");
-            output.AppendLine($"PartyMemberCount: {registeredParty.MemberRoster.TotalManCount}");
-            output.AppendLine($"PartyPrisonerCount: {registeredParty.PrisonRoster.TotalManCount}");
-            output.AppendLine($"PartyPosition: {registeredParty.Position.X:R},{registeredParty.Position.Y:R}");
-            output.AppendLine($"PartyIsOnLand: {registeredParty.Position.IsOnLand}");
-            output.AppendLine($"PartyMoveMode: {registeredParty.PartyMoveMode}");
-            output.AppendLine($"MoveTargetPoint: {registeredParty.MoveTargetPoint.X:R},{registeredParty.MoveTargetPoint.Y:R}");
-        }
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
 
-        output.AppendLine($"CaptorPrisonerCount: {captorParty?.PrisonRoster.GetTroopCount(hero.CharacterObject) ?? 0}");
-        return output.ToString();
-    }
-
-    private const string RansomPlayerAtSettlementUsage =
-@"Usage:
-  coop.debug.player_captivity.ransom_player_at_settlement <heroId>
-
-Example:
-  coop.debug.player_captivity.ransom_player_at_settlement Player
-
-Ransoms the captive player hero for zero gold and releases them at a nearby neutral or allied settlement.";
-
-    [CommandLineArgumentFunction("ransom_player_at_settlement", "coop.debug.player_captivity")]
-    public static string RansomPlayerAtSettlement(List<string> args)
-    {
-        var ctx = new CommandContext(
-            "ransom_player_at_settlement",
-            RansomPlayerAtSettlementUsage,
-            args);
-
-        if (!ctx.RequireServer(out var error))
-            return error;
-
-        if (!ctx.RequireArgCount(1, out error))
-            return error;
-
-        if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to ransom hero: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
-            return "Failed to ransom hero: " + error;
-
-        if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner == null)
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.";
-
-        if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
-            !playerManager.Contains(hero))
-            return $"Hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.";
-
-        var captorParty = hero.PartyBelongedToAsPrisoner;
-        var currentSettlement = captorParty.MobileParty?.CurrentSettlement;
-        if (currentSettlement == null)
-            return $"Captor for '{GetHeroDisplayName(hero)}' is not in a settlement.";
-
-        if (!ContainerProvider.TryResolve<IPrisonerSaleProcessor>(out var prisonerSaleProcessor))
-            return "Failed to ransom hero: could not resolve PrisonerSaleProcessor.";
-
-        if (!ContainerProvider.TryResolve<IPlayerRansomReleaseSettlementProvider>(out var releaseSettlementProvider))
-            return "Failed to ransom hero: could not resolve PlayerRansomReleaseSettlementProvider.";
-
-        var releaseSettlement = releaseSettlementProvider.GetReleaseSettlement(captorParty, hero);
-        var playerFaction = hero.MapFaction;
-        var releaseFaction = releaseSettlement.MapFaction;
-        var releaseSettlementHostile = playerFaction != null && releaseFaction != null &&
-            FactionManager.IsAtWarAgainstFaction(playerFaction, releaseFaction);
-
-        var requestedPrisoners = new TroopRoster();
-        requestedPrisoners.AddToCounts(hero.CharacterObject, 1);
-        var seller = captorParty.LeaderHero;
-        var sellerGoldBefore = seller?.Gold ?? 0;
-
-        prisonerSaleProcessor.Sell(captorParty, requestedPrisoners);
-
-        var sellerGoldAfter = seller?.Gold ?? 0;
-        return
-            "Hero ransomed successfully.\n" +
-            $"Hero: {GetHeroDisplayName(hero)}\n" +
-            $"Ransom settlement: {currentSettlement.Name} ({currentSettlement.StringId})\n" +
-            $"Release settlement: {releaseSettlement.Name} ({releaseSettlement.StringId})\n" +
-            $"Player faction: {playerFaction?.StringId ?? "none"}\n" +
-            $"Release settlement faction: {releaseFaction?.StringId ?? "none"}\n" +
-            $"Release settlement hostile: {releaseSettlementHostile}\n" +
-            $"Release gate X: {releaseSettlement.GatePosition.X.ToString(CultureInfo.InvariantCulture)}\n" +
-            $"Release gate Y: {releaseSettlement.GatePosition.Y.ToString(CultureInfo.InvariantCulture)}\n" +
-            $"Seller gold change: {sellerGoldAfter - sellerGoldBefore}";
-    }
-
-    [CommandLineArgumentFunction("captivity_state", "coop.debug.player_captivity")]
-    public static string CaptivityState(List<string> args)
-    {
-        if (args.Count != 1)
-            return "Usage: coop.debug.player_captivity.captivity_state <heroId>";
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
-            return "Failed to inspect captivity: " + error;
-
-        if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
-            return "Failed to inspect captivity: " + error;
-
-        MobileParty playerParty = null;
-        if (ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
         {
-            var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == args[0]);
-            if (player != null)
-                objectManager.TryGetObject(player.MobilePartyId, out playerParty);
-        }
+            string error;
+            var ctx = new CommandContext("observe_player", "Argument must not be empty.", new List<string>(args));
 
-        var result = new StringBuilder();
-        result.AppendLine("HeroId=" + hero.StringId);
-        result.AppendLine("IsPrisoner=" + hero.IsPrisoner);
-        result.AppendLine("CaptorPartyId=" + (hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none"));
-        result.AppendLine("PlayerPartyId=" + (playerParty?.StringId ?? "none"));
-        result.AppendLine("PlayerPartyActive=" + (playerParty?.IsActive.ToString() ?? "none"));
-        result.AppendLine("PlayerPartyLeaderHeroId=" + (playerParty?.LeaderHero?.StringId ?? "none"));
-        result.AppendLine("PlayerPartyMemberCount=" + (playerParty?.MemberRoster.TotalManCount.ToString(CultureInfo.InvariantCulture) ?? "none"));
-        result.AppendLine("PlayerPartyX=" + FormatCoordinate(playerParty?.Position.X));
-        result.AppendLine("PlayerPartyY=" + FormatCoordinate(playerParty?.Position.Y));
-        result.AppendLine("PlayerPartyIsOnLand=" + (playerParty?.Position.IsOnLand.ToString() ?? "none"));
-        result.AppendLine("PlayerPartySettlementId=" + (playerParty?.CurrentSettlement?.StringId ?? "none"));
-        return result.ToString();
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to observe player: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to observe player: " + error);
+
+            if (!objectManager.TryGetId(hero, out var registeredHeroId))
+                return Failed("Failed to observe player: hero is not registered.");
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+                return Failed("Failed to observe player: unable to resolve player manager.");
+
+            var player = playerManager.Players.FirstOrDefault(candidate => candidate.HeroId == registeredHeroId);
+            var partyId = player?.MobilePartyId;
+            MobileParty registeredParty = null;
+            if (!string.IsNullOrEmpty(partyId))
+                objectManager.TryGetObject(partyId, out registeredParty);
+            var captorParty = hero.PartyBelongedToAsPrisoner?.MobileParty;
+
+            var output = new StringBuilder();
+            output.AppendLine($"HeroId: {registeredHeroId}");
+            output.AppendLine($"IsPrisoner: {hero.IsPrisoner}");
+            output.AppendLine($"HeroPartyId: {hero.PartyBelongedTo?.StringId ?? "<none>"}");
+            output.AppendLine($"CaptorPartyId: {captorParty?.StringId ?? "<none>"}");
+            output.AppendLine($"RegisteredPartyId: {partyId ?? "<none>"}");
+            output.AppendLine($"PartyResolved: {registeredParty != null}");
+
+            if (registeredParty != null)
+            {
+                output.AppendLine($"PartyActive: {registeredParty.IsActive}");
+                output.AppendLine($"PartyVisible: {registeredParty.IsVisible}");
+                output.AppendLine($"PartyVisualPresent: {registeredParty.Party.GetPartyVisual() != null}");
+                output.AppendLine($"PartyLeaderId: {registeredParty.LeaderHero?.StringId ?? "<none>"}");
+                output.AppendLine($"HeroMemberCount: {registeredParty.MemberRoster.GetTroopCount(hero.CharacterObject)}");
+                output.AppendLine($"PartyMemberCount: {registeredParty.MemberRoster.TotalManCount}");
+                output.AppendLine($"PartyPrisonerCount: {registeredParty.PrisonRoster.TotalManCount}");
+                output.AppendLine($"PartyPosition: {registeredParty.Position.X:R},{registeredParty.Position.Y:R}");
+                output.AppendLine($"PartyIsOnLand: {registeredParty.Position.IsOnLand}");
+                output.AppendLine($"PartyMoveMode: {registeredParty.PartyMoveMode}");
+                output.AppendLine($"MoveTargetPoint: {registeredParty.MoveTargetPoint.X:R},{registeredParty.MoveTargetPoint.Y:R}");
+            }
+
+            output.AppendLine($"CaptorPrisonerCount: {captorParty?.PrisonRoster.GetTroopCount(hero.CharacterObject) ?? 0}");
+            return Succeeded(output.ToString());
+        }
     }
 
-    [CommandLineArgumentFunction("party_fixture_state", "coop.debug.player_captivity")]
-    public static string PartyFixtureState(List<string> args)
+        public sealed class PlayerCaptivityRansomPlayerAtSettlementCoopCommand : ICoopCommand
     {
-        if (args.Count != 1)
-            return "Usage: coop.debug.player_captivity.party_fixture_state <partyId>";
+        public string Prefix => "coop.debug.player_captivity";
 
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
-            return "Failed to inspect party: " + error;
+        public string Name => "ransom_player_at_settlement";
 
-        if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
-            return "Failed to inspect party: " + error;
+        public string Description => "Runs the ransom player at settlement debug operation.";
 
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext(
+                "ransom_player_at_settlement",
+                "Argument must not be empty.",
+                new List<string>(args));
+
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+
+            if (!ctx.TryGetArg(0, "heroId", out var heroId, out error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to ransom hero: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, heroId, out var hero, out error))
+                return Failed("Failed to ransom hero: " + error);
+
+            if (!hero.IsPrisoner || hero.PartyBelongedToAsPrisoner == null)
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a prisoner.");
+
+            if (!ContainerProvider.TryResolve<IPlayerManager>(out var playerManager) ||
+                !playerManager.Contains(hero))
+                return Failed($"Hero '{GetHeroDisplayName(hero)}' is not a registered co-op player.");
+
+            var captorParty = hero.PartyBelongedToAsPrisoner;
+            var currentSettlement = captorParty.MobileParty?.CurrentSettlement;
+            if (currentSettlement == null)
+                return Failed($"Captor for '{GetHeroDisplayName(hero)}' is not in a settlement.");
+
+            if (!ContainerProvider.TryResolve<IPrisonerSaleProcessor>(out var prisonerSaleProcessor))
+                return Failed("Failed to ransom hero: could not resolve PrisonerSaleProcessor.");
+
+            if (!ContainerProvider.TryResolve<IPlayerRansomReleaseSettlementProvider>(out var releaseSettlementProvider))
+                return Failed("Failed to ransom hero: could not resolve PlayerRansomReleaseSettlementProvider.");
+
+            var releaseSettlement = releaseSettlementProvider.GetReleaseSettlement(captorParty, hero);
+            var playerFaction = hero.MapFaction;
+            var releaseFaction = releaseSettlement.MapFaction;
+            var releaseSettlementHostile = playerFaction != null && releaseFaction != null &&
+                FactionManager.IsAtWarAgainstFaction(playerFaction, releaseFaction);
+
+            var requestedPrisoners = new TroopRoster();
+            requestedPrisoners.AddToCounts(hero.CharacterObject, 1);
+            var seller = captorParty.LeaderHero;
+            var sellerGoldBefore = seller?.Gold ?? 0;
+
+            prisonerSaleProcessor.Sell(captorParty, requestedPrisoners);
+
+            var sellerGoldAfter = seller?.Gold ?? 0;
+            return Succeeded("Hero ransomed successfully.\n" +
+                $"Hero: {GetHeroDisplayName(hero)}\n" +
+                $"Ransom settlement: {currentSettlement.Name} ({currentSettlement.StringId})\n" +
+                $"Release settlement: {releaseSettlement.Name} ({releaseSettlement.StringId})\n" +
+                $"Player faction: {playerFaction?.StringId ?? "none"}\n" +
+                $"Release settlement faction: {releaseFaction?.StringId ?? "none"}\n" +
+                $"Release settlement hostile: {releaseSettlementHostile}\n" +
+                $"Release gate X: {releaseSettlement.GatePosition.X.ToString(CultureInfo.InvariantCulture)}\n" +
+                $"Release gate Y: {releaseSettlement.GatePosition.Y.ToString(CultureInfo.InvariantCulture)}\n" +
+                $"Seller gold change: {sellerGoldAfter - sellerGoldBefore}");
+        }
+    }
+
+    public sealed class PlayerCaptivityCaptivityStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "captivity_state";
+
+        public string Description => "Reports captivity state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
+                return Failed("Failed to inspect captivity: " + error);
+
+            if (!CommandHelpers.TryGetManagedObject<Hero>(objectManager, args[0], out var hero, out error))
+                return Failed("Failed to inspect captivity: " + error);
+
+            MobileParty playerParty = null;
+            if (ContainerProvider.TryResolve<IPlayerManager>(out var playerManager))
+            {
+                var player = playerManager.Players.SingleOrDefault(candidate => candidate.HeroId == args[0]);
+                if (player != null)
+                    objectManager.TryGetObject(player.MobilePartyId, out playerParty);
+            }
+
+            var result = new StringBuilder();
+            result.AppendLine("HeroId=" + hero.StringId);
+            result.AppendLine("IsPrisoner=" + hero.IsPrisoner);
+            result.AppendLine("CaptorPartyId=" + (hero.PartyBelongedToAsPrisoner?.MobileParty?.StringId ?? "none"));
+            result.AppendLine("PlayerPartyId=" + (playerParty?.StringId ?? "none"));
+            result.AppendLine("PlayerPartyActive=" + (playerParty?.IsActive.ToString() ?? "none"));
+            result.AppendLine("PlayerPartyLeaderHeroId=" + (playerParty?.LeaderHero?.StringId ?? "none"));
+            result.AppendLine("PlayerPartyMemberCount=" + (playerParty?.MemberRoster.TotalManCount.ToString(CultureInfo.InvariantCulture) ?? "none"));
+            result.AppendLine("PlayerPartyX=" + FormatCoordinate(playerParty?.Position.X));
+            result.AppendLine("PlayerPartyY=" + FormatCoordinate(playerParty?.Position.Y));
+            result.AppendLine("PlayerPartyIsOnLand=" + (playerParty?.Position.IsOnLand.ToString() ?? "none"));
+            result.AppendLine("PlayerPartySettlementId=" + (playerParty?.CurrentSettlement?.StringId ?? "none"));
+            return Succeeded(result.ToString());
+        }
+    }
+
+    public sealed class PlayerCaptivityPartyFixtureStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "party_fixture_state";
+
+        public string Description => "Reports party fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out var error))
+                return Failed("Failed to inspect party: " + error);
+
+            if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
+                return Failed("Failed to inspect party: " + error);
+
+            return Succeeded(GetPartyFixtureState(party));
+        }
+    }
+
+    public sealed class PlayerCaptivityRestorePartyFixtureStateCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug.player_captivity";
+
+        public string Name => "restore_party_fixture_state";
+
+        public string Description => "Reports restore party fixture state.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
+            new ExpectedArgs("settlement_id_or_none", "The settlement id, or none.", isRequired: true),
+            new ExpectedArgs("x", "The map x coordinate.", isRequired: true),
+            new ExpectedArgs("y", "The map y coordinate.", isRequired: true),
+            new ExpectedArgs("is_on_land", "Whether the position is on land.", isRequired: true),
+            new ExpectedArgs("is_active", "Whether the party is active.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            var ctx = new CommandContext("restore_party_fixture_state", "Argument must not be empty.", new List<string>(args));
+            if (!ctx.RequireServer(out var error))
+                return Failed(error);
+
+            if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
+                return Failed("Failed to restore party: " + error);
+            if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
+                return Failed("Failed to restore party: " + error);
+            if (!ContainerProvider.TryResolve<INetwork>(out var network))
+                return Failed("Failed to restore party: could not resolve Network.");
+            if (!objectManager.TryGetIdWithLogging(party, out var partyId))
+                return Failed("Failed to restore party: the party is not registered.");
+            if (!float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
+                !float.TryParse(args[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var y) ||
+                !bool.TryParse(args[4], out var isOnLand) ||
+                !bool.TryParse(args[5], out var isActive))
+                return Failed("Coordinates and active-state values must use valid numeric and boolean formats.");
+
+            if (args[1] == "none")
+            {
+                if (party.CurrentSettlement != null)
+                    LeaveSettlementAction.ApplyForParty(party);
+
+                party.Position = new CampaignVec2(new Vec2(x, y), isOnLand);
+            }
+            else
+            {
+                var settlement = Settlement.Find(args[1]);
+                if (settlement == null)
+                    return Failed($"Failed to restore party: settlement '{args[1]}' not found.");
+
+                if (party.CurrentSettlement != settlement)
+                {
+                    if (party.CurrentSettlement != null)
+                        LeaveSettlementAction.ApplyForParty(party);
+                    EnterSettlementAction.ApplyForParty(party, settlement);
+                }
+            }
+
+            party.IsActive = isActive;
+            network.SendAll(new NetworkPlayerCaptivityReleasePositionSet(partyId, party.Position));
+
+            return Succeeded("Restored party fixture state.\n" + GetPartyFixtureState(party));
+        }
+    }
+
+    private static string GetPartyFixtureState(MobileParty party)
+    {
         var result = new StringBuilder();
         result.AppendLine("PartyId=" + party.StringId);
         result.AppendLine("IsActive=" + party.IsActive);
@@ -917,57 +1061,6 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         result.AppendLine("MemberCount=" + party.MemberRoster.TotalManCount.ToString(CultureInfo.InvariantCulture));
         result.AppendLine("PrisonerCount=" + party.PrisonRoster.TotalManCount.ToString(CultureInfo.InvariantCulture));
         return result.ToString();
-    }
-
-    [CommandLineArgumentFunction("restore_party_fixture_state", "coop.debug.player_captivity")]
-    public static string RestorePartyFixtureState(List<string> args)
-    {
-        const string usage = "Usage: coop.debug.player_captivity.restore_party_fixture_state <partyId> <settlementId|none> <x> <y> <isOnLand> <isActive>";
-        var ctx = new CommandContext("restore_party_fixture_state", usage, args);
-        if (!ctx.RequireServer(out var error))
-            return error;
-        if (!ctx.RequireArgCount(6, out error))
-            return error;
-
-        if (!CommandHelpers.TryGetObjectManager(out var objectManager, out error))
-            return "Failed to restore party: " + error;
-        if (!TryResolveMobileParty(objectManager, args[0], out var party, out error))
-            return "Failed to restore party: " + error;
-        if (!ContainerProvider.TryResolve<INetwork>(out var network))
-            return "Failed to restore party: could not resolve Network.";
-        if (!objectManager.TryGetIdWithLogging(party, out var partyId))
-            return "Failed to restore party: the party is not registered.";
-        if (!float.TryParse(args[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
-            !float.TryParse(args[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var y) ||
-            !bool.TryParse(args[4], out var isOnLand) ||
-            !bool.TryParse(args[5], out var isActive))
-            return usage;
-
-        if (args[1] == "none")
-        {
-            if (party.CurrentSettlement != null)
-                LeaveSettlementAction.ApplyForParty(party);
-
-            party.Position = new CampaignVec2(new Vec2(x, y), isOnLand);
-        }
-        else
-        {
-            var settlement = Settlement.Find(args[1]);
-            if (settlement == null)
-                return $"Failed to restore party: settlement '{args[1]}' not found.";
-
-            if (party.CurrentSettlement != settlement)
-            {
-                if (party.CurrentSettlement != null)
-                    LeaveSettlementAction.ApplyForParty(party);
-                EnterSettlementAction.ApplyForParty(party, settlement);
-            }
-        }
-
-        party.IsActive = isActive;
-        network.SendAll(new NetworkPlayerCaptivityReleasePositionSet(partyId, party.Position));
-
-        return "Restored party fixture state.\n" + PartyFixtureState(new List<string> { args[0] });
     }
 
     private static bool TryGetRandomCaptor(out MobileParty newCaptor, out string error)
@@ -1069,22 +1162,16 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
         }
     }
 
-    private static string CaptureHero(Hero hero, MobileParty newCaptor)
+    private static CoopCommandResult CaptureHero(Hero hero, MobileParty newCaptor)
     {
         if (hero == null)
-        {
-            return "Failed to capture hero: hero is null.";
-        }
+            return Failed("Failed to capture hero: hero is null.");
 
         if (newCaptor == null)
-        {
-            return "Failed to capture hero: captor party is null.";
-        }
+            return Failed("Failed to capture hero: captor party is null.");
 
         if (newCaptor.Party == null)
-        {
-            return $"Failed to capture hero: MobileParty '{newCaptor.StringId}' has no Party.";
-        }
+            return Failed($"Failed to capture hero: MobileParty '{newCaptor.StringId}' has no Party.");
 
         if (hero.IsPrisoner)
         {
@@ -1092,9 +1179,9 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
                 ?? hero.PartyBelongedTo?.StringId
                 ?? "unknown";
 
-            return
+            return Failed(
                 $"Hero '{GetHeroDisplayName(hero)}' is already a prisoner.\n" +
-                $"Current captor: {currentCaptor}.";
+                $"Current captor: {currentCaptor}.");
         }
 
         try
@@ -1103,17 +1190,17 @@ Ransoms the captive player hero for zero gold and releases them at a nearby neut
 
             var captorName = newCaptor.Name?.ToString() ?? newCaptor.StringId;
 
-            return
+            return Succeeded(
                 "Hero captured successfully.\n" +
                 $"Hero: {GetHeroDisplayName(hero)}\n" +
                 $"Captor: {captorName}\n" +
-                $"Captor StringId: {newCaptor.StringId}";
+                $"Captor StringId: {newCaptor.StringId}");
         }
         catch (Exception ex)
         {
-            return CommandHelpers.FormatException(
+            return Failed(CommandHelpers.FormatException(
                 $"Failed to capture hero '{GetHeroDisplayName(hero)}' by '{newCaptor.StringId}'",
-                ex);
+                ex));
         }
     }
 

--- a/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
+++ b/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
@@ -1,4 +1,6 @@
-﻿using Common;
+﻿using System;
+using Common.Commands;
+using Common;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -9,40 +11,67 @@ namespace GameInterface.Services.Save.Commands
 {
     public class SaveDebugCommand
     {
+        private static CoopCommandResult Succeeded(string output) =>
+            new CoopCommandResult(true, output);
+
+        private static CoopCommandResult Failed(string output) =>
+            new CoopCommandResult(false, output, "command_failed");
+
         private static readonly Regex SafeSaveName = new("^[A-Za-z0-9_-]{1,64}$");
 
 #if DEBUG
         private static int evidenceHoldMilliseconds;
 #endif
 
-        [CommandLineArgumentFunction("save_as", "coop.debug.save")]
-        public static string SaveAs(List<string> args)
+        public sealed class SaveSaveAsCoopCommand : ICoopCommand
         {
-            if (!ModInformation.IsServer)
-                return "Command can only be run on the server.";
-            if (args.Count != 1 || !SafeSaveName.IsMatch(args[0]))
-                return "Usage: coop.debug.save.save_as <1-64 letters, digits, underscores, or hyphens>";
+            public string Prefix => "coop.debug.save";
 
-            SaveHandler saveHandler = Campaign.Current?.SaveHandler;
-            if (saveHandler == null)
-                return "No active campaign / SaveHandler.";
-            if (saveHandler.IsSaving)
-                return "A save is already queued.";
+            public string Name => "save_as";
 
-            saveHandler.SaveAs(args[0]);
-            return $"Enqueued save as {args[0]} on the server.";
+            public string Description => "Runs the save as debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("save_name", "A save name using 1 through 64 letters, digits, underscores, or hyphens.", isRequired: true),
+            };
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+                if (!ModInformation.IsServer)
+                    return Failed("Command can only be run on the server.");
+                if (!SafeSaveName.IsMatch(args[0]))
+                    return Failed("Save name must contain 1 through 64 letters, digits, underscores, or hyphens.");
+
+                SaveHandler saveHandler = Campaign.Current?.SaveHandler;
+                if (saveHandler == null)
+                    return Failed("No active campaign / SaveHandler.");
+                if (saveHandler.IsSaving)
+                    return Failed("A save is already queued.");
+
+                saveHandler.SaveAs(args[0]);
+                return Succeeded($"Enqueued save as {args[0]} on the server.");
+            }
         }
 
-        [CommandLineArgumentFunction("state", "coop.debug.save")]
-        public static string State(List<string> args)
+        public sealed class SaveStateCoopCommand : ICoopCommand
         {
-            if (args.Count != 0)
-                return "Usage: coop.debug.save.state";
+            public string Prefix => "coop.debug.save";
 
-            SaveHandler saveHandler = Campaign.Current?.SaveHandler;
-            return saveHandler == null
-                ? "saveHandler=unavailable"
-                : $"saveHandler=ready|isSaving={saveHandler.IsSaving}";
+            public string Name => "state";
+
+            public string Description => "Reports state.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+            {
+
+                SaveHandler saveHandler = Campaign.Current?.SaveHandler;
+                return Succeeded(saveHandler == null
+                    ? "saveHandler=unavailable"
+                    : $"saveHandler=ready|isSaving={saveHandler.IsSaving}");
+            }
         }
 
         /// <summary>
@@ -50,57 +79,69 @@ namespace GameInterface.Services.Save.Commands
         /// client save block can be exercised on demand. On a client SetSaveArgs is blocked, so
         /// nothing is enqueued and no file is written; on the host a save file appears.
         /// </summary>
-        [CommandLineArgumentFunction("force_autosave", "coop.debug.save")]
-        public static string ForceAutoSave(List<string> args)
+        public sealed class SaveForceAutosaveCoopCommand : ICoopCommand
         {
-            if (Campaign.Current?.SaveHandler == null) return "No active campaign / SaveHandler.";
+            public string Prefix => "coop.debug.save";
 
-            int holdMilliseconds = 0;
-            if (args.Count > 1 ||
-                (args.Count == 1 &&
-                 (int.TryParse(args[0], out holdMilliseconds) == false ||
-                  holdMilliseconds < 1 ||
-                  holdMilliseconds > 5000)))
+            public string Name => "force_autosave";
+
+            public string Description => "Runs the force autosave debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
-                return "Usage: coop.debug.save.force_autosave [evidence hold milliseconds from 1 to 5000]";
-            }
+                new ExpectedArgs("evidence_hold_milliseconds", "The optional evidence hold from 1 through 5000 milliseconds.", isRequired: false),
+            };
 
-#if DEBUG
-            if (args.Count == 1)
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
             {
-                if (ModInformation.IsClient)
-                {
-                    return "The evidence hold is server-only.";
-                }
+                            if (Campaign.Current?.SaveHandler == null) return Failed("No active campaign / SaveHandler.");
 
-                if (Campaign.Current.SaveHandler.IsSaving)
-                {
-                    return "Cannot add an evidence hold while a save is already queued.";
-                }
+                            int holdMilliseconds = 0;
+                            if (args.Count == 1 &&
+                                (int.TryParse(args[0], out holdMilliseconds) == false ||
+                                 holdMilliseconds < 1 ||
+                                 holdMilliseconds > 5000))
+                            {
+                                return Failed("Evidence hold must be an integer from 1 through 5000 milliseconds.");
+                            }
+
+                #if DEBUG
+                            if (args.Count == 1)
+                            {
+                                if (ModInformation.IsClient)
+                                {
+                                    return Failed("The evidence hold is server-only.");
+                                }
+
+                                if (Campaign.Current.SaveHandler.IsSaving)
+                                {
+                                    return Failed("Cannot add an evidence hold while a save is already queued.");
+                                }
+                            }
+                #else
+                            if (args.Count == 1)
+                            {
+                                return Failed("The evidence hold is only available in DEBUG builds.");
+                            }
+                #endif
+
+                            Campaign.Current.SaveHandler.ForceAutoSave();
+
+                #if DEBUG
+                            if (args.Count == 1)
+                            {
+                                if (Campaign.Current.SaveHandler.IsSaving == false)
+                                {
+                                    return Failed("Autosaves are disabled; no save was enqueued.");
+                                }
+
+                                Interlocked.Exchange(ref evidenceHoldMilliseconds, holdMilliseconds);
+                            }
+                #endif
+
+                            string side = ModInformation.IsClient ? "client (save should be BLOCKED)" : "host (save should succeed)";
+                            return Succeeded($"Enqueued autosave on {side}. Check the Saves folder.");
             }
-#else
-            if (args.Count == 1)
-            {
-                return "The evidence hold is only available in DEBUG builds.";
-            }
-#endif
-
-            Campaign.Current.SaveHandler.ForceAutoSave();
-
-#if DEBUG
-            if (args.Count == 1)
-            {
-                if (Campaign.Current.SaveHandler.IsSaving == false)
-                {
-                    return "Autosaves are disabled; no save was enqueued.";
-                }
-
-                Interlocked.Exchange(ref evidenceHoldMilliseconds, holdMilliseconds);
-            }
-#endif
-
-            string side = ModInformation.IsClient ? "client (save should be BLOCKED)" : "host (save should succeed)";
-            return $"Enqueued autosave on {side}. Check the Saves folder.";
         }
 
         internal static void HoldForEvidenceIfRequested()

--- a/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
+++ b/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System;
+using Common.Commands;
+using Autofac;
 using Common;
 using Common.Logging;
 using GameInterface.Configuration;
@@ -18,6 +20,12 @@ namespace GameInterface.Services.Smithing.Commands;
 
 internal class SmithingCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private static readonly ILogger Logger = LogManager.GetLogger<SmithingCommands>();
 
     /// <summary>
@@ -34,337 +42,429 @@ internal class SmithingCommands
     /// <summary>
     /// Give debug crafting materials to heroes with a given name
     /// </summary>
-    [CommandLineArgumentFunction("givesupplies", "coop.debug.crafting")]
-    public static string SmithingSuppliesCommand(List<string> strings)
+    public sealed class CraftingGiveSuppliesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (strings.Count == 0)
-        {
-            return "Hero name argument required.";
-        }
+        public string Name => "give_supplies";
 
-        if (TryGetObjectManager(out var objectManager) == false)
-        {
-            return "Unable to resolve ObjectManager.";
-        }
+        public string Description => "Runs the give supplies debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false)
             {
-                var itemsToAdd = new Dictionary<string, int>()
-                {
-                    { "hardwood", 100 },
-                    { "iron", 50 },
-                    { "charcoal", 100 },
-                    { "ironIngot1", 50 },
-                    { "ironIngot2", 50 },
-                    { "ironIngot3", 50 },
-                    { "ironIngot4", 50 },
-                    { "ironIngot5", 50 },
-                    { "ironIngot6", 50 },
-                    { "empire_sword_4_t4", 3 }
-                };
-
-                foreach (var itemId in itemsToAdd.Keys)
-                {
-                    if (!objectManager.TryGetObject(itemId, out ItemObject itemObject)) 
-                    {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
-                    }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
-                    }
-                }
-
-                stringBuilder.AppendLine(strings[0] + " was given smithing supplies.");
+                return Failed("Unable to resolve ObjectManager.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
+            {
+                if (hero.Name.ToString() == strings[0])
+                {
+                    var itemsToAdd = new Dictionary<string, int>()
+                    {
+                        { "hardwood", 100 },
+                        { "iron", 50 },
+                        { "charcoal", 100 },
+                        { "ironIngot1", 50 },
+                        { "ironIngot2", 50 },
+                        { "ironIngot3", 50 },
+                        { "ironIngot4", 50 },
+                        { "ironIngot5", 50 },
+                        { "ironIngot6", 50 },
+                        { "empire_sword_4_t4", 3 }
+                    };
+
+                    foreach (var itemId in itemsToAdd.Keys)
+                    {
+                        if (!objectManager.TryGetObject(itemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + itemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, itemsToAdd[itemId]);
+                        }
+                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given smithing supplies.");
+                }
+            }
+
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Hero not found.");
         }
-        return "Hero not found.";
     }
 
     /// <summary>
     /// Unlock all crafting pieces on a client
     /// OpenPart is patched to already update CoopSession and persist across sessions
     /// </summary>
-    [CommandLineArgumentFunction("unlockallcraftingpieces", "coop.debug.crafting")]
-    public static string UnlockAllCraftingPiecesCommand(List<string> strings)
+    public sealed class CraftingUnlockAllCraftingPiecesCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "Command can only be run on a client.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
-            return "Cheats are currently disabled on clients. Enable in mod-config.";
+        public string Name => "unlock_all_crafting_pieces";
 
-        var craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-        if (craftingCampaignBehavior == null)
-            return "Unable to get crafting campaign behavior.";
+        public string Description => "Runs the unlock all crafting pieces debug operation.";
 
-        foreach (var craftingTemplate in CraftingTemplate.All)
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (var craftingPiece in craftingTemplate.Pieces)
-            {
-                // Turn off notification, otherwise unlocking client gets hundreds of notifications
-                craftingCampaignBehavior.OpenPart(craftingPiece, craftingTemplate, false);
-            }
-        }
+            if (ModInformation.IsServer)
+                return Failed("Command can only be run on a client.");
 
-        return "All crafting pieces unlocked.";
+            if (!ModConfigProvider.ModOptions.ClientsCanUseCheats)
+                return Failed("Cheats are currently disabled on clients. Enable in mod-config.");
+
+            var craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+            if (craftingCampaignBehavior == null)
+                return Failed("Unable to get crafting campaign behavior.");
+
+            foreach (var craftingTemplate in CraftingTemplate.All)
+            {
+                foreach (var craftingPiece in craftingTemplate.Pieces)
+                {
+                    // Turn off notification, otherwise unlocking client gets hundreds of notifications
+                    craftingCampaignBehavior.OpenPart(craftingPiece, craftingTemplate, false);
+                }
+            }
+
+            return Succeeded("All crafting pieces unlocked.");
+        }
     }
 
     /// <summary>
     /// View town orders for a specified town
     /// </summary>
-    [CommandLineArgumentFunction("townorders", "coop.debug.crafting")]
-    public static string ViewTownOrdersCommand(List<string> strings)
+    public sealed class CraftingTownOrdersCoopCommand : ICoopCommand
     {
-        if (strings.Count == 0) return "Town name argument required.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Name => "town_orders";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var town in Town.AllTowns)
+        public string Description => "Runs the town orders debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (town.Name.ToString() == strings[0])
+            new ExpectedArgs("town_name", "The exact town display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var town in Town.AllTowns)
             {
-                stringBuilder.AppendLine("Target town " + town.Name.ToString() + " has orders:");
-                CraftingOrder[] slots = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftingOrders[town].Slots;
-                foreach (CraftingOrder order in slots)
+                if (town.Name.ToString() == strings[0])
                 {
-                    stringBuilder.AppendLine("Order slot: " + order?.OrderDifficulty + " for hero: " + order?.OrderOwner);
+                    stringBuilder.AppendLine("Target town " + town.Name.ToString() + " has orders:");
+                    CraftingOrder[] slots = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftingOrders[town].Slots;
+                    foreach (CraftingOrder order in slots)
+                    {
+                        stringBuilder.AppendLine("Order slot: " + order?.OrderDifficulty + " for hero: " + order?.OrderOwner);
+                    }
                 }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Town not found.");
         }
-        return "Town not found.";
     }
 
     /// <summary>
     /// Add orders to a town by a hero in that town
     /// </summary>
-    [CommandLineArgumentFunction("addtownorder", "coop.debug.crafting")]
-    public static string AddTestingTownOrderCommand(List<string> strings)
+    public sealed class CraftingAddTownOrderCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (strings.Count == 0) return "Hero name argument required.";
+        public string Name => "add_town_order";
 
-        var heroName = strings[0]; // Example hero name: "Vaminesa the Minter"
+        public string Description => "Runs the add town order debug operation.";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == heroName)
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            var heroName = strings[0]; // Example hero name: "Vaminesa the Minter"
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                for (int i = 0; i < 6; i++)
+                if (hero.Name.ToString() == heroName)
                 {
-                    Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>().CreateTownOrder(hero, i);
+                    for (int i = 0; i < 6; i++)
+                    {
+                        Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>().CreateTownOrder(hero, i);
+                    }
+
+                    stringBuilder.AppendLine("Orders have been added for " + heroName + " in " + hero.CurrentSettlement.Town.Name.ToString());
                 }
-
-                stringBuilder.AppendLine("Orders have been added for " + heroName + " in " + hero.CurrentSettlement.Town.Name.ToString());
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Town not found.");
         }
-        return "Town not found.";
     }
 
     /// <summary>
     /// Add all existing crafted items to a given hero
     /// </summary>
-    [CommandLineArgumentFunction("addcrafteditems", "coop.debug.crafting")]
-    public static string AddCraftedItemCommand(List<string> strings)
+    public sealed class CraftingAddCraftedItemsCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsClient) return "Command can only be run on the server.";
+        public string Prefix => "coop.debug.crafting";
 
-        if (strings.Count == 0) return "Hero name argument required.";
+        public string Name => "add_crafted_items";
 
-        if (TryGetObjectManager(out var objectManager) == false) return "Unable to resolve ObjectManager.";
+        public string Description => "Runs the add crafted items debug operation.";
 
-        var craftedItemPrefix = "crafted_item_";
-
-        StringBuilder stringBuilder = new StringBuilder();
-        foreach (var hero in Hero.AllAliveHeroes)
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            if (hero.Name.ToString() == strings[0])
+            new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsClient) return Failed("Command can only be run on the server.");
+
+            if (TryGetObjectManager(out var objectManager) == false) return Failed("Unable to resolve ObjectManager.");
+
+            var craftedItemPrefix = "crafted_item_";
+
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var hero in Hero.AllAliveHeroes)
             {
-                int craftedItemCount = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftedItemCount;
-                for (int i = 0; i < craftedItemCount; i++)
+                if (hero.Name.ToString() == strings[0])
                 {
-                    string craftedItemId = craftedItemPrefix + i.ToString();
-                    if (!objectManager.TryGetObject(craftedItemId, out ItemObject itemObject))
+                    int craftedItemCount = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>()._craftedItemCount;
+                    for (int i = 0; i < craftedItemCount; i++)
                     {
-                        stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + craftedItemId);
+                        string craftedItemId = craftedItemPrefix + i.ToString();
+                        if (!objectManager.TryGetObject(craftedItemId, out ItemObject itemObject))
+                        {
+                            stringBuilder.AppendLine("Failed to retrieve object for ItemObject id: " + craftedItemId);
+                        }
+                        else
+                        {
+                            hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, 1);
+                        }
                     }
-                    else
-                    {
-                        hero.PartyBelongedTo.ItemRoster.AddToCounts(itemObject, 1);
-                    }
+
+                    stringBuilder.AppendLine(strings[0] + " was given all crafted items.");
                 }
-
-                stringBuilder.AppendLine(strings[0] + " was given all crafted items.");
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Town not found.");
         }
-        return "Town not found.";
     }
 
     /// <summary>
     /// View crafting stamina of all heroes in party on client and all heroes on server
     /// </summary>
-    [CommandLineArgumentFunction("stamina", "coop.debug.crafting")]
-    public static string ViewCraftingStaminaCommand(List<string> strings)
+    public sealed class CraftingStaminaCoopCommand : ICoopCommand
     {
-        StringBuilder stringBuilder = new StringBuilder();
-        CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+        public string Prefix => "coop.debug.crafting";
 
-        foreach (var heroCraftingRecord in craftingCampaignBehavior._heroCraftingRecords)
+        public string Name => "stamina";
+
+        public string Description => "Runs the stamina debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            if (ModInformation.IsServer || heroCraftingRecord.Key.PartyBelongedTo == Hero.MainHero.PartyBelongedTo)
+            StringBuilder stringBuilder = new StringBuilder();
+            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+
+            foreach (var heroCraftingRecord in craftingCampaignBehavior._heroCraftingRecords)
             {
-                stringBuilder.AppendLine($"{heroCraftingRecord.Key.Name} ({heroCraftingRecord.Key.StringId}): {heroCraftingRecord.Value.CraftingStamina}");
+                if (ModInformation.IsServer || heroCraftingRecord.Key.PartyBelongedTo == Hero.MainHero.PartyBelongedTo)
+                {
+                    stringBuilder.AppendLine($"{heroCraftingRecord.Key.Name} ({heroCraftingRecord.Key.StringId}): {heroCraftingRecord.Value.CraftingStamina}");
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("No hero crafting stamina data was found.");
         }
-        return "No hero crafting stamina data was found.";
     }
 
     /// <summary>
     /// View crafted item history, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("crafteditemhistory", "coop.debug.crafting")]
-    public static string ViewCraftedItemHistoryCommand(List<string> strings)
+    public sealed class CraftingCraftedItemHistoryCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
+        public string Prefix => "coop.debug.crafting";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Name => "crafted_item_history";
+
+        public string Description => "Runs the crafted item history debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (KeyValuePair<string, List<string>> craftedItemHistory in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerCraftedItemsHistory)
+            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                stringBuilder.AppendLine(craftedItemHistory.Key);
-                foreach (string craftedItemId in craftedItemHistory.Value)
+                foreach (KeyValuePair<string, List<string>> craftedItemHistory in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerCraftedItemsHistory)
                 {
-                    stringBuilder.AppendLine(craftedItemId);
+                    stringBuilder.AppendLine(craftedItemHistory.Key);
+                    foreach (string craftedItemId in craftedItemHistory.Value)
+                    {
+                        stringBuilder.AppendLine(craftedItemId);
+                    }
                 }
             }
-        }
-        else
-        {
-            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-            foreach (ItemObject item in craftingCampaignBehavior._cratingItemsHistory)
+            else
             {
-                stringBuilder.AppendLine(item.StringId);
+                CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+                foreach (ItemObject item in craftingCampaignBehavior._cratingItemsHistory)
+                {
+                    stringBuilder.AppendLine(item.StringId);
+                }
             }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Error finding crafting player data or no crafted item history");
         }
-        return "Error finding crafting player data or no crafted item history";
     }
 
     /// <summary>
     /// View crafted pieces xp, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("craftingpiecesxp", "coop.debug.crafting")]
-    public static string ViewPartsXpCommand(List<string> strings)
+    public sealed class CraftingCraftingPiecesXpCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
+        public string Prefix => "coop.debug.crafting";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Name => "crafting_pieces_xp";
+
+        public string Description => "Runs the crafting pieces xp debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (KeyValuePair<string, Dictionary<string, float>> playerPartXp in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenNewPartXpDictionary)
+            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                stringBuilder.AppendLine(playerPartXp.Key);
-                foreach (KeyValuePair<string, float> partXp in playerPartXp.Value)
+                foreach (KeyValuePair<string, Dictionary<string, float>> playerPartXp in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenNewPartXpDictionary)
+                {
+                    stringBuilder.AppendLine(playerPartXp.Key);
+                    foreach (KeyValuePair<string, float> partXp in playerPartXp.Value)
+                    {
+                        stringBuilder.AppendLine(partXp.Key + ": " + partXp.Value);
+                    }
+                }
+            }
+            else
+            {
+                CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+                foreach (KeyValuePair<CraftingTemplate, float> partXp in craftingCampaignBehavior._openNewPartXpDictionary)
                 {
                     stringBuilder.AppendLine(partXp.Key + ": " + partXp.Value);
                 }
             }
-        }
-        else
-        {
-            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-            foreach (KeyValuePair<CraftingTemplate, float> partXp in craftingCampaignBehavior._openNewPartXpDictionary)
-            {
-                stringBuilder.AppendLine(partXp.Key + ": " + partXp.Value);
-            }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Error finding crafting player data or no parts xp data");
         }
-        return "Error finding crafting player data or no parts xp data";
     }
 
     /// <summary>
     /// View unlocked crafted pieces, showing all players on server and current player on client
     /// </summary>
-    [CommandLineArgumentFunction("unlockedcraftingpieces", "coop.debug.crafting")]
-    public static string ViewUnlockedCraftingPieces(List<string> strings)
+    public sealed class CraftingUnlockedCraftingPiecesCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return "Unable to resolve CoopSessionProvider";
+        public string Prefix => "coop.debug.crafting";
 
-        StringBuilder stringBuilder = new StringBuilder();
-        if (ModInformation.IsServer)
+        public string Name => "unlocked_crafting_pieces";
+
+        public string Description => "Runs the unlocked crafting pieces debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            foreach (KeyValuePair<string, Dictionary<string, List<string>>> playerUnlockedPieces in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenedPartsDictionary)
+            if (!ContainerProvider.TryResolve<ICoopSessionProvider>(out var coopSessionProvider)) return Failed("Unable to resolve CoopSessionProvider");
+
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ModInformation.IsServer)
             {
-                stringBuilder.AppendLine(playerUnlockedPieces.Key);
-                foreach (KeyValuePair<string, List<string>> templateUnlockedPieces in playerUnlockedPieces.Value)
+                foreach (KeyValuePair<string, Dictionary<string, List<string>>> playerUnlockedPieces in coopSessionProvider.CoopSession.CraftingPlayerData.PlayerOpenedPartsDictionary)
+                {
+                    stringBuilder.AppendLine(playerUnlockedPieces.Key);
+                    foreach (KeyValuePair<string, List<string>> templateUnlockedPieces in playerUnlockedPieces.Value)
+                    {
+                        stringBuilder.AppendLine(templateUnlockedPieces.Key + ": " + templateUnlockedPieces.Value.Count);
+                    }
+                }
+            }
+            else
+            {
+                CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
+                foreach (KeyValuePair<CraftingTemplate, List<CraftingPiece>> templateUnlockedPieces in craftingCampaignBehavior._openedPartsDictionary)
                 {
                     stringBuilder.AppendLine(templateUnlockedPieces.Key + ": " + templateUnlockedPieces.Value.Count);
                 }
             }
-        }
-        else
-        {
-            CraftingCampaignBehavior craftingCampaignBehavior = Campaign.Current.GetCampaignBehavior<CraftingCampaignBehavior>();
-            foreach (KeyValuePair<CraftingTemplate, List<CraftingPiece>> templateUnlockedPieces in craftingCampaignBehavior._openedPartsDictionary)
-            {
-                stringBuilder.AppendLine(templateUnlockedPieces.Key + ": " + templateUnlockedPieces.Value.Count);
-            }
-        }
 
-        string result = stringBuilder.ToString();
-        if (result.Length > 0)
-        {
-            return result;
+            string result = stringBuilder.ToString();
+            if (result.Length > 0)
+            {
+                return Succeeded(result);
+            }
+            return Failed("Error finding crafting player data or no unlocked parts");
         }
-        return "Error finding crafting player data or no unlocked parts";
     }
 }

--- a/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
+++ b/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using Common.Commands;
+using System.Collections.Generic;
 using static TaleWorlds.Library.CommandLineFunctionality;
 
 namespace GameInterface.Services.Template.Commands;
@@ -8,12 +10,28 @@ namespace GameInterface.Services.Template.Commands;
 /// </summary>
 internal class TemplateCommands
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     /// <summary>
     /// TODO fill me out
     /// </summary>
-    [CommandLineArgumentFunction("template", "coop.debug")]
-    public static string TemplateCommand(List<string> strings)
+    public sealed class TemplateCoopCommand : ICoopCommand
     {
-        return "This is a template command";
+        public string Prefix => "coop.debug";
+
+        public string Name => "template";
+
+        public string Description => "Runs the template debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            return Succeeded("This is a template command");
+        }
     }
 }

--- a/source/GameInterface/Services/Time/Commands/TimeCommands.cs
+++ b/source/GameInterface/Services/Time/Commands/TimeCommands.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using Common.Commands;
+using Common;
 using Common.Messaging;
 using GameInterface.Services.Heroes.Enum;
 using GameInterface.Services.Heroes.Interaces;
@@ -13,100 +14,155 @@ namespace GameInterface.Services.Time.Commands;
 
 internal class TimeCommands
 {
-    [CommandLineArgumentFunction("get_time_mode", "coop.debug")]
-    public static string GetTimeMode(List<string> strings)
-    {
-        if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
-        {
-            return "Failed to get time control interface";
-        }
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
 
-        return $"{timeControlInterface.GetTimeControl()}";
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
+    public sealed class GetTimeModeCoopCommand : ICoopCommand
+    {
+        public string Prefix => "coop.debug";
+
+        public string Name => "get_time_mode";
+
+        public string Description => "Reports get time mode.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
+            {
+                return Failed("Failed to get time control interface");
+            }
+
+            return Succeeded($"{timeControlInterface.GetTimeControl()}");
+        }
     }
 
-    [CommandLineArgumentFunction("set_time_mode", "coop.debug")]
-    public static string SetTimeMode(List<string> strings)
+    public sealed class SetTimeModeCoopCommand : ICoopCommand
     {
-        if (!ModInformation.IsServer)
+            public string Prefix => "coop.debug";
+
+            public string Name => "set_time_mode";
+
+            public string Description => "Runs the set time mode debug operation.";
+
+            public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+            {
+                new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+        #if DEBUG
+                new ExpectedArgs("force_live_test", "The DEBUG live-test override token.", isRequired: false),
+        #endif
+            };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            return "set_time_mode must be run on the server/host.";
+                    if (!ModInformation.IsServer)
+                    {
+                        return Failed("set_time_mode must be run on the server/host.");
+                    }
+
+            #if DEBUG
+                    bool forceForLiveTest = strings.Count == 2 &&
+                        strings[1].Equals("force-live-test", StringComparison.OrdinalIgnoreCase);
+                    if (strings.Count == 2 && !forceForLiveTest)
+                        return Failed("The optional override token must be force-live-test.");
+            #endif
+
+                    if (!Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
+                        return Failed($"Invalid time mode '{strings[0]}'. Expected Pause, Play_1x, or Play_2x.");
+
+                    if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
+                    {
+                        return Failed("Failed to get time control interface");
+                    }
+
+            #if DEBUG
+                    if (forceForLiveTest)
+                    {
+                        timeControlInterface.ServerSetTimeControlForLiveTest(timeMode);
+                        return Succeeded($"Time control force-set for live testing to {timeControlInterface.GetTimeControl()}");
+                    }
+            #endif
+
+                    timeControlInterface.ServerSetTimeControl(timeMode);
+                    return Succeeded($"Time control set to {timeControlInterface.GetTimeControl()}");
         }
-
-#if DEBUG
-        bool forceForLiveTest = strings.Count == 2 &&
-            strings[1].Equals("force-live-test", StringComparison.OrdinalIgnoreCase);
-#else
-        const bool forceForLiveTest = false;
-#endif
-
-        if ((strings.Count != 1 && !forceForLiveTest) ||
-            !Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
-        {
-            return "Usage: coop.debug.set_time_mode <Pause|Play_1x|Play_2x>";
-        }
-
-        if (!ContainerProvider.TryResolve<ITimeControlInterface>(out var timeControlInterface))
-        {
-            return "Failed to get time control interface";
-        }
-
-#if DEBUG
-        if (forceForLiveTest)
-        {
-            timeControlInterface.ServerSetTimeControlForLiveTest(timeMode);
-            return $"Time control force-set for live testing to {timeControlInterface.GetTimeControl()}";
-        }
-#endif
-
-        timeControlInterface.ServerSetTimeControl(timeMode);
-        return $"Time control set to {timeControlInterface.GetTimeControl()}";
     }
 
 #if DEBUG
-    [CommandLineArgumentFunction("request_time_mode", "coop.debug")]
-    public static string RequestTimeMode(List<string> strings)
+    public sealed class RequestTimeModeCoopCommand : ICoopCommand
     {
-        if (ModInformation.IsServer)
-            return "request_time_mode must be run on a client.";
-        if (strings.Count != 1 ||
-            !Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
-            return "Usage: coop.debug.request_time_mode <Pause|Play_1x|Play_2x>";
+        public string Prefix => "coop.debug";
 
-        MessageBroker.Instance.Publish(typeof(TimeCommands), new TimeSpeedChangedAttempted(timeMode));
-        return $"Requested time control {timeMode}.";
+        public string Name => "request_time_mode";
+
+        public string Description => "Runs the request time mode debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
+        {
+            new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
+        {
+            if (ModInformation.IsServer)
+                return Failed("request_time_mode must be run on a client.");
+            if (!Enum.TryParse(strings[0], true, out TimeControlEnum timeMode))
+                return Failed($"Invalid time mode '{strings[0]}'. Expected Pause, Play_1x, or Play_2x.");
+
+            MessageBroker.Instance.Publish(typeof(TimeCommands), new TimeSpeedChangedAttempted(timeMode));
+            return Succeeded($"Requested time control {timeMode}.");
+        }
     }
 #endif
 
-    [CommandLineArgumentFunction("advance_time", "coop.debug")]
-    public static string AdvanceTime(List<string> strings)
+    public sealed class AdvanceTimeCoopCommand : ICoopCommand
     {
-        // Time is authoritative on the server; advancing it elsewhere would just be
-        // overwritten by the next server sync.
-        if (ModInformation.IsClient)
+        public string Prefix => "coop.debug";
+
+        public string Name => "advance_time";
+
+        public string Description => "Runs the advance time debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            return "advance_time must be run on the server/host. The server is authoritative for campaign time.";
-        }
+            new ExpectedArgs("days", "The number of campaign days to advance.", isRequired: false),
+        };
 
-        if (Campaign.Current == null)
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
         {
-            return "No campaign is currently loaded.";
+            // Time is authoritative on the server; advancing it elsewhere would just be
+            // overwritten by the next server sync.
+            if (ModInformation.IsClient)
+            {
+                return Failed("advance_time must be run on the server/host. The server is authoritative for campaign time.");
+            }
+
+            if (Campaign.Current == null)
+            {
+                return Failed("No campaign is currently loaded.");
+            }
+
+            float days = 5f;
+            if (strings.Count > 0)
+            {
+                if (!float.TryParse(strings[0], out days))
+                    return Failed("Days must be a valid number.");
+            }
+
+            if (!ContainerProvider.TryResolve<IMapTimeTrackerInterface>(out var mapTimeTrackerInterface))
+            {
+                return Failed("Failed to get map time tracker interface");
+            }
+
+            long ticks = CampaignTime.Days(days).NumTicks;
+            mapTimeTrackerInterface.AdvanceTime(ticks);
+
+            return Succeeded($"Advanced campaign time forward by {days} day(s) ({ticks} ticks). " +
+                $"Connected clients should apply the jump on the next time update.");
         }
-
-        float days = 5f;
-        if (strings.Count > 0 && float.TryParse(strings[0], out var parsedDays))
-        {
-            days = parsedDays;
-        }
-
-        if (!ContainerProvider.TryResolve<IMapTimeTrackerInterface>(out var mapTimeTrackerInterface))
-        {
-            return "Failed to get map time tracker interface";
-        }
-
-        long ticks = CampaignTime.Days(days).NumTicks;
-        mapTimeTrackerInterface.AdvanceTime(ticks);
-
-        return $"Advanced campaign time forward by {days} day(s) ({ticks} ticks). " +
-            $"Connected clients should apply the jump on the next time update.";
     }
 }

--- a/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
@@ -1,4 +1,6 @@
-﻿using Common.Messaging;
+﻿using System;
+using Common.Commands;
+using Common.Messaging;
 using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
@@ -16,6 +18,12 @@ namespace GameInterface.Services.UI.Commands;
 /// </summary>
 public class SteamDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     [CommandLineArgumentFunction("status", "coop.debug.steam")]
     public static string Status(List<string> args)
     {
@@ -32,36 +40,57 @@ public class SteamDebugCommand
         return $"Steam integration active; advertising={advertiser.IsAdvertising}";
     }
 
-    [CommandLineArgumentFunction("host_lobby", "coop.debug.steam")]
-    public static string HostLobby(List<string> args)
+    public sealed class SteamHostLobbyCoopCommand : ICoopCommand
     {
-        if (!SessionDiscovery.SteamAvailable) return "Steam integration inactive";
-        if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "No session advertiser; join a session first";
-        if (!ContainerProvider.TryResolve<ISessionJoinInfoSource>(out var joinInfoSource)) return "No join info source; join a session first";
-        if (!ContainerProvider.TryResolve<INetworkConfig>(out var networkConfig)) return "No network config; join a session first";
-        if (!ContainerProvider.TryResolve<ISessionTunnelHost>(out var tunnelHost)) return "No session tunnel host; join a session first";
+        public string Prefix => "coop.debug.steam";
 
-        // Only the host's own client (connected over loopback) may advertise the session; a
-        // tunneled joiner's loopback address is its own join pump, not a local server.
-        if (networkConfig.IsTunneled || !TunnelAdvertisement.IsLoopbackAddress(networkConfig.Address))
-            return "Run coop.debug.steam.host_lobby on the host's own client (connected to localhost)";
+        public string Name => "host_lobby";
 
-        var info = joinInfoSource.Get();
-        TunnelAdvertisement.StartAndStamp(tunnelHost, networkConfig, info);
+        public string Description => "Runs the host lobby debug operation.";
 
-        advertiser.Advertise(info);
-        return $"Advertising session (address='{info.Address}', port={info.Port}, version={info.Version})";
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!SessionDiscovery.SteamAvailable) return Failed("Steam integration inactive");
+            if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return Failed("No session advertiser; join a session first");
+            if (!ContainerProvider.TryResolve<ISessionJoinInfoSource>(out var joinInfoSource)) return Failed("No join info source; join a session first");
+            if (!ContainerProvider.TryResolve<INetworkConfig>(out var networkConfig)) return Failed("No network config; join a session first");
+            if (!ContainerProvider.TryResolve<ISessionTunnelHost>(out var tunnelHost)) return Failed("No session tunnel host; join a session first");
+
+            // Only the host's own client (connected over loopback) may advertise the session; a
+            // tunneled joiner's loopback address is its own join pump, not a local server.
+            if (networkConfig.IsTunneled || !TunnelAdvertisement.IsLoopbackAddress(networkConfig.Address))
+                return Failed("Run coop.debug.steam.host_lobby on the host's own client (connected to localhost)");
+
+            var info = joinInfoSource.Get();
+            TunnelAdvertisement.StartAndStamp(tunnelHost, networkConfig, info);
+
+            advertiser.Advertise(info);
+            return Succeeded($"Advertising session (address='{info.Address}', port={info.Port}, version={info.Version})");
+        }
     }
 
-    [CommandLineArgumentFunction("invite", "coop.debug.steam")]
-    public static string Invite(List<string> args)
+    public sealed class SteamInviteCoopCommand : ICoopCommand
     {
-        if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return "No session advertiser; join a session first";
-        if (!advertiser.IsAdvertising) return "Not advertising; run coop.debug.steam.host_lobby first or enable Steam invites when connecting";
+        public string Prefix => "coop.debug.steam";
 
-        return advertiser.InviteFriends()
-            ? "Invite dialog opened"
-            : SessionInviteText.OverlayUnavailableHint;
+        public string Name => "invite";
+
+        public string Description => "Runs the invite debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!ContainerProvider.TryResolve<ISessionAdvertiser>(out var advertiser)) return Failed("No session advertiser; join a session first");
+            if (!advertiser.IsAdvertising) return Failed("Not advertising; run coop.debug.steam.host_lobby first or enable Steam invites when connecting");
+
+            if (!advertiser.InviteFriends())
+                return Failed(SessionInviteText.OverlayUnavailableHint);
+
+            return Succeeded("Invite dialog opened");
+        }
     }
 
     [CommandLineArgumentFunction("join", "coop.debug.steam")]

--- a/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
@@ -1,3 +1,4 @@
+﻿using Common.Commands;
 using Autofac;
 using GameInterface.Services.UI.Handlers;
 using GameInterface.Utils.Commands;
@@ -8,41 +9,57 @@ namespace GameInterface.Services.UI.Commands;
 
 public class TacticalUnitSymbolsDebugCommand
 {
+    private static CoopCommandResult Succeeded(string output) =>
+        new CoopCommandResult(true, output);
+
+    private static CoopCommandResult Failed(string output) =>
+        new CoopCommandResult(false, output, "command_failed");
+
     private const string CommandName = "coop.debug.ui.tactical_symbols";
-    private const string Usage = "Usage: coop.debug.ui.tactical_symbols <on|off|toggle|status>";
-
-    [CommandLineArgumentFunction("tactical_symbols", "coop.debug.ui")]
-    public static string TacticalSymbols(List<string> args)
+    public sealed class UiTacticalSymbolsCoopCommand : ICoopCommand
     {
-        if (!CommandHelpers.IsServerOnlyCommand(out var error, CommandName)) return error;
-        if (args.Count != 1) return Usage;
+        public string Prefix => "coop.debug.ui";
 
-        switch (args[0].ToLowerInvariant())
+        public string Name => "tactical_symbols";
+
+        public string Description => "Runs the tactical symbols debug operation.";
+
+        public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
-            case "on":
-            case "true":
-            case "1":
-                return Apply(false);
-            case "off":
-            case "false":
-            case "0":
-                return Apply(true);
-            case "toggle":
-                return Apply(!TacticalUnitSymbolsSettings.HideTacticalUnitSymbols);
-            case "status":
-                return StatusText;
-            default:
-                return Usage;
+            new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: true),
+        };
+
+        public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
+        {
+            if (!CommandHelpers.IsServerOnlyCommand(out var error, CommandName)) return Failed(error);
+
+            switch (args[0].ToLowerInvariant())
+            {
+                case "on":
+                case "true":
+                case "1":
+                    return Apply(false);
+                case "off":
+                case "false":
+                case "0":
+                    return Apply(true);
+                case "toggle":
+                    return Apply(!TacticalUnitSymbolsSettings.HideTacticalUnitSymbols);
+                case "status":
+                    return Succeeded(StatusText);
+                default:
+                    return Failed($"Invalid mode '{args[0]}'. Expected on, off, toggle, or status.");
+            }
         }
     }
 
-    private static string Apply(bool hideTacticalUnitSymbols)
+    private static CoopCommandResult Apply(bool hideTacticalUnitSymbols)
     {
         if (!ContainerProvider.TryResolve<TacticalUnitSymbolsConfigHandler>(out var handler))
-            return "Tactical unit symbols configuration is unavailable.";
+            return Failed("Tactical unit symbols configuration is unavailable.");
 
         handler.SetAndBroadcast(hideTacticalUnitSymbols);
-        return StatusText;
+        return Succeeded(StatusText);
     }
 
     private static string StatusText =>


### PR DESCRIPTION
## PR Checklist

- [ ] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

System, developer, item, save, UI, and connection debug commands still use attributed static methods with command-specific argument handling.

## What is the new behavior?

Migrates 108 session commands within their original files. Each replacement directly implements `ICoopCommand`, contains its behavior, returns explicit results, and uses registry-generated argument validation. Five commands that must work outside session DI remain process-lifetime commands.

## Bot Changelog Entry

## Other information

Replaces #3487. Process-lifetime exceptions are connection `start`/`reconnect`, Steam `status`/`join`, and bug-report consent.

Tests:

- Release `CoopTests.slnf` build
- Release `CoopUnitTests.slnf` tests
- System/developer command, connection lifecycle, and container tests
