### PR TITLE
 Add option to show player nameplates with other indicators

### DIFF
--- a/UIMovies/CoopOptionsUIMovie.xml
+++ b/UIMovies/CoopOptionsUIMovie.xml
@@ -286,29 +286,11 @@
 			                        <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="64"
 			                                   HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
 			                            <Children>
-			                                <ButtonWidget DoNotPassEventsToChildren="true"
-			                                              WidthSizePolicy="Fixed" HeightSizePolicy="Fixed"
-			                                              SuggestedWidth="40" SuggestedHeight="40"
-			                                              VerticalAlignment="Center"
-			                                              Brush="SPOptions.Checkbox.Empty.Button"
-			                                              ButtonType="Toggle"
-			                                              IsSelected="@ShowPlayerNameplates"
-			                                              ToggleIndicator="ToggleIndicator"
-			                                              UpdateChildrenStates="true">
-			                                    <Children>
-			                                        <BrushWidget Id="ToggleIndicator"
-			                                                     WidthSizePolicy="StretchToParent"
-			                                                     HeightSizePolicy="StretchToParent"
-			                                                     Brush="SPOptions.Checkbox.Full.Button"/>
-			                                    </Children>
-			                                </ButtonWidget>
-			                                <TextWidget WidthSizePolicy="CoverChildren"
-			                                            HeightSizePolicy="StretchToParent"
-			                                            MarginLeft="16"
-			                                            Brush="Clan.TabControl.Text"
-			                                            Brush.FontSize="28"
-			                                            Brush.TextVerticalAlignment="Center"
-			                                            Text="@ShowPlayerNameplatesText"/>
+			                                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="StretchToParent"
+			                                            MarginRight="16" Brush="Clan.TabControl.Text" Brush.FontSize="28"
+			                                            Brush.TextVerticalAlignment="Center" Text="@DisplayModeText"/>
+			                                <Standard.DropdownWithHorizontalControl VerticalAlignment="Center"
+			                                                                        Parameter.SelectorDataSource="{DisplayModeSelector}"/>
 			                            </Children>
 			                        </ListPanel>
 			                    </Children>

--- a/source/GameInterface.Tests/Services/UI/PlayerNameplatesOptionsTests.cs
+++ b/source/GameInterface.Tests/Services/UI/PlayerNameplatesOptionsTests.cs
@@ -67,6 +67,96 @@ public class PlayerNameplatesOptionsTests
         }
     }
 
+    [Theory]
+    [InlineData(true, PlayerNameplatesDisplayMode.Always)]
+    [InlineData(false, PlayerNameplatesDisplayMode.Never)]
+    public void PlayerNameplates_LegacyBool_MapsToDisplayMode(bool legacyValue, PlayerNameplatesDisplayMode expected)
+    {
+        string filePath = CreateTempFilePath();
+
+        try
+        {
+            File.WriteAllText(
+                filePath,
+                "{\""
+                    + PlayerNameplatesOptionsTabProvider.TabId
+                    + "\":{\""
+                    + PlayerNameplatesSection.SectionId
+                    + "\":{\"showPlayerNameplates\":"
+                    + (legacyValue ? "true" : "false")
+                    + "}}}");
+
+            var store = new CoopOptionsStore(filePath);
+
+            Assert.Equal(expected, PlayerNameplatesOptionsTabProvider.GetDisplayModeOrDefault(store.LoadOrDefault()));
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Theory]
+    [InlineData("\"Always\"", PlayerNameplatesDisplayMode.Always)]
+    [InlineData("\"HoldIndicators\"", PlayerNameplatesDisplayMode.HoldIndicators)]
+    [InlineData("\"Never\"", PlayerNameplatesDisplayMode.Never)]
+    public void PlayerNameplates_DisplayMode_RoundTripsUnderLegacyKey(string jsonValue, PlayerNameplatesDisplayMode expected)
+    {
+        string filePath = CreateTempFilePath();
+
+        try
+        {
+            File.WriteAllText(
+                filePath,
+                "{\""
+                    + PlayerNameplatesOptionsTabProvider.TabId
+                    + "\":{\""
+                    + PlayerNameplatesSection.SectionId
+                    + "\":{\"showPlayerNameplates\":"
+                    + jsonValue
+                    + "}}}");
+
+            var store = new CoopOptionsStore(filePath);
+
+            Assert.Equal(expected, PlayerNameplatesOptionsTabProvider.GetDisplayModeOrDefault(store.LoadOrDefault()));
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public void PlayerNameplates_Apply_PersistsUnderLegacyKey()
+    {
+        string filePath = CreateTempFilePath();
+
+        try
+        {
+            var store = new CoopOptionsStore(filePath);
+            using var messageBroker = new MessageBroker();
+            var provider = new PlayerNameplatesOptionsTabProvider();
+            var tab = provider.CreateTab(store.LoadOrDefault(), messageBroker, _ => { });
+            var section = Assert.IsType<PlayerNameplatesSection>(Assert.Single(tab.Sections));
+
+            section.DisplayModeSelector.SelectedIndex = (int)PlayerNameplatesDisplayMode.HoldIndicators;
+            var options = store.LoadOrDefault();
+            tab.Apply(options);
+            store.Save(options);
+
+            string saved = File.ReadAllText(filePath);
+            Assert.Contains("\"showPlayerNameplates\"", saved);
+            Assert.DoesNotContain("playerNameplatesDisplayMode", saved);
+            Assert.Equal(
+                PlayerNameplatesDisplayMode.HoldIndicators,
+                PlayerNameplatesOptionsTabProvider.GetDisplayModeOrDefault(store.LoadOrDefault()));
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
     [Fact]
     public void ServerDisabled_HidesPlayerNameplatesTab()
     {

--- a/source/GameInterface.Tests/Services/UI/PlayerNameplatesOptionsTests.cs
+++ b/source/GameInterface.Tests/Services/UI/PlayerNameplatesOptionsTests.cs
@@ -20,7 +20,7 @@ namespace GameInterface.Tests.Services.UI;
 public class PlayerNameplatesOptionsTests
 {
     [Fact]
-    public void PlayerNameplates_DefaultToEnabled()
+    public void PlayerNameplates_DefaultToAlways()
     {
         using var messageBroker = new MessageBroker();
         var provider = new PlayerNameplatesOptionsTabProvider();
@@ -28,11 +28,14 @@ public class PlayerNameplatesOptionsTests
         var tab = provider.CreateTab(new CoopOptionsData(), messageBroker, _ => { });
 
         var section = Assert.IsType<PlayerNameplatesSection>(Assert.Single(tab.Sections));
-        Assert.True(section.ShowPlayerNameplates);
+        Assert.Equal(PlayerNameplatesDisplayMode.Always, section.SelectedDisplayMode);
     }
 
-    [Fact]
-    public void PlayerNameplates_Disabled_PersistAndPublishAfterApply()
+    [Theory]
+    [InlineData(PlayerNameplatesDisplayMode.Always)]
+    [InlineData(PlayerNameplatesDisplayMode.HoldIndicators)]
+    [InlineData(PlayerNameplatesDisplayMode.Never)]
+    public void PlayerNameplates_Mode_PersistAndPublishAfterApply(PlayerNameplatesDisplayMode mode)
     {
         string filePath = CreateTempFilePath();
 
@@ -47,15 +50,15 @@ public class PlayerNameplatesOptionsTests
             var tab = provider.CreateTab(store.LoadOrDefault(), messageBroker, _ => { });
             var section = Assert.IsType<PlayerNameplatesSection>(Assert.Single(tab.Sections));
 
-            section.ShowPlayerNameplates = false;
+            section.DisplayModeSelector.SelectedIndex = (int)mode;
             var options = store.LoadOrDefault();
             tab.Apply(options);
             store.Save(options);
             tab.AfterApply();
 
-            Assert.False(PlayerNameplatesOptionsTabProvider.GetShowPlayerNameplatesOrDefault(store.LoadOrDefault()));
+            Assert.Equal(mode, PlayerNameplatesOptionsTabProvider.GetDisplayModeOrDefault(store.LoadOrDefault()));
             Assert.True(selected.HasValue);
-            Assert.False(selected.Value.ShowPlayerNameplates);
+            Assert.Equal(mode, selected.Value.DisplayMode);
             GC.KeepAlive(handler);
         }
         finally

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/PlayerNameplatesDisplayMode.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/PlayerNameplatesDisplayMode.cs
@@ -1,0 +1,9 @@
+﻿namespace GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
+
+/// <summary>How a client chooses to display player nameplates in missions.</summary>
+public enum PlayerNameplatesDisplayMode
+{
+    Always = 0,
+    HoldIndicators = 1,
+    Never = 2,
+}

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/PlayerNameplatesDisplayMode.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/PlayerNameplatesDisplayMode.cs
@@ -1,4 +1,8 @@
-﻿namespace GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
 
 /// <summary>How a client chooses to display player nameplates in missions.</summary>
 public enum PlayerNameplatesDisplayMode
@@ -6,4 +10,38 @@ public enum PlayerNameplatesDisplayMode
     Always = 0,
     HoldIndicators = 1,
     Never = 2,
+}
+
+/// <summary>Reads the legacy bool (<c>true</c>/<c>false</c>) as Always/Never, plus enum strings.</summary>
+public sealed class PlayerNameplatesDisplayModeConverter : JsonConverter<PlayerNameplatesDisplayMode>
+{
+    public override PlayerNameplatesDisplayMode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.True:
+                return PlayerNameplatesDisplayMode.Always;
+            case JsonTokenType.False:
+                return PlayerNameplatesDisplayMode.Never;
+            case JsonTokenType.Number:
+                if (reader.TryGetInt32(out int numeric)
+                    && Enum.IsDefined(typeof(PlayerNameplatesDisplayMode), numeric))
+                    return (PlayerNameplatesDisplayMode)numeric;
+                break;
+            case JsonTokenType.String:
+                string text = reader.GetString();
+                if (bool.TryParse(text, out bool flag))
+                    return flag ? PlayerNameplatesDisplayMode.Always : PlayerNameplatesDisplayMode.Never;
+                if (Enum.TryParse<PlayerNameplatesDisplayMode>(text, true, out var mode))
+                    return mode;
+                break;
+        }
+
+        throw new JsonException($"Unable to convert token {reader.TokenType} to {nameof(PlayerNameplatesDisplayMode)}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, PlayerNameplatesDisplayMode value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
 }

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/PlayerNameplatesOptionsTabProvider.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/PlayerNameplatesOptionsTabProvider.cs
@@ -24,17 +24,17 @@ public class PlayerNameplatesOptionsTabProvider : ICoopOptionsTabProvider
             TabName,
             new CoopOptionsSectionVM[]
             {
-                new PlayerNameplatesSection(GetShowPlayerNameplatesOrDefault(options), messageBroker)
+                new PlayerNameplatesSection(GetDisplayModeOrDefault(options), messageBroker)
             },
             onSelect);
     }
 
-    public static bool GetShowPlayerNameplatesOrDefault(CoopOptionsData options)
+    public static PlayerNameplatesDisplayMode GetDisplayModeOrDefault(CoopOptionsData options)
     {
         var sectionOptions = (options ?? new CoopOptionsData()).GetSectionOrDefault(
             TabId,
             PlayerNameplatesSection.SectionId,
             new PlayerNameplatesSectionOptions());
-        return sectionOptions.GetShowPlayerNameplatesOrDefault();
+        return sectionOptions.GetDisplayModeOrDefault();
     }
 }

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSection.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSection.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Messaging;
 using GameInterface.Services.UI.Messages;
+using TaleWorlds.Core.ViewModelCollection.Selector;
 using TaleWorlds.Library;
 
 namespace GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab.Sections;
@@ -10,42 +11,37 @@ public class PlayerNameplatesSection : CoopOptionsSectionVM
     public const string SectionId = "PlayerNameplatesSection";
 
     private readonly IMessageBroker messageBroker;
-    private bool showPlayerNameplates;
 
-    public PlayerNameplatesSection(bool showPlayerNameplates, IMessageBroker messageBroker)
+    public PlayerNameplatesSection(PlayerNameplatesDisplayMode displayMode, IMessageBroker messageBroker)
     {
-        this.showPlayerNameplates = showPlayerNameplates;
         this.messageBroker = messageBroker;
+        DisplayModeSelector = new SelectorVM<SelectorItemVM>(
+            new[] { "Always", "Hold Indicators", "Never" },
+            (int)displayMode,
+            null);
     }
 
     public override string Id => SectionId;
     public string TitleText => "Player Nameplates";
     public string DescriptionText => "Show names above allied players in co-op missions.";
-    public string ShowPlayerNameplatesText => "Show Player Nameplates";
+    public string DisplayModeText => "Display Mode";
 
     [DataSourceProperty]
-    public bool ShowPlayerNameplates
-    {
-        get => showPlayerNameplates;
-        set
-        {
-            if (showPlayerNameplates == value) return;
+    public SelectorVM<SelectorItemVM> DisplayModeSelector { get; }
 
-            showPlayerNameplates = value;
-            OnPropertyChanged(nameof(ShowPlayerNameplates));
-        }
-    }
+    public PlayerNameplatesDisplayMode SelectedDisplayMode =>
+        (PlayerNameplatesDisplayMode)DisplayModeSelector.SelectedIndex;
 
     public override void Apply(string tabId, CoopOptionsData options)
     {
         options.SetSection(
             tabId,
             Id,
-            new PlayerNameplatesSectionOptions { ShowPlayerNameplates = showPlayerNameplates });
+            new PlayerNameplatesSectionOptions { DisplayMode = SelectedDisplayMode });
     }
 
     public override void AfterApply()
     {
-        messageBroker.Publish(this, new PlayerNameplateVisibilitySelected(showPlayerNameplates));
+        messageBroker.Publish(this, new PlayerNameplateVisibilitySelected(SelectedDisplayMode));
     }
 }

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSection.xml
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSection.xml
@@ -14,29 +14,11 @@
         <ListPanel WidthSizePolicy="CoverChildren" HeightSizePolicy="Fixed" SuggestedHeight="64"
                    HorizontalAlignment="Center" LayoutImp.LayoutMethod="HorizontalLeftToRight">
             <Children>
-                <ButtonWidget DoNotPassEventsToChildren="true"
-                              WidthSizePolicy="Fixed" HeightSizePolicy="Fixed"
-                              SuggestedWidth="40" SuggestedHeight="40"
-                              VerticalAlignment="Center"
-                              Brush="SPOptions.Checkbox.Empty.Button"
-                              ButtonType="Toggle"
-                              IsSelected="@ShowPlayerNameplates"
-                              ToggleIndicator="ToggleIndicator"
-                              UpdateChildrenStates="true">
-                    <Children>
-                        <BrushWidget Id="ToggleIndicator"
-                                     WidthSizePolicy="StretchToParent"
-                                     HeightSizePolicy="StretchToParent"
-                                     Brush="SPOptions.Checkbox.Full.Button"/>
-                    </Children>
-                </ButtonWidget>
-                <TextWidget WidthSizePolicy="CoverChildren"
-                            HeightSizePolicy="StretchToParent"
-                            MarginLeft="16"
-                            Brush="Clan.TabControl.Text"
-                            Brush.FontSize="28"
-                            Brush.TextVerticalAlignment="Center"
-                            Text="@ShowPlayerNameplatesText"/>
+                <TextWidget WidthSizePolicy="CoverChildren" HeightSizePolicy="StretchToParent"
+                            MarginRight="16" Brush="Clan.TabControl.Text" Brush.FontSize="28"
+                            Brush.TextVerticalAlignment="Center" Text="@DisplayModeText"/>
+                <Standard.DropdownWithHorizontalControl VerticalAlignment="Center"
+                                                        Parameter.SelectorDataSource="{DisplayModeSelector}"/>
             </Children>
         </ListPanel>
     </Children>

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSectionOptions.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSectionOptions.cs
@@ -5,13 +5,14 @@ namespace GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab.Se
 /// <summary>Stores the client's optional nameplate preference.</summary>
 public class PlayerNameplatesSectionOptions
 {
-    public const bool DefaultShowPlayerNameplates = true;
+    public const PlayerNameplatesDisplayMode DefaultDisplayMode = PlayerNameplatesDisplayMode.Always;
 
-    [JsonPropertyName("showPlayerNameplates")]
-    public bool? ShowPlayerNameplates { get; set; }
+    [JsonPropertyName("playerNameplatesDisplayMode")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public PlayerNameplatesDisplayMode? DisplayMode { get; set; }
 
-    public bool GetShowPlayerNameplatesOrDefault()
+    public PlayerNameplatesDisplayMode GetDisplayModeOrDefault()
     {
-        return ShowPlayerNameplates ?? DefaultShowPlayerNameplates;
+        return DisplayMode ?? DefaultDisplayMode;
     }
 }

--- a/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSectionOptions.cs
+++ b/source/GameInterface/Services/UI/CoopOptions/Providers/PlayerNameplatesTab/Sections/PlayerNameplatesSectionOptions.cs
@@ -7,8 +7,8 @@ public class PlayerNameplatesSectionOptions
 {
     public const PlayerNameplatesDisplayMode DefaultDisplayMode = PlayerNameplatesDisplayMode.Always;
 
-    [JsonPropertyName("playerNameplatesDisplayMode")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonPropertyName("showPlayerNameplates")]
+    [JsonConverter(typeof(PlayerNameplatesDisplayModeConverter))]
     public PlayerNameplatesDisplayMode? DisplayMode { get; set; }
 
     public PlayerNameplatesDisplayMode GetDisplayModeOrDefault()

--- a/source/GameInterface/Services/UI/Messages/PlayerNameplateVisibilitySelected.cs
+++ b/source/GameInterface/Services/UI/Messages/PlayerNameplateVisibilitySelected.cs
@@ -1,13 +1,14 @@
 ﻿using Common.Messaging;
+using GameInterface.Services.UI.CoopOptions.Providers.PlayerNameplatesTab;
 
 namespace GameInterface.Services.UI.Messages;
 
 public readonly struct PlayerNameplateVisibilitySelected : IEvent
 {
-    public readonly bool ShowPlayerNameplates;
+    public readonly PlayerNameplatesDisplayMode DisplayMode;
 
-    public PlayerNameplateVisibilitySelected(bool showPlayerNameplates)
+    public PlayerNameplateVisibilitySelected(PlayerNameplatesDisplayMode displayMode)
     {
-        ShowPlayerNameplates = showPlayerNameplates;
+        DisplayMode = displayMode;
     }
 }

--- a/source/GameInterface/Services/UI/PlayerNameplates/PlayerNameplateMissionView.cs
+++ b/source/GameInterface/Services/UI/PlayerNameplates/PlayerNameplateMissionView.cs
@@ -39,6 +39,7 @@ public sealed class PlayerNameplateMissionView : MissionView, ILocationMissionBe
     private GauntletMovieIdentifier movie;
     private bool serverAllowsPlayerNameplates;
     private bool showPlayerNameplates;
+    private PlayerNameplatesDisplayMode displayMode = PlayerNameplatesDisplayMode.Always;
     private float targetRefreshElapsed;
 
     public bool IsVisible => dataSource?.IsEnabled == true;
@@ -75,7 +76,7 @@ public sealed class PlayerNameplateMissionView : MissionView, ILocationMissionBe
         messageBroker.Subscribe<ModConfigApplied>(HandleModConfigApplied);
         messageBroker.Subscribe<PlayerNameplateVisibilitySelected>(HandleVisibilitySelected);
         serverAllowsPlayerNameplates = ModConfigProvider.ModOptions.ShowPlayerNameplates;
-        ApplyVisibility(PlayerNameplatesOptionsTabProvider.GetShowPlayerNameplatesOrDefault(
+        ApplyMode(PlayerNameplatesOptionsTabProvider.GetDisplayModeOrDefault(
             optionsStore.LoadOrDefault()));
     }
 
@@ -83,7 +84,10 @@ public sealed class PlayerNameplateMissionView : MissionView, ILocationMissionBe
     {
         base.OnMissionScreenTick(dt);
 
-        if (dataSource == null || !showPlayerNameplates) return;
+        if (dataSource == null) return;
+
+        UpdateVisibility();
+        if (!showPlayerNameplates) return;
 
         targetRefreshElapsed += dt;
         if (targetRefreshElapsed >= TargetRefreshInterval)
@@ -183,24 +187,51 @@ public sealed class PlayerNameplateMissionView : MissionView, ILocationMissionBe
     {
         GameThread.RunSafe(() =>
         {
-            ApplyVisibility(payload.What.ShowPlayerNameplates);
+            ApplyMode(payload.What.DisplayMode);
         }, context: nameof(PlayerNameplateMissionView));
     }
 
     private void HandleModConfigApplied(MessagePayload<ModConfigApplied> payload)
     {
         serverAllowsPlayerNameplates = payload.What.ModOptions.ShowPlayerNameplates;
-        ApplyVisibility(PlayerNameplatesOptionsTabProvider.GetShowPlayerNameplatesOrDefault(
+        ApplyMode(PlayerNameplatesOptionsTabProvider.GetDisplayModeOrDefault(
             optionsStore.LoadOrDefault()));
     }
 
-    private void ApplyVisibility(bool clientAllowsPlayerNameplates)
+    private void ApplyMode(PlayerNameplatesDisplayMode mode)
     {
         if (dataSource == null) return;
 
-        showPlayerNameplates = serverAllowsPlayerNameplates && clientAllowsPlayerNameplates;
-        dataSource.IsEnabled = showPlayerNameplates;
-        if (showPlayerNameplates) RefreshTargets();
+        displayMode = mode;
+        UpdateVisibility();
+    }
+
+    private void UpdateVisibility()
+    {
+        bool shouldShow = serverAllowsPlayerNameplates && displayMode switch
+        {
+            PlayerNameplatesDisplayMode.Always => true,
+            PlayerNameplatesDisplayMode.HoldIndicators => IsShowIndicatorsHeld(),
+            _ => false,
+        };
+
+        if (shouldShow == showPlayerNameplates) return;
+
+        showPlayerNameplates = shouldShow;
+        dataSource.IsEnabled = shouldShow;
+        if (shouldShow)
+        {
+            RefreshTargets();
+        }
+        else
+        {
+            dataSource.ClearTargets();
+        }
+    }
+
+    private bool IsShowIndicatorsHeld()
+    {
+        return MissionScreen != null && Input.IsGameKeyDown(GenericGameKeyContext.ShowIndicators);
     }
 
     private bool TryGetControllerId(Agent agent, out string controllerId)

--- a/source/GameInterface/Services/UI/PlayerNameplates/PlayerNameplatesVM.cs
+++ b/source/GameInterface/Services/UI/PlayerNameplates/PlayerNameplatesVM.cs
@@ -30,7 +30,7 @@ public sealed class PlayerNameplatesVM : ViewModel
         }
     }
 
-    public override void OnFinalize()
+    public void ClearTargets()
     {
         foreach (var target in Targets)
         {
@@ -38,6 +38,11 @@ public sealed class PlayerNameplatesVM : ViewModel
         }
 
         Targets.Clear();
+    }
+
+    public override void OnFinalize()
+    {
+        ClearTargets();
         base.OnFinalize();
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Player nameplates are either always on or always off

## What is the new behavior?

Player nameplates can be set to only show when other indicators are being shown (Left Alt by default) such as troop icons.
Also fix the issue when nameplates kept rendering statically on the screen when user switched from "always shown" to "always hidden" midbattle.

<!-- Insert issue id after hashtag. -->
Resolves #3477
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry

Add option to show player nameplates with other indicators
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->


## Other information

This does invalidate the previous nameplate visibility setting but for the sake of PR size and to avoid tech debt I opted to not make it backward compatible with the previous on-off switch.