### PR TITLE
Add mission receive-path diagnostics

### DIFF
--- a/source/Common.Tests/Logging/ReceivePathDiagnosticsTests.cs
+++ b/source/Common.Tests/Logging/ReceivePathDiagnosticsTests.cs
@@ -1,0 +1,80 @@
+﻿using Common.Logging;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Common.Tests.Logging;
+
+public class ReceivePathDiagnosticsTests
+{
+    [Fact]
+    public void Categories_EmitFirstEvidenceThenAggregateUntilIntervalOrTeardown()
+    {
+        long now = 0;
+        var sink = new CaptureSink();
+        using var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        var diagnostics = new ReceivePathDiagnostics(() => now, 100);
+        diagnostics.Start(logger, "mission instance=MapEvent_Created_8683 peer=97");
+        diagnostics.Record(ReceivePathEvent.MappedReceive, 10);
+        diagnostics.Record(ReceivePathEvent.UnmappedDrop, 20);
+        for (int i = 0; i < 1000; i++) diagnostics.Record(ReceivePathEvent.UnmappedDrop, 20);
+        Assert.Equal(3, sink.Events.Count);
+        now = 100;
+        diagnostics.Record(ReceivePathEvent.MappedReceive, 10);
+        Assert.Equal(4, sink.Events.Count);
+        diagnostics.End("peer-removed");
+        diagnostics.End("duplicate-end");
+        diagnostics.Record(ReceivePathEvent.MappedReceive, 10);
+        Assert.Equal(5, sink.Events.Count);
+        string summary = sink.Events.Last().RenderMessage();
+        Assert.Contains("MappedReceive\": 2", summary);
+        Assert.Contains("UnmappedDrop\": 1001", summary);
+        Assert.Contains("UnmappedDrop\": 20020", summary);
+        Assert.Contains("MapEvent_Created_8683", summary);
+        Assert.Contains("utc=", summary);
+    }
+
+    [Fact]
+    public void Restart_ResetsTotalsFirstEvidenceAndCorrelation()
+    {
+        var sink = new CaptureSink();
+        using var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        var diagnostics = new ReceivePathDiagnostics(() => 0, 100);
+        diagnostics.Start(logger, "old-peer");
+        diagnostics.Record(ReceivePathEvent.UdpForwardFailed, 42, SocketError.ConnectionRefused);
+        diagnostics.End("closed");
+        var oldLifetime = sink.Events.Last().Properties["Lifetime"];
+        diagnostics.Start(logger, "new-peer");
+        diagnostics.Record(ReceivePathEvent.UdpForwarded, 8);
+        var latest = sink.Events.Last();
+        Assert.NotEqual(oldLifetime, latest.Properties["Lifetime"]);
+        Assert.Contains("UdpForwardFailed\": 0", latest.RenderMessage());
+        Assert.Contains("UdpForwarded\": 1", latest.RenderMessage());
+        Assert.Contains("Success", latest.RenderMessage());
+        Assert.DoesNotContain("old-peer", latest.RenderMessage());
+    }
+
+    [Fact]
+    public void ConcurrentFailures_CountExactlyAndKeepFirstSocketErrorEvidenceBounded()
+    {
+        var sink = new CaptureSink();
+        using var logger = new LoggerConfiguration().WriteTo.Sink(sink).CreateLogger();
+        var diagnostics = new ReceivePathDiagnostics(() => 0, 100);
+        diagnostics.Start(logger, "steam-host connection=7");
+        Parallel.For(0, 10000, _ => diagnostics.Record(ReceivePathEvent.UdpForwardFailed, 3, SocketError.NoBufferSpaceAvailable));
+        Assert.Equal(2, sink.Events.Count);
+        Assert.Contains("NoBufferSpaceAvailable", sink.Events.Last().RenderMessage());
+        diagnostics.End("stopped");
+        Assert.Contains("UdpForwardFailed\": 10000", sink.Events.Last().RenderMessage());
+        Assert.Contains("UdpForwardFailed\": 30000", sink.Events.Last().RenderMessage());
+    }
+
+    private sealed class CaptureSink : ILogEventSink
+    {
+        public ConcurrentQueue<LogEvent> Events { get; } = new();
+        public void Emit(LogEvent logEvent) => Events.Enqueue(logEvent);
+    }
+}

--- a/source/Common/Logging/ReceivePathDiagnostics.cs
+++ b/source/Common/Logging/ReceivePathDiagnostics.cs
@@ -1,0 +1,112 @@
+﻿using Serilog;
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Net.Sockets;
+
+namespace Common.Logging;
+
+public interface IReceivePathDiagnostics
+{
+    void Start(ILogger context, string correlation);
+    void Record(ReceivePathEvent kind, int bytes = 0, SocketError error = SocketError.Success);
+    void End(string reason);
+}
+
+/// <summary>One peer/route lifetime, with first evidence and cumulative, bounded traffic summaries.</summary>
+public class ReceivePathDiagnostics : IReceivePathDiagnostics
+{
+    private readonly object gate = new object();
+    private readonly Func<long> timestamp;
+    private readonly long interval;
+    private readonly long[] counts = new long[(int)ReceivePathEvent.Count];
+    private readonly long[] bytes = new long[(int)ReceivePathEvent.Count];
+    private ILogger logger;
+    private string correlation;
+    private Guid lifetime;
+    private long lastEmission;
+    private SocketError lastSocketError;
+    private bool ended;
+
+    public ReceivePathDiagnostics() : this(Stopwatch.GetTimestamp, Stopwatch.Frequency * 10) { }
+
+    internal ReceivePathDiagnostics(Func<long> timestamp, long interval)
+    {
+        this.timestamp = timestamp;
+        this.interval = interval;
+    }
+
+    public void Start(ILogger context, string correlation)
+    {
+        lock (gate)
+        {
+            logger = context;
+            this.correlation = correlation;
+            lifetime = Guid.NewGuid();
+            Array.Clear(counts, 0, counts.Length);
+            Array.Clear(bytes, 0, bytes.Length);
+            lastSocketError = SocketError.Success;
+            lastEmission = timestamp();
+            ended = false;
+            logger.Information("[ReceivePath] utc={Utc:O} scope={Scope} lifetime={Lifetime} started",
+                DateTime.UtcNow, correlation, lifetime);
+        }
+    }
+
+    public void Record(ReceivePathEvent kind, int bytes = 0, SocketError error = SocketError.Success)
+    {
+        lock (gate)
+        {
+            if (ended || logger == null) return;
+            int index = (int)kind;
+            counts[index]++;
+            this.bytes[index] += bytes;
+            if (error != SocketError.Success) lastSocketError = error;
+            long now = timestamp();
+            // Each fixed category gets one prompt sample; repeats share a ten-second budget.
+            if (counts[index] != 1 && now - lastEmission < interval) return;
+            lastEmission = now;
+            Emit(kind.ToString());
+        }
+    }
+
+    public void End(string reason)
+    {
+        lock (gate)
+        {
+            if (ended || logger == null) return;
+            ended = true;
+            Emit(reason);
+        }
+    }
+
+    private void Emit(string reason)
+    {
+        var totals = new Dictionary<string, long>();
+        var byteTotals = new Dictionary<string, long>();
+        for (int i = 0; i < counts.Length; i++)
+        {
+            totals[((ReceivePathEvent)i).ToString()] = counts[i];
+            byteTotals[((ReceivePathEvent)i).ToString()] = bytes[i];
+        }
+        logger.Information(
+            "[ReceivePath] utc={Utc:O} scope={Scope} lifetime={Lifetime} reason={Reason} counts={@Counts} bytes={@Bytes} lastSocketError={SocketError}",
+            DateTime.UtcNow, correlation, lifetime, reason, totals, byteTotals, lastSocketError);
+    }
+}
+
+// Fixed categories bound both memory and first-evidence emissions.
+public enum ReceivePathEvent
+{
+    MappedReceive,
+    UnmappedDrop,
+    MissionPeerSend,
+    CampaignRelaySend,
+    SteamReceive,
+    UdpForwarded,
+    UdpForwardFailed,
+    NoEndpointDrop,
+    UdpReceiveError,
+    DisposedSocket,
+    Count,
+}

--- a/source/Coop.Core/Common/CommonModule.cs
+++ b/source/Coop.Core/Common/CommonModule.cs
@@ -21,6 +21,7 @@ public abstract class CommonModule : Module
 {
     protected override void Load(ContainerBuilder builder)
     {
+        builder.RegisterType<ReceivePathDiagnostics>().As<IReceivePathDiagnostics>().InstancePerDependency();
         builder.RegisterType<TaleWorldsModuleInfoProvider>().As<IModuleInfoProvider>().SingleInstance();
         builder.RegisterInstance(new CoopLogFile(null)).As<ICoopLogFile>().SingleInstance();
 

--- a/source/Coop.IntegrationTests/Missions/MissionDisconnectDetectionTests.cs
+++ b/source/Coop.IntegrationTests/Missions/MissionDisconnectDetectionTests.cs
@@ -168,7 +168,7 @@ public class MissionDisconnectDetectionTests
             controllerIdProvider.Object,
             steamBridge.Object,
             movementPacketCompressor.Object,
-            new ReliableMessageBatcher<string>(serializer.Object));
+            new ReliableMessageBatcher<string>(serializer.Object), () => new Common.Logging.ReceivePathDiagnostics());
 
         var droppedPeer = CreatePeer(new IPEndPoint(IPAddress.Loopback, 55001), 1);
 

--- a/source/Coop.Steam/SteamBoot.cs
+++ b/source/Coop.Steam/SteamBoot.cs
@@ -75,7 +75,7 @@ public static class SteamBoot
         JoinListener = new SteamJoinListener(messageBroker, lobbyApi);
         LobbyBrowser = new SteamLobbyBrowser(lobbyApi);
         Common.Network.Session.SessionDiscovery.SteamLobbyBrowser = LobbyBrowser;
-        TunnelPreparer = new SteamTunnelJoinEndpointPreparer();
+        TunnelPreparer = new SteamTunnelJoinEndpointPreparer(() => new ReceivePathDiagnostics());
         JoinListener.ProcessLaunchArguments(commandLine);
     }
 }

--- a/source/Coop.Steam/SteamMissionBridge.cs
+++ b/source/Coop.Steam/SteamMissionBridge.cs
@@ -1,4 +1,4 @@
-using Common;
+﻿using Common;
 using Common.Logging;
 using Common.Network.Session;
 using Serilog;
@@ -23,6 +23,7 @@ public class SteamMissionBridge : ISteamMissionBridge
     private readonly object gate = new object();
     private readonly object lifecycleGate = new object();
     private readonly ISteamTunnelTransport hostTransport;
+    private readonly Func<IReceivePathDiagnostics> diagnosticsFactory;
     private readonly SteamTunnelHost host;
     private readonly Func<ISteamTunnelTransport> clientTransportFactory;
     private readonly Action<Action> retiredCleanupScheduler;
@@ -31,11 +32,12 @@ public class SteamMissionBridge : ISteamMissionBridge
     private bool started;
     private bool disposed;
 
-    public SteamMissionBridge() : this(
+    public SteamMissionBridge(Func<IReceivePathDiagnostics> diagnosticsFactory) : this(
         SteamUser.GetSteamID().m_SteamID,
         new SteamNetworkingTunnelTransport(),
         () => new SteamNetworkingTunnelTransport(),
-        ScheduleRetiredCleanup)
+        ScheduleRetiredCleanup,
+        diagnosticsFactory)
     {
     }
 
@@ -43,15 +45,18 @@ public class SteamMissionBridge : ISteamMissionBridge
         ulong localSteamId,
         ISteamTunnelTransport hostTransport,
         Func<ISteamTunnelTransport> clientTransportFactory,
-        Action<Action> retiredCleanupScheduler)
+        Action<Action> retiredCleanupScheduler,
+        Func<IReceivePathDiagnostics> diagnosticsFactory)
     {
         LocalSteamId = localSteamId;
+        if (diagnosticsFactory == null) throw new ArgumentNullException(nameof(diagnosticsFactory));
+        this.diagnosticsFactory = diagnosticsFactory;
         this.hostTransport = hostTransport ?? throw new ArgumentNullException(nameof(hostTransport));
         this.clientTransportFactory = clientTransportFactory
             ?? throw new ArgumentNullException(nameof(clientTransportFactory));
         this.retiredCleanupScheduler = retiredCleanupScheduler
             ?? throw new ArgumentNullException(nameof(retiredCleanupScheduler));
-        host = new SteamTunnelHost(hostTransport);
+        host = new SteamTunnelHost(hostTransport, diagnosticsFactory);
         host.PeerDisconnected += HandlePeerDisconnected;
     }
 
@@ -104,7 +109,7 @@ public class SteamMissionBridge : ISteamMissionBridge
                 }
             }
 
-            client = new SteamTunnelClient(clientTransportFactory());
+            client = new SteamTunnelClient(clientTransportFactory(), diagnosticsFactory());
             client.Closed += () => HandleClientClosed(remoteSteamId, client);
 
             bool cannotStart;

--- a/source/Coop.Steam/SteamTunnelClient.cs
+++ b/source/Coop.Steam/SteamTunnelClient.cs
@@ -16,6 +16,7 @@ public class SteamTunnelClient : IDisposable
     private static readonly ILogger Logger = LogManager.GetLogger<SteamTunnelClient>();
 
     private readonly ISteamTunnelTransport transport;
+    private readonly IReceivePathDiagnostics diagnostics;
     private readonly byte[] udpBuffer = new byte[SteamTunnel.MaxDatagramBytes];
     private readonly byte[] steamBuffer = new byte[SteamTunnel.MaxDatagramBytes];
 
@@ -30,9 +31,11 @@ public class SteamTunnelClient : IDisposable
     // udpBuffer, which nothing overwrites until the retry succeeds.
     private int pendingLength;
 
-    public SteamTunnelClient(ISteamTunnelTransport transport)
+    public SteamTunnelClient(ISteamTunnelTransport transport, IReceivePathDiagnostics diagnostics)
     {
         this.transport = transport;
+        if (diagnostics == null) throw new ArgumentNullException(nameof(diagnostics));
+        this.diagnostics = diagnostics;
         transport.ConnectionStateChanged += OnConnectionStateChanged;
     }
 
@@ -55,6 +58,7 @@ public class SteamTunnelClient : IDisposable
 
         connection = transport.ConnectToHost(hostSteamId, virtualPort);
 
+        diagnostics.Start(Logger, $"steam-client connection={connection} remoteSteamId={hostSteamId} localRelay=127.0.0.1:{LocalPort} virtualPort={virtualPort}");
         poller = new Poller(Update, SteamTunnel.PumpInterval);
         poller.Start();
 
@@ -66,20 +70,28 @@ public class SteamTunnelClient : IDisposable
     {
         PumpToSteam();
 
+        int forwardingBytes = 0;
         try
         {
             int size;
             while ((size = transport.ReceiveDatagram(connection, steamBuffer)) > 0)
             {
                 // Nothing has dialed the pump yet; the server never sends first, so drop.
-                if (clientEndpoint == null) continue;
+                diagnostics.Record(ReceivePathEvent.SteamReceive, size);
+                if (clientEndpoint == null)
+                {
+                    diagnostics.Record(ReceivePathEvent.NoEndpointDrop, size);
+                    continue;
+                }
 
-                socket.SendTo(steamBuffer, size, SocketFlags.None, clientEndpoint);
+                forwardingBytes = size;
+                int sent = socket.SendTo(steamBuffer, size, SocketFlags.None, clientEndpoint);
+                diagnostics.Record(sent == size ? ReceivePathEvent.UdpForwarded : ReceivePathEvent.UdpForwardFailed, sent);
             }
         }
-        catch (SocketException)
+        catch (SocketException ex)
         {
-            // A refused loopback send loses one datagram; LiteNetLib retransmits what matters.
+            diagnostics.Record(ReceivePathEvent.UdpForwardFailed, forwardingBytes, ex.SocketErrorCode);
         }
     }
 
@@ -97,10 +109,15 @@ public class SteamTunnelClient : IDisposable
 
         while (true)
         {
-            int length = TunnelSocket.TryReceiveFrom(socket, udpBuffer, ref receiveSender);
+            int length = TunnelSocket.TryReceiveFrom(socket, udpBuffer, ref receiveSender, diagnostics);
             if (length < 0) break;
             if (length == 0) continue;
 
+            if (clientEndpoint == null)
+            {
+                Logger.Information("[ReceivePath] utc={Utc:O} connection={Connection} localRelayPort={LocalPort} UDP destination learned target={Target}",
+                    DateTime.UtcNow, connection, LocalPort, receiveSender);
+            }
             clientEndpoint = receiveSender;
             bool droppable = SteamTunnel.IsDroppableDatagram(udpBuffer, length);
             if (!transport.SendDatagram(connection, udpBuffer, length, droppable))
@@ -137,5 +154,6 @@ public class SteamTunnelClient : IDisposable
         transport.CloseConnection(connection);
         transport.Dispose();
         socket?.Close();
+        diagnostics.End("client-disposed");
     }
 }

--- a/source/Coop.Steam/SteamTunnelHost.cs
+++ b/source/Coop.Steam/SteamTunnelHost.cs
@@ -24,6 +24,7 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
     private sealed class TunnelPeer
     {
         public Socket Socket;
+        public IReceivePathDiagnostics Diagnostics;
         public IPEndPoint ServerPeerEndpoint;
         public ulong RemoteSteamId;
         public byte[] PendingDatagram = new byte[SteamTunnel.MaxDatagramBytes];
@@ -31,6 +32,7 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
     }
 
     private readonly ISteamTunnelTransport transport;
+    private readonly Func<IReceivePathDiagnostics> diagnosticsFactory;
     private readonly object gate = new object();
     private readonly HashSet<uint> connectingConnections = new HashSet<uint>();
     private readonly Dictionary<uint, TunnelPeer> peers = new Dictionary<uint, TunnelPeer>();
@@ -51,9 +53,11 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
     private const int StatsLogTicks = 5000;
     private int ticksSinceStatsLog;
 
-    public SteamTunnelHost(ISteamTunnelTransport transport)
+    public SteamTunnelHost(ISteamTunnelTransport transport, Func<IReceivePathDiagnostics> diagnosticsFactory)
     {
         this.transport = transport;
+        if (diagnosticsFactory == null) throw new ArgumentNullException(nameof(diagnosticsFactory));
+        this.diagnosticsFactory = diagnosticsFactory;
         transport.ConnectionStateChanged += OnConnectionStateChanged;
     }
 
@@ -87,6 +91,7 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
     {
         if (listening) return;
 
+        ticksSinceStatsLog = 0;
         serverEndpoint = new IPEndPoint(IPAddress.Loopback, serverPort);
         transport.EnsureRelayAccess();
         transport.ListenForClients(virtualPort);
@@ -149,6 +154,7 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
         {
             transport.CloseConnection(peer.Key);
             peer.Value.Socket.Close();
+            peer.Value.Diagnostics.End("host-stopped");
         }
 
         Logger.Information("Steam tunnel host stopped");
@@ -198,9 +204,12 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
                         {
                             identityResolver.TryGetRemoteSteamId(connection, out steamId);
                         }
+                        var diagnostics = diagnosticsFactory();
+                        diagnostics.Start(Logger, $"steam-host connection={connection} remoteSteamId={steamId} localRelay={serverPeerEndpoint} target={serverEndpoint}");
                         peers[connection] = new TunnelPeer
                         {
                             Socket = socket,
+                            Diagnostics = diagnostics,
                             ServerPeerEndpoint = serverPeerEndpoint,
                             RemoteSteamId = steamId,
                         };
@@ -238,6 +247,7 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
 
     private void RemovePeerLocked(uint connection, TunnelPeer peer)
     {
+        peer.Diagnostics.End("peer-removed");
         peers.Remove(connection);
         remoteSteamIds.Remove(peer.ServerPeerEndpoint);
         peerSnapshot = peers.ToArray();
@@ -257,6 +267,8 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
 
         foreach (var peer in peerSnapshot)
         {
+            bool forwarding = false;
+            int forwardingBytes = 0;
             try
             {
                 PumpToSteam(peer.Key, peer.Value);
@@ -264,17 +276,22 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
                 int size;
                 while ((size = transport.ReceiveDatagram(peer.Key, steamBuffer)) > 0)
                 {
-                    peer.Value.Socket.Send(steamBuffer, size, SocketFlags.None);
+                    peer.Value.Diagnostics.Record(ReceivePathEvent.SteamReceive, size);
+                    forwarding = true;
+                    forwardingBytes = size;
+                    int sent = peer.Value.Socket.Send(steamBuffer, size, SocketFlags.None);
+                    peer.Value.Diagnostics.Record(sent == size ? ReceivePathEvent.UdpForwarded : ReceivePathEvent.UdpForwardFailed, sent);
+                    forwarding = false;
                 }
             }
             catch (ObjectDisposedException)
             {
-                // The Closed handler disposed this peer's socket mid-tick; the next tick's
-                // snapshot no longer contains it.
+                peer.Value.Diagnostics.Record(ReceivePathEvent.DisposedSocket);
             }
-            catch (SocketException)
+            catch (SocketException ex)
             {
-                // A refused loopback send loses one datagram; LiteNetLib retransmits what matters.
+                peer.Value.Diagnostics.Record(forwarding ? ReceivePathEvent.UdpForwardFailed : ReceivePathEvent.UdpReceiveError,
+                    forwarding ? forwardingBytes : 0, ex.SocketErrorCode);
             }
         }
     }
@@ -292,7 +309,7 @@ public class SteamTunnelHost : ISessionTunnelHost, ISessionTunnelIdentityResolve
         }
 
         int length;
-        while ((length = TunnelSocket.TryReceiveFrom(peer.Socket, serverBuffer, ref receiveSender)) >= 0)
+        while ((length = TunnelSocket.TryReceiveFrom(peer.Socket, serverBuffer, ref receiveSender, peer.Diagnostics)) >= 0)
         {
             if (length == 0) continue;
 

--- a/source/Coop.Steam/SteamTunnelJoinEndpointPreparer.cs
+++ b/source/Coop.Steam/SteamTunnelJoinEndpointPreparer.cs
@@ -18,6 +18,13 @@ public class SteamTunnelJoinEndpointPreparer : IJoinEndpointPreparer
 
     private readonly object gate = new object();
     private SteamTunnelClient tunnel;
+    private readonly Func<IReceivePathDiagnostics> diagnosticsFactory;
+
+    public SteamTunnelJoinEndpointPreparer(Func<IReceivePathDiagnostics> diagnosticsFactory)
+    {
+        if (diagnosticsFactory == null) throw new ArgumentNullException(nameof(diagnosticsFactory));
+        this.diagnosticsFactory = diagnosticsFactory;
+    }
 
     public Task<SessionJoinInfo> PrepareAsync(SessionJoinInfo info)
     {
@@ -28,7 +35,7 @@ public class SteamTunnelJoinEndpointPreparer : IJoinEndpointPreparer
             SteamTunnelClient client = null;
             try
             {
-                client = new SteamTunnelClient(new SteamNetworkingTunnelTransport());
+                client = new SteamTunnelClient(new SteamNetworkingTunnelTransport(), diagnosticsFactory());
                 client.Start(info.HostSteamId);
             }
             catch (Exception ex)

--- a/source/Coop.Steam/TunnelSocket.cs
+++ b/source/Coop.Steam/TunnelSocket.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Common.Logging;
+using System;
 using System.Net;
 using System.Net.Sockets;
 
@@ -29,8 +30,11 @@ internal static class TunnelSocket
         {
             socket.IOControl(SioUdpConnReset, new byte[] { 0 }, null);
         }
-        catch (SocketException)
+        catch (SocketException ex)
         {
+            LogManager.GetLogger(typeof(TunnelSocket)).Warning(
+                "[ReceivePath] utc={Utc:O} UDP reset suppression unavailable socketError={SocketError}",
+                DateTime.UtcNow, ex.SocketErrorCode);
         }
         catch (PlatformNotSupportedException)
         {
@@ -43,7 +47,7 @@ internal static class TunnelSocket
     public static EndPoint AnyEndpoint() => new IPEndPoint(IPAddress.Any, 0);
 
     /// <summary>Returns the datagram length, 0 for a transient error worth skipping, -1 when drained.</summary>
-    public static int TryReceiveFrom(Socket socket, byte[] buffer, ref EndPoint sender)
+    public static int TryReceiveFrom(Socket socket, byte[] buffer, ref EndPoint sender, IReceivePathDiagnostics diagnostics)
     {
         try
         {
@@ -53,6 +57,8 @@ internal static class TunnelSocket
         }
         catch (SocketException ex)
         {
+            if (ex.SocketErrorCode != SocketError.WouldBlock)
+                diagnostics.Record(ReceivePathEvent.UdpReceiveError, error: ex.SocketErrorCode);
             return ex.SocketErrorCode == SocketError.WouldBlock ? -1 : 0;
         }
     }

--- a/source/Coop.Tests/Steam/SteamMissionBridgeTests.cs
+++ b/source/Coop.Tests/Steam/SteamMissionBridgeTests.cs
@@ -1,4 +1,4 @@
-using Coop.Steam;
+﻿using Coop.Steam;
 using System;
 using Xunit;
 
@@ -17,7 +17,7 @@ namespace Coop.Tests.Steam
                 localSteamId: 2,
                 hostTransport,
                 () => clientTransport,
-                scheduledCleanup => cleanup = scheduledCleanup);
+                scheduledCleanup => cleanup = scheduledCleanup, () => new Common.Logging.ReceivePathDiagnostics());
 
             bridge.Start(4200);
             Assert.True(bridge.TryConnect(remoteSteamId: 1, out _));

--- a/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelClientTests.cs
@@ -1,4 +1,7 @@
 ﻿using Coop.Steam;
+using Common.Logging;
+using Moq;
+using System.Reflection;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -16,7 +19,7 @@ namespace Coop.Tests.Steam
 
         public SteamTunnelClientTests()
         {
-            client = new SteamTunnelClient(transport);
+            client = new SteamTunnelClient(transport, new Common.Logging.ReceivePathDiagnostics());
         }
 
         public void Dispose() => client.Dispose();
@@ -113,6 +116,45 @@ namespace Coop.Tests.Steam
 
             // Drained without a destination: the pump has not learned the client endpoint yet.
             WaitUntil(() => transport.ReceiveDatagram(transport.NextConnection, new byte[16]) == 0);
+        }
+
+        [Fact]
+        public void FailedLocalUdpForward_RecordsSocketErrorAndConsumedSteamDatagram()
+        {
+            var diagnostics = new Mock<IReceivePathDiagnostics>();
+            int failures = 0;
+            diagnostics.Setup(d => d.Record(ReceivePathEvent.UdpForwardFailed, 3, It.IsAny<SocketError>()))
+                .Callback<ReceivePathEvent, int, SocketError>((_, _, error) =>
+                {
+                    Assert.NotEqual(SocketError.Success, error);
+                    Interlocked.Increment(ref failures);
+                });
+            using var failingClient = new SteamTunnelClient(transport, diagnostics.Object);
+            // Broadcast is disabled on the pump socket; exercise the real Socket.SendTo failure.
+            typeof(SteamTunnelClient).GetField("clientEndpoint", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(failingClient, new IPEndPoint(IPAddress.Broadcast, 4200));
+            failingClient.Start(76561198000000042);
+            transport.EnqueueReceive(transport.NextConnection, new byte[] { 1, 2, 3 });
+            WaitUntil(() => Volatile.Read(ref failures) == 1);
+            diagnostics.Verify(d => d.Record(ReceivePathEvent.SteamReceive, 3, SocketError.Success), Times.Once);
+            diagnostics.Verify(d => d.Record(ReceivePathEvent.UdpForwarded, It.IsAny<int>(), It.IsAny<SocketError>()), Times.Never);
+            failingClient.Dispose();
+            diagnostics.Verify(d => d.End("client-disposed"), Times.Once);
+        }
+
+        [Fact]
+        public void InboundWithoutEndpoint_RecordsDropWithoutForwarding()
+        {
+            var diagnostics = new Mock<IReceivePathDiagnostics>();
+            int drops = 0;
+            diagnostics.Setup(d => d.Record(ReceivePathEvent.NoEndpointDrop, 1, SocketError.Success))
+                .Callback(() => Interlocked.Increment(ref drops));
+            using var waitingClient = new SteamTunnelClient(transport, diagnostics.Object);
+            waitingClient.Start(76561198000000042);
+            transport.EnqueueReceive(transport.NextConnection, new byte[] { 5 });
+            WaitUntil(() => Volatile.Read(ref drops) == 1);
+            diagnostics.Verify(d => d.Record(ReceivePathEvent.SteamReceive, 1, SocketError.Success), Times.Once);
+            diagnostics.Verify(d => d.Record(ReceivePathEvent.UdpForwarded, It.IsAny<int>(), It.IsAny<SocketError>()), Times.Never);
         }
 
         [Fact]

--- a/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
+++ b/source/Coop.Tests/Steam/SteamTunnelHostTests.cs
@@ -1,4 +1,7 @@
 ﻿using Coop.Steam;
+using Common.Logging;
+using Moq;
+using System.Threading;
 using System;
 using System.Linq;
 using System.Net;
@@ -14,7 +17,7 @@ namespace Coop.Tests.Steam
 
         public SteamTunnelHostTests()
         {
-            host = new SteamTunnelHost(transport);
+            host = new SteamTunnelHost(transport, () => new Common.Logging.ReceivePathDiagnostics());
         }
 
         public void Dispose() => host.Dispose();
@@ -241,6 +244,29 @@ namespace Coop.Tests.Steam
             // LiteNetLib keys peers by endpoint, so each tunneled client must arrive
             // from its own local port.
             Assert.NotEqual(((IPEndPoint)firstSender).Port, ((IPEndPoint)secondSender).Port);
+        }
+
+        [Fact]
+        public void SteamReceive_RecordsSuccessfulUdpForwardAndPeerTeardown()
+        {
+            var measuredTransport = new FakeSteamTunnelTransport();
+            var diagnostics = new Mock<IReceivePathDiagnostics>();
+            int forwards = 0;
+            diagnostics.Setup(d => d.Record(ReceivePathEvent.UdpForwarded, 3, SocketError.Success))
+                .Callback(() => Interlocked.Increment(ref forwards));
+            using var measuredHost = new SteamTunnelHost(measuredTransport, () => diagnostics.Object);
+            using var serverSocket = CreateServerSocket();
+            measuredHost.Start(((IPEndPoint)serverSocket.LocalEndPoint!).Port);
+            measuredTransport.RaiseConnectionState(7, TunnelConnectionState.Connecting);
+            measuredTransport.RaiseConnectionState(7, TunnelConnectionState.Connected);
+            measuredTransport.EnqueueReceive(7, new byte[] { 1, 2, 3 });
+            byte[] buffer = new byte[16];
+            Assert.Equal(3, serverSocket.Receive(buffer));
+            SteamTunnelClientTests.WaitUntil(() => Volatile.Read(ref forwards) == 1);
+            diagnostics.Verify(d => d.Record(ReceivePathEvent.SteamReceive, 3, SocketError.Success), Times.Once);
+            diagnostics.Verify(d => d.Record(ReceivePathEvent.UdpForwardFailed, It.IsAny<int>(), It.IsAny<SocketError>()), Times.Never);
+            measuredTransport.RaiseConnectionState(7, TunnelConnectionState.Closed);
+            diagnostics.Verify(d => d.End("peer-removed"), Times.Once);
         }
 
         private static Socket CreateServerSocket()

--- a/source/E2E.Tests/Services/Missions/BattleMessageBatchingTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleMessageBatchingTests.cs
@@ -65,7 +65,7 @@ public class BattleMessageBatchingTests : MissionTestEnvironment
             controllerIdProvider.Object,
             steamBridge.Object,
             compressor,
-            new ReliableMessageBatcher<string>(serializer));
+            new ReliableMessageBatcher<string>(serializer), () => new Common.Logging.ReceivePathDiagnostics());
         client.ConnectToInstance(instanceId);
 
         var logicalPayloads = new List<byte[]>(logicalMessageCount);
@@ -138,7 +138,7 @@ public class BattleMessageBatchingTests : MissionTestEnvironment
             controllerIdProvider.Object,
             steamBridge.Object,
             new MovementPacketCompressor(serializer),
-            new ReliableMessageBatcher<string>(serializer));
+            new ReliableMessageBatcher<string>(serializer), () => new Common.Logging.ReceivePathDiagnostics());
 
         client.Send(controllerId, CreateDeath(CreateGuid(10), 10));
         client.Send(controllerId, CreateDeath(CreateGuid(11), 11));
@@ -186,7 +186,7 @@ public class BattleMessageBatchingTests : MissionTestEnvironment
             controllerIdProvider.Object,
             steamBridge.Object,
             new MovementPacketCompressor(serializer),
-            new ReliableMessageBatcher<string>(serializer));
+            new ReliableMessageBatcher<string>(serializer), () => new Common.Logging.ReceivePathDiagnostics());
         NetPeer peer = NetPeerExtensions.CreatePeer(99);
         Guid first = CreateGuid(1);
         Guid second = CreateGuid(2);

--- a/source/E2E.Tests/Services/Missions/LiteNetP2PClientTests.cs
+++ b/source/E2E.Tests/Services/Missions/LiteNetP2PClientTests.cs
@@ -1,4 +1,7 @@
 ﻿using Common.Messaging;
+using Common.Logging;
+using Common.Util;
+using System.Net.Sockets;
 using Common.Network;
 using Common.Network.Data;
 using Common.Network.Session;
@@ -53,7 +56,7 @@ public class LiteNetP2PClientTests
             controllerIdProvider.Object,
             steamBridge.Object,
             new MovementPacketCompressor(serializer),
-            batcher);
+            batcher, () => new Common.Logging.ReceivePathDiagnostics());
         NetPeer peer = NetPeerExtensions.CreatePeer(97);
         GetPendingPeerControllers(client)[peer] = controllerId;
 
@@ -80,6 +83,40 @@ public class LiteNetP2PClientTests
         Assert.True(batcher.PromotionFlushAcquiredBuffer);
         Assert.Equal(new[] { "relay", "map" }, routeOrder);
         missionContext.Verify(context => context.MapPeer(controllerId, peer), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void OnNetworkReceive_CountsMappingDecisionWithoutChangingDispatch(bool mapped)
+    {
+        var serializer = new Mock<ICommonSerializer>();
+        var packet = new Mock<IPacket>();
+        byte[] bytes = { 1, 2, 3 };
+        serializer.Setup(s => s.Deserialize(It.IsAny<byte[]>())).Returns(packet.Object);
+        var packetManager = new Mock<IPacketManager>();
+        var context = new Mock<IMissionContext>();
+        var diagnostics = new Mock<IReceivePathDiagnostics>();
+        using var client = new LiteNetP2PClient(
+            Mock.Of<INetworkConfig>(), Mock.Of<IRelayNetwork>(), context.Object,
+            serializer.Object, Mock.Of<IMessageBroker>(), packetManager.Object,
+            Mock.Of<IMessagePacketHandler>(), Mock.Of<IControllerIdProvider>(),
+            Mock.Of<ISteamMissionBridge>(), Mock.Of<IMovementPacketCompressor>(),
+            new ReliableMessageBatcher<string>(serializer.Object), () => diagnostics.Object);
+        NetPeer peer = NetPeerExtensions.CreatePeer(98);
+        GetPendingPeerControllers(client)[peer] = "receiving-peer";
+        if (mapped) client.OnPeerConnected(peer);
+        var reader = ObjectHelper.SkipConstructor<NetPacketReader>();
+        reader.SetSource(bytes);
+
+        client.OnNetworkReceive(peer, reader, 0, DeliveryMethod.ReliableOrdered);
+
+        diagnostics.Verify(d => d.Record(
+            mapped ? ReceivePathEvent.MappedReceive : ReceivePathEvent.UnmappedDrop,
+            3, SocketError.Success), Times.Once);
+        serializer.Verify(s => s.Deserialize(It.IsAny<byte[]>()), mapped ? Times.Once() : Times.Never());
+        packetManager.Verify(p => p.HandleReceive(peer, packet.Object), mapped ? Times.Once() : Times.Never());
+        Assert.Equal(mapped ? 0 : 3, reader.AvailableBytes);
     }
 
     private static Dictionary<NetPeer, string> GetPendingPeerControllers(LiteNetP2PClient client)

--- a/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
+++ b/source/E2E.Tests/Services/Missions/MovementTrafficTests.cs
@@ -1138,7 +1138,7 @@ public class MovementTrafficTests : MissionTestEnvironment
             controllerIdProvider.Object,
             steamBridge.Object,
             compressor,
-            new ReliableMessageBatcher<string>(serializer));
+            new ReliableMessageBatcher<string>(serializer), () => new Common.Logging.ReceivePathDiagnostics());
         client.ConnectToInstance(instanceId);
 
         Assert.Equal(0, client.GetMaxUnreliablePayloadBytes());
@@ -1221,7 +1221,7 @@ public class MovementTrafficTests : MissionTestEnvironment
             controllerIdProvider.Object,
             steamBridge.Object,
             compressor,
-            new ReliableMessageBatcher<string>(serializer));
+            new ReliableMessageBatcher<string>(serializer), () => new Common.Logging.ReceivePathDiagnostics());
         client.ConnectToInstance(instanceId);
 
         client.Send(controllerId, oversizedPacket);

--- a/source/Missions/MissionModule.cs
+++ b/source/Missions/MissionModule.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common.Commands;
+using Common.Logging;
 using Common.Network.Session;
 using GameInterface;
 using GameInterface.Services.Locations;
@@ -41,6 +42,7 @@ public class MissionModule : Module
 
     protected override void Load(ContainerBuilder builder)
     {
+        builder.RegisterType<ReceivePathDiagnostics>().As<IReceivePathDiagnostics>().InstancePerDependency();
         base.Load(builder);
 
         foreach (HarmonyPatchCategoryRegistration registration in CreatePatchCategoryRegistrations())

--- a/source/Missions/Services/Network/LiteNetP2PClient.cs
+++ b/source/Missions/Services/Network/LiteNetP2PClient.cs
@@ -59,6 +59,9 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     private readonly HashSet<NetPeer> connectedPendingPeers = new();
     private readonly object relayPayloadBudgetGate = new();
     private readonly Dictionary<(string InstanceId, string ControllerId), int> relayPayloadBudgets = new();
+    private readonly Func<IReceivePathDiagnostics> diagnosticsFactory;
+    private readonly Dictionary<NetPeer, IReceivePathDiagnostics> receiveDiagnostics = new();
+    private readonly Dictionary<string, IReceivePathDiagnostics> routeDiagnostics = new();
     private bool disposed;
 
     private string instanceId = null;
@@ -93,8 +96,11 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         IControllerIdProvider controllerIdProvider,
         ISteamMissionBridge steamBridge,
         IMovementPacketCompressor movementPacketCompressor,
-        IReliableMessageBatcher<string> reliableMessageBatcher)
+        IReliableMessageBatcher<string> reliableMessageBatcher,
+        Func<IReceivePathDiagnostics> diagnosticsFactory)
     {
+        if (diagnosticsFactory == null) throw new ArgumentNullException(nameof(diagnosticsFactory));
+        this.diagnosticsFactory = diagnosticsFactory;
         Config = config;
         this.relayNetwork = relayNetwork;
         this.missionContext = missionContext;
@@ -173,6 +179,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         FlushReliableSends();
         lock (peerGate)
         {
+            EndDiagnostics("disconnect-all");
             instanceId = null;
             instanceGeneration++;
         }
@@ -186,6 +193,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             mappedPeerControllers.Clear();
             peerSteamIds.Clear();
             connectedPendingPeers.Clear();
+            EndDiagnostics("disconnect-complete");
         }
 
         lock (relayPayloadBudgetGate)
@@ -244,6 +252,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         // when the punch below is skipped.
         lock (peerGate)
         {
+            EndDiagnostics("connect-instance");
             this.instanceId = instanceId;
             instanceGeneration++;
         }
@@ -287,6 +296,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             if (peer != null)
             {
                 pendingPeerControllers[peer] = connectionToken.ControllerId;
+                LogPeerState(peer, "pending-connect");
             }
         }
     }
@@ -370,6 +380,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
                 {
                     pendingPeerControllers[peer] = connectionToken.ControllerId;
                     if (authenticated) peerSteamIds[peer] = authenticatedSteamId;
+                    LogPeerState(peer, "accepted-pending");
                 }
                 return;
             }
@@ -393,6 +404,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
                 if (expectedSteamId == 0 && actualSteamId != 0)
                 {
                     connectedPendingPeers.Add(peer);
+                    LogPeerState(peer, "awaiting-membership");
                 }
                 else if (expectedSteamId != 0 && expectedSteamId != actualSteamId)
                 {
@@ -409,12 +421,11 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
         if (controllerIdToPromote != null) PromotePeer(peer, controllerIdToPromote);
         if (rejectPeer) netManager.DisconnectPeer(peer);
 
-        // Proof-of-P2P diagnostic: the remote endpoint here is the OTHER CLIENT's socket, reached
-        // directly. Compare its port against the rendezvous (server) port — if they differ, this is
-        // a direct client-to-client link, not server-relayed.
-        Logger.Information("[LocationSync] P2P link established: remote(other client)={Remote} | myP2PPort={LocalPort} | rendezvous(server)={Server}:{ServerPort}. " +
-            "remote != rendezvous => DIRECT P2P (not server-relayed).",
-            peer, netManager.LocalPort, Config.LanAddress, Config.LanPort);
+        lock (peerGate)
+        {
+            // A connected socket does not prove mapping readiness or Steam's physical route.
+            LogPeerState(peer, rejectPeer ? "connected-rejected" : "transport-connected");
+        }
     }
 
     private void Handle_MissionPeerEntered(MessagePayload<NetworkMissionPeerEntered> payload)
@@ -431,6 +442,8 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             if (entered.InstanceId != instanceId) return;
             generation = instanceGeneration;
             controllerSteamIds[entered.ControllerId] = entered.SteamId;
+            Logger.Information("[ReceivePath] utc={Utc:O} instance={Instance} generation={Generation} localController={LocalController} membershipController={Controller} expectedSteamId={SteamId}",
+                DateTime.UtcNow, instanceId, instanceGeneration, controllerIdProvider.ControllerId, entered.ControllerId, entered.SteamId);
 
             foreach (var pair in pendingPeerControllers
                 .Where(pair => pair.Value == entered.ControllerId)
@@ -483,6 +496,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
                 {
                     pendingPeerControllers[peer] = entered.ControllerId;
                     peerSteamIds[peer] = entered.SteamId;
+                    LogPeerState(peer, "steam-pending-connect");
                 }
             }
         }
@@ -513,6 +527,11 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
                 controllerSteamIds.Remove(controllerId);
             }
             trackedPeer = RemoveTrackedPeer(controllerId);
+            if (routeDiagnostics.TryGetValue(controllerId, out var diagnostics))
+            {
+                diagnostics.End("controller-departed");
+                routeDiagnostics.Remove(controllerId);
+            }
         }
 
         reliableMessageBatcher.Remove(controllerId);
@@ -596,6 +615,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
                     connectedPendingPeers.Remove(peer);
                     mappedPeerControllers[peer] = controllerId;
                     missionContext.MapPeer(controllerId, peer);
+                    LogPeerState(peer, "promoted");
                 }
             });
     }
@@ -607,10 +627,75 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             mappedPeerControllers.TryGetValue(peer, out controllerId);
         }
 
+        LogPeerState(peer, "removing");
+        if (receiveDiagnostics.TryGetValue(peer, out var diagnostics))
+        {
+            diagnostics.End("peer-removed");
+            receiveDiagnostics.Remove(peer);
+        }
         pendingPeerControllers.Remove(peer);
         mappedPeerControllers.Remove(peer);
         peerSteamIds.Remove(peer);
         connectedPendingPeers.Remove(peer);
+    }
+
+    // Called under peerGate, including receive callbacks, so no per-packet context allocation.
+    private IReceivePathDiagnostics GetReceiveDiagnostics(NetPeer peer)
+    {
+        if (!receiveDiagnostics.TryGetValue(peer, out var diagnostics))
+        {
+            pendingPeerControllers.TryGetValue(peer, out var controller);
+            if (controller == null) mappedPeerControllers.TryGetValue(peer, out controller);
+            diagnostics = diagnosticsFactory();
+            diagnostics.Start(Logger, $"mission-receive instance={instanceId} generation={instanceGeneration} " +
+                $"localController={controllerIdProvider.ControllerId} remoteController={controller} " +
+                $"peer={peer} peerId={peer.Id} localPort={netManager.LocalPort}");
+            receiveDiagnostics[peer] = diagnostics;
+        }
+        return diagnostics;
+    }
+
+    private void RecordRoute(string controllerId, ReceivePathEvent route, int bytes)
+    {
+        lock (peerGate)
+        {
+            if (!routeDiagnostics.TryGetValue(controllerId, out var diagnostics))
+            {
+                diagnostics = diagnosticsFactory();
+                diagnostics.Start(Logger, $"mission-send-attempt instance={instanceId} generation={instanceGeneration} " +
+                    $"localController={controllerIdProvider.ControllerId} remoteController={controllerId}");
+                routeDiagnostics[controllerId] = diagnostics;
+            }
+            diagnostics.Record(route, bytes);
+        }
+    }
+
+    private void LogPeerState(NetPeer peer, string transition)
+    {
+        pendingPeerControllers.TryGetValue(peer, out var pendingController);
+        mappedPeerControllers.TryGetValue(peer, out var mappedController);
+        string controller = mappedController ?? pendingController;
+        if (controller != null) GetReceiveDiagnostics(peer);
+        ulong expectedSteamId = 0;
+        if (controller != null) controllerSteamIds.TryGetValue(controller, out expectedSteamId);
+        peerSteamIds.TryGetValue(peer, out var actualSteamId);
+        bool contextMapped = controller != null && missionContext.TryGetPeer(controller, out var contextPeer)
+            && ReferenceEquals(peer, contextPeer);
+        Logger.Information("[ReceivePath] utc={Utc:O} instance={Instance} generation={Generation} localController={LocalController} " +
+            "transition={Transition} peer={Peer} peerId={PeerId} localPort={LocalPort} pendingController={PendingController} " +
+            "mappedController={MappedController} contextMapped={ContextMapped} awaitingMembership={AwaitingMembership} " +
+            "expectedSteamId={ExpectedSteamId} trackedSteamId={ActualSteamId}",
+            DateTime.UtcNow, instanceId, instanceGeneration, controllerIdProvider.ControllerId, transition,
+            peer, peer.Id, netManager.LocalPort, pendingController, mappedController, contextMapped,
+            connectedPendingPeers.Contains(peer), expectedSteamId, actualSteamId);
+    }
+
+    private void EndDiagnostics(string reason)
+    {
+        foreach (var diagnostics in receiveDiagnostics.Values) diagnostics.End(reason);
+        foreach (var diagnostics in routeDiagnostics.Values) diagnostics.End(reason);
+        receiveDiagnostics.Clear();
+        routeDiagnostics.Clear();
     }
 
     public void SendAll(IMessage message)
@@ -686,6 +771,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     {
         if (missionContext.TryGetPeer(controllerId, out NetPeer peer))
         {
+            RecordRoute(controllerId, ReceivePathEvent.MissionPeerSend, data.Length);
             Send(peer, packet, data);
             return;
         }
@@ -715,6 +801,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             }
         }
 
+        RecordRoute(controllerId, ReceivePathEvent.CampaignRelaySend, data.Length);
         relayNetwork.SendAll(new RelayPacket(
             packet.DeliveryMethod,
             relayInstanceId,
@@ -726,6 +813,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     {
         if (missionContext.TryGetPeer(controllerId, out NetPeer peer))
         {
+            RecordRoute(controllerId, ReceivePathEvent.MissionPeerSend, data.Length);
             peer.Send(data, DeliveryMethod.ReliableOrdered);
             return;
         }
@@ -736,6 +824,7 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
             relayInstanceId = instanceId;
         }
 
+        RecordRoute(controllerId, ReceivePathEvent.CampaignRelaySend, data.Length);
         relayNetwork.SendAll(new RelayPacket(
             DeliveryMethod.ReliableOrdered,
             relayInstanceId,
@@ -901,7 +990,11 @@ public class LiteNetP2PClient : INatPunchListener, INetEventListener, IUpdateabl
     {
         lock (peerGate)
         {
-            if (!mappedPeerControllers.ContainsKey(peer)) return;
+            bool mapped = mappedPeerControllers.ContainsKey(peer);
+            GetReceiveDiagnostics(peer).Record(
+                mapped ? ReceivePathEvent.MappedReceive : ReceivePathEvent.UnmappedDrop,
+                reader.AvailableBytes);
+            if (!mapped) return;
         }
 
         HandleReceivedPayload(peer, reader.GetRemainingBytes());


### PR DESCRIPTION
## What is the current behavior?

mission packets from unmapped peers and Steam-to-UDP forwarding failures can disappear without useful logs. #1318 shows one client losing allied spawns after its Steam mission connection takes over, but the logs dont establish where delivery stops.

related: https://github.com/Bannerlord-Coop-Team/Bannerlord-Coop-Issues/issues/1318 and https://github.com/Bannerlord-Coop-Team/Bannerlord-Coop-Issues/issues/1332

## What is the new behavior?

adds `[ReceivePath]` logs for peer mapping, selected send routes, mapped/unmapped receives, and Steam UDP forwarding results. first events are logged immediately, repeats are aggregated every ten seconds while traffic continues, and teardown records totals. includes UTC and connection/mission identifiers, and removes the misleading direct-P2P readiness claim.

diagnostics only, routing and identity checks are unchanged. this does not claim to fix either report.

## How to test

42 focused tests passed across counter, Steam tunnel, mission routing/batching and disconnect tests. Release and Debug compile-only builds passed.

live test not run: use an in-game `/server` and two Steam clients, enter the same field battle near Danustica and complete deployment. run `coop.debug.battle.state` and `coop.debug.movement.state` on both clients, keep traffic running for 30 seconds, then leave and join another battle. preserve both client logs and the server log. compare `[ReceivePath]` mapping and route records, `SteamReceive`, `UdpForwarded`, `UdpForwardFailed`, and `UnmappedDrop`, alongside spawn transfer ids. check that rejoining starts fresh diagnostic lifetimes. forwarded UDP and mapped receives are not gameplay-delivery acknowledgements.
