### PR TITLE
Include co-op session data in bug reports

### DIFF
--- a/source/GameInterface.Tests/Services/BugReporting/BugReportServerSaveProviderTests.cs
+++ b/source/GameInterface.Tests/Services/BugReporting/BugReportServerSaveProviderTests.cs
@@ -1,0 +1,116 @@
+﻿using Common.Messaging;
+using GameInterface.Services.BugReporting;
+using GameInterface.Services.Heroes.Interfaces;
+using GameInterface.Services.Heroes.Messages;
+using Moq;
+using Serilog;
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace GameInterface.Tests.Services.BugReporting;
+
+public class BugReportServerSaveProviderTests : IDisposable
+{
+    private readonly string tempRoot = Path.Combine(
+        Path.GetTempPath(), "BugReportServerSaveProviderTests_" + Guid.NewGuid().ToString("N"));
+    private readonly byte[] campaignData = Encoding.UTF8.GetBytes("current campaign save");
+    private readonly byte[] currentSidecarData = Encoding.UTF8.GetBytes("{\"players\":[\"current\"]}");
+    private string SidecarPath => Path.Combine(tempRoot, "coop_bug_report.json");
+
+    public BugReportServerSaveProviderTests()
+    {
+        Directory.CreateDirectory(tempRoot);
+        File.WriteAllText(SidecarPath, "{\"players\":[\"previous\"]}");
+    }
+
+    [Fact]
+    public void TryCapture_PreviousSidecarAndSuppressedCurrentWriteFailure_OmitsSidecar()
+    {
+        using var broker = new MessageBroker();
+        using var logger = new LoggerConfiguration().CreateLogger();
+        var writeFailed = false;
+        Action<MessagePayload<GameSaved>> writeSidecar = _ =>
+        {
+            using var lockedFile = new FileStream(SidecarPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            try
+            {
+                File.WriteAllBytes(SidecarPath, currentSidecarData);
+            }
+            catch (IOException)
+            {
+                writeFailed = true;
+                throw;
+            }
+        };
+        broker.Subscribe(writeSidecar);
+        var saveInterface = CreateSaveInterface(() => broker.Publish(this, new GameSaved(BugReportServerSaveProvider.SaveName)));
+        var provider = new BugReportServerSaveProvider(saveInterface.Object, logger);
+
+        var captured = provider.TryCapture(out var save);
+
+        Assert.True(writeFailed);
+        Assert.True(captured);
+        Assert.Equal(campaignData, save.Data);
+        Assert.Null(save.SidecarFileName);
+        Assert.Null(save.SidecarData);
+        GC.KeepAlive(writeSidecar);
+    }
+
+    [Fact]
+    public void TryCapture_PreviousSidecarAndSuccessfulWrite_ReturnsCurrentPair()
+    {
+        var saveInterface = CreateSaveInterface(() =>
+        {
+            Assert.False(File.Exists(SidecarPath));
+            File.WriteAllBytes(SidecarPath, currentSidecarData);
+        });
+        var provider = new BugReportServerSaveProvider(saveInterface.Object, Mock.Of<ILogger>());
+
+        var captured = provider.TryCapture(out var save);
+
+        Assert.True(captured);
+        Assert.Equal("coop_bug_report.sav", save.FileName);
+        Assert.Equal(campaignData, save.Data);
+        Assert.Equal("coop_bug_report.json", save.SidecarFileName);
+        Assert.Equal(currentSidecarData, save.SidecarData);
+        Assert.Equal(currentSidecarData, File.ReadAllBytes(SidecarPath));
+    }
+
+    [Fact]
+    public void TryCapture_PreviousSidecarCannotBeDeleted_DoesNotSaveOrReadSidecar()
+    {
+        using var logger = new LoggerConfiguration().CreateLogger();
+        var saveInterface = CreateSaveInterface(() => File.WriteAllBytes(SidecarPath, currentSidecarData));
+        saveInterface.Setup(value => value.DeleteSaveFile("coop_bug_report.json"))
+            .Throws(new IOException("Sidecar is locked"));
+        var provider = new BugReportServerSaveProvider(saveInterface.Object, logger);
+
+        var captured = provider.TryCapture(out var save);
+
+        Assert.False(captured);
+        Assert.Null(save);
+        Assert.Equal("{\"players\":[\"previous\"]}", File.ReadAllText(SidecarPath));
+        saveInterface.Verify(value => value.SaveCurrentGameToFile(It.IsAny<string>()), Times.Never);
+        saveInterface.Verify(value => value.ReadSaveFile(It.IsAny<string>()), Times.Never);
+    }
+
+    private Mock<ISaveInterface> CreateSaveInterface(Action saveSidecar)
+    {
+        var saveInterface = new Mock<ISaveInterface>(MockBehavior.Strict);
+        saveInterface.Setup(value => value.DeleteSaveFile("coop_bug_report.json"))
+            .Callback(() => File.Delete(SidecarPath));
+        saveInterface.Setup(value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName))
+            .Callback(saveSidecar)
+            .Returns(new SaveResults(true, campaignData, "campaign-id"));
+        saveInterface.Setup(value => value.ReadSaveFile("coop_bug_report.json"))
+            .Returns(() => File.Exists(SidecarPath) ? File.ReadAllBytes(SidecarPath) : null);
+        return saveInterface;
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(tempRoot, recursive: true);
+    }
+}

--- a/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
+++ b/source/GameInterface.Tests/Services/BugReporting/CoopLogBugReportTests.cs
@@ -8,6 +8,7 @@ using GameInterface.Services.Heroes.Interfaces;
 using GameInterface.Services.Players;
 using GameInterface.Services.UI.BugReporting;
 using Moq;
+using Serilog;
 using System;
 using System.IO;
 using System.IO.Compression;
@@ -63,6 +64,7 @@ public class CoopLogBugReportTests : IDisposable
         var logBytes = Compress("client diagnostic\n");
         var serverLogBytes = Compress("server diagnostic\n");
         var serverSaveBytes = Encoding.UTF8.GetBytes("server save data");
+        var serverSaveSidecarBytes = Encoding.UTF8.GetBytes("{\"players\":[]}");
         var requestId = Guid.NewGuid().ToString("N");
         using var builder = new BugReportArchiveBuilder(tempRoot);
         var contents = new BugReportArchiveContents(
@@ -76,7 +78,11 @@ public class CoopLogBugReportTests : IDisposable
             new CollectedBugReportServerLog(
                 serverLogBytes,
                 Encoding.UTF8.GetByteCount("server diagnostic\n")),
-            new CollectedBugReportServerSave("coop_bug_report.sav", serverSaveBytes),
+            new CollectedBugReportServerSave(
+                "coop_bug_report.sav",
+                serverSaveBytes,
+                "coop_bug_report.json",
+                serverSaveSidecarBytes),
             DateTimeOffset.UtcNow,
             new[] { new CollectedBugReportLog(2, logBytes, Encoding.UTF8.GetByteCount("client diagnostic\n")) },
             expectedClients: 3,
@@ -96,6 +102,7 @@ public class CoopLogBugReportTests : IDisposable
             Assert.Contains("Commit: " + ModInformation.Commit, manifest);
             Assert.Contains("Build version: " + ModInformation.BuildVersion, manifest);
             Assert.Contains("Triggers: player-submitted", manifest);
+            Assert.Contains("Server save sidecar included: yes", manifest);
         }
         var reportEntry = Assert.Single(archive.Entries, entry => entry.FullName.StartsWith("reports/"));
         using (var reportReader = new StreamReader(reportEntry.Open()))
@@ -115,6 +122,14 @@ public class CoopLogBugReportTests : IDisposable
             using var saveStream = serverSaveEntry.Open();
             saveStream.CopyTo(saveData);
             Assert.Equal(serverSaveBytes, saveData.ToArray());
+        }
+        var serverSaveSidecarEntry = Assert.IsType<ZipArchiveEntry>(
+            archive.GetEntry("server/coop_bug_report.json"));
+        using (var sidecarData = new MemoryStream())
+        {
+            using var sidecarStream = serverSaveSidecarEntry.Open();
+            sidecarStream.CopyTo(sidecarData);
+            Assert.Equal(serverSaveSidecarBytes, sidecarData.ToArray());
         }
         var logEntry = Assert.Single(archive.Entries, entry => entry.FullName.StartsWith("clients/"));
         Assert.Equal("clients/client-02.log", logEntry.FullName);
@@ -182,10 +197,14 @@ public class CoopLogBugReportTests : IDisposable
     public void ServerSaveProvider_PersistsAndReturnsTheCampaignSave()
     {
         var saveData = Encoding.UTF8.GetBytes("campaign save");
+        var sidecarData = Encoding.UTF8.GetBytes("{\"players\":[]}");
         var saveInterface = new Mock<ISaveInterface>();
         saveInterface
             .Setup(value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName))
             .Returns(new SaveResults(true, saveData, "campaign-id"));
+        saveInterface
+            .Setup(value => value.ReadSaveFile("coop_bug_report.json"))
+            .Returns(sidecarData);
         var provider = new BugReportServerSaveProvider(saveInterface.Object, Mock.Of<Serilog.ILogger>());
 
         var captured = provider.TryCapture(out var save);
@@ -193,9 +212,30 @@ public class CoopLogBugReportTests : IDisposable
         Assert.True(captured);
         Assert.Equal("coop_bug_report.sav", save.FileName);
         Assert.Equal(saveData, save.Data);
+        Assert.Equal("coop_bug_report.json", save.SidecarFileName);
+        Assert.Equal(sidecarData, save.SidecarData);
         saveInterface.Verify(
             value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName),
             Times.Once);
+    }
+
+    [Fact]
+    public void ServerSaveProvider_MissingSidecarStillReturnsCampaignSave()
+    {
+        var saveData = Encoding.UTF8.GetBytes("campaign save");
+        var saveInterface = new Mock<ISaveInterface>();
+        saveInterface
+            .Setup(value => value.SaveCurrentGameToFile(BugReportServerSaveProvider.SaveName))
+            .Returns(new SaveResults(true, saveData, "campaign-id"));
+        using var logger = new LoggerConfiguration().CreateLogger();
+        var provider = new BugReportServerSaveProvider(saveInterface.Object, logger);
+
+        var captured = provider.TryCapture(out var save);
+
+        Assert.True(captured);
+        Assert.Equal(saveData, save.Data);
+        Assert.Null(save.SidecarFileName);
+        Assert.Null(save.SidecarData);
     }
 
     [Fact]
@@ -308,6 +348,7 @@ public class CoopLogBugReportTests : IDisposable
         var serverLog = Compress("server diagnostic\n");
         var clientLog = Compress("client diagnostic\n");
         var serverSave = Encoding.UTF8.GetBytes("server campaign save");
+        var serverSaveSidecar = Encoding.UTF8.GetBytes("{\"players\":[]}");
         var report = new BugReportArchiveContents(
             Guid.NewGuid().ToString("N"),
             "network-client-1",
@@ -319,7 +360,11 @@ public class CoopLogBugReportTests : IDisposable
             new CollectedBugReportServerLog(
                 serverLog,
                 Encoding.UTF8.GetByteCount("server diagnostic\n")),
-            new CollectedBugReportServerSave("coop_bug_report.sav", serverSave),
+            new CollectedBugReportServerSave(
+                "coop_bug_report.sav",
+                serverSave,
+                "coop_bug_report.json",
+                serverSaveSidecar),
             DateTimeOffset.UtcNow,
             new[] { new CollectedBugReportLog(
                 1,
@@ -342,6 +387,7 @@ public class CoopLogBugReportTests : IDisposable
         Assert.Equal(serverLog, handler.ServerLogBody);
         Assert.Equal(clientLog, handler.ClientLogBody);
         Assert.Equal(serverSave, handler.ServerSaveBody);
+        Assert.Equal(serverSaveSidecar, handler.ServerSaveSidecarBody);
         using var json = JsonDocument.Parse(handler.Body);
         var root = json.RootElement;
         Assert.Equal("network-client-1", root.GetProperty("reportingClientNetworkId").GetString());
@@ -358,6 +404,12 @@ public class CoopLogBugReportTests : IDisposable
         Assert.False(root.GetProperty("clientLogs")[0].TryGetProperty("data", out _));
         Assert.Equal("server-save", root.GetProperty("serverSave").GetProperty("artifact").GetString());
         Assert.Equal(serverSave.Length, root.GetProperty("serverSave").GetProperty("length").GetInt64());
+        Assert.Equal(
+            "coop_bug_report.json",
+            root.GetProperty("serverSave").GetProperty("sidecarFileName").GetString());
+        Assert.Equal(
+            serverSaveSidecar.Length,
+            root.GetProperty("serverSave").GetProperty("sidecarLength").GetInt64());
     }
 
     [Fact]
@@ -426,6 +478,10 @@ public class CoopLogBugReportTests : IDisposable
             BugReportUploader.MaximumServerSaveBytes));
         Assert.False(BugReportUploader.IsWithinServerSaveLimit(
             (long)BugReportUploader.MaximumServerSaveBytes + 1));
+        Assert.True(BugReportUploader.IsWithinServerSaveSidecarLimit(
+            BugReportUploader.MaximumServerSaveSidecarBytes));
+        Assert.False(BugReportUploader.IsWithinServerSaveSidecarLimit(
+            (long)BugReportUploader.MaximumServerSaveSidecarBytes + 1));
     }
 
     public void Dispose()
@@ -490,6 +546,7 @@ public class CoopLogBugReportTests : IDisposable
         public byte[] ServerLogBody { get; private set; }
         public byte[] ClientLogBody { get; private set; }
         public byte[] ServerSaveBody { get; private set; }
+        public byte[] ServerSaveSidecarBody { get; private set; }
         public bool FailUpload { get; set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(
@@ -512,6 +569,8 @@ public class CoopLogBugReportTests : IDisposable
                 if (name == "report") Body = await part.ReadAsStringAsync();
                 else if (name == "serverLog") ServerLogBody = await part.ReadAsByteArrayAsync();
                 else if (name == "serverSave") ServerSaveBody = await part.ReadAsByteArrayAsync();
+                else if (name == "serverSaveSidecar")
+                    ServerSaveSidecarBody = await part.ReadAsByteArrayAsync();
                 else if (name == BugReportUploader.GetClientLogPartName(1))
                     ClientLogBody = await part.ReadAsByteArrayAsync();
             }

--- a/source/GameInterface.Tests/Services/UI/BugReportConsentTests.cs
+++ b/source/GameInterface.Tests/Services/UI/BugReportConsentTests.cs
@@ -16,8 +16,8 @@ public class BugReportConsentTests
     {
         Assert.Contains("sent to the dedicated server", BugReportConsentCoordinator.PromptText);
         Assert.Contains("IP addresses", BugReportConsentCoordinator.PromptText);
-        Assert.Contains("current campaign save", BugReportConsentCoordinator.PromptText);
-        Assert.Contains("campaign save is still included", BugReportConsentCoordinator.PromptText);
+        Assert.Contains("current campaign save and paired co-op session data", BugReportConsentCoordinator.PromptText);
+        Assert.Contains("campaign save and paired co-op session data are still included", BugReportConsentCoordinator.PromptText);
         Assert.Contains("Client saves, configuration files, and memory dumps are not included",
             BugReportConsentCoordinator.PromptText);
         Assert.Contains("cancel this bug report", BugReportSubmissionConsent.PromptText);
@@ -27,7 +27,7 @@ public class BugReportConsentTests
         Assert.Contains("public GitHub issue", BugReportSubmissionConsent.PromptText);
         Assert.Contains("publicly accessible links", BugReportSubmissionConsent.PromptText);
         Assert.Contains("remote deletion or expiry is not guaranteed", BugReportSubmissionConsent.PromptText);
-        Assert.Contains("current campaign save", BugReportSubmissionConsent.PromptText);
+        Assert.Contains("current campaign save and paired co-op", BugReportSubmissionConsent.PromptText);
         Assert.Contains("Client saves, configuration files, and memory dumps are not included",
             BugReportSubmissionConsent.PromptText);
     }
@@ -53,7 +53,7 @@ public class BugReportConsentTests
     }
 
     [Fact]
-    public void ConsentWithoutServerSaveDisclosure_IsDisabledAndPromptedAgain()
+    public void ConsentWithoutSaveSidecarDisclosure_IsDisabledAndPromptedAgain()
     {
         var store = new TestOptionsStore();
         var options = store.LoadOrDefault();
@@ -63,7 +63,7 @@ public class BugReportConsentTests
             new BugReportConsentOptions
             {
                 ShareBugReportLogs = true,
-                DisclosureVersion = 2,
+                DisclosureVersion = 3,
             });
         store.Save(options);
         var coordinator = new BugReportConsentCoordinator(store, _ => { });

--- a/source/GameInterface/Services/BugReporting/BugReportArchiveBuilder.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportArchiveBuilder.cs
@@ -56,16 +56,24 @@ public sealed class CollectedBugReportServerLog
     }
 }
 
-/// <summary>Contains the persistent server campaign save captured for a diagnostic report.</summary>
+/// <summary>Contains the server campaign save and paired co-op session data.</summary>
 public sealed class CollectedBugReportServerSave
 {
     public string FileName { get; }
     public byte[] Data { get; }
+    public string SidecarFileName { get; }
+    public byte[] SidecarData { get; }
 
-    public CollectedBugReportServerSave(string fileName, byte[] data)
+    public CollectedBugReportServerSave(
+        string fileName,
+        byte[] data,
+        string sidecarFileName = null,
+        byte[] sidecarData = null)
     {
         FileName = fileName;
         Data = data;
+        SidecarFileName = sidecarFileName;
+        SidecarData = sidecarData;
     }
 }
 
@@ -378,12 +386,14 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
         writer.WriteLine("Packaged: " + DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture));
         writer.WriteLine("Player submissions: " + contents.Submissions.Count.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Server save included: " + (contents.ServerSave != null ? "yes" : "no"));
+        writer.WriteLine("Server save sidecar included: " +
+                         (contents.ServerSave?.SidecarData != null ? "yes" : "no"));
         writer.WriteLine("Expected clients: " + contents.ExpectedClients.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Logs included: " + contents.Logs.Count.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Clients declined: " + contents.DeclinedClients.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Clients failed: " + contents.FailedClients.ToString(CultureInfo.InvariantCulture));
         writer.WriteLine("Clients timed out: " + contents.TimedOutClients.ToString(CultureInfo.InvariantCulture));
-        writer.WriteLine("The current server campaign save and current BannerlordCoop logs are included; client saves, configs, and dumps are excluded.");
+        writer.WriteLine("The current server campaign save, its co-op session data, and current BannerlordCoop logs are included; client saves, configs, and dumps are excluded.");
     }
 
     private static void AddSubmissions(
@@ -413,15 +423,37 @@ public class BugReportArchiveBuilder : IBugReportArchiveBuilder
     {
         if (save.Data == null || save.Data.Length == 0)
             throw new InvalidDataException("The collected server save was empty.");
-        if (string.IsNullOrWhiteSpace(save.FileName) ||
-            !string.Equals(Path.GetFileName(save.FileName), save.FileName, StringComparison.Ordinal))
-        {
+        if (!IsValidFileName(save.FileName))
             throw new InvalidDataException("The collected server save had an invalid file name.");
-        }
 
         var entry = archive.CreateEntry("server/" + save.FileName, CompressionLevel.NoCompression);
-        using var destination = entry.Open();
-        destination.Write(save.Data, 0, save.Data.Length);
+        using (var destination = entry.Open())
+        {
+            destination.Write(save.Data, 0, save.Data.Length);
+        }
+
+        if (save.SidecarFileName == null && save.SidecarData == null) return;
+        if (!IsValidFileName(save.SidecarFileName) ||
+            !string.Equals(
+                Path.ChangeExtension(save.FileName, ".json"),
+                save.SidecarFileName,
+                StringComparison.OrdinalIgnoreCase) ||
+            save.SidecarData == null || save.SidecarData.Length == 0)
+        {
+            throw new InvalidDataException("The collected server save sidecar was invalid.");
+        }
+
+        var sidecarEntry = archive.CreateEntry(
+            "server/" + save.SidecarFileName,
+            CompressionLevel.Optimal);
+        using var sidecarDestination = sidecarEntry.Open();
+        sidecarDestination.Write(save.SidecarData, 0, save.SidecarData.Length);
+    }
+
+    private static bool IsValidFileName(string fileName)
+    {
+        return !string.IsNullOrWhiteSpace(fileName) &&
+               string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal);
     }
 
     private static void AddServerLog(ZipArchive archive, CollectedBugReportServerLog log)

--- a/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace GameInterface.Services.BugReporting;
 
-/// <summary>Creates the persistent server campaign save attached to a diagnostic report.</summary>
+/// <summary>Creates the server save pair attached to a diagnostic report.</summary>
 public interface IBugReportServerSaveProvider
 {
     bool TryCapture(out CollectedBugReportServerSave save);
@@ -38,7 +38,13 @@ public class BugReportServerSaveProvider : IBugReportServerSaveProvider
                 return false;
             }
 
-            save = new CollectedBugReportServerSave(SaveName + ".sav", result.Data);
+            var sidecarFileName = SaveName + ".json";
+            var sidecarData = ReadSidecar(sidecarFileName);
+            save = new CollectedBugReportServerSave(
+                SaveName + ".sav",
+                result.Data,
+                sidecarData == null ? null : sidecarFileName,
+                sidecarData);
             return true;
         }
         catch (Exception exception)
@@ -46,5 +52,22 @@ public class BugReportServerSaveProvider : IBugReportServerSaveProvider
             logger.Warning(exception, "Creating the server campaign save for the diagnostic bug report failed");
             return false;
         }
+    }
+
+    private byte[] ReadSidecar(string fileName)
+    {
+        try
+        {
+            var data = saveInterface.ReadSaveFile(fileName);
+            if (data != null && data.Length > 0) return data;
+
+            logger.Warning("The co-op session data for the diagnostic bug report could not be read");
+        }
+        catch (Exception exception)
+        {
+            logger.Warning(exception, "Reading the co-op session data for the diagnostic bug report failed");
+        }
+
+        return null;
     }
 }

--- a/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportServerSaveProvider.cs
@@ -31,6 +31,9 @@ public class BugReportServerSaveProvider : IBugReportServerSaveProvider
         save = null;
         try
         {
+            var sidecarFileName = SaveName + ".json";
+            // GameSaved subscriber failures do not fail the campaign save, so discard the previous sidecar first.
+            saveInterface.DeleteSaveFile(sidecarFileName);
             var result = saveInterface.SaveCurrentGameToFile(SaveName);
             if (!result.Success || result.Data == null || result.Data.Length == 0)
             {
@@ -38,7 +41,6 @@ public class BugReportServerSaveProvider : IBugReportServerSaveProvider
                 return false;
             }
 
-            var sidecarFileName = SaveName + ".json";
             var sidecarData = ReadSidecar(sidecarFileName);
             save = new CollectedBugReportServerSave(
                 SaveName + ".sav",

--- a/source/GameInterface/Services/BugReporting/BugReportUploader.cs
+++ b/source/GameInterface/Services/BugReporting/BugReportUploader.cs
@@ -28,6 +28,7 @@ public class BugReportUploader : IBugReportUploader, IDisposable
         "https://wfvqnijwuyqjibhlcrhz.supabase.co/functions/v1/create-github-issue-bug-report";
     internal const int MaximumCompressedReportBytes = 10 * 1024 * 1024;
     internal const int MaximumServerSaveBytes = 48 * 1024 * 1024;
+    internal const int MaximumServerSaveSidecarBytes = 8 * 1024 * 1024;
 
     private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
     {
@@ -84,11 +85,7 @@ public class BugReportUploader : IBugReportUploader, IDisposable
 
         if (report.ServerSave != null)
         {
-            if (string.IsNullOrWhiteSpace(report.ServerSave.FileName) ||
-                !string.Equals(
-                    Path.GetFileName(report.ServerSave.FileName),
-                    report.ServerSave.FileName,
-                    StringComparison.Ordinal))
+            if (!IsValidFileName(report.ServerSave.FileName))
             {
                 return new BugReportUploadResult(false, true, "The server campaign save had an invalid file name.");
             }
@@ -99,6 +96,31 @@ public class BugReportUploader : IBugReportUploader, IDisposable
                     false,
                     true,
                     "The server campaign save exceeds the upload size limit.");
+            }
+
+            var hasSidecarFileName = report.ServerSave.SidecarFileName != null;
+            var hasSidecarData = report.ServerSave.SidecarData != null;
+            if (hasSidecarFileName != hasSidecarData ||
+                (hasSidecarFileName &&
+                 (!IsValidFileName(report.ServerSave.SidecarFileName) ||
+                  !string.Equals(
+                      Path.ChangeExtension(report.ServerSave.FileName, ".json"),
+                      report.ServerSave.SidecarFileName,
+                      StringComparison.OrdinalIgnoreCase))))
+            {
+                return new BugReportUploadResult(
+                    false,
+                    true,
+                    "The server campaign save sidecar was invalid.");
+            }
+
+            if (hasSidecarData &&
+                !IsWithinServerSaveSidecarLimit(report.ServerSave.SidecarData.LongLength))
+            {
+                return new BugReportUploadResult(
+                    false,
+                    true,
+                    "The server campaign save sidecar exceeds the upload size limit.");
             }
         }
 
@@ -139,6 +161,17 @@ public class BugReportUploader : IBugReportUploader, IDisposable
         return saveBytes > 0 && saveBytes <= MaximumServerSaveBytes;
     }
 
+    internal static bool IsWithinServerSaveSidecarLimit(long sidecarBytes)
+    {
+        return sidecarBytes > 0 && sidecarBytes <= MaximumServerSaveSidecarBytes;
+    }
+
+    private static bool IsValidFileName(string fileName)
+    {
+        return !string.IsNullOrWhiteSpace(fileName) &&
+               string.Equals(Path.GetFileName(fileName), fileName, StringComparison.Ordinal);
+    }
+
     private static MultipartFormDataContent CreateMultipartContent(
         BugReportArchiveContents report,
         string json)
@@ -168,6 +201,14 @@ public class BugReportUploader : IBugReportUploader, IDisposable
                 CreateBinaryContent(report.ServerSave.Data, "application/octet-stream"),
                 "serverSave",
                 report.ServerSave.FileName);
+
+            if (report.ServerSave.SidecarData != null)
+            {
+                content.Add(
+                    CreateBinaryContent(report.ServerSave.SidecarData, "application/json"),
+                    "serverSaveSidecar",
+                    report.ServerSave.SidecarFileName);
+            }
         }
 
         return content;
@@ -226,7 +267,9 @@ public class BugReportUploader : IBugReportUploader, IDisposable
             ? null
             : new BugReportJsonServerSave(
                 report.ServerSave.FileName,
-                report.ServerSave.Data.LongLength);
+                report.ServerSave.Data.LongLength,
+                report.ServerSave.SidecarFileName,
+                report.ServerSave.SidecarData?.LongLength);
 
         return new BugReportJsonRequest(
             report.RequestId,
@@ -345,17 +388,25 @@ internal sealed class BugReportJsonLog
     }
 }
 
-/// <summary>Describes the raw server-save artifact uploaded before the JSON report.</summary>
+/// <summary>Describes the server-save pair uploaded before the JSON report.</summary>
 internal sealed class BugReportJsonServerSave
 {
     public string FileName { get; }
     public string Artifact => "server-save";
     public long Length { get; }
+    public string SidecarFileName { get; }
+    public long? SidecarLength { get; }
 
-    public BugReportJsonServerSave(string fileName, long length)
+    public BugReportJsonServerSave(
+        string fileName,
+        long length,
+        string sidecarFileName,
+        long? sidecarLength)
     {
         FileName = fileName;
         Length = length;
+        SidecarFileName = sidecarFileName;
+        SidecarLength = sidecarLength;
     }
 }
 

--- a/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
+++ b/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
@@ -13,6 +13,7 @@ public interface ISaveInterface : IGameAbstraction
 {
     SaveResults SaveCurrentGame();
     SaveResults SaveCurrentGameToFile(string saveName);
+    byte[] ReadSaveFile(string fileName);
 }
 
 internal class SaveInterface : ISaveInterface
@@ -38,10 +39,18 @@ internal class SaveInterface : ISaveInterface
         var result = SaveCurrentGame(saveName, saveDriver);
         if (!result.Success) return result;
 
-        var data = FileHelper.GetFileContent(FileDriver.GetSaveFilePath(saveName + ".sav"));
+        var data = ReadSaveFile(saveName + ".sav");
         if (data == null || data.Length == 0) return ReportSaveFailure("saved game file");
 
         return new SaveResults(true, data, result.CampaignId);
+    }
+
+    public byte[] ReadSaveFile(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            throw new ArgumentException("File name cannot be empty.", nameof(fileName));
+
+        return FileHelper.GetFileContent(FileDriver.GetSaveFilePath(fileName));
     }
 
     private SaveResults SaveCurrentGame(string saveName, ISaveDriver saveDriver)

--- a/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
+++ b/source/GameInterface/Services/Save/Interfaces/SaveInterface.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Logging;
 using Serilog;
 using System;
+using System.IO;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
@@ -14,6 +15,7 @@ public interface ISaveInterface : IGameAbstraction
     SaveResults SaveCurrentGame();
     SaveResults SaveCurrentGameToFile(string saveName);
     byte[] ReadSaveFile(string fileName);
+    void DeleteSaveFile(string fileName);
 }
 
 internal class SaveInterface : ISaveInterface
@@ -51,6 +53,18 @@ internal class SaveInterface : ISaveInterface
             throw new ArgumentException("File name cannot be empty.", nameof(fileName));
 
         return FileHelper.GetFileContent(FileDriver.GetSaveFilePath(fileName));
+    }
+
+    public void DeleteSaveFile(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            throw new ArgumentException("File name cannot be empty.", nameof(fileName));
+
+        var path = FileDriver.GetSaveFilePath(fileName);
+        FileHelper.DeleteFile(path);
+        // FileHelper discards the platform helper's deletion result.
+        if (FileHelper.FileExists(path))
+            throw new IOException("Save file could not be deleted: " + fileName);
     }
 
     private SaveResults SaveCurrentGame(string saveName, ISaveDriver saveDriver)

--- a/source/GameInterface/Services/UI/BugReporting/BugReportConsentCoordinator.cs
+++ b/source/GameInterface/Services/UI/BugReporting/BugReportConsentCoordinator.cs
@@ -10,20 +10,21 @@ public class BugReportConsentCoordinator
 {
     public const string TabId = "BugReporting";
     public const string SectionId = "BugReportLogSharingConsent";
-    public const int CurrentDisclosureVersion = 3;
+    public const int CurrentDisclosureVersion = 4;
     public const string PromptTitle = "Share Co-op Diagnostic Logs?";
     public const string PromptText =
         "When the dedicated server creates a diagnostic bug report, allow this client's current " +
         "BannerlordCoop log to be sent to the dedicated server, packaged with logs from other consenting " +
         "clients, and submitted to BannerlordCoop's bug-report service? Reports create a public GitHub " +
         "issue containing the reporting player's network ID. The server also creates and uploads its current " +
-        "campaign save for every report. The save and included server and client logs are uploaded to publicly " +
+        "campaign save and paired co-op session data for every report. The save data and included server and " +
+        "client logs are uploaded to publicly " +
         "accessible links, and remote deletion or expiry is not guaranteed. Reports may be triggered " +
         "automatically by recovery actions such as the coop unstuck command. The server save and logs may contain " +
         "player names, Steam IDs, IP addresses, file paths, and gameplay or network details. Runtime " +
         "command arguments and common credential values are redacted from logs. Client saves, configuration " +
         "files, and memory dumps are not included. Choose No thanks to keep this client's log local; the server " +
-        "campaign save is still included. " +
+        "campaign save and paired co-op session data are still included. " +
         "Change this later with coop.bug_report_log_sharing enable or disable.";
 
     private readonly ICoopOptionsStore optionsStore;

--- a/source/GameInterface/Services/UI/BugReporting/BugReportSubmissionConsent.cs
+++ b/source/GameInterface/Services/UI/BugReporting/BugReportSubmissionConsent.cs
@@ -18,8 +18,9 @@ public class BugReportSubmissionConsent : IBugReportSubmissionConsent
     public const string PromptText =
         "Submitting this report sends your network ID, summary, and description to the dedicated " +
         "server and BannerlordCoop's bug-report service. The reporting network ID is published in a " +
-        "public GitHub issue. The server creates and uploads its current campaign save with the report. " +
-        "The save and included server and client logs are uploaded to publicly accessible links, and remote " +
+        "public GitHub issue. The server creates and uploads its current campaign save and paired co-op " +
+        "session data with the report. The save data and included server and client logs are uploaded to " +
+        "publicly accessible links, and remote " +
         "deletion or expiry is not guaranteed. Allowing also enables sharing this client's current " +
         "BannerlordCoop log with the report. The server save and logs may contain player names, Steam IDs, " +
         "IP addresses, file paths, and gameplay or network details. Runtime command arguments and common " +


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] New feature (non-breaking change that adds functionality)

## What is the current behavior?

Diagnostic bug reports upload `coop_bug_report.sav` but omit its paired `coop_bug_report.json`, so the player-to-hero and co-op session state needed to reproduce the save is missing.

## What is the new behavior?

The server reads the paired co-op session file after creating the report save and includes both files in multipart uploads and fallback archives. A missing sidecar is logged but does not discard the campaign save. The consent text now discloses the paired session data, and the disclosure version is bumped.

The bug-report edge function was updated to version 27 to validate, store, and link the optional sidecar while remaining compatible with existing reports.

## How to test

- Submit a Coop Bug Report and confirm its Server Save section links both `coop_bug_report.sav` and `coop_bug_report.json`.
- Confirm a fallback archive contains both files under `server/`.
- `dotnet test source/GameInterface.Tests/GameInterface.Tests.csproj -c Release -p:NuGetAudit=false`

## Bot Changelog Entry

- Bug reports now include the co-op session data paired with the server save.