### PR TITLE
Restore MapEventParty updates on clients

### DIFF
--- a/source/GameInterface.Tests/Services/MapEventParties/MapEventPartyPatchesTests.cs
+++ b/source/GameInterface.Tests/Services/MapEventParties/MapEventPartyPatchesTests.cs
@@ -18,4 +18,18 @@ public class MapEventPartyPatchesTests
         bool result = MapEventPartyPatches.ShouldRunTroopStateUpdate(isOriginalAllowed, isServer);
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public void ShouldUseClientTroopStateFallback_ReturnsExpectedResults(
+        bool battleSpawnEnabled,
+        bool isCoopBattleActive,
+        bool expected)
+    {
+        bool result = MapEventPartyPatches.ShouldUseClientTroopStateFallback(battleSpawnEnabled, isCoopBattleActive);
+        Assert.Equal(expected, result);
+    }
 }

--- a/source/GameInterface/Services/MapEventParties/Patches/MapEventPartyPatches.cs
+++ b/source/GameInterface/Services/MapEventParties/Patches/MapEventPartyPatches.cs
@@ -23,20 +23,32 @@ internal class MapEventPartyPatches
 {
     [HarmonyPatch(nameof(MapEventParty.OnTroopKilled))]
     [HarmonyPrefix]
-    private static bool PrefixOnTroopKilled()
+    private static bool PrefixOnTroopKilled(MapEventParty __instance, ref UniqueTroopDescriptor troopSeed)
     {
-        // Casualties are reported from inside the mission and applied through the synchronization path.
-        // Allow server or explicitly synchronized calls, skip locally generated MapEventParty calls on clients.
-        return ShouldRunTroopStateUpdate(CallOriginalPolicy.IsOriginalAllowed(), ModInformation.IsServer);
+        if (ShouldRunTroopStateUpdate(CallOriginalPolicy.IsOriginalAllowed(), ModInformation.IsServer)) return true;
+
+        // Only apply on clients if not in active coop battle
+        if (!ShouldUseClientTroopStateFallback(BattleSpawnConfig.Enabled, BattleSpawnGate.IsCoopBattleActive)) return false;
+
+        __instance._roster.OnTroopKilled(troopSeed);
+        MessageBroker.Instance.Publish(__instance, new OnTroopKilledAttempted(__instance, troopSeed.UniqueSeed));
+
+        return false;
     }
 
     [HarmonyPatch(nameof(MapEventParty.OnTroopWounded))]
     [HarmonyPrefix]
-    private static bool PrefixOnTroopWounded()
+    private static bool PrefixOnTroopWounded(MapEventParty __instance, ref UniqueTroopDescriptor troopSeed)
     {
-        // Casualties are reported from inside the mission and applied through the synchronization path.
-        // Allow server or explicitly synchronized calls, skip locally generated MapEventParty calls on clients.
-        return ShouldRunTroopStateUpdate(CallOriginalPolicy.IsOriginalAllowed(), ModInformation.IsServer);
+        if (ShouldRunTroopStateUpdate(CallOriginalPolicy.IsOriginalAllowed(), ModInformation.IsServer)) return true;
+
+        // Only apply on clients if not in active coop battle
+        if (!ShouldUseClientTroopStateFallback(BattleSpawnConfig.Enabled, BattleSpawnGate.IsCoopBattleActive)) return false;
+
+        __instance._roster.OnTroopWounded(troopSeed);
+        MessageBroker.Instance.Publish(__instance, new OnTroopWoundedAttempted(__instance, troopSeed.UniqueSeed));
+
+        return false;
     }
 
     [HarmonyPatch(nameof(MapEventParty.OnTroopRouted))]
@@ -75,11 +87,15 @@ internal class MapEventPartyPatches
     
     /// <summary>
     /// Determines whether a troop state update may execute the original game method.
-    /// Normal client generated calls are skipped because troop casualties are synchronized from the mission.
     /// </summary>
     internal static bool ShouldRunTroopStateUpdate(bool isOriginalAllowed, bool isServer)
     {
         return isOriginalAllowed || isServer;
+    }
+
+    internal static bool ShouldUseClientTroopStateFallback(bool battleSpawnEnabled, bool isCoopBattleActive)
+    {
+        return !battleSpawnEnabled || !isCoopBattleActive;
     }
 
     [HarmonyPatch(nameof(MapEventParty.CommitXpGain))]


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
#3169 removed troop update clients on clients. This means that for non-coop battles (such as in hideouts) there are no troops marked as dead or wounded sent to the server for each involved `MapEventParty`. In `MapEventsResultInterface`, `KilledInBattle` and `WoundedInBattle` are used to determine equipment loot, causing all hideouts to only give misc items as loot from their regular `ItemRosters`.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3503 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Restore `MapEventParty` updates on clients as a fallback when the battle isn't a coop battle.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed hideouts only giving misc items as loot.
