### PR TITLE
Sync board-game tavern and lord rewards

### DIFF
--- a/source/E2E.Tests/Services/Locations/BoardGameRewardTests.cs
+++ b/source/E2E.Tests/Services/Locations/BoardGameRewardTests.cs
@@ -1,0 +1,327 @@
+﻿using Common.Network;
+using E2E.Tests.Services.MapEvents;
+using GameInterface.Services.Locations.BoardGames.Messages;
+using GameInterface.Services.Locations.BoardGames.Patches;
+using GameInterface.Services.Players;
+using Helpers;
+using SandBox.CampaignBehaviors;
+using System.Linq;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.Locations;
+
+public sealed class BoardGameRewardTests : MapEventTestBase
+{
+    public BoardGameRewardTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public void TavernWin_ForwardsCapturedBetAndServerAppliesGold()
+    {
+        var client = Clients.First();
+        var (heroId, _) = CreatePlayerHeroParty("BoardGameRewards");
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().SetPeer("BoardGameRewards", client.NetPeer);
+        }, MapEventDisabledMethods);
+        Server.Call(() => Server.GetRegisteredObject<Hero>(heroId).Gold = 1000);
+
+        client.Call(() =>
+        {
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._betAmount = 500;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._betAmount = 0; // vanilla SetBetAmount(0) at the end of OnPlayerBoardGameOver
+            BoardGameRewardPatches.Postfix(behavior, null, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        var message = Assert.Single(client.NetworkSentMessages.GetMessages<NetworkBoardGameTavernResult>());
+        Assert.Equal(500, message.BetAmount);
+        Assert.Equal(BoardGameHelper.BoardGameState.Win, message.GameOver);
+
+        int gold = 0;
+        Server.Call(() => gold = Server.GetRegisteredObject<Hero>(heroId).Gold);
+        Assert.Equal(1500, gold);
+    }
+
+    [Fact]
+    public void TavernLoss_ForwardsCapturedBetAndServerDeductsGold()
+    {
+        var client = Clients.First();
+        var (heroId, _) = CreatePlayerHeroParty("BoardGameRewards");
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().SetPeer("BoardGameRewards", client.NetPeer);
+        }, MapEventDisabledMethods);
+        Server.Call(() => Server.GetRegisteredObject<Hero>(heroId).Gold = 1000);
+
+        client.Call(() =>
+        {
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._betAmount = 200;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._betAmount = 0;
+            BoardGameRewardPatches.Postfix(behavior, null, BoardGameHelper.BoardGameState.Loss, bet);
+        });
+
+        var message = Assert.Single(client.NetworkSentMessages.GetMessages<NetworkBoardGameTavernResult>());
+        Assert.Equal(200, message.BetAmount);
+        Assert.Equal(BoardGameHelper.BoardGameState.Loss, message.GameOver);
+
+        int gold = 0;
+        Server.Call(() => gold = Server.GetRegisteredObject<Hero>(heroId).Gold);
+        Assert.Equal(800, gold);
+    }
+
+    [Fact]
+    public void TavernWin_ZeroBet_SendsNothing()
+    {
+        var client = Clients.First();
+
+        client.Call(() =>
+        {
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._betAmount = 0;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            BoardGameRewardPatches.Postfix(behavior, null, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkBoardGameTavernResult>());
+    }
+
+    [Fact]
+    public void TavernWin_OnServer_SendsNothing()
+    {
+        Server.Call(() =>
+        {
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._betAmount = 500;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._betAmount = 0;
+            BoardGameRewardPatches.Postfix(behavior, null, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkBoardGameTavernResult>());
+    }
+
+    [Fact]
+    public void TavernDraw_SendsNothing()
+    {
+        var client = Clients.First();
+
+        client.Call(() =>
+        {
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._betAmount = 500;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._betAmount = 0;
+            BoardGameRewardPatches.Postfix(behavior, null, BoardGameHelper.BoardGameState.Draw, bet);
+        });
+
+        Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkBoardGameTavernResult>());
+    }
+
+    [Fact]
+    public void TavernWin_InvalidBet_ServerDropsGold()
+    {
+        var client = Clients.First();
+        var (heroId, _) = CreatePlayerHeroParty("BoardGameRewards");
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().SetPeer("BoardGameRewards", client.NetPeer);
+        }, MapEventDisabledMethods);
+        Server.Call(() => Server.GetRegisteredObject<Hero>(heroId).Gold = 1000);
+
+        client.Call(() =>
+        {
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._betAmount = 50;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._betAmount = 0;
+            BoardGameRewardPatches.Postfix(behavior, null, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        // Patch forwards any positive bet; the server validates the vanilla set.
+        var message = Assert.Single(client.NetworkSentMessages.GetMessages<NetworkBoardGameTavernResult>());
+        Assert.Equal(50, message.BetAmount);
+
+        int gold = 0;
+        Server.Call(() => gold = Server.GetRegisteredObject<Hero>(heroId).Gold);
+        Assert.Equal(1000, gold);
+    }
+
+    [Fact]
+    public void LordLoss_SendsNothing()
+    {
+        var client = Clients.First();
+        var opposingHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(opposingHeroId, out var opposing));
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._difficulty = BoardGameHelper.AIDifficulty.Normal;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            BoardGameRewardPatches.Postfix(behavior, opposing, BoardGameHelper.BoardGameState.Loss, bet);
+        });
+
+        Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkBoardGameLordResult>());
+    }
+
+    [Fact]
+    public void LordDraw_SendsNothing()
+    {
+        var client = Clients.First();
+        var opposingHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(opposingHeroId, out var opposing));
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._difficulty = BoardGameHelper.AIDifficulty.Normal;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            BoardGameRewardPatches.Postfix(behavior, opposing, BoardGameHelper.BoardGameState.Draw, bet);
+        });
+
+        Assert.Empty(client.NetworkSentMessages.GetMessages<NetworkBoardGameLordResult>());
+    }
+
+    [Fact]
+    public void LordWin_Normal_None_ForwardsAndAppliesStewardXp()
+    {
+        var client = Clients.First();
+        var (heroId, _) = CreatePlayerHeroParty("BoardGameRewards");
+        var opposingHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().SetPeer("BoardGameRewards", client.NetPeer);
+        }, MapEventDisabledMethods);
+
+        float xpBefore = 0;
+        Server.Call(() => xpBefore = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(opposingHeroId, out var opposing));
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._difficulty = BoardGameHelper.AIDifficulty.Normal;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._opposingHeroExtraXPGained = false;
+            BoardGameRewardPatches.Postfix(behavior, opposing, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        var message = Assert.Single(client.NetworkSentMessages.GetMessages<NetworkBoardGameLordResult>());
+        Assert.Equal(BoardGameHelper.AIDifficulty.Normal, message.Difficulty);
+        Assert.Equal(LordBoardGameReward.None, message.Reward);
+        Assert.False(message.ExtraXp);
+
+        float xpAfter = 0;
+        Server.Call(() => xpAfter = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+        Assert.True(xpAfter > xpBefore);
+    }
+
+    [Fact]
+    public void LordWin_Normal_Relation_ForwardsReward()
+    {
+        var client = Clients.First();
+        var (heroId, _) = CreatePlayerHeroParty("BoardGameRewards");
+        var opposingHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().SetPeer("BoardGameRewards", client.NetPeer);
+        }, MapEventDisabledMethods);
+
+        float xpBefore = 0;
+        Server.Call(() => xpBefore = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(opposingHeroId, out var opposing));
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._difficulty = BoardGameHelper.AIDifficulty.Normal;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._relationGained = true;
+            behavior._opposingHeroExtraXPGained = false;
+            BoardGameRewardPatches.Postfix(behavior, opposing, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        var message = Assert.Single(client.NetworkSentMessages.GetMessages<NetworkBoardGameLordResult>());
+        Assert.Equal(LordBoardGameReward.Relation, message.Reward);
+
+        // Steward XP runs for every lord win regardless of reward, proving the
+        // MainHero-substituted server apply ran without throwing.
+        float xpAfter = 0;
+        Server.Call(() => xpAfter = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+        Assert.True(xpAfter > xpBefore);
+    }
+
+    [Fact]
+    public void LordWin_InfluenceOnNormal_Dropped()
+    {
+        var client = Clients.First();
+        var (heroId, _) = CreatePlayerHeroParty("BoardGameRewards");
+        var opposingHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().SetPeer("BoardGameRewards", client.NetPeer);
+        }, MapEventDisabledMethods);
+
+        float xpBefore = 0;
+        Server.Call(() => xpBefore = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(opposingHeroId, out var opposing));
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._difficulty = BoardGameHelper.AIDifficulty.Normal;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._influenceGained = true;
+            behavior._opposingHeroExtraXPGained = false;
+            BoardGameRewardPatches.Postfix(behavior, opposing, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        var message = Assert.Single(client.NetworkSentMessages.GetMessages<NetworkBoardGameLordResult>());
+        Assert.Equal(LordBoardGameReward.Influence, message.Reward);
+
+        // Influence only exists on Hard; the server drops the whole message.
+        float xpAfter = 0;
+        Server.Call(() => xpAfter = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+        Assert.Equal(xpBefore, xpAfter);
+    }
+
+    [Fact]
+    public void LordWin_ExtraXpOnHard_Dropped()
+    {
+        var client = Clients.First();
+        var (heroId, _) = CreatePlayerHeroParty("BoardGameRewards");
+        var opposingHeroId = TestEnvironment.CreateRegisteredObject<Hero>();
+        Server.Call(() =>
+        {
+            Server.Resolve<IPlayerManager>().SetPeer("BoardGameRewards", client.NetPeer);
+        }, MapEventDisabledMethods);
+
+        float xpBefore = 0;
+        Server.Call(() => xpBefore = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+
+        client.Call(() =>
+        {
+            Assert.True(client.ObjectManager.TryGetObject<Hero>(opposingHeroId, out var opposing));
+            var behavior = new BoardGameCampaignBehavior();
+            behavior._difficulty = BoardGameHelper.AIDifficulty.Hard;
+            BoardGameRewardPatches.Prefix(behavior, out int bet);
+            behavior._opposingHeroExtraXPGained = true;
+            BoardGameRewardPatches.Postfix(behavior, opposing, BoardGameHelper.BoardGameState.Win, bet);
+        });
+
+        var message = Assert.Single(client.NetworkSentMessages.GetMessages<NetworkBoardGameLordResult>());
+        Assert.True(message.ExtraXp);
+
+        float xpAfter = 0;
+        Server.Call(() => xpAfter = Server.GetRegisteredObject<Hero>(heroId).HeroDeveloper.GetSkillXp(DefaultSkills.Steward));
+        Assert.Equal(xpBefore, xpAfter);
+    }
+}

--- a/source/GameInterface.Tests/Serialization/BoardGameRewardSerializationTest.cs
+++ b/source/GameInterface.Tests/Serialization/BoardGameRewardSerializationTest.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using GameInterface.Services.Locations.BoardGames.Messages;
+using Helpers;
+using ProtoBuf;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization;
+
+public class BoardGameRewardSerializationTest
+{
+    [Fact]
+    public void NetworkBoardGameTavernResult_RoundTrips()
+    {
+        var original = new NetworkBoardGameTavernResult(
+            500,
+            BoardGameHelper.BoardGameState.Win);
+
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, original);
+        stream.Position = 0;
+        var copy = Serializer.Deserialize<NetworkBoardGameTavernResult>(stream);
+
+        Assert.Equal(original.BetAmount, copy.BetAmount);
+        Assert.Equal(original.GameOver, copy.GameOver);
+    }
+
+    [Fact]
+    public void NetworkBoardGameLordResult_RoundTrips()
+    {
+        var original = new NetworkBoardGameLordResult(
+            "hero_2",
+            BoardGameHelper.AIDifficulty.Hard,
+            LordBoardGameReward.Influence,
+            extraXp: false);
+
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, original);
+        stream.Position = 0;
+        var copy = Serializer.Deserialize<NetworkBoardGameLordResult>(stream);
+
+        Assert.Equal(original.OpposingHeroId, copy.OpposingHeroId);
+        Assert.Equal(original.Difficulty, copy.Difficulty);
+        Assert.Equal(original.Reward, copy.Reward);
+        Assert.Equal(original.ExtraXp, copy.ExtraXp);
+    }
+}

--- a/source/GameInterface/Services/Locations/BoardGames/Handlers/BoardGameRewardHandler.cs
+++ b/source/GameInterface/Services/Locations/BoardGames/Handlers/BoardGameRewardHandler.cs
@@ -1,0 +1,183 @@
+﻿using Common;
+using Common.Logging;
+using Common.Messaging;
+using Common.Network;
+using GameInterface.Services.Heroes.Patches;
+using GameInterface.Services.Locations.BoardGames.Messages;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.Players;
+using Helpers;
+using LiteNetLib;
+using Serilog;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
+using TaleWorlds.CampaignSystem.CharacterDevelopment;
+
+namespace GameInterface.Services.Locations.BoardGames.Handlers;
+
+internal class BoardGameRewardHandler : IHandler
+{
+    private static readonly ILogger Logger = LogManager.GetLogger<BoardGameRewardHandler>();
+
+    // No vanilla constant exists for these: they are literals in the
+    // taverngamehost_player_{100,200,300,400,500}_denars dialog lines and the
+    // matching SetBetAmount(N) consequences in BoardGameCampaignBehavior.
+    private static readonly int[] ValidBets = { 100, 200, 300, 400, 500 };
+
+    private readonly IMessageBroker messageBroker;
+    private readonly IObjectManager objectManager;
+    private readonly INetwork network;
+    private readonly IPlayerManager playerManager;
+
+    public BoardGameRewardHandler(
+        IMessageBroker messageBroker,
+        IObjectManager objectManager,
+        INetwork network,
+        IPlayerManager playerManager)
+    {
+        this.messageBroker = messageBroker;
+        this.objectManager = objectManager;
+        this.network = network;
+        this.playerManager = playerManager;
+
+        messageBroker.Subscribe<BoardGameTavernResult>(Handle_BoardGameTavernResult);
+        messageBroker.Subscribe<NetworkBoardGameTavernResult>(Handle_NetworkBoardGameTavernResult);
+        messageBroker.Subscribe<BoardGameLordResult>(Handle_BoardGameLordResult);
+        messageBroker.Subscribe<NetworkBoardGameLordResult>(Handle_NetworkBoardGameLordResult);
+    }
+
+    public void Dispose()
+    {
+        messageBroker.Unsubscribe<BoardGameTavernResult>(Handle_BoardGameTavernResult);
+        messageBroker.Unsubscribe<NetworkBoardGameTavernResult>(Handle_NetworkBoardGameTavernResult);
+        messageBroker.Unsubscribe<BoardGameLordResult>(Handle_BoardGameLordResult);
+        messageBroker.Unsubscribe<NetworkBoardGameLordResult>(Handle_NetworkBoardGameLordResult);
+    }
+
+    private void Handle_BoardGameTavernResult(MessagePayload<BoardGameTavernResult> obj)
+    {
+        var data = obj.What;
+        GameThread.RunSafe(() =>
+        {
+            network.SendAll(new NetworkBoardGameTavernResult(
+                data.BetAmount, data.GameOver));
+            Logger.Information("Forwarding board-game tavern result: bet {Bet} outcome {Outcome}",
+                data.BetAmount, data.GameOver);
+        }, context: nameof(BoardGameRewardHandler));
+    }
+
+    private void Handle_NetworkBoardGameTavernResult(MessagePayload<NetworkBoardGameTavernResult> obj)
+    {
+        if (ModInformation.IsClient) return;
+        var data = obj.What;
+        if (obj.Who is not NetPeer peer || !playerManager.TryGetPlayer(peer, out var player))
+        {
+            Logger.Error("Received {Message} without a registered player peer", nameof(NetworkBoardGameTavernResult));
+            return;
+        }
+
+        GameThread.RunSafe(() =>
+        {
+            // All registry lookups stay inside the game-thread closure so they
+            // run ordered behind deferred registrations on the same FIFO queue.
+            if (!objectManager.TryGetObjectWithLogging<Hero>(player.HeroId, out var playerHero)) return;
+            if (System.Array.IndexOf(ValidBets, data.BetAmount) < 0)
+            {
+                Logger.Warning("Dropping board-game tavern result with invalid bet {Bet}", data.BetAmount);
+                return;
+            }
+
+            if (data.GameOver == BoardGameHelper.BoardGameState.Win)
+            {
+                GiveGoldAction.ApplyBetweenCharacters(null, playerHero, data.BetAmount, false);
+                Logger.Information("Applied board-game tavern win: {Bet} gold for hero {HeroId}", data.BetAmount, player.HeroId);
+            }
+            else if (data.GameOver == BoardGameHelper.BoardGameState.Loss)
+            {
+                GiveGoldAction.ApplyBetweenCharacters(playerHero, null, data.BetAmount, false);
+                Logger.Information("Applied board-game tavern loss: {Bet} gold from hero {HeroId}", data.BetAmount, player.HeroId);
+            }
+            else
+                Logger.Warning("Dropping board-game tavern result with invalid outcome {Outcome}", data.GameOver);
+            // Runs with patches live: Hero.Gold autosync and NotifyGoldChanged
+            // replicate to clients. Never wrap in AllowedThread here.
+        }, context: nameof(BoardGameRewardHandler));
+    }
+
+    private void Handle_BoardGameLordResult(MessagePayload<BoardGameLordResult> obj)
+    {
+        var data = obj.What;
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetIdWithLogging(data.OpposingHero, out var opposingHeroId)) return;
+            network.SendAll(new NetworkBoardGameLordResult(
+                opposingHeroId, data.Difficulty, data.Reward, data.ExtraXp));
+            Logger.Information("Forwarding board-game lord result: reward {Reward} difficulty {Difficulty} against hero {HeroId}",
+                data.Reward, data.Difficulty, opposingHeroId);
+        }, context: nameof(BoardGameRewardHandler));
+    }
+
+    private void Handle_NetworkBoardGameLordResult(MessagePayload<NetworkBoardGameLordResult> obj)
+    {
+        if (ModInformation.IsClient) return;
+        var data = obj.What;
+        if (!(obj.Who is NetPeer peer) || !playerManager.TryGetPlayer(peer, out var player))
+        {
+            Logger.Error("Received {Message} without a registered player peer", nameof(NetworkBoardGameLordResult));
+            return;
+        }
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<Hero>(player.HeroId, out var playerHero)) return;
+            if (!objectManager.TryGetObjectWithLogging<Hero>(data.OpposingHeroId, out var opposingHero)) return;
+            if (!System.Enum.IsDefined(typeof(BoardGameHelper.AIDifficulty), data.Difficulty)
+                || !System.Enum.IsDefined(typeof(LordBoardGameReward), data.Reward)
+                || data.Difficulty == BoardGameHelper.AIDifficulty.NumTypes)
+            {
+                Logger.Warning("Dropping board-game lord result with invalid payload");
+                return;
+            }
+            // Mirror vanilla legality (OnPlayerBoardGameOver: flag2 and the
+            // influence branch both require Hard; extra XP is only rolled
+            // otherwise): influence and renown only exist on Hard, extra XP
+            // only on non-Hard difficulties.
+            bool isHard = data.Difficulty == BoardGameHelper.AIDifficulty.Hard;
+            if ((data.Reward == LordBoardGameReward.Influence || data.Reward == LordBoardGameReward.Renown) && !isHard)
+            {
+                Logger.Warning("Dropping board-game lord result with {Reward} on non-Hard difficulty", data.Reward);
+                return;
+            }
+            if (data.ExtraXp && isHard)
+            {
+                Logger.Warning("Dropping board-game lord result with extra XP on Hard difficulty");
+                return;
+            }
+
+            // Makes vanilla Hero.MainHero derefs resolve to the requesting
+            // player and feeds ResolvedMainHeroContext for the relation patch.
+            using (new MainHeroSubstitutionScope(playerHero, playerHero.PartyBelongedTo))
+            {
+                SkillLevelingManager.OnBoardGameWonAgainstLord(
+                    opposingHero,
+                    data.Difficulty,
+                    data.ExtraXp);
+
+                switch (data.Reward)
+                {
+                    case LordBoardGameReward.Relation:
+                        ChangeRelationAction.ApplyPlayerRelation(opposingHero, 1, true, true);
+                        break;
+                    case LordBoardGameReward.Influence:
+                        GainKingdomInfluenceAction.ApplyForBoardGameWon(opposingHero, 1f);
+                        break;
+                    case LordBoardGameReward.Renown:
+                        GainRenownAction.Apply(playerHero, 1f, false);
+                        break;
+                }
+                Logger.Information("Applied board-game lord win: reward {Reward} difficulty {Difficulty} for hero {HeroId} against hero {OpposingHeroId}",
+                    data.Reward, data.Difficulty, player.HeroId, data.OpposingHeroId);
+            }
+        }, context: nameof(BoardGameRewardHandler));
+    }
+}

--- a/source/GameInterface/Services/Locations/BoardGames/Messages/BoardGameRewardMessages.cs
+++ b/source/GameInterface/Services/Locations/BoardGames/Messages/BoardGameRewardMessages.cs
@@ -1,0 +1,82 @@
+﻿using Common.Messaging;
+using Helpers;
+using ProtoBuf;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Locations.BoardGames.Messages;
+
+public enum LordBoardGameReward
+{
+    None = 0,
+    Relation = 1,
+    Influence = 2,
+    Renown = 3,
+}
+
+// Local events, published by the patch on the client.
+public readonly struct BoardGameTavernResult : IEvent
+{
+    public readonly int BetAmount;
+    public readonly BoardGameHelper.BoardGameState GameOver;
+
+    public BoardGameTavernResult(int betAmount, BoardGameHelper.BoardGameState gameOver)
+    {
+        BetAmount = betAmount;
+        GameOver = gameOver;
+    }
+}
+
+public readonly struct BoardGameLordResult : IEvent
+{
+    public readonly Hero OpposingHero;
+    public readonly BoardGameHelper.AIDifficulty Difficulty;
+    public readonly LordBoardGameReward Reward;
+    public readonly bool ExtraXp;
+
+    public BoardGameLordResult(Hero opposingHero, BoardGameHelper.AIDifficulty difficulty, LordBoardGameReward reward, bool extraXp)
+    {
+        OpposingHero = opposingHero;
+        Difficulty = difficulty;
+        Reward = reward;
+        ExtraXp = extraXp;
+    }
+}
+
+// Network commands, client to server. The tavern payout hero is resolved
+// server-side from the sending peer's player registry, so no hero or
+// settlement ids travel on the wire.
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkBoardGameTavernResult : ICommand
+{
+    [ProtoMember(1)]
+    public readonly int BetAmount;
+    [ProtoMember(2)]
+    public readonly BoardGameHelper.BoardGameState GameOver;
+
+    public NetworkBoardGameTavernResult(int betAmount, BoardGameHelper.BoardGameState gameOver)
+    {
+        BetAmount = betAmount;
+        GameOver = gameOver;
+    }
+}
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkBoardGameLordResult : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string OpposingHeroId;
+    [ProtoMember(2)]
+    public readonly BoardGameHelper.AIDifficulty Difficulty;
+    [ProtoMember(3)]
+    public readonly LordBoardGameReward Reward;
+    [ProtoMember(4)]
+    public readonly bool ExtraXp;
+
+    public NetworkBoardGameLordResult(string opposingHeroId, BoardGameHelper.AIDifficulty difficulty, LordBoardGameReward reward, bool extraXp)
+    {
+        OpposingHeroId = opposingHeroId;
+        Difficulty = difficulty;
+        Reward = reward;
+        ExtraXp = extraXp;
+    }
+}

--- a/source/GameInterface/Services/Locations/BoardGames/Patches/BoardGameRewardPatches.cs
+++ b/source/GameInterface/Services/Locations/BoardGames/Patches/BoardGameRewardPatches.cs
@@ -1,0 +1,56 @@
+﻿using Common;
+using Common.Messaging;
+using GameInterface.Services.Locations.BoardGames.Messages;
+using HarmonyLib;
+using Helpers;
+using SandBox.CampaignBehaviors;
+using TaleWorlds.CampaignSystem;
+
+namespace GameInterface.Services.Locations.BoardGames.Patches;
+
+[HarmonyPatch(typeof(BoardGameCampaignBehavior), "OnPlayerBoardGameOver")]
+internal static class BoardGameRewardPatches
+{
+    // Prefix runs before vanilla's rolls. Resetting the sticky flags lets the
+    // postfix attribute exactly this game's outcome to this game.
+    internal static void Prefix(BoardGameCampaignBehavior __instance, out int __state)
+    {
+        __state = 0;
+        if (ModInformation.IsServer) return;
+        // Captured here: vanilla ends the call with SetBetAmount(0), so
+        // the postfix would otherwise always see a zero bet and forward nothing.
+        __state = __instance._betAmount;
+        __instance._relationGained = false;
+        __instance._influenceGained = false;
+        __instance._renownGained = false;
+        __instance._gainedNothing = false;
+    }
+
+    internal static void Postfix(BoardGameCampaignBehavior __instance, Hero opposingHero, BoardGameHelper.BoardGameState state, int __state)
+    {
+        if (ModInformation.IsServer) return;
+
+        if (opposingHero == null)
+        {
+            // Tavern game. Bet 0, draw, and cancel need no forwarding.
+            if (__state <= 0) return;
+            if (state != BoardGameHelper.BoardGameState.Win && state != BoardGameHelper.BoardGameState.Loss) return;
+            MessageBroker.Instance.Publish(__instance, new BoardGameTavernResult(
+                __state,
+                state));
+            return;
+        }
+
+        // Lord game
+        if (state != BoardGameHelper.BoardGameState.Win) return;
+        var reward = LordBoardGameReward.None;
+        if (__instance._relationGained) reward = LordBoardGameReward.Relation;
+        else if (__instance._influenceGained) reward = LordBoardGameReward.Influence;
+        else if (__instance._renownGained) reward = LordBoardGameReward.Renown;
+        MessageBroker.Instance.Publish(__instance, new BoardGameLordResult(
+            opposingHero,
+            __instance._difficulty,
+            reward,
+            __instance._opposingHeroExtraXPGained));
+    }
+}


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Winning or loosing in board game in the tavern or against the lord does not yield any rewards or deduct the bet amount from the player.

## What is the new behavior?

- Bet amount properly awarded/deducted when winning/loosing a game in the tavern
- When winning a game against a lord it awards XP and relationship mimicking the vanilla behavior

<!-- Insert issue id after hashtag. -->
Resolves #2301
<!-- Describe functionality added. Add images or videos to show how it works if applies -->


## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Sync board-game tavern and lord rewards

## Other information
