### PR TITLE
Defer caravan trade item resolution until campaign apply

### DIFF
--- a/source/GameInterface.Tests/Serialization/CaravanTradeItemSerializationTests.cs
+++ b/source/GameInterface.Tests/Serialization/CaravanTradeItemSerializationTests.cs
@@ -1,0 +1,91 @@
+﻿using GameInterface.Services.Caravans.Messages;
+using GameInterface.Surrogates;
+using ProtoBuf;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using TaleWorlds.CampaignSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Serialization;
+
+/// <summary>Checks that caravan trade messages retain unresolved item identities.</summary>
+public class CaravanTradeItemSerializationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("unregistered-caravan-modifier")]
+    public async Task Receive_PreservesUnknownItemsAndHistoricalWireShape(string? modifierId)
+    {
+        _ = new SurrogateCollection();
+        var original = new HistoricalMessage
+        {
+            PartyId = "caravan-party",
+            Rows = new List<HistoricalRow>
+            {
+                new HistoricalRow
+                {
+                    BoughtSettlementId = "town_ES1",
+                    BuyPrice = 14,
+                    SellPrice = 19,
+                    Item = new ItemRosterElementSurrogate
+                    {
+                        ItemObjectId = "unregistered-caravan-item",
+                        Amount = 7,
+                        ItemModifierId = modifierId,
+                    },
+                    SoldSettlementId = "town_V1",
+                    BoughtTime = new CampaignTime(12345),
+                },
+            },
+        };
+
+        byte[] bytes = Serialize(original);
+        var received = await Task.Run(() => Deserialize<NetworkUpdateTradeActionLogsForParty>(bytes));
+        byte[] forwarded = Serialize(received);
+        var historical = Deserialize<HistoricalMessage>(forwarded);
+
+        Assert.Equal(bytes, forwarded);
+        Assert.Equal(original.PartyId, historical.PartyId);
+        var row = Assert.Single(historical.Rows);
+        Assert.Equal("unregistered-caravan-item", row.Item.ItemObjectId);
+        Assert.Equal(modifierId, row.Item.ItemModifierId);
+        Assert.Equal(7, row.Item.Amount);
+        Assert.Equal(14, row.BuyPrice);
+        Assert.Equal(19, row.SellPrice);
+        Assert.Equal(12345, row.BoughtTime.NumTicks);
+    }
+
+    private static byte[] Serialize<T>(T value)
+    {
+        using var stream = new MemoryStream();
+        Serializer.Serialize(stream, value);
+        return stream.ToArray();
+    }
+
+    private static T Deserialize<T>(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        return Serializer.Deserialize<T>(stream);
+    }
+
+    /// <summary>Historical outer wire contract, without native roster reconstruction.</summary>
+    [ProtoContract]
+    private sealed class HistoricalMessage
+    {
+        [ProtoMember(1)] public string PartyId { get; set; } = null!;
+        [ProtoMember(2)] public List<HistoricalRow> Rows { get; set; } = new();
+    }
+
+    /// <summary>Historical row with the roster surrogate exposed as data.</summary>
+    [ProtoContract]
+    private sealed class HistoricalRow
+    {
+        [ProtoMember(1)] public string BoughtSettlementId { get; set; } = null!;
+        [ProtoMember(2)] public int BuyPrice { get; set; }
+        [ProtoMember(3)] public int SellPrice { get; set; }
+        [ProtoMember(4)] public ItemRosterElementSurrogate Item { get; set; }
+        [ProtoMember(5)] public string SoldSettlementId { get; set; } = null!;
+        [ProtoMember(6)] public CampaignTime BoughtTime { get; set; }
+    }
+}

--- a/source/GameInterface.Tests/Services/Caravans/CaravanTradeApplyTests.cs
+++ b/source/GameInterface.Tests/Services/Caravans/CaravanTradeApplyTests.cs
@@ -1,0 +1,76 @@
+﻿using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Services.Caravans.Data;
+using GameInterface.Services.Caravans.Handlers;
+using GameInterface.Services.Caravans.Interfaces;
+using GameInterface.Services.MobileParties.Interfaces;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Tests.Bootstrap;
+using Moq;
+using System;
+using TaleWorlds.Core;
+using TaleWorlds.ObjectSystem;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Caravans;
+
+/// <summary>Checks native trade-item reconstruction after queued registration.</summary>
+[Collection(ModInformationRoleCollection.Name)]
+public class CaravanTradeApplyTests
+{
+    [Theory]
+    [InlineData(true, false, false, true)]
+    [InlineData(true, true, true, true)]
+    [InlineData(false, false, false, false)]
+    [InlineData(true, true, false, false)]
+    public void Apply_RequiresAllReferencedObjects(
+        bool registerItem, bool hasModifier, bool registerModifier, bool expected)
+    {
+        GameBootStrap.Initialize();
+        var manager = MBObjectManager.Instance;
+        var item = ObjectHelper.SkipConstructor<ItemObject>();
+        item.StringId = "caravan-test-" + Guid.NewGuid().ToString("N");
+        var modifier = ObjectHelper.SkipConstructor<ItemModifier>();
+        modifier.StringId = "caravan-modifier-test-" + Guid.NewGuid().ToString("N");
+        var row = new TradeActionLogData
+        {
+            BuyPrice = 10,
+            SellPrice = 12,
+            ItemRosterElement = new CaravanTradeItemData
+            {
+                ItemObjectId = item.StringId,
+                ItemModifierId = hasModifier ? modifier.StringId : null!,
+                Amount = 3,
+            },
+        };
+        using var handler = new CaravansCampaignBehaviorHandler(
+            new Mock<IMessageBroker>().Object,
+            new Mock<IObjectManager>().Object,
+            new Mock<INetwork>().Object,
+            new Mock<ISessionCaravansPlayerDataInterface>().Object,
+            new Mock<ISessionInteractionsPlayerDataInterface>().Object);
+
+        try
+        {
+            Assert.False(handler.UnpackTradeActionLogData(row, out _));
+            if (registerItem) manager.RegisterObject(item);
+            if (registerModifier) manager.RegisterObject(modifier);
+
+            Assert.Equal(expected, handler.UnpackTradeActionLogData(row, out var result));
+            if (expected)
+            {
+                Assert.Same(item, result.ItemRosterElement.EquipmentElement.Item);
+                Assert.Same(hasModifier ? modifier : null, result.ItemRosterElement.EquipmentElement.ItemModifier);
+                Assert.Equal(3, result.ItemRosterElement.Amount);
+                Assert.Equal(10, result.BuyPrice);
+                Assert.Equal(12, result.SellPrice);
+            }
+        }
+        finally
+        {
+            if (registerModifier) manager.UnregisterObject(modifier);
+            if (registerItem) manager.UnregisterObject(item);
+        }
+    }
+}

--- a/source/GameInterface/Services/Caravans/Data/TradeActionLogData.cs
+++ b/source/GameInterface/Services/Caravans/Data/TradeActionLogData.cs
@@ -17,7 +17,7 @@ public struct TradeActionLogData
     public int SellPrice { get; set; }
 
     [ProtoMember(4)]
-    public ItemRosterElement ItemRosterElement { get; set; }
+    public CaravanTradeItemData ItemRosterElement { get; set; }
 
     [ProtoMember(5)]
     public string SoldSettlementId { get; set; }
@@ -36,8 +36,30 @@ public struct TradeActionLogData
         BoughtSettlementId = boughtSettlementId;
         BuyPrice = buyPrice;
         SellPrice = sellPrice;
-        ItemRosterElement = itemRosterElement;
+        ItemRosterElement = new CaravanTradeItemData
+        {
+            ItemObjectId = itemRosterElement.EquipmentElement.Item?.StringId,
+            Amount = itemRosterElement.Amount,
+            ItemModifierId = itemRosterElement.EquipmentElement.ItemModifier?.StringId,
+        };
         SoldSettlementId = soldSettlementId;
         BoughtTime = boughtTime;
     }
+}
+
+/// <summary>
+/// Retains native item identities until the caravan update reaches the game thread.
+/// Field numbers match the existing ItemRosterElement surrogate wire contract.
+/// </summary>
+[ProtoContract(SkipConstructor = true)]
+public struct CaravanTradeItemData
+{
+    [ProtoMember(1)]
+    public string ItemObjectId { get; set; }
+
+    [ProtoMember(2)]
+    public int Amount { get; set; }
+
+    [ProtoMember(3)]
+    public string ItemModifierId { get; set; }
 }

--- a/source/GameInterface/Services/Caravans/Handlers/CaravansCampaignBehaviorHandler.cs
+++ b/source/GameInterface/Services/Caravans/Handlers/CaravansCampaignBehaviorHandler.cs
@@ -15,6 +15,8 @@ using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
 using TaleWorlds.CampaignSystem.Party;
 using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using TaleWorlds.ObjectSystem;
 
 namespace GameInterface.Services.Caravans.Handlers;
 
@@ -290,9 +292,24 @@ internal class CaravansCampaignBehaviorHandler : IHandler
         return true;
     }
 
-    private bool UnpackTradeActionLogData(TradeActionLogData tradeActionLogData, out CaravansCampaignBehavior.TradeActionLog tradeActionLog)
+    internal bool UnpackTradeActionLogData(TradeActionLogData tradeActionLogData, out CaravansCampaignBehavior.TradeActionLog tradeActionLog)
     {
         tradeActionLog = new();
+
+        // The preceding queued crafted-item creation must run before these native lookups.
+        var itemData = tradeActionLogData.ItemRosterElement;
+        var item = string.IsNullOrEmpty(itemData.ItemObjectId)
+            ? null
+            : MBObjectManager.Instance.GetObject<ItemObject>(itemData.ItemObjectId);
+        var modifier = string.IsNullOrEmpty(itemData.ItemModifierId)
+            ? null
+            : MBObjectManager.Instance.GetObject<ItemModifier>(itemData.ItemModifierId);
+        if (item == null || (!string.IsNullOrEmpty(itemData.ItemModifierId) && modifier == null))
+        {
+            Logger.Debug("Skipping caravan trade record with unavailable item {ItemId} or modifier {ModifierId}",
+                itemData.ItemObjectId, itemData.ItemModifierId);
+            return false;
+        }
 
         Settlement boughtSettlement = null;
         if (tradeActionLogData.BoughtSettlementId != null && !objectManager.TryGetObjectWithLogging(tradeActionLogData.BoughtSettlementId, out boughtSettlement)) return false;
@@ -305,7 +322,7 @@ internal class CaravansCampaignBehaviorHandler : IHandler
             BoughtSettlement = boughtSettlement,
             BuyPrice = tradeActionLogData.BuyPrice,
             SellPrice = tradeActionLogData.SellPrice,
-            ItemRosterElement = tradeActionLogData.ItemRosterElement,
+            ItemRosterElement = new ItemRosterElement(item, itemData.Amount, modifier),
             SoldSettlement = soldSettlement,
             BoughtTime = tradeActionLogData.BoughtTime
         };


### PR DESCRIPTION
## What is the current behavior?
caravan trade messages resolve native items while decoding the packet. a crafted item can still be waiting in the game-thread queue, so the trade record loses its item before that creation runs.

## What is the new behavior?
keep item and modifier ids in the message and resolve them in the existing queued caravan apply. native StringIds and protobuf field numbers are unchanged. records with unavailable references are skipped.

## How to test
- six tests cover historical wire compatibility, unresolved ids, native registration and missing item/modifier references. both wire regressions fail before the fix.
- GameInterface.Tests: 1,315 passed, 11 existing skips on the unchanged rerun. the initial full run had two command-discovery failures; those six dispatcher tests pass in isolation. the intermittent failure cause is unconfirmed.
- live server/client verification not run.

## Bot Changelog Entry
- Preserve caravan trade records when their crafted items are still being synchronized.