### PR TITLE
Disable crash reporter in debug builds

### DIFF
--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -327,7 +327,9 @@ namespace Coop
             bugReportConsent = new BugReportConsentCoordinator(
                 new CoopOptionsStore(),
                 exception => Logger.Warning(exception, "Diagnostic bug-report log-sharing preference could not be saved"));
+#if !DEBUG
             TryStartCrashReporter(role);
+#endif
         }
 
         private void TryStartCrashReporter(string role)


### PR DESCRIPTION
## PR Type
- [x] Bug fix

## What is the current behavior?
Debug builds start `Coop.CrashReporter.exe`, so stopping the game under the debugger can create crash reports.

## What is the new behavior?
Debug builds skip starting the crash reporter. Release behavior is unchanged.

## How to test
- Build `source/Coop/Coop.csproj` in Debug and Release.

## Bot Changelog Entry
