### PR TITLE
Display injectable commands in RGL console

### DIFF
--- a/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
@@ -21,7 +21,10 @@ public class CoopCommandLineRegistrarTests
             Mock.Of<ILogger>());
         var argsFactory = new CoopCommandArgsFactory();
 
-        using (var registrar = new CoopCommandLineRegistrar(registry, argsFactory))
+        using (var registrar = new CoopCommandLineRegistrar(
+                   registry,
+                   argsFactory,
+                   Mock.Of<IRglCommandLineRegistry>()))
         {
             string output = CommandLineFunctionality.CallFunction(
                 FullName,
@@ -37,14 +40,35 @@ public class CoopCommandLineRegistrarTests
     }
 
     [Fact]
+    public void Registration_AdvertisesCommandToRglCommandLine()
+    {
+        var registry = new CoopCommandRegistry(
+            new[] { new CaptureCommand() },
+            Mock.Of<ILogger>());
+        var argsFactory = new CoopCommandArgsFactory();
+        var rglCommandLineRegistry = new Mock<IRglCommandLineRegistry>();
+
+        using (var registrar = new CoopCommandLineRegistrar(
+                   registry,
+                   argsFactory,
+                   rglCommandLineRegistry.Object))
+        {
+            rglCommandLineRegistry.Verify(
+                commandLineRegistry => commandLineRegistry.RegisterCommand(FullName),
+                Times.Once);
+        }
+    }
+
+    [Fact]
     public void Registration_WhenFrameworkRegistrationAlreadyExists_ReplacesItForNewLifetime()
     {
         var registry = new CoopCommandRegistry(
             new[] { new CaptureCommand() },
             Mock.Of<ILogger>());
         var argsFactory = new CoopCommandArgsFactory();
-        var first = new CoopCommandLineRegistrar(registry, argsFactory);
-        var second = new CoopCommandLineRegistrar(registry, argsFactory);
+        IRglCommandLineRegistry rglCommandLineRegistry = Mock.Of<IRglCommandLineRegistry>();
+        var first = new CoopCommandLineRegistrar(registry, argsFactory, rglCommandLineRegistry);
+        var second = new CoopCommandLineRegistrar(registry, argsFactory, rglCommandLineRegistry);
 
         try
         {
@@ -118,9 +142,10 @@ public class CoopCommandLineRegistrarTests
         var thirdRegistry = new CoopCommandRegistry(
             new[] { new CaptureCommand() },
             Mock.Of<ILogger>());
-        var firstRegistrar = new CoopCommandLineRegistrar(firstRegistry, argsFactory);
-        var secondRegistrar = new CoopCommandLineRegistrar(secondRegistry, argsFactory);
-        var thirdRegistrar = new CoopCommandLineRegistrar(thirdRegistry, argsFactory);
+        IRglCommandLineRegistry rglCommandLineRegistry = Mock.Of<IRglCommandLineRegistry>();
+        var firstRegistrar = new CoopCommandLineRegistrar(firstRegistry, argsFactory, rglCommandLineRegistry);
+        var secondRegistrar = new CoopCommandLineRegistrar(secondRegistry, argsFactory, rglCommandLineRegistry);
+        var thirdRegistrar = new CoopCommandLineRegistrar(thirdRegistry, argsFactory, rglCommandLineRegistry);
 
         var firstRegistrarReference = new WeakReference(firstRegistrar);
         var firstRegistryReference = new WeakReference(firstRegistry);

--- a/source/GameInterface.Tests/Utils/Commands/RglCommandLineRegistryTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/RglCommandLineRegistryTests.cs
@@ -1,0 +1,40 @@
+﻿using GameInterface.Utils.Commands;
+using System;
+using Xunit;
+
+namespace GameInterface.Tests.Utils.Commands;
+
+public class RglCommandLineRegistryTests
+{
+    [Fact]
+    public void RegisterCommand_AcrossInstances_RegistersNameOnlyOnce()
+    {
+        string fullName = $"coop.debug.rgl_registry_test.{Guid.NewGuid():N}";
+        int registrationCount = 0;
+        Action<string> registerCommand = _ => registrationCount++;
+        var firstRegistry = new RglCommandLineRegistry(registerCommand);
+        var secondRegistry = new RglCommandLineRegistry(registerCommand);
+
+        firstRegistry.RegisterCommand(fullName);
+        secondRegistry.RegisterCommand(fullName);
+
+        Assert.Equal(1, registrationCount);
+    }
+
+    [Fact]
+    public void RegisterCommand_WhenEngineBecomesAvailable_RetriesRegistration()
+    {
+        string fullName = $"coop.debug.rgl_registry_test.{Guid.NewGuid():N}";
+        bool isEngineAvailable = false;
+        int registrationCount = 0;
+        var registry = new RglCommandLineRegistry(
+            _ => registrationCount++,
+            () => isEngineAvailable);
+
+        registry.RegisterCommand(fullName);
+        isEngineAvailable = true;
+        registry.RegisterCommand(fullName);
+
+        Assert.Equal(1, registrationCount);
+    }
+}

--- a/source/GameInterface/GameInterfaceModule.cs
+++ b/source/GameInterface/GameInterfaceModule.cs
@@ -84,6 +84,7 @@ public class GameInterfaceModule : Module
         builder.RegisterType<SurrogateCollection>().As<ISurrogateCollection>().InstancePerLifetimeScope().AutoActivate();
 
         builder.RegisterType<CoopCommandArgsFactory>().As<ICoopCommandArgsFactory>().InstancePerDependency();
+        builder.RegisterType<RglCommandLineRegistry>().As<IRglCommandLineRegistry>().InstancePerDependency();
         builder.RegisterType<CoopCommandRegistry>().As<ICoopCommandRegistry>().InstancePerLifetimeScope();
         builder.RegisterAssemblyTypes(typeof(GameInterfaceModule).Assembly)
             .Where(type => type.IsClass &&

--- a/source/GameInterface/Utils/Commands/CoopCommandLineRegistrar.cs
+++ b/source/GameInterface/Utils/Commands/CoopCommandLineRegistrar.cs
@@ -15,6 +15,7 @@ public sealed class CoopCommandLineRegistrar : ICoopCommandLineRegistrar
 {
     private readonly ICoopCommandRegistry commandRegistry;
     private readonly ICoopCommandArgsFactory argsFactory;
+    private readonly IRglCommandLineRegistry rglCommandLineRegistry;
     private readonly IDictionary gameCommands;
     private readonly Type gameCommandType;
     private readonly FieldInfo gameCommandDelegateField;
@@ -24,13 +25,16 @@ public sealed class CoopCommandLineRegistrar : ICoopCommandLineRegistrar
 
     public CoopCommandLineRegistrar(
         ICoopCommandRegistry commandRegistry,
-        ICoopCommandArgsFactory argsFactory)
+        ICoopCommandArgsFactory argsFactory,
+        IRglCommandLineRegistry rglCommandLineRegistry)
     {
         if (commandRegistry == null) throw new ArgumentNullException(nameof(commandRegistry));
         if (argsFactory == null) throw new ArgumentNullException(nameof(argsFactory));
+        if (rglCommandLineRegistry == null) throw new ArgumentNullException(nameof(rglCommandLineRegistry));
 
         this.commandRegistry = commandRegistry;
         this.argsFactory = argsFactory;
+        this.rglCommandLineRegistry = rglCommandLineRegistry;
 
         // Publicizing TaleWorlds.Library here produces duplicate InformationManager members.
         FieldInfo allFunctionsField = typeof(CommandLineFunctionality).GetField(
@@ -108,6 +112,7 @@ public sealed class CoopCommandLineRegistrar : ICoopCommandLineRegistrar
 
             gameCommands[fullName] = gameCommand;
             registrations.Add(fullName, new Registration(gameCommand, previousRegistration));
+            rglCommandLineRegistry.RegisterCommand(fullName);
         }
     }
 

--- a/source/GameInterface/Utils/Commands/RglCommandLineRegistry.cs
+++ b/source/GameInterface/Utils/Commands/RglCommandLineRegistry.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using TaleWorlds.Engine;
+
+namespace GameInterface.Utils.Commands;
+
+public interface IRglCommandLineRegistry
+{
+    void RegisterCommand(string fullName);
+}
+
+/// <summary>Registers command names with the native RGL command line.</summary>
+public sealed class RglCommandLineRegistry : IRglCommandLineRegistry
+{
+    // RGL has no remove API, so names remain registered across coop containers.
+    private static readonly object registrationLock = new object();
+    private static readonly HashSet<string> registeredCommands =
+        new HashSet<string>(StringComparer.Ordinal);
+
+    private readonly Action<string> registerCommand;
+    private readonly Func<bool> isEngineAvailable;
+
+    public RglCommandLineRegistry()
+        : this(
+            Utilities.AddCommandLineFunction,
+            () => EngineApplicationInterface.IUtil != null)
+    {
+    }
+
+    internal RglCommandLineRegistry(
+        Action<string> registerCommand,
+        Func<bool> isEngineAvailable = null)
+    {
+        if (registerCommand == null) throw new ArgumentNullException(nameof(registerCommand));
+
+        this.registerCommand = registerCommand;
+        this.isEngineAvailable = isEngineAvailable ?? (() => true);
+    }
+
+    public void RegisterCommand(string fullName)
+    {
+        if (fullName == null) throw new ArgumentNullException(nameof(fullName));
+        if (!isEngineAvailable()) return;
+
+        lock (registrationLock)
+        {
+            if (registeredCommands.Contains(fullName)) return;
+
+            registerCommand(fullName);
+            registeredCommands.Add(fullName);
+        }
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

Commands migrated to the injectable command framework are only registered with the managed command dictionary, so they do not appear in the RGL command line.

## What is the new behavior?

Advertises injectable command names to RGL when the coop container is built. Native registrations are kept once per process so reconnecting does not add duplicate command names.

## How to test

1. Start Bannerlord with the Coop module and host a new campaign.
2. Open the RGL command line and enter `coop.debug.hero.`.
3. Confirm `coop.debug.hero.id` appears in the command list.
4. Run `coop.debug.hero.id Rhagaea` and confirm the command returns her registered id.

## Bot Changelog Entry

- Coop debug commands now appear in the RGL command line after hosting or joining.
