### PR TITLE
Map trackers for new parties/caravans

### DIFF
--- a/source/GameInterface/Services/UI/Handlers/MapTrackerProviderRefreshHandler.cs
+++ b/source/GameInterface/Services/UI/Handlers/MapTrackerProviderRefreshHandler.cs
@@ -1,6 +1,10 @@
-﻿using Common.Messaging;
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.ObjectManager;
 using GameInterface.Services.UI.Messages;
 using GameInterface.Services.UI.Patches;
+using TaleWorlds.CampaignSystem.Party;
 
 namespace GameInterface.Services.UI.Handlers;
 
@@ -10,26 +14,78 @@ namespace GameInterface.Services.UI.Handlers;
 internal class MapTrackerProviderRefreshHandler : IHandler
 {
     private readonly IMessageBroker messageBroker;
+    private readonly INetwork network;
+    private readonly IObjectManager objectManager;
     private readonly IMapTrackerProviderHolder holder;
 
     public MapTrackerProviderRefreshHandler(
         IMessageBroker messageBroker,
+        INetwork network,
+        IObjectManager objectManager,
         IMapTrackerProviderHolder holder)
     {
         this.messageBroker = messageBroker;
+        this.network = network;
+        this.objectManager = objectManager;
         this.holder = holder;
 
         messageBroker.Subscribe<SwitchedPlayer>(Handle_SwitchedPlayer);
+
+        messageBroker.Subscribe<MapTrackerPartyCreated>(Handle_MapTrackerPartyCreated);
+        messageBroker.Subscribe<NetworkMapTrackerPartyCreated>(Handle_NetworkMapTrackerPartyCreated);
+
+        messageBroker.Subscribe<MapTrackerPartyRemoved>(Handle_MapTrackerPartyRemoved);
+        messageBroker.Subscribe<NetworkMapTrackerPartyRemoved>(Handle_NetworkMapTrackerPartyRemoved);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<SwitchedPlayer>(Handle_SwitchedPlayer);
+
+        messageBroker.Unsubscribe<MapTrackerPartyCreated>(Handle_MapTrackerPartyCreated);
+        messageBroker.Unsubscribe<NetworkMapTrackerPartyCreated>(Handle_NetworkMapTrackerPartyCreated);
+
+        messageBroker.Unsubscribe<MapTrackerPartyRemoved>(Handle_MapTrackerPartyRemoved);
+        messageBroker.Unsubscribe<NetworkMapTrackerPartyRemoved>(Handle_NetworkMapTrackerPartyRemoved);
     }
 
     private void Handle_SwitchedPlayer(MessagePayload<SwitchedPlayer> payload)
     {
         if (holder.Current == null) return;
         holder.Current.ResetTrackers();
+    }
+
+    private void Handle_MapTrackerPartyCreated(MessagePayload<MapTrackerPartyCreated> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.MobileParty, out var mobilePartyId)) return;
+
+        network.SendAll(new NetworkMapTrackerPartyCreated(mobilePartyId));
+    }
+
+    private void Handle_NetworkMapTrackerPartyCreated(MessagePayload<NetworkMapTrackerPartyCreated> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.MobilePartyId, out var mobileParty)) return;
+
+            holder.Current?.AddIfEligible(mobileParty);
+        });
+    }
+
+    private void Handle_MapTrackerPartyRemoved(MessagePayload<MapTrackerPartyRemoved> obj)
+    {
+        if (!objectManager.TryGetIdWithLogging(obj.What.MobileParty, out var mobilePartyId)) return;
+
+        network.SendAll(new NetworkMapTrackerPartyRemoved(mobilePartyId));
+    }
+
+    private void Handle_NetworkMapTrackerPartyRemoved(MessagePayload<NetworkMapTrackerPartyRemoved> obj)
+    {
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<MobileParty>(obj.What.MobilePartyId, out var mobileParty)) return;
+
+            holder.Current?.RemoveIfExists(mobileParty);
+        });
     }
 }

--- a/source/GameInterface/Services/UI/Messages/MapTrackerProviderMessages.cs
+++ b/source/GameInterface/Services/UI/Messages/MapTrackerProviderMessages.cs
@@ -1,0 +1,24 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.UI.Messages;
+
+public readonly struct MapTrackerPartyCreated : IEvent
+{
+    public readonly MobileParty MobileParty;
+
+    public MapTrackerPartyCreated(MobileParty mobileParty)
+    {
+        MobileParty = mobileParty;
+    }
+}
+
+public readonly struct MapTrackerPartyRemoved : IEvent
+{
+    public readonly MobileParty MobileParty;
+
+    public MapTrackerPartyRemoved(MobileParty mobileParty)
+    {
+        MobileParty = mobileParty;
+    }
+}

--- a/source/GameInterface/Services/UI/Messages/NetworkMapTrackerProviderMessages.cs
+++ b/source/GameInterface/Services/UI/Messages/NetworkMapTrackerProviderMessages.cs
@@ -1,0 +1,28 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.UI.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkMapTrackerPartyCreated : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string MobilePartyId;
+
+    public NetworkMapTrackerPartyCreated(string mobilePartyId)
+    {
+        MobilePartyId = mobilePartyId;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkMapTrackerPartyRemoved : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string MobilePartyId;
+
+    public NetworkMapTrackerPartyRemoved(string mobilePartyId)
+    {
+        MobilePartyId = mobilePartyId;
+    }
+}

--- a/source/GameInterface/Services/UI/Patches/MapTrackerProviderPatches.cs
+++ b/source/GameInterface/Services/UI/Patches/MapTrackerProviderPatches.cs
@@ -1,0 +1,39 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.UI.Messages;
+using HarmonyLib;
+using SandBox.ViewModelCollection.Map.Tracker;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.UI.Patches;
+
+[HarmonyPatch(typeof(MapTrackerProvider))]
+internal class MapTrackerProviderPatches
+{
+    [HarmonyPatch(nameof(MapTrackerProvider.OnMobilePartyCreated))]
+    [HarmonyPrefix]
+    public static void OnMobilePartyCreatedPrefix(MapTrackerProvider __instance, MobileParty mobileParty)
+    {
+        if (ModInformation.IsClient) return;
+
+        MessageBroker.Instance.Publish(__instance, new MapTrackerPartyCreated(mobileParty));
+    }
+
+    [HarmonyPatch(nameof(MapTrackerProvider.OnPartyDisbanded))]
+    [HarmonyPrefix]
+    public static void OnPartyDisbandedPrefix(MapTrackerProvider __instance, MobileParty disbandedParty)
+    {
+        if (ModInformation.IsClient) return;
+
+        MessageBroker.Instance.Publish(__instance, new MapTrackerPartyRemoved(disbandedParty));
+    }
+
+    [HarmonyPatch(nameof(MapTrackerProvider.OnPartyDestroyed))]
+    [HarmonyPrefix]
+    public static void OnPartyDestroyedPrefix(MapTrackerProvider __instance, MobileParty mobileParty)
+    {
+        if (ModInformation.IsClient) return;
+
+        MessageBroker.Instance.Publish(__instance, new MapTrackerPartyRemoved(mobileParty));
+    }
+}

--- a/source/GameInterface/Services/UI/Patches/MapTrackerProviderPatches.cs
+++ b/source/GameInterface/Services/UI/Patches/MapTrackerProviderPatches.cs
@@ -2,38 +2,49 @@
 using Common.Messaging;
 using GameInterface.Services.UI.Messages;
 using HarmonyLib;
-using SandBox.ViewModelCollection.Map.Tracker;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.UI.Patches;
 
-[HarmonyPatch(typeof(MapTrackerProvider))]
-internal class MapTrackerProviderPatches
+[HarmonyPatch(typeof(CampaignEventDispatcher))]
+internal class MapTrackerProviderUpdatePatches
 {
-    [HarmonyPatch(nameof(MapTrackerProvider.OnMobilePartyCreated))]
-    [HarmonyPrefix]
-    public static void OnMobilePartyCreatedPrefix(MapTrackerProvider __instance, MobileParty mobileParty)
+    [HarmonyPatch(nameof(CampaignEventDispatcher.OnMobilePartyCreated))]
+    [HarmonyPostfix]
+    public static void OnMobilePartyCreatedPostfix(MobileParty party)
     {
         if (ModInformation.IsClient) return;
 
-        MessageBroker.Instance.Publish(__instance, new MapTrackerPartyCreated(mobileParty));
+        MessageBroker.Instance.Publish(null, new MapTrackerPartyCreated(party));
     }
 
-    [HarmonyPatch(nameof(MapTrackerProvider.OnPartyDisbanded))]
-    [HarmonyPrefix]
-    public static void OnPartyDisbandedPrefix(MapTrackerProvider __instance, MobileParty disbandedParty)
+    [HarmonyPatch(nameof(CampaignEventDispatcher.OnPartyDisbanded))]
+    [HarmonyPostfix]
+    public static void OnPartyDisbandedPostfix(MobileParty disbandParty, Settlement relatedSettlement)
     {
         if (ModInformation.IsClient) return;
 
-        MessageBroker.Instance.Publish(__instance, new MapTrackerPartyRemoved(disbandedParty));
+        MessageBroker.Instance.Publish(null, new MapTrackerPartyRemoved(disbandParty));
     }
 
-    [HarmonyPatch(nameof(MapTrackerProvider.OnPartyDestroyed))]
-    [HarmonyPrefix]
-    public static void OnPartyDestroyedPrefix(MapTrackerProvider __instance, MobileParty mobileParty)
+    [HarmonyPatch(nameof(CampaignEventDispatcher.OnMobilePartyDestroyed))]
+    [HarmonyPostfix]
+    public static void OnMobilePartyDestroyedPostfix(MobileParty mobileParty, PartyBase destroyerParty)
     {
         if (ModInformation.IsClient) return;
 
-        MessageBroker.Instance.Publish(__instance, new MapTrackerPartyRemoved(mobileParty));
+        MessageBroker.Instance.Publish(null, new MapTrackerPartyRemoved(mobileParty));
+    }
+
+    [HarmonyPatch(nameof(CampaignEventDispatcher.OnClanCreated))]
+    [HarmonyPostfix]
+    public static void OnCompanionClanCreatedPostfix(Clan clan, bool isCompanion)
+    {
+        if (ModInformation.IsClient) return;
+        if (!isCompanion || clan.Leader.PartyBelongedTo == null) return;
+
+        MessageBroker.Instance.Publish(null, new MapTrackerPartyRemoved(clan.Leader.PartyBelongedTo));
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Players with existing parties can see map trackers when connecting. Map trackers however are not sent to clients when parties/caravans are created while connected.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3471 
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Send messages to clients after clan parties are created and destroyed to update map trackers.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed not being able to see map icons for own clan parties/caravans.
