### PR TITLE
Remember direct connection details

### DIFF
--- a/UIMovies/CoopConnectionUIMovie.xml
+++ b/UIMovies/CoopConnectionUIMovie.xml
@@ -111,8 +111,39 @@
                       </Children>
                     </ListPanel>
 
+                    <ListPanel WidthSizePolicy="Fixed" SuggestedWidth="490" HeightSizePolicy="Fixed" SuggestedHeight="52"
+                               HorizontalAlignment="Center" StackLayout.LayoutMethod="HorizontalLeftToRight">
+                      <Children>
+                        <ButtonWidget Id="RememberConnectionCheckbox" DoNotPassEventsToChildren="true"
+                                      WidthSizePolicy="Fixed" HeightSizePolicy="Fixed"
+                                      SuggestedWidth="40" SuggestedHeight="40"
+                                      VerticalAlignment="Center"
+                                      Brush="SPOptions.Checkbox.Empty.Button"
+                                      ButtonType="Toggle" IsSelected="@RememberConnection"
+                                      ToggleIndicator="ToggleIndicator" UpdateChildrenStates="true">
+                          <Children>
+                            <BrushWidget Id="ToggleIndicator" WidthSizePolicy="StretchToParent"
+                                         HeightSizePolicy="StretchToParent"
+                                         Brush="SPOptions.Checkbox.Full.Button"/>
+                          </Children>
+                        </ButtonWidget>
+                        <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="StretchToParent"
+                                    MarginLeft="14" Brush="Clan.TabControl.Text" Brush.FontSize="24"
+                                    Brush.TextVerticalAlignment="Center" Text="@RememberConnectionText"/>
+                        <HintWidget DataSource="{RememberConnectionHint}" WidthSizePolicy="Fixed" SuggestedWidth="44"
+                                    HeightSizePolicy="StretchToParent" MarginLeft="12"
+                                    Command.HoverBegin="ExecuteBeginHint" Command.HoverEnd="ExecuteEndHint">
+                          <Children>
+                            <TextWidget WidthSizePolicy="StretchToParent" HeightSizePolicy="StretchToParent"
+                                        DoNotAcceptEvents="true" Brush="Clan.TabControl.Text"
+                                        Brush.TextVerticalAlignment="Center" Text="(i)"/>
+                          </Children>
+                        </HintWidget>
+                      </Children>
+                    </ListPanel>
+
                     <Standard.Button WidthSizePolicy="Fixed" SuggestedWidth="160" HeightSizePolicy="Fixed" SuggestedHeight="64"
-                                     HorizontalAlignment="Center" MarginTop="30"
+                                     HorizontalAlignment="Center" MarginTop="18"
                                      Command.Click="ActionConnect" Parameter.Text="@JoinButtonText"/>
                   </Children>
                 </ListPanel>

--- a/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectMenuVMTests.cs
@@ -2,8 +2,10 @@
 using Common.Messaging;
 using Common.Network.Session;
 using GameInterface.Services.UI;
+using GameInterface.Services.UI.CoopOptions;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -12,11 +14,127 @@ namespace GameInterface.Tests.Services.UI;
 public class CoopConnectMenuVMTests
 {
     [Fact]
+    public void RememberedDirectConnection_IsRestored()
+    {
+        var options = new CoopOptionsData();
+        options.SetSection(
+            CoopConnectMenuVM.DirectTabId,
+            CoopConnectMenuVM.DirectConnectionSectionId,
+            new DirectConnectionOptions
+            {
+                RememberConnection = true,
+                Address = "203.0.113.7",
+                Port = "4300",
+                Password = "Secret",
+            });
+        var store = new TestOptionsStore(options);
+        using var messageBroker = new MessageBroker();
+        using var viewModel = new CoopConnectMenuVM(null, messageBroker, store);
+
+        Assert.True(viewModel.RememberConnection);
+        Assert.Equal("203.0.113.7", viewModel.Ip);
+        Assert.Equal("4300", viewModel.Port);
+        Assert.Equal("Secret", viewModel.Password);
+    }
+
+    [Fact]
+    public void ActionConnect_SavesRememberedDirectConnection()
+    {
+        var store = new TestOptionsStore();
+        using var messageBroker = new MessageBroker();
+        using var viewModel = new CoopConnectMenuVM(null, messageBroker, store)
+        {
+            Ip = "203.0.113.7",
+            Port = "4300",
+            Password = "Secret",
+            RememberConnection = true,
+        };
+
+        viewModel.ActionConnect();
+
+        Assert.True(store.Options.TryGetSection(
+            CoopConnectMenuVM.DirectTabId,
+            CoopConnectMenuVM.DirectConnectionSectionId,
+            out DirectConnectionOptions saved));
+        Assert.True(saved.RememberConnection);
+        Assert.Equal("203.0.113.7", saved.Address);
+        Assert.Equal("4300", saved.Port);
+        Assert.Equal("Secret", saved.Password);
+    }
+
+    [Fact]
+    public void RememberedDirectConnection_RoundTripsThroughOptionsFile()
+    {
+        string filePath = Path.Combine(
+            Path.GetTempPath(),
+            $"BannerlordCoop-connection-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            using var messageBroker = new MessageBroker();
+            using (var firstViewModel = new CoopConnectMenuVM(
+                       null,
+                       messageBroker,
+                       new CoopOptionsStore(filePath)))
+            {
+                firstViewModel.Ip = "203.0.113.7";
+                firstViewModel.Port = "4300";
+                firstViewModel.Password = "Secret";
+                firstViewModel.RememberConnection = true;
+                firstViewModel.ActionConnect();
+            }
+
+            using var restoredViewModel = new CoopConnectMenuVM(
+                null,
+                messageBroker,
+                new CoopOptionsStore(filePath));
+
+            Assert.True(restoredViewModel.RememberConnection);
+            Assert.Equal("203.0.113.7", restoredViewModel.Ip);
+            Assert.Equal("4300", restoredViewModel.Port);
+            Assert.Equal("Secret", restoredViewModel.Password);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public void DisablingRememberConnection_ClearsSavedCredentials()
+    {
+        var options = new CoopOptionsData();
+        options.SetSection(
+            CoopConnectMenuVM.DirectTabId,
+            CoopConnectMenuVM.DirectConnectionSectionId,
+            new DirectConnectionOptions
+            {
+                RememberConnection = true,
+                Address = "203.0.113.7",
+                Port = "4300",
+                Password = "Secret",
+            });
+        var store = new TestOptionsStore(options);
+        using var messageBroker = new MessageBroker();
+        using var viewModel = new CoopConnectMenuVM(null, messageBroker, store);
+
+        viewModel.RememberConnection = false;
+
+        Assert.True(store.Options.TryGetSection(
+            CoopConnectMenuVM.DirectTabId,
+            CoopConnectMenuVM.DirectConnectionSectionId,
+            out DirectConnectionOptions saved));
+        Assert.False(saved.RememberConnection);
+        Assert.Equal(string.Empty, saved.Address);
+        Assert.Equal(string.Empty, saved.Port);
+        Assert.Equal(string.Empty, saved.Password);
+    }
+    [Fact]
     public void SteamLobbyPages_SliceResultsAndStopAtBoundaries()
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
 
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(Enumerable.Range(1, 9)
@@ -53,7 +171,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
 
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(
@@ -96,7 +214,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
 
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(Enumerable.Range(1, 9)
@@ -124,7 +242,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
 
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(
@@ -147,7 +265,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
 
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(
@@ -181,7 +299,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
 
         Assert.Equal("Hosted Steam Servers (0 servers; 0 players)", viewModel.SteamLobbiesHeaderText);
 
@@ -201,7 +319,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
 
         Assert.Equal("Host Name", viewModel.HostSearchLabelText);
         Assert.Equal("Type a host name...", viewModel.HostSearchPlaceholderText);
@@ -218,7 +336,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
         int activationCount = 0;
         viewModel.SteamLobbiesTabActivated += () => activationCount++;
 
@@ -232,7 +350,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
         
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(
@@ -262,7 +380,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
         
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(
@@ -285,7 +403,7 @@ public class CoopConnectMenuVMTests
     {
         var browser = new TestSteamLobbyBrowser();
         using var messageBroker = new MessageBroker();
-        using var viewModel = new CoopConnectMenuVM(browser, messageBroker);
+        using var viewModel = new CoopConnectMenuVM(browser, messageBroker, new TestOptionsStore());
         
         SelectSteamLobbiesTab(viewModel);
         browser.Complete(
@@ -342,6 +460,30 @@ public class CoopConnectMenuVMTests
         {
             Assert.NotNull(onCompleted);
             onCompleted!(lobbies, string.Empty);
+        }
+    }
+
+    private sealed class TestOptionsStore : ICoopOptionsStore
+    {
+        public TestOptionsStore(CoopOptionsData options = null)
+        {
+            Options = options ?? new CoopOptionsData();
+        }
+
+        public string FilePath => string.Empty;
+        public CoopOptionsData Options { get; private set; }
+
+        public bool TryLoad(out CoopOptionsData options)
+        {
+            options = Options;
+            return true;
+        }
+
+        public CoopOptionsData LoadOrDefault() => Options;
+
+        public void Save(CoopOptionsData options)
+        {
+            Options = options;
         }
     }
 }

--- a/source/GameInterface.Tests/Services/UI/CoopConnectionUIMovieTests.cs
+++ b/source/GameInterface.Tests/Services/UI/CoopConnectionUIMovieTests.cs
@@ -83,6 +83,17 @@ public class CoopConnectionUIMovieTests
         Assert.Equal("0", minimumPlayersInput.Attribute("MinInt")?.Value);
         Assert.Equal("true", minimumPlayersInput.Attribute("EnableClamp")?.Value);
     }
+
+    [Fact]
+    public void DirectConnection_BindsRememberConnectionCheckbox()
+    {
+        var document = XDocument.Load(FindMoviePath());
+        var checkbox = FindById(document, "RememberConnectionCheckbox");
+
+        Assert.Equal("Toggle", checkbox.Attribute("ButtonType")?.Value);
+        Assert.Equal("@RememberConnection", checkbox.Attribute("IsSelected")?.Value);
+        Assert.Equal("ToggleIndicator", checkbox.Attribute("ToggleIndicator")?.Value);
+    }
     
     private static XElement FindById(XDocument document, string id)
     {

--- a/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
+++ b/source/GameInterface/Services/UI/CoopConnectMenuVM.cs
@@ -2,6 +2,7 @@
 using Common.Network;
 using Common.Network.Session;
 using Common.Network.Session.Messages;
+using GameInterface.Services.UI.CoopOptions;
 using GameInterface.Services.UI.Donate;
 using GameInterface.Services.UI.Messages;
 using System;
@@ -29,6 +30,7 @@ public enum SteamLobbyPasswordFilter
 public class CoopConnectMenuVM : ViewModel, IDisposable
 {
     public const string DirectTabId = "direct";
+    public const string DirectConnectionSectionId = "connection";
     public const string SteamLobbiesTabId = "steam_lobbies";
     public const int SteamLobbyPageSize = 4;
 
@@ -36,6 +38,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
 
     private readonly ISteamLobbyBrowser steamLobbyBrowser;
     private readonly IMessageBroker messageBroker;
+    private readonly ICoopOptionsStore optionsStore;
     private readonly List<SteamLobbyListItemVM> discoveredSteamLobbies = new();
 
     private CoopConnectionTabVM selectedTab;
@@ -49,6 +52,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     private int filteredSteamLobbyCount;
     private long filteredSteamLobbyPlayerCount;
     private int steamLobbyPageIndex;
+    private bool rememberConnection;
 
     public string JoinButtonText => "Join";
     public string RefreshButtonText => "Refresh";
@@ -80,6 +84,7 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string IpText => "Server IP Address:";
     public string PortText => "Port:";
     public string PasswordText => "Password:";
+    public string RememberConnectionText => "Remember connection details";
 
     [DataSourceProperty]
     public HintViewModel ServerAddressHint { get; } = new HintViewModel(new TextObject(
@@ -94,6 +99,10 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         "The session password set by the host. Leave empty if the host has not set one."));
 
     [DataSourceProperty]
+    public HintViewModel RememberConnectionHint { get; } = new HintViewModel(new TextObject(
+        "Saves the server address, port, and password locally in your Bannerlord Coop options."));
+
+    [DataSourceProperty]
     public string PasswordFilterButtonText => SteamLobbyPasswordFilter switch
     {
         SteamLobbyPasswordFilter.NoPassword => "No Password",
@@ -106,14 +115,28 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     public string connectPassword = "";
 
     public CoopConnectMenuVM()
-        : this(SessionDiscovery.SteamLobbyBrowser, MessageBroker.Instance)
+        : this(SessionDiscovery.SteamLobbyBrowser, MessageBroker.Instance, new CoopOptionsStore())
     {
     }
 
     public CoopConnectMenuVM(ISteamLobbyBrowser steamLobbyBrowser, IMessageBroker messageBroker)
+        : this(steamLobbyBrowser, messageBroker, new CoopOptionsStore())
     {
+    }
+
+    public CoopConnectMenuVM(
+        ISteamLobbyBrowser steamLobbyBrowser,
+        IMessageBroker messageBroker,
+        ICoopOptionsStore optionsStore)
+    {
+        if (messageBroker == null) throw new ArgumentNullException(nameof(messageBroker));
+        if (optionsStore == null) throw new ArgumentNullException(nameof(optionsStore));
+
         this.steamLobbyBrowser = steamLobbyBrowser;
-        this.messageBroker = messageBroker ?? throw new ArgumentNullException(nameof(messageBroker));
+        this.messageBroker = messageBroker;
+        this.optionsStore = optionsStore;
+
+        RestoreRememberedConnection();
 
         Tabs = new MBBindingList<CoopConnectionTabVM>
         {
@@ -297,6 +320,24 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
         }
     }
 
+    [DataSourceProperty]
+    public bool RememberConnection
+    {
+        get => rememberConnection;
+        set
+        {
+            if (rememberConnection == value) return;
+
+            rememberConnection = value;
+            OnPropertyChanged(nameof(RememberConnection));
+
+            if (!rememberConnection)
+            {
+                SaveConnectionSettings(clearCredentials: true);
+            }
+        }
+    }
+
     public void ActionCycleSteamLobbyPasswordFilter()
     {
         if (disposed || IsRefreshingSteamLobbies) return;
@@ -395,6 +436,11 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
                     InformationManager.DisplayMessage(new InformationMessage("ERROR: No IPv4 address found for host"));
                     return;
                 }
+            }
+
+            if (RememberConnection)
+            {
+                SaveConnectionSettings(clearCredentials: false);
             }
 
             messageBroker.Publish(this, new AttemptJoin(ip, port, connectPassword, steamInvites));
@@ -574,5 +620,47 @@ public class CoopConnectMenuVM : ViewModel, IDisposable
     {
         return string.Equals(address, "localhost", StringComparison.OrdinalIgnoreCase) ||
             (IPAddress.TryParse(address, out var ip) && IPAddress.IsLoopback(ip));
+    }
+
+    private void RestoreRememberedConnection()
+    {
+        var options = optionsStore.LoadOrDefault();
+        if (!options.TryGetSection(
+                DirectTabId,
+                DirectConnectionSectionId,
+                out DirectConnectionOptions saved) ||
+            !saved.RememberConnection)
+        {
+            return;
+        }
+
+        connectIP = string.IsNullOrWhiteSpace(saved.Address) ? "localhost" : saved.Address;
+        connectPort = string.IsNullOrWhiteSpace(saved.Port) ? "4200" : saved.Port;
+        connectPassword = saved.Password ?? string.Empty;
+        rememberConnection = true;
+    }
+
+    private void SaveConnectionSettings(bool clearCredentials)
+    {
+        try
+        {
+            var options = optionsStore.LoadOrDefault();
+            options.SetSection(
+                DirectTabId,
+                DirectConnectionSectionId,
+                new DirectConnectionOptions
+                {
+                    RememberConnection = !clearCredentials,
+                    Address = clearCredentials ? string.Empty : connectIP,
+                    Port = clearCredentials ? string.Empty : connectPort,
+                    Password = clearCredentials ? string.Empty : connectPassword,
+                });
+            optionsStore.Save(options);
+        }
+        catch
+        {
+            InformationManager.DisplayMessage(new InformationMessage(
+                "WARNING: Connection settings could not be saved"));
+        }
     }
 }

--- a/source/GameInterface/Services/UI/DirectConnectionOptions.cs
+++ b/source/GameInterface/Services/UI/DirectConnectionOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace GameInterface.Services.UI;
+
+/// <summary>Locally persisted values for the direct connection form.</summary>
+internal sealed class DirectConnectionOptions
+{
+    public bool RememberConnection { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string Port { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

Direct Connection resets the address, port, and password whenever the menu is reopened.

## What is the new behavior?

Adds a `Remember connection details` checkbox. When selected, a successful join saves the address, port, and password in the existing local Coop options file and restores them the next time the menu opens. Turning it off clears the stored credentials.

## Bot Changelog Entry

- Direct Connection can now remember the server address, port, and password.

## Other information

Tests: `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Release --filter "FullyQualifiedName~CoopConnectMenuVMTests|FullyQualifiedName~CoopConnectionUIMovieTests"`

Manual test: loaded the v0.1.4 client, opened Direct Connection, and confirmed the checkbox renders in the live Gauntlet UI.
