### PR TITLE
Log party membership differences when join baselines fail

### DIFF
--- a/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotMembershipTests.cs
+++ b/source/GameInterface.Tests/Services/MobileParties/MobilePartyBehaviorSnapshotMembershipTests.cs
@@ -1,0 +1,218 @@
+﻿using Common.Util;
+using GameInterface.Services.MobileParties.Data;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Tests.Services.SiegeEvents;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Library;
+using Xunit;
+
+namespace GameInterface.Tests.Services.MobileParties;
+
+[Collection(nameof(CampaignCurrentCollection))]
+public class MobilePartyBehaviorSnapshotMembershipTests : IDisposable
+{
+    private readonly Campaign previousCampaign = Campaign.Current;
+    private readonly Campaign campaign = ObjectHelper.SkipConstructor<Campaign>();
+    private readonly Mock<IObjectManager> registry = new();
+    private readonly MobilePartyBehaviorSnapshot snapshot;
+
+    public MobilePartyBehaviorSnapshotMembershipTests()
+    {
+        campaign.CampaignObjectManager = new CampaignObjectManager
+        {
+            Settlements = new MBReadOnlyList<Settlement>(new List<Settlement>()),
+        };
+        Campaign.Current = campaign;
+        snapshot = new MobilePartyBehaviorSnapshot(registry.Object);
+    }
+
+    public void Dispose() => Campaign.Current = previousCampaign;
+
+    [Fact]
+    public void TryApplyJoinBaseline_MatchingEmptyMembership_DoesNotLogDiagnostics()
+    {
+        Assert.True(snapshot.TryApplyJoinBaseline(Array.Empty<MobilePartyJoinState>(), () => { }));
+        Assert.Null(snapshot.LastJoinBaselineMembership);
+        Assert.Equal(0, snapshot.LoggedJoinBaselineMembershipCount);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MatchingMembershipWithInvalidBehavior_DoesNotReportFalseDifferences()
+    {
+        Party("Created_42");
+        Reject(State("Created_42"));
+        Assert.Equal("state 0 party 'Created_42' failed validation: party AI is unavailable", snapshot.LastJoinBaselineFailure);
+        Assert.Contains("missing=0, inactive=0, outsideCollection=0, extraActive=0", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("detailsShown=0/0", snapshot.LastJoinBaselineMembership);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MissingObject_IdentifiesBaselineIdWithoutApplying()
+    {
+        bool applied = false;
+        Assert.False(snapshot.TryApplyJoinBaseline(new[] { State("Created_42") }, () => applied = true));
+        Assert.False(applied);
+        Assert.Equal("party count mismatch (baseline=1, client=0)", snapshot.LastJoinBaselineFailure);
+        Assert.Contains("missing=1, inactive=0, outsideCollection=0, extraActive=0", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("missing baseline id: Created_42", snapshot.LastJoinBaselineMembership);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_InactiveObject_ReportsPlayerAndSettlementInsteadOfMissing()
+    {
+        MobileParty party = Party("Player", active: false);
+        campaign.MainParty = party;
+        var settlement = ObjectHelper.SkipConstructor<Settlement>();
+        settlement.StringId = "town_ES1";
+        party._currentSettlement = settlement;
+
+        Reject(State("Player"));
+
+        Assert.Contains("missing=0, inactive=1, outsideCollection=0", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("inactive baseline id: Player", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("main=True", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("settlement=town_ES1", snapshot.LastJoinBaselineMembership);
+        Assert.False(party.IsActive);
+        Assert.Same(settlement, party.CurrentSettlement);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_RegisteredObjectOutsideCollection_DistinguishesItFromMissing()
+    {
+        MobileParty party = Party("Created_42");
+        campaign.CampaignObjectManager._mobileParties.Remove(party);
+        Reject(State("Created_42"));
+        Assert.Contains("missing=0, inactive=0, outsideCollection=1", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("baseline object outside local collection: Created_42", snapshot.LastJoinBaselineMembership);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_EqualCountDifferentMembership_ReportsMissingAndExtra()
+    {
+        Party("Created_43");
+        Reject(State("Created_42"));
+        Assert.Equal("state 0 references missing mobile party 'Created_42'", snapshot.LastJoinBaselineFailure);
+        Assert.Contains("missing=1, inactive=0, outsideCollection=0, extraActive=1", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("active local absent from baseline: id=MobileParty_Created_43", snapshot.LastJoinBaselineMembership);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_Duplicates_ReportsBaselineIdsAndLocalMembership()
+    {
+        MobileParty party = Party("Created_42");
+        campaign.CampaignObjectManager._mobileParties.Add(party);
+        Reject(State("Created_42"), State("Created_42"));
+        Assert.Contains("duplicateBaselineIds=1", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("duplicateLocalMembership=1", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("duplicate baseline id: Created_42", snapshot.LastJoinBaselineMembership);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_RegistryAliasesAndUnregisteredActive_AreReported()
+    {
+        MobileParty party = Party("Created_42");
+        registry.Setup(m => m.TryGetObject("Alias", out party)).Returns(true);
+        object alias = party;
+        registry.Setup(m => m.TryGetObject<object>("MobileParty_Alias", out alias)).Returns(true);
+        MobileParty other = Party("Created_43");
+        string duplicateId = "MobileParty_Created_42";
+        registry.Setup(m => m.TryGetId(other, out duplicateId)).Returns(true);
+        MobileParty unregistered = Party("Created_44");
+        string missingId = null!;
+        registry.Setup(m => m.TryGetId(unregistered, out missingId)).Returns(false);
+        Reject(State("Created_42"), State("Alias"));
+        Assert.Contains("aliasedBaselineIds=1", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("duplicateLocalIds=1, unregisteredActive=1", snapshot.LastJoinBaselineMembership);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_MovementAndOrderChanges_SuppressIdenticalMembership()
+    {
+        Reject(State("Created_42"), State("Created_43"));
+        string first = snapshot.LastJoinBaselineMembership;
+        MobilePartyJoinState moved = State("Created_42");
+        moved.Bearing = new Vec2(30f, 40f);
+        PartyBehaviorUpdateData behavior = moved.Behavior;
+        behavior.PartyPosition = new CampaignVec2(new Vec2(70f, 80f), true);
+        moved.Behavior = behavior;
+        Reject(State("Created_43"), moved);
+        Assert.Equal(first, snapshot.LastJoinBaselineMembership);
+        Assert.Equal(1, snapshot.LoggedJoinBaselineMembershipCount);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_LargeMismatch_BoundsDetailsAndIdentifierLength()
+    {
+        var states = Enumerable.Range(0, 100)
+            .Select(i => State($"{i:D3}_" + new string('x', 1000))).ToArray();
+        Reject(states);
+        Assert.Contains("missing=100", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("detailsShown=16/100 (limit=16)", snapshot.LastJoinBaselineMembership);
+        Assert.True(snapshot.LastJoinBaselineMembership.Length < 3000);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_ChangingFailures_BoundsReportsAndSuccessResetsBudget()
+    {
+        for (int i = 0; i < 20; i++) Reject(State($"Created_{i}"));
+        Assert.Equal(8, snapshot.LoggedJoinBaselineMembershipCount);
+        Assert.True(snapshot.TryApplyJoinBaseline(Array.Empty<MobilePartyJoinState>(), () => { }));
+        Assert.Equal(0, snapshot.LoggedJoinBaselineMembershipCount);
+        Assert.Null(snapshot.LastJoinBaselineMembership);
+        Reject(State("Created_0"));
+        Assert.Equal(1, snapshot.LoggedJoinBaselineMembershipCount);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_DiagnosticLookupThrows_PreservesOriginalRejectionAndSuppressesFailure()
+    {
+        object party = null!;
+        registry.Setup(m => m.TryGetObject<object>("MobileParty_Created_42", out party)).Throws<InvalidOperationException>();
+        Reject(State("Created_42"));
+        Reject(State("Created_42"));
+        Assert.Equal("party count mismatch (baseline=1, client=0)", snapshot.LastJoinBaselineFailure);
+        Assert.Equal(1, snapshot.LoggedJoinBaselineMembershipCount);
+    }
+
+    [Fact]
+    public void TryApplyJoinBaseline_WrongTypeRegistration_DoesNotUseErrorLoggingTypedLookup()
+    {
+        object registered = new object();
+        registry.Setup(m => m.TryGetObject<object>("MobileParty_Created_42", out registered)).Returns(true);
+        Reject(State("Created_42"));
+        Reject(State("Created_42"));
+        Assert.Contains("wrongType=1", snapshot.LastJoinBaselineMembership);
+        Assert.Contains("wrong-type baseline id: Created_42 type=Object", snapshot.LastJoinBaselineMembership);
+        Assert.Equal(1, snapshot.LoggedJoinBaselineMembershipCount);
+        MobileParty party = null!;
+        registry.Verify(m => m.TryGetObject("Created_42", out party), Times.Never);
+    }
+
+    private void Reject(params MobilePartyJoinState[] states) =>
+        Assert.False(snapshot.TryApplyJoinBaseline(states, () => throw new InvalidOperationException("must not apply")));
+
+    private MobileParty Party(string id, bool active = true)
+    {
+        var party = ObjectHelper.SkipConstructor<MobileParty>();
+        party.StringId = "MobileParty_" + id;
+        party.IsActive = active;
+        campaign.CampaignObjectManager._mobileParties.Add(party);
+        string registryId = "MobileParty_" + id;
+        registry.Setup(m => m.TryGetId(party, out registryId)).Returns(true);
+        registry.Setup(m => m.TryGetObject(id, out party)).Returns(true);
+        object registered = party;
+        registry.Setup(m => m.TryGetObject<object>(registryId, out registered)).Returns(true);
+        return party;
+    }
+
+    private static MobilePartyJoinState State(string id) => new()
+    {
+        Behavior = new PartyBehaviorUpdateData(id, AiBehavior.Hold, null, default, default, AiBehavior.Hold, default, default),
+    };
+}

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.Diagnostics.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.Diagnostics.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+
+namespace GameInterface.Services.MobileParties.Data;
+
+public sealed partial class MobilePartyBehaviorSnapshot
+{
+    private const int MembershipReportLimit = 8;
+    private const int MembershipDetailLimit = 16;
+    private readonly HashSet<string> loggedJoinBaselineMembership = new HashSet<string>();
+
+    internal string LastJoinBaselineMembership { get; private set; }
+    internal int LoggedJoinBaselineMembershipCount => loggedJoinBaselineMembership.Count;
+
+    // The receive handler already runs on the game thread, behind replayed registrations.
+    private void LogJoinBaselineMembership(MobilePartyJoinState[] states, IEnumerable<MobileParty> parties)
+    {
+        if (loggedJoinBaselineMembership.Count >= MembershipReportLimit) return;
+
+        try
+        {
+            string report = DescribeJoinBaselineMembership(states, parties);
+            LastJoinBaselineMembership = report;
+            if (!loggedJoinBaselineMembership.Add(report)) return;
+
+            Logger.Warning(
+                "Mobile-party join baseline membership: {Membership}. Identical membership retries are suppressed; report {ReportNumber}/{ReportLimit} until a successful baseline",
+                report, loggedJoinBaselineMembership.Count, MembershipReportLimit);
+        }
+        catch (Exception ex)
+        {
+            // Diagnostics must not replace the original rejection or prevent the next retry.
+            string failure = "membership diagnostics failed: " + ex.GetType().Name;
+            if (loggedJoinBaselineMembership.Add(failure))
+                Logger.Warning(ex, "Could not inspect rejected mobile-party join baseline membership");
+        }
+    }
+
+    private string DescribeJoinBaselineMembership(MobilePartyJoinState[] states, IEnumerable<MobileParty> parties)
+    {
+        var details = new SortedSet<string>(StringComparer.Ordinal);
+        int detailCount = 0;
+        void Detail(string text)
+        {
+            detailCount++;
+            details.Add(text);
+            if (details.Count > MembershipDetailLimit) details.Remove(details.Max);
+        }
+
+        var localParties = new HashSet<MobileParty>();
+        var localIds = new Dictionary<string, MobileParty>(StringComparer.Ordinal);
+        int duplicateMembership = 0, duplicateLocalIds = 0, unregisteredActive = 0, active = 0;
+        foreach (MobileParty party in parties)
+        {
+            if (party == null) continue;
+            if (!localParties.Add(party))
+            {
+                duplicateMembership++;
+                Detail("duplicate local membership: " + DescribeJoinParty(party));
+                continue;
+            }
+            if (party.IsActive) active++;
+            if (!objectManager.TryGetId(party, out string id) || string.IsNullOrEmpty(id))
+            {
+                if (party.IsActive)
+                {
+                    unregisteredActive++;
+                    Detail("unregistered active local: " + DescribeJoinParty(party));
+                }
+            }
+            else if (localIds.ContainsKey(id))
+            {
+                duplicateLocalIds++;
+                Detail("duplicate local registry id: " + DescribeJoinParty(party));
+            }
+            else localIds.Add(id, party);
+        }
+
+        var baselineIds = new HashSet<string>(StringComparer.Ordinal);
+        var baselineParties = new HashSet<MobileParty>();
+        int missing = 0, inactive = 0, absent = 0, duplicateIds = 0, aliases = 0, emptyIds = 0, wrongType = 0;
+        foreach (MobilePartyJoinState state in states)
+        {
+            string id = state.Behavior.MobilePartyId;
+            if (string.IsNullOrEmpty(id))
+            {
+                emptyIds++;
+                continue;
+            }
+            if (!baselineIds.Add(id))
+            {
+                duplicateIds++;
+                Detail("duplicate baseline id: " + DiagnosticValue(id));
+                continue;
+            }
+            // Resolve as object to avoid the registry's per-lookup error on a wrong-type entry.
+            if (!objectManager.TryGetObject<object>($"MobileParty_{id}", out var registered) &&
+                !objectManager.TryGetObject<object>(id, out registered))
+            {
+                missing++;
+                Detail("missing baseline id: " + DiagnosticValue(id));
+                continue;
+            }
+            if (registered is not MobileParty party)
+            {
+                wrongType++;
+                Detail("wrong-type baseline id: " + DiagnosticValue(id) + " type=" + DiagnosticValue(registered?.GetType().Name));
+                continue;
+            }
+            if (!baselineParties.Add(party))
+            {
+                aliases++;
+                Detail("baseline ids resolve to same party: " + DiagnosticValue(id) + " " + DescribeJoinParty(party));
+            }
+            if (!party.IsActive)
+            {
+                inactive++;
+                Detail("inactive baseline id: " + DiagnosticValue(id) + " " + DescribeJoinParty(party));
+            }
+            if (!localParties.Contains(party))
+            {
+                absent++;
+                Detail("baseline object outside local collection: " + DiagnosticValue(id) + " " + DescribeJoinParty(party));
+            }
+        }
+
+        int extra = 0;
+        foreach (MobileParty party in localParties)
+        {
+            if (!party.IsActive || baselineParties.Contains(party)) continue;
+            extra++;
+            Detail("active local absent from baseline: " + DescribeJoinParty(party));
+        }
+
+        return $"baselineEntries={states.Length}, localActiveUnique={active}, missing={missing}, inactive={inactive}, outsideCollection={absent}, extraActive={extra}, " +
+            $"emptyBaselineIds={emptyIds}, wrongType={wrongType}, duplicateBaselineIds={duplicateIds}, aliasedBaselineIds={aliases}, duplicateLocalMembership={duplicateMembership}, duplicateLocalIds={duplicateLocalIds}, unregisteredActive={unregisteredActive}; " +
+            $"mainParty=[{DescribeJoinParty(Campaign.Current?.MainParty)}]; detailsShown={details.Count}/{detailCount} (limit={MembershipDetailLimit}): " +
+            string.Join("; ", details);
+    }
+
+    private string DescribeJoinParty(MobileParty party)
+    {
+        if (party == null) return "none";
+        objectManager.TryGetId(party, out string id);
+        var leader = party.LeaderHero;
+        return $"id={DiagnosticValue(id)}, stringId={DiagnosticValue(party.StringId)}, active={party.IsActive}, " +
+            $"main={ReferenceEquals(party, Campaign.Current?.MainParty)}, leader={DiagnosticValue(leader?.StringId)}, captive={leader?.IsPrisoner}, settlement={DiagnosticValue(party.CurrentSettlement?.StringId)}";
+    }
+
+    private static string DiagnosticValue(string value)
+    {
+        if (value == null) return "none";
+        // Bound identifiers too, so even a malformed baseline cannot produce an oversized log.
+        if (value.Length > 80) value = value.Substring(0, 80) + "...";
+        return value.Replace('\r', ' ').Replace('\n', ' ');
+    }
+}

--- a/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
+++ b/source/GameInterface/Services/MobileParties/Data/MobilePartyBehaviorSnapshot.cs
@@ -29,7 +29,7 @@ public interface IMobilePartyBehaviorSnapshot
     bool TryApplyJoinBaseline(MobilePartyJoinState[] states, Action beforeApply);
 }
 
-public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
+public sealed partial class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
 {
     private static readonly ILogger Logger = LogManager.GetLogger<MobilePartyBehaviorSnapshot>();
 
@@ -296,9 +296,16 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
             if (party?.IsActive == true) liveParties.Add(party);
         }
 
+        bool RejectMembership(string failure)
+        {
+            RejectJoinBaseline(failure);
+            LogJoinBaselineMembership(states, parties);
+            return false;
+        }
+
         if (states.Length != liveParties.Count)
         {
-            return RejectJoinBaseline(
+            return RejectMembership(
                 $"party count mismatch (baseline={states.Length}, client={liveParties.Count})");
         }
 
@@ -310,21 +317,21 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
         {
             PartyBehaviorUpdateData behavior = states[i].Behavior;
             if (string.IsNullOrEmpty(behavior.MobilePartyId))
-                return RejectJoinBaseline($"state {i} has no mobile-party id");
+                return RejectMembership($"state {i} has no mobile-party id");
             if (!this.objectManager.TryGetObject(
                 behavior.MobilePartyId,
                 out MobileParty party))
             {
-                return RejectJoinBaseline(
+                return RejectMembership(
                     $"state {i} references missing mobile party '{behavior.MobilePartyId}'");
             }
             if (!liveParties.Contains(party))
             {
-                return RejectJoinBaseline(
+                return RejectMembership(
                     $"state {i} party '{behavior.MobilePartyId}' is not in the client campaign collection");
             }
             if (!seenParties.Add(party))
-                return RejectJoinBaseline($"state {i} duplicates party '{behavior.MobilePartyId}'");
+                return RejectMembership($"state {i} duplicates party '{behavior.MobilePartyId}'");
             if (!TryPrepare(
                 party,
                 behavior,
@@ -334,14 +341,14 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
                 out resolved[i],
                 out string failure))
             {
-                return RejectJoinBaseline(
+                return RejectMembership(
                     $"state {i} party '{behavior.MobilePartyId}' failed validation: {failure}");
             }
         }
 
         if (seenParties.Count != liveParties.Count)
         {
-            return RejectJoinBaseline(
+            return RejectMembership(
                 $"party coverage mismatch (baseline={seenParties.Count}, client={liveParties.Count})");
         }
 
@@ -359,6 +366,8 @@ public sealed class MobilePartyBehaviorSnapshot : IMobilePartyBehaviorSnapshot
 
             lastJoinBaselineFailure = null;
             loggedJoinBaselineFailures.Clear();
+            loggedJoinBaselineMembership.Clear();
+            LastJoinBaselineMembership = null;
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## What is the current behavior?
#3511 and #3489 show repeated party-count baseline failures, but the logs dont identify which parties differ.

## What is the new behavior?
logs missing, inactive, extra and duplicate parties with their ids and local player/settlement state after a rejected baseline. details are capped at 16, identical reports are suppressed, and at most eight distinct reports are logged until a baseline succeeds. validation and retry behavior are unchanged.

## How to test
Release build passed. all 107 `Services.MobileParties` tests passed, including 13 new diagnostic tests covering mismatches, suppression, limits and lookup failures.

on the next affected client, preserve `Coop_client.log` before restarting and find `Mobile-party join baseline membership` after the rejection. no affected save was available for a live reproduction.
