### PR TITLE
Add CoopMcpServer for local co-op testing

### DIFF
--- a/source/Common/LiveTesting/LiveTestProtocol.cs
+++ b/source/Common/LiveTesting/LiveTestProtocol.cs
@@ -240,6 +240,8 @@ public sealed class LiveTestProcessInfo
     public string PlatformId { get; set; }
 
     public string RunToken { get; set; }
+
+    public DateTime ProcessStartedUtc { get; set; }
 }
 
 public sealed class LiveTestError

--- a/source/Coop/LiveTesting/LiveTestControlServer.cs
+++ b/source/Coop/LiveTesting/LiveTestControlServer.cs
@@ -85,6 +85,7 @@ namespace Coop.LiveTesting
             processInfo = new LiveTestProcessInfo
             {
                 Pid = processId,
+                ProcessStartedUtc = processStartedUtc,
                 Role = isServer ? "server" : "client",
                 PlatformId = ReadArgument(arguments, "/platformId"),
                 RunToken = NormalizeRunToken(ReadArgument(arguments, "/cooptestrun")),
@@ -187,15 +188,6 @@ namespace Coop.LiveTesting
             if (!TryReadCommand(request.Parameters, out var command, out var arguments, out var error))
             {
                 return Failure(request.Id, "invalid_parameters", error, false);
-            }
-
-            if (!command.StartsWith("coop.debug.", StringComparison.Ordinal))
-            {
-                return Failure(
-                    request.Id,
-                    "command_not_allowed",
-                    "Only coop.debug.* commands may be run through live testing.",
-                    false);
             }
 
             return ExecuteOnGameThread(request, () =>
@@ -770,6 +762,9 @@ namespace Coop.LiveTesting
                 registeredControllerIds,
                 connectedControllerIds,
                 deferredClientJoinEnabled,
+                readyForClientJoin = !isServer && deferredClientJoinEnabled &&
+                    Volatile.Read(ref deferredClientJoinAttempted) == 0 &&
+                    GameStateManager.Current?.ActiveState is InitialState && !campaignLoaded,
                 deferredClientJoinAttempted = Volatile.Read(ref deferredClientJoinAttempted) != 0,
                 readyForCampaignTests,
                 readyForMissionTests = readyForCampaignTests && missionActive,
@@ -894,6 +889,7 @@ namespace Coop.LiveTesting
             return new LiveTestProcessInfo
             {
                 Pid = processInfo.Pid,
+                ProcessStartedUtc = processStartedUtc,
                 Role = processInfo.Role,
                 PlatformId = processInfo.PlatformId,
                 RunToken = processInfo.RunToken,

--- a/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
+++ b/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
@@ -42,7 +42,7 @@ public class LiveTestCommandDispatcherTests
     [Fact]
     public void Execute_WhenFrameworkCommandExists_PreservesStructuredArguments()
     {
-        const string commandName = "coop.debug.live_testing_dispatcher_test.framework_capture";
+        const string commandName = "coop.live_testing_dispatcher_test.framework_capture";
         var registry = new CoopCommandRegistry(
             new[] { new FrameworkCaptureCommand() },
             Mock.Of<ILogger>());
@@ -55,6 +55,7 @@ public class LiveTestCommandDispatcherTests
 
         LiveTestCommandResult result = dispatcher.Execute(commandName, arguments);
 
+        Assert.Contains(commandName, dispatcher.GetCommandNames());
         Assert.True(result.Found);
         Assert.Equal("argument with spaces|quoted \"value\"", result.Output);
     }
@@ -96,7 +97,7 @@ public class LiveTestCommandDispatcherTests
         LiveTestCommandResult result = new LiveTestCommandDispatcher().Execute(NonDebugCommand, new List<string>());
 
         Assert.False(result.Found);
-        Assert.Equal("Only coop.debug. commands may be run through live testing", result.Output);
+        Assert.Equal("Only registered co-op commands and legacy coop.debug.* commands may be run through live testing", result.Output);
         Assert.Equal(0, nonDebugInvocations);
     }
 
@@ -115,7 +116,7 @@ public class LiveTestCommandDispatcherTests
 
     private sealed class FrameworkCaptureCommand : ICoopCommand
     {
-        public string Prefix => "coop.debug.live_testing_dispatcher_test";
+        public string Prefix => "coop.live_testing_dispatcher_test";
 
         public string Name => "framework_capture";
 

--- a/source/GameInterface/Services/LiveTesting/LiveTestCommandDispatcher.cs
+++ b/source/GameInterface/Services/LiveTesting/LiveTestCommandDispatcher.cs
@@ -21,7 +21,7 @@ public interface ILiveTestCommandDispatcher
 
 public class LiveTestCommandDispatcher : ILiveTestCommandDispatcher
 {
-    private const string AllowedCommandPrefix = "coop.debug.";
+    private const string LegacyDebugCommandPrefix = "coop.debug.";
 
     private static bool functionsCollected;
 
@@ -87,8 +87,8 @@ public class LiveTestCommandDispatcher : ILiveTestCommandDispatcher
                     : commandRegistry.Commands.Select(command => command.FullName);
                 commandNames = allFunctions.Keys
                     .Cast<string>()
+                    .Where(command => command.StartsWith(LegacyDebugCommandPrefix, StringComparison.Ordinal))
                     .Concat(registeredCommands)
-                    .Where(command => command.StartsWith(AllowedCommandPrefix, StringComparison.Ordinal))
                     .Distinct(StringComparer.Ordinal)
                     .OrderBy(command => command, StringComparer.Ordinal)
                     .ToArray();
@@ -106,9 +106,10 @@ public class LiveTestCommandDispatcher : ILiveTestCommandDispatcher
     public LiveTestCommandResult Execute(string command, List<string> arguments)
     {
         if (string.IsNullOrEmpty(command) ||
-            command.StartsWith(AllowedCommandPrefix, StringComparison.Ordinal) == false)
+            (!(commandRegistry?.Contains(command) ?? false) &&
+             !command.StartsWith(LegacyDebugCommandPrefix, StringComparison.Ordinal)))
         {
-            return new LiveTestCommandResult(false, $"Only {AllowedCommandPrefix} commands may be run through live testing");
+            return new LiveTestCommandResult(false, "Only registered co-op commands and legacy coop.debug.* commands may be run through live testing");
         }
 
         if (arguments == null) throw new ArgumentNullException(nameof(arguments));

--- a/tools/CoopMcpServer.Tests/CoopMcpServer.Tests.csproj
+++ b/tools/CoopMcpServer.Tests/CoopMcpServer.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <ProjectReference Include="../CoopMcpServer/CoopMcpServer.csproj" />
+    <Compile Include="../../source/Common/Commands/*.cs" Link="Commands/%(Filename)%(Extension)" />
+    <Compile Include="../../source/GameInterface/Services/LiveTesting/LiveTestCommandDispatcher.cs" Link="LiveTestCommandDispatcher.cs" />
+    <Compile Include="../../source/Common.Tests/LiveTesting/LiveTestProtocolTests.cs" Link="LiveTestProtocolTests.cs" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tools/CoopMcpServer.Tests/Fakes/CommandLineFunctionality.cs
+++ b/tools/CoopMcpServer.Tests/Fakes/CommandLineFunctionality.cs
@@ -1,0 +1,18 @@
+﻿namespace TaleWorlds.Library;
+
+// Supplies the vanilla registry seam without loading Bannerlord or native DLLs.
+public static class CommandLineFunctionality
+{
+    private static readonly Dictionary<string, object> AllFunctions = new()
+    {
+        ["coop.debug.legacy"] = new(), ["campaign.do_something"] = new(), ["coop.unregistered"] = new(),
+    };
+    public static void CollectCommandLineFunctions() { }
+    public static string CallFunction(string command, List<string> arguments, out bool found)
+    {
+        if (!command.StartsWith("coop.debug.", StringComparison.Ordinal))
+            throw new InvalidOperationException("Arbitrary vanilla dispatch is forbidden in this test.");
+        found = AllFunctions.ContainsKey(command);
+        return "legacy result";
+    }
+}

--- a/tools/CoopMcpServer.Tests/Fakes/GameThread.cs
+++ b/tools/CoopMcpServer.Tests/Fakes/GameThread.cs
@@ -1,0 +1,7 @@
+﻿namespace Common;
+
+// Executes the linked dispatcher without loading Bannerlord or native DLLs.
+public static class GameThread
+{
+    public static void Run(Action action, bool blocking) => action();
+}

--- a/tools/CoopMcpServer.Tests/InGameProcessLauncherTests.cs
+++ b/tools/CoopMcpServer.Tests/InGameProcessLauncherTests.cs
@@ -1,0 +1,36 @@
+﻿namespace CoopMcpServer.Tests;
+
+public sealed class InGameProcessLauncherTests
+{
+    [Theory]
+    [InlineData("server", false)]
+    [InlineData("client", true)]
+    public void LaunchArgumentsAreStructuredAndClientsDeferJoining(string role, bool deferred)
+    {
+        var profile = new LaunchProfile { Executable = @"C:\Game Folder\Bannerlord.exe" };
+        var info = new InGameProcessLauncher().CreateStartInfo(profile, role, "testclient1", "run-token");
+        Assert.False(info.UseShellExecute);
+        Assert.Equal(profile.Executable, info.FileName);
+        Assert.Equal(@"C:\Game Folder", info.WorkingDirectory);
+        Assert.Contains("/" + role, info.ArgumentList);
+        Assert.Contains("/autoconnect", info.ArgumentList);
+        Assert.Contains("run-token", info.ArgumentList);
+        Assert.Equal(deferred, info.ArgumentList.Contains("/cooptestmanualjoin"));
+        Assert.Contains("_MODULES_*Native*SandBoxCore*SandBox*StoryMode*Coop*_MODULES_", info.ArgumentList);
+    }
+
+    [Fact]
+    public void DuplicatePlatformIdsAreRejectedBeforeLaunch()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string path = Path.Combine(directory, "Bannerlord.exe");
+            File.WriteAllText(path, "fake, never launched");
+            var profile = new LaunchProfile { Executable = path, ClientPlatformIds = new[] { "testclient", "TESTCLIENT" } };
+            Assert.Throws<ArgumentException>(() => profile.Validate(2));
+        }
+        finally { Directory.Delete(directory, true); }
+    }
+}

--- a/tools/CoopMcpServer.Tests/IncrementalLogReaderTests.cs
+++ b/tools/CoopMcpServer.Tests/IncrementalLogReaderTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Text;
+
+namespace CoopMcpServer.Tests;
+
+public sealed class IncrementalLogReaderTests : IDisposable
+{
+    private readonly string path = Path.GetTempFileName();
+    private readonly IncrementalLogReader reader = new();
+
+    [Fact]
+    public void AppendsAdvanceCursorWithoutDuplicatesAndRespectUtf8Boundaries()
+    {
+        File.WriteAllText(path, "abc😀tail", new UTF8Encoding(false));
+        var first = reader.Read(path, null, 4);
+        Assert.Equal("abc", first.Text);
+        var second = reader.Read(path, first.Cursor, 4);
+        Assert.Equal("😀", second.Text);
+        Assert.False(second.Reset);
+        var third = reader.Read(path, second.Cursor, 100);
+        Assert.Equal("tail", third.Text);
+        File.AppendAllText(path, "new");
+        var fourth = reader.Read(path, third.Cursor, 100);
+        Assert.Equal("new", fourth.Text);
+        Assert.False(fourth.Reset);
+        Assert.False(fourth.HasMore);
+    }
+
+    [Fact]
+    public void IncompleteTailFinishesDrainingAndResumesWhenCharacterIsCompleted()
+    {
+        File.WriteAllBytes(path, new byte[] { 0xF0, 0x9F });
+        var first = reader.Read(path, null, 4);
+        Assert.Empty(first.Text);
+        Assert.False(first.HasMore);
+        var second = reader.Read(path, first.Cursor, 4);
+        Assert.Empty(second.Text);
+        Assert.False(second.HasMore);
+        Assert.Equal(first.Cursor, second.Cursor);
+        using (var stream = new FileStream(path, FileMode.Append))
+            stream.Write(new byte[] { 0x98, 0x80 });
+        var completed = reader.Read(path, second.Cursor, 4);
+        Assert.Equal("😀", completed.Text);
+        Assert.False(completed.Reset);
+        Assert.False(completed.HasMore);
+    }
+
+    [Fact]
+    public void TruncationAndSameLengthRewriteResetCursor()
+    {
+        File.WriteAllText(path, "123456789");
+        var first = reader.Read(path, null, 4);
+        File.WriteAllText(path, "abcdefghi");
+        var rewritten = reader.Read(path, first.Cursor, 100);
+        Assert.True(rewritten.Reset);
+        Assert.Equal("abcdefghi", rewritten.Text);
+        File.WriteAllText(path, "x");
+        var truncated = reader.Read(path, rewritten.Cursor, 100);
+        Assert.True(truncated.Reset);
+        Assert.Equal("x", truncated.Text);
+    }
+
+    [Fact]
+    public void CompactionMarkerChangeResetsEvenWhenStartupPrefixIsPreservedAndFileRegrows()
+    {
+        string prefix = new string('a', 1024 * 1024);
+        File.WriteAllText(path, prefix + "marker 1" + new string('b', 2000));
+        var first = reader.Read(path, null, 4);
+        File.WriteAllText(path, prefix + "marker 2" + new string('c', 3000));
+        var next = reader.Read(path, first.Cursor, 4);
+        Assert.True(next.Reset);
+        Assert.Equal("aaaa", next.Text);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(65537)]
+    public void OutputLimitIsEnforced(int maxBytes) => Assert.Throws<ArgumentOutOfRangeException>(() => reader.Read(path, null, maxBytes));
+
+    [Fact]
+    public void MalformedCursorIsRejected() => Assert.Throws<ArgumentException>(() => reader.Read(path, "not a cursor", 100));
+
+    public void Dispose() => File.Delete(path);
+}

--- a/tools/CoopMcpServer.Tests/LiveTestCommandDispatcherTests.cs
+++ b/tools/CoopMcpServer.Tests/LiveTestCommandDispatcherTests.cs
@@ -1,0 +1,81 @@
+﻿using Common.Commands;
+using GameInterface.Services.LiveTesting;
+using Serilog;
+
+namespace CoopMcpServer.Tests
+{
+    public sealed class LiveTestCommandDispatcherTests
+    {
+        [Theory]
+        [InlineData("coop")]
+        [InlineData("coop.connection")]
+        [InlineData("coop.debug.test")]
+        public void EveryRegisteredFrameworkPrefixIsListedAndExecutable(string prefix)
+        {
+            var command = new CaptureCommand(prefix);
+            using var logger = new LoggerConfiguration().CreateLogger();
+            var registry = new CoopCommandRegistry(new[] { command }, logger);
+            var dispatcher = new LiveTestCommandDispatcher(registry, new CoopCommandArgsFactory());
+            string name = prefix + ".capture";
+            Assert.Contains(name, dispatcher.GetCommandNames());
+            var result = dispatcher.Execute(name, new List<string> { "argument with spaces", "quoted \"value\"" });
+            Assert.True(result.Found);
+            Assert.Equal("argument with spaces|quoted \"value\"", result.Output);
+        }
+
+        [Theory]
+        [InlineData("campaign.do_something")]
+        [InlineData("coop.unregistered")]
+        public void UnregisteredNonDebugCommandsNeverReachVanilla(string name)
+        {
+            var dispatcher = new LiveTestCommandDispatcher();
+            Assert.DoesNotContain(name, dispatcher.GetCommandNames());
+            Assert.False(dispatcher.Execute(name, new List<string>()).Found);
+        }
+
+        [Fact]
+        public void LegacyDebugCommandsRemainAvailable()
+        {
+            var dispatcher = new LiveTestCommandDispatcher();
+            Assert.Contains("coop.debug.legacy", dispatcher.GetCommandNames());
+            Assert.True(dispatcher.Execute("coop.debug.legacy", new List<string>()).Found);
+        }
+
+        private sealed class CaptureCommand(string prefix) : ICoopCommand
+        {
+            public string Prefix => prefix;
+            public string Name => "capture";
+            public string Description => "Capture arguments.";
+            public IExpectedArgs[] ExpectedArgs => new IExpectedArgs[] { new ExpectedArgs("first", "First value."), new ExpectedArgs("second", "Second value.") };
+            public CoopCommandResult ProcessCommand(ICoopCommandArgs args) => new(true, string.Join("|", args));
+        }
+    }
+}
+
+// These fakes exercise the linked dispatcher without loading Bannerlord or native DLLs.
+namespace Common
+{
+    public static class GameThread
+    {
+        public static void Run(Action action, bool blocking) => action();
+    }
+}
+
+namespace TaleWorlds.Library
+{
+    public static class CommandLineFunctionality
+    {
+        private static readonly Dictionary<string, object> AllFunctions = new()
+        {
+            ["coop.debug.legacy"] = new(), ["campaign.do_something"] = new(), ["coop.unregistered"] = new(),
+        };
+        public static void CollectCommandLineFunctions() { }
+        public static string CallFunction(string command, List<string> arguments, out bool found)
+        {
+            if (!command.StartsWith("coop.debug.", StringComparison.Ordinal))
+                throw new InvalidOperationException("Arbitrary vanilla dispatch is forbidden in this test.");
+            found = AllFunctions.ContainsKey(command);
+            return "legacy result";
+        }
+    }
+}

--- a/tools/CoopMcpServer.Tests/LiveTestCommandDispatcherTests.cs
+++ b/tools/CoopMcpServer.Tests/LiveTestCommandDispatcherTests.cs
@@ -51,31 +51,3 @@ namespace CoopMcpServer.Tests
         }
     }
 }
-
-// These fakes exercise the linked dispatcher without loading Bannerlord or native DLLs.
-namespace Common
-{
-    public static class GameThread
-    {
-        public static void Run(Action action, bool blocking) => action();
-    }
-}
-
-namespace TaleWorlds.Library
-{
-    public static class CommandLineFunctionality
-    {
-        private static readonly Dictionary<string, object> AllFunctions = new()
-        {
-            ["coop.debug.legacy"] = new(), ["campaign.do_something"] = new(), ["coop.unregistered"] = new(),
-        };
-        public static void CollectCommandLineFunctions() { }
-        public static string CallFunction(string command, List<string> arguments, out bool found)
-        {
-            if (!command.StartsWith("coop.debug.", StringComparison.Ordinal))
-                throw new InvalidOperationException("Arbitrary vanilla dispatch is forbidden in this test.");
-            found = AllFunctions.ContainsKey(command);
-            return "legacy result";
-        }
-    }
-}

--- a/tools/CoopMcpServer.Tests/LiveTestPipeClientTests.cs
+++ b/tools/CoopMcpServer.Tests/LiveTestPipeClientTests.cs
@@ -1,0 +1,128 @@
+﻿using Common.LiveTesting;
+using System.IO.Pipes;
+using System.Text;
+using System.Text.Json;
+
+namespace CoopMcpServer.Tests;
+
+public sealed class LiveTestPipeClientTests
+{
+    [Fact]
+    public async Task BoundedReaderRejectsOversizedAndIncompleteResponses()
+    {
+        var client = new LiveTestPipeClient();
+        using var oversized = new MemoryStream(Encoding.UTF8.GetBytes(new string('x', LiveTestProtocol.MaximumMessageBytes + 1) + "\n"));
+        await Assert.ThrowsAsync<IOException>(() => client.ReadResponseAsync(oversized, default));
+        using var incomplete = new MemoryStream(Encoding.UTF8.GetBytes("{}"));
+        await Assert.ThrowsAsync<IOException>(() => client.ReadResponseAsync(incomplete, default));
+    }
+
+    [Fact]
+    public async Task StaleRegistrationIsRejectedBeforeMutationIsSent()
+    {
+        using var endpoint = new Endpoint();
+        endpoint.Register(endpoint.Identity with { StartedUtc = endpoint.Identity.StartedUtc.AddSeconds(-1) });
+        var response = await new LiveTestPipeClient().SendAsync(endpoint.Identity, "command", new { }, true, default);
+        Assert.False(response.Ok);
+        Assert.False(response.Error.OutcomeUncertain);
+    }
+
+    [Theory]
+    [InlineData("pid")]
+    [InlineData("start")]
+    [InlineData("token")]
+    [InlineData("role")]
+    [InlineData("platform")]
+    [InlineData("id")]
+    public async Task ResponseIdentityMismatchPreservesMutationUncertainty(string mismatch)
+    {
+        using var endpoint = new Endpoint();
+        endpoint.Register(endpoint.Identity);
+        var server = endpoint.ServeAsync(request =>
+        {
+            var identity = endpoint.Identity;
+            var process = new LiveTestProcessInfo
+            {
+                Pid = identity.Pid + (mismatch == "pid" ? 1 : 0),
+                ProcessStartedUtc = identity.StartedUtc.AddSeconds(mismatch == "start" ? 1 : 0),
+                RunToken = mismatch == "token" ? "other" : identity.RunToken,
+                Role = mismatch == "role" ? "client" : identity.Role,
+                PlatformId = mismatch == "platform" ? "other" : identity.PlatformId,
+            };
+            return LiveTestResponse.Success(mismatch == "id" ? "other" : request.Id, process, new { });
+        });
+        var response = await new LiveTestPipeClient().SendAsync(endpoint.Identity, "command", new { }, true, default);
+        await server;
+        Assert.False(response.Ok);
+        Assert.True(response.Error.OutcomeUncertain);
+    }
+
+    [Fact]
+    public async Task BrokenPipeAfterWriteDoesNotClaimMutationWasNotApplied()
+    {
+        using var endpoint = new Endpoint();
+        endpoint.Register(endpoint.Identity);
+        var server = endpoint.ServeAsync(_ => null);
+        var response = await new LiveTestPipeClient().SendAsync(endpoint.Identity, "join", new { }, true, default);
+        await server;
+        Assert.False(response.Ok);
+        Assert.True(response.Error.OutcomeUncertain);
+    }
+
+    [Fact]
+    public async Task ValidResponseAndArgumentArrayRoundTrip()
+    {
+        using var endpoint = new Endpoint();
+        endpoint.Register(endpoint.Identity);
+        var server = endpoint.ServeAsync(request =>
+        {
+            Assert.Equal("value with spaces", request.Parameters.GetProperty("arguments")[0].GetString());
+            return LiveTestResponse.Success(request.Id, new LiveTestProcessInfo
+            {
+                Pid = endpoint.Identity.Pid, ProcessStartedUtc = endpoint.Identity.StartedUtc,
+                RunToken = endpoint.Identity.RunToken, Role = endpoint.Identity.Role, PlatformId = endpoint.Identity.PlatformId,
+            }, new { output = "success" });
+        });
+        var response = await new LiveTestPipeClient().SendAsync(endpoint.Identity, "command", new { arguments = new[] { "value with spaces" } }, true, default);
+        await server;
+        Assert.True(response.Ok);
+    }
+
+    private sealed class Endpoint : IDisposable
+    {
+        public InstanceIdentity Identity { get; } = new(Random.Shared.Next(100000000, int.MaxValue), DateTime.UtcNow,
+            "server", "testserver", "test-" + Guid.NewGuid().ToString("N"));
+        private string DirectoryPath => Path.Combine(Path.GetTempPath(), "BannerlordCoop.LiveTest.v1", Identity.RunToken);
+
+        public void Register(InstanceIdentity identity)
+        {
+            Directory.CreateDirectory(DirectoryPath);
+            File.WriteAllText(Path.Combine(DirectoryPath, Identity.Pid + ".json"), JsonSerializer.Serialize(new
+            {
+                version = LiveTestProtocol.Version, pid = identity.Pid, processStartedUtc = identity.StartedUtc,
+                role = identity.Role, platformId = identity.PlatformId, runToken = identity.RunToken,
+                pipeName = LiveTestProtocol.GetPipeName(identity.Pid),
+            }));
+        }
+
+        public async Task ServeAsync(Func<LiveTestRequest, LiveTestResponse> respond)
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var pipe = new NamedPipeServerStream(LiveTestProtocol.GetPipeName(Identity.Pid), PipeDirection.InOut,
+                1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+            await pipe.WaitForConnectionAsync(timeout.Token);
+            using var reader = new StreamReader(pipe, Encoding.UTF8, leaveOpen: true);
+            string line = await reader.ReadLineAsync(timeout.Token);
+            Assert.True(LiveTestProtocol.TryDeserializeRequest(line, out var request, out _));
+            var response = respond(request);
+            if (response != null)
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(LiveTestProtocol.SerializeResponse(response) + "\n");
+                await pipe.WriteAsync(bytes, timeout.Token);
+                await pipe.FlushAsync(timeout.Token);
+            }
+        }
+
+        public void Dispose() { if (Directory.Exists(DirectoryPath)) Directory.Delete(DirectoryPath, true); }
+    }
+}

--- a/tools/CoopMcpServer.Tests/McpStdioTests.cs
+++ b/tools/CoopMcpServer.Tests/McpStdioTests.cs
@@ -1,0 +1,66 @@
+﻿using ModelContextProtocol.Client;
+using System.Text.Json;
+
+namespace CoopMcpServer.Tests;
+
+public sealed class McpStdioTests
+{
+    [Fact]
+    public async Task StdioEofStopsTheMcpHostWithoutForceKillingIt()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "CoopMcpEof-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string config = Path.Combine(directory, "profiles.json");
+            File.WriteAllText(config, JsonSerializer.Serialize(new { artifactDirectory = directory, profiles = new { } }));
+            var info = new System.Diagnostics.ProcessStartInfo(Path.Combine(AppContext.BaseDirectory, "CoopMcpServer.exe"))
+            {
+                UseShellExecute = false, RedirectStandardInput = true, RedirectStandardOutput = true, RedirectStandardError = true,
+            };
+            info.ArgumentList.Add("--config");
+            info.ArgumentList.Add(config);
+            using var process = System.Diagnostics.Process.Start(info);
+            Task<string> errors = process.StandardError.ReadToEndAsync();
+            Task<string> output = process.StandardOutput.ReadToEndAsync();
+            try
+            {
+                process.StandardInput.Close();
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await process.WaitForExitAsync(timeout.Token);
+                Assert.True(process.ExitCode == 0, await errors);
+                Assert.Equal("", await output);
+            }
+            finally { if (!process.HasExited) process.Kill(); }
+        }
+        finally { Directory.Delete(directory, true); }
+    }
+
+    [Fact]
+    public async Task InitializeAndToolsListWorkWithoutGameOrConfiguredProfiles()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "CoopMcpSmoke-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string config = Path.Combine(directory, "profiles.json");
+            File.WriteAllText(config, JsonSerializer.Serialize(new { artifactDirectory = directory, profiles = new { } }));
+            var transport = new StdioClientTransport(new StdioClientTransportOptions
+            {
+                Name = "Coop MCP smoke",
+                Command = Path.Combine(AppContext.BaseDirectory, "CoopMcpServer.exe"),
+                Arguments = new[] { "--config", config },
+                ShutdownTimeout = TimeSpan.FromSeconds(10),
+            });
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await using var client = await McpClient.CreateAsync(transport, cancellationToken: timeout.Token);
+            var tools = await client.ListToolsAsync(cancellationToken: timeout.Token);
+            string[] expected = { "start_run", "get_run", "wait_for_state", "list_commands", "execute_command",
+                "join_client", "read_logs", "screenshot", "screenshot_status", "stop_run" };
+            Assert.Equal(expected.Order(), tools.Select(t => t.Name).Order());
+            var result = await client.CallToolAsync("get_run", new Dictionary<string, object> { ["run_id"] = "missing" }, cancellationToken: timeout.Token);
+            Assert.True(result.IsError);
+        }
+        finally { Directory.Delete(directory, true); }
+    }
+}

--- a/tools/CoopMcpServer.Tests/RunOrchestratorTests.cs
+++ b/tools/CoopMcpServer.Tests/RunOrchestratorTests.cs
@@ -1,0 +1,214 @@
+﻿using Common.LiveTesting;
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace CoopMcpServer.Tests;
+
+public sealed class RunOrchestratorTests : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "CoopMcpServerTests-" + Guid.NewGuid().ToString("N"));
+    private readonly FakeLauncher launcher = new();
+    private readonly FakePipe pipe = new();
+    private readonly RunOrchestrator runs;
+
+    public RunOrchestratorTests()
+    {
+        Directory.CreateDirectory(directory);
+        string executable = Path.Combine(directory, "Bannerlord.exe");
+        File.WriteAllText(executable, "not executable; fake launcher only");
+        var settings = new CoopMcpServerSettings
+        {
+            ArtifactDirectory = directory,
+            Profiles = new() { ["test"] = new LaunchProfile { Executable = executable } },
+        };
+        runs = new RunOrchestrator(settings, launcher, pipe, new IncrementalLogReader());
+    }
+
+    [Fact]
+    public async Task StartLaunchesDistinctOwnedInstancesWithoutImplyingReadinessOrJoining()
+    {
+        var run = await runs.StartAsync("test", 2, default);
+        Assert.Equal(3, run.Instances.Length);
+        Assert.Equal(3, run.Instances.Select(i => i.Identity.PlatformId).Distinct().Count());
+        Assert.All(run.Instances, i => { Assert.True(i.ProcessAlive); Assert.Null(i.Status); Assert.Equal(run.RunId, i.Identity.RunToken); });
+        Assert.Empty(pipe.Methods);
+        Assert.True(File.Exists(Path.Combine(run.ArtifactDirectory, "run.json")));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => runs.StartAsync("test", 0, default));
+    }
+
+    [Fact]
+    public async Task PartialLaunchFailureStopsOnlySuccessfullyOwnedProcesses()
+    {
+        launcher.FailAt = 2;
+        pipe.Throw = true;
+        var run = await runs.StartAsync("test", 2, default);
+        Assert.Equal("launch_failed", run.State);
+        Assert.Single(launcher.Processes);
+        Assert.All(launcher.Processes, p => Assert.Equal(1, p.Stops));
+        Assert.All(run.Instances, i => Assert.False(i.ProcessAlive));
+    }
+
+    [Fact]
+    public async Task CommandsAreSerializedPerInstanceAndUncertainMutationIsNotRetried()
+    {
+        var run = await runs.StartAsync("test", 0, default);
+        pipe.Delay = 30;
+        pipe.Uncertain = true;
+        var first = runs.RequestAsync(run.RunId, "server", "command", new { name = "coop.capture", arguments = new[] { "one two" } }, true, default);
+        var second = runs.RequestAsync(run.RunId, "server", "command", new { name = "coop.capture", arguments = Array.Empty<string>() }, true, default);
+        var responses = await Task.WhenAll(first, second);
+        Assert.Equal(1, pipe.MaxConcurrent);
+        Assert.Equal(2, pipe.Methods.Count);
+        Assert.All(responses, r => Assert.True(r.Error.OutcomeUncertain));
+        Assert.Equal(2, Directory.GetFiles(run.ArtifactDirectory, "server-*.json").Length);
+    }
+
+    [Fact]
+    public async Task IndependentInstancesCanExecuteConcurrently()
+    {
+        var run = await runs.StartAsync("test", 1, default);
+        pipe.Delay = 50;
+        await Task.WhenAll(
+            runs.RequestAsync(run.RunId, "server", "command", new { }, true, default),
+            runs.RequestAsync(run.RunId, "client1", "command", new { }, true, default));
+        Assert.Equal(2, pipe.MaxConcurrent);
+    }
+
+    [Fact]
+    public async Task ArtifactFailureAfterMutationIsReportedAsUncertain()
+    {
+        var run = await runs.StartAsync("test", 0, default);
+        Directory.Delete(run.ArtifactDirectory, true);
+        var response = await runs.RequestAsync(run.RunId, "server", "command", new { }, true, default);
+        Assert.Equal("artifact_write_failed", response.Error.Code);
+        Assert.True(response.Error.OutcomeUncertain);
+        Assert.Single(pipe.Methods);
+    }
+
+    [Fact]
+    public async Task FailedOwnedProcessStopBlocksNewRunUntilCleanupIsRetried()
+    {
+        var run = await runs.StartAsync("test", 0, default);
+        launcher.Processes.Single().FailStop = true;
+        Assert.Equal("cleanup_failed", (await runs.StopAsync(run.RunId)).State);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => runs.StartAsync("test", 0, default));
+        launcher.Processes.Single().FailStop = false;
+        var stopped = await runs.StopAsync(run.RunId);
+        Assert.Equal("stopped", stopped.State);
+        Assert.Null(stopped.Error);
+        Assert.False(stopped.Instances.Single().ProcessAlive);
+    }
+
+    [Fact]
+    public async Task StopAllContinuesAfterCompletedRunArtifactsBecomeUnavailable()
+    {
+        var completed = await runs.StartAsync("test", 0, default);
+        await runs.StopAsync(completed.RunId);
+        var active = await runs.StartAsync("test", 0, default);
+        Directory.Delete(completed.ArtifactDirectory, true);
+
+        var error = await Assert.ThrowsAsync<AggregateException>(() => runs.StopAllAsync());
+
+        Assert.Single(error.InnerExceptions);
+        Assert.All(launcher.Processes, process => Assert.False(process.IsAlive));
+        Assert.All(launcher.Processes, process => Assert.Equal(1, process.Stops));
+        Assert.True(File.Exists(Path.Combine(active.ArtifactDirectory, "run.json")));
+    }
+
+    [Fact]
+    public async Task WaitReportsFalseWhenAliveButNotReadyAndRejectsUnboundedWaits()
+    {
+        var run = await runs.StartAsync("test", 0, default);
+        var result = JsonSerializer.SerializeToElement(await runs.WaitAsync(run.RunId, "server", "readyForCampaignTests", 1, default));
+        Assert.False(result.GetProperty("reached").GetBoolean());
+        Assert.True(result.GetProperty("instance").GetProperty("ProcessAlive").GetBoolean());
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => runs.WaitAsync(run.RunId, "server", "controlReady", 301, default));
+        await Assert.ThrowsAsync<ArgumentException>(() => runs.WaitAsync(run.RunId, "server", "invented", 1, default));
+    }
+
+    [Fact]
+    public async Task WaitUsesEndpointReadinessAndStopArchivesActualLogPathIdempotently()
+    {
+        string log = Path.Combine(directory, "actual-process-specific.log");
+        File.WriteAllText(log, "the log");
+        pipe.Status = new { readyForCampaignTests = true, logPath = log };
+        var run = await runs.StartAsync("test", 0, default);
+        var result = JsonSerializer.SerializeToElement(await runs.WaitAsync(run.RunId, "server", "readyForCampaignTests", 1, default));
+        Assert.True(result.GetProperty("reached").GetBoolean());
+        Assert.Equal("the log", (await runs.ReadLogsAsync(run.RunId, "server", null, 100, default)).Text);
+        Assert.Equal("stopped", (await runs.StopAsync(run.RunId)).State);
+        File.WriteAllText(log, "later unrelated process");
+        Assert.Equal("the log", (await runs.ReadLogsAsync(run.RunId, "server", null, 100, default)).Text);
+        await runs.StopAsync(run.RunId);
+        Assert.Equal(1, launcher.Processes.Single().Stops);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(3)]
+    [InlineData(17)]
+    public async Task InvalidClientCountNeverLaunches(int count)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => runs.StartAsync("test", count, default));
+        Assert.Empty(launcher.Processes);
+    }
+
+    public void Dispose() => Directory.Delete(directory, true);
+
+    private sealed class FakeLauncher : IGameProcessLauncher
+    {
+        public int FailAt;
+        public List<FakeProcess> Processes = new();
+        public IOwnedProcess Launch(LaunchProfile profile, string role, string platformId, string runToken)
+        {
+            if (Processes.Count + 1 == FailAt) throw new IOException("fake launch failure");
+            var process = new FakeProcess(Processes.Count + 1);
+            Processes.Add(process);
+            return process;
+        }
+    }
+
+    private sealed class FakeProcess(int pid) : IOwnedProcess
+    {
+        public int Pid => pid;
+        public DateTime StartedUtc { get; } = DateTime.UtcNow;
+        public bool IsAlive { get; private set; } = true;
+        public int Stops;
+        public bool FailStop;
+        public Task StopAsync(TimeSpan grace)
+        {
+            Stops++;
+            if (FailStop) throw new IOException("fake stop failure");
+            IsAlive = false;
+            return Task.CompletedTask;
+        }
+        public void Dispose() { }
+    }
+
+    private sealed class FakePipe : ILiveTestPipeClient
+    {
+        public ConcurrentQueue<string> Methods = new();
+        public bool Throw;
+        public bool Uncertain;
+        public int Delay;
+        public int MaxConcurrent;
+        private int concurrent;
+        public object Status = new { readyForCampaignTests = false };
+        public async Task<LiveTestResponse> SendAsync(InstanceIdentity identity, string method, object parameters, bool mutation, CancellationToken cancellationToken)
+        {
+            Methods.Enqueue(method);
+            int count = Interlocked.Increment(ref concurrent);
+            MaxConcurrent = Math.Max(MaxConcurrent, count);
+            try
+            {
+                if (Throw) throw new IOException("fake pipe failure");
+                if (Delay > 0) await Task.Delay(Delay, cancellationToken);
+                var process = new LiveTestProcessInfo { Pid = identity.Pid, RunToken = identity.RunToken, ProcessStartedUtc = identity.StartedUtc };
+                return Uncertain
+                    ? LiveTestResponse.Failure(Guid.NewGuid().ToString("N"), process, new LiveTestError("game_thread_timeout", "fake timeout", true))
+                    : LiveTestResponse.Success(Guid.NewGuid().ToString("N"), process, JsonSerializer.SerializeToElement(Status));
+            }
+            finally { Interlocked.Decrement(ref concurrent); }
+        }
+    }
+}

--- a/tools/CoopMcpServer/CoopMcpServer.csproj
+++ b/tools/CoopMcpServer/CoopMcpServer.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <Compile Include="../../source/Common/LiveTesting/LiveTestProtocol.cs" Link="Protocol/LiveTestProtocol.cs" />
+  </ItemGroup>
+</Project>

--- a/tools/CoopMcpServer/CoopMcpServerSettings.cs
+++ b/tools/CoopMcpServer/CoopMcpServerSettings.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.Json;
+
+namespace CoopMcpServer;
+
+public sealed class CoopMcpServerSettings
+{
+    public string ArtifactDirectory { get; set; }
+    public Dictionary<string, LaunchProfile> Profiles { get; set; } = new();
+
+    public static CoopMcpServerSettings Load(string path)
+    {
+        var settings = JsonSerializer.Deserialize<CoopMcpServerSettings>(File.ReadAllText(path),
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        if (settings == null || !Path.IsPathFullyQualified(settings.ArtifactDirectory ?? ""))
+            throw new ArgumentException("artifactDirectory must be an absolute path.");
+        return settings;
+    }
+}
+
+public sealed class LaunchProfile
+{
+    public string Executable { get; set; }
+    public string[] Modules { get; set; } = { "Native", "SandBoxCore", "SandBox", "StoryMode", "Coop" };
+    public string ServerPlatformId { get; set; } = "testserver";
+    public string[] ClientPlatformIds { get; set; } = { "testclient1", "testclient2" };
+
+    public void Validate(int clientCount)
+    {
+        if (clientCount < 0 || clientCount > 16 || ClientPlatformIds == null || clientCount > ClientPlatformIds.Length)
+            throw new ArgumentException("client_count must be 0..16 and fit the profile's clientPlatformIds.");
+        if (!Path.IsPathFullyQualified(Executable ?? "") ||
+            !string.Equals(Path.GetFileName(Executable), "Bannerlord.exe", StringComparison.OrdinalIgnoreCase) ||
+            !File.Exists(Executable))
+            throw new ArgumentException("The in-game profile requires an existing absolute Bannerlord.exe path.");
+        var ids = new[] { ServerPlatformId }.Concat(ClientPlatformIds.Take(clientCount)).ToArray();
+        if (ids.Any(id => string.IsNullOrWhiteSpace(id) || id.Length > 64 ||
+                id.Any(c => !char.IsAsciiLetterOrDigit(c) && c != '-' && c != '_')) ||
+            ids.Distinct(StringComparer.OrdinalIgnoreCase).Count() != ids.Length)
+            throw new ArgumentException("All selected platform IDs must be distinct, 1..64 ASCII letters/digits, '-' or '_'.");
+        if (Modules == null || Modules.Length == 0 || Modules.Length > 32 ||
+            Modules.Any(m => string.IsNullOrWhiteSpace(m) || m.Length > 128 ||
+                m.Any(c => !char.IsAsciiLetterOrDigit(c) && c != '_' && c != '-')) ||
+            !Modules.Contains("Coop", StringComparer.Ordinal))
+            throw new ArgumentException("modules must include Coop and contain only module identifiers.");
+    }
+}

--- a/tools/CoopMcpServer/DebugTools.cs
+++ b/tools/CoopMcpServer/DebugTools.cs
@@ -1,0 +1,64 @@
+﻿using Common.LiveTesting;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace CoopMcpServer;
+
+public interface IDebugTools
+{
+    Task<RunView> StartRun(string profile, int client_count, CancellationToken cancellationToken);
+    Task<RunView> GetRun(string run_id, CancellationToken cancellationToken);
+    Task<object> WaitForState(string run_id, string instance, string state, int timeout_seconds, CancellationToken cancellationToken);
+    Task<LiveTestResponse> ListCommands(string run_id, string instance, CancellationToken cancellationToken);
+    Task<LiveTestResponse> ExecuteCommand(string run_id, string instance, string name, string[] arguments, CancellationToken cancellationToken);
+    Task<LiveTestResponse> JoinClient(string run_id, string instance, CancellationToken cancellationToken);
+    Task<LogChunk> ReadLogs(string run_id, string instance, CancellationToken cancellationToken, string cursor = null, int max_bytes = 16384);
+    Task<LiveTestResponse> Screenshot(string run_id, string instance, CancellationToken cancellationToken);
+    Task<LiveTestResponse> ScreenshotStatus(string run_id, string instance, string capture_id, CancellationToken cancellationToken);
+    Task<RunView> StopRun(string run_id);
+}
+
+[McpServerToolType]
+public sealed class DebugTools : IDebugTools
+{
+    private readonly IRunOrchestrator runs;
+    public DebugTools(IRunOrchestrator runs) { this.runs = runs; }
+
+    [McpServerTool(Name = "start_run", UseStructuredContent = true), Description("Launch a configured in-game server and 0..16 deferred clients. Returns booting, NOT connected or ready. Next wait for server readyForCampaignTests, each client readyToJoin, join_client each, then wait each client readyForCampaignTests. Only one active run per MCP session.")]
+    public Task<RunView> StartRun(string profile, int client_count, CancellationToken cancellationToken) =>
+        runs.StartAsync(profile, client_count, cancellationToken);
+
+    [McpServerTool(Name = "get_run", ReadOnly = true, UseStructuredContent = true), Description("Refresh owned instances: process alive is distinct from endpoint readiness, campaign readiness and mission readiness. Includes endpoint status and diagnostic errors.")]
+    public Task<RunView> GetRun(string run_id, CancellationToken cancellationToken) => runs.GetAsync(run_id, cancellationToken);
+
+    [McpServerTool(Name = "wait_for_state", ReadOnly = true, UseStructuredContent = true), Description("Bounded wait, 1..300 seconds, for one instance state: controlReady, readyToJoin, commandRegistryReady, readyForCampaignTests, readyForMissionTests, exited. Returns reached=false and diagnostics on timeout or early exit. No mutation retries.")]
+    public Task<object> WaitForState(string run_id, string instance, string state, int timeout_seconds, CancellationToken cancellationToken) =>
+        runs.WaitAsync(run_id, instance, state, timeout_seconds, cancellationToken);
+
+    [McpServerTool(Name = "list_commands", ReadOnly = true, UseStructuredContent = true), Description("List ALL registered co-op framework commands plus legacy coop.debug.* commands for this instance. Wait for commandRegistryReady for the full session registry. Arbitrary vanilla console commands are not exposed.")]
+    public Task<LiveTestResponse> ListCommands(string run_id, string instance, CancellationToken cancellationToken) =>
+        runs.RequestAsync(run_id, instance, "command-catalog", new { }, false, cancellationToken);
+
+    [McpServerTool(Name = "execute_command", UseStructuredContent = true), Description("Execute a catalog command on the target game thread. arguments is a string array, not a shell or console line. Preserve argument boundaries; do not add quoting. Run authoritative mutations on server, read-only inspections on clients. Inspect ok/error and output; outcomeUncertain=true means it may still execute, never blindly retry.")]
+    public Task<LiveTestResponse> ExecuteCommand(string run_id, string instance, string name, string[] arguments, CancellationToken cancellationToken) =>
+        runs.RequestAsync(run_id, instance, "command", new { name, arguments }, true, cancellationToken);
+
+    [McpServerTool(Name = "join_client", UseStructuredContent = true), Description("Attempt one deferred client join after server readyForCampaignTests and client readyToJoin. This schedules joining, not completion. Then wait for client readyForCampaignTests. Do not retry uncertain outcomes.")]
+    public Task<LiveTestResponse> JoinClient(string run_id, string instance, CancellationToken cancellationToken) =>
+        runs.RequestAsync(run_id, instance, "join", new { }, true, cancellationToken);
+
+    [McpServerTool(Name = "read_logs", ReadOnly = true, UseStructuredContent = true), Description("Read 4..65536 UTF-8 bytes from the endpoint-reported log (or archived log after stop). Omit cursor for beginning. Pass returned cursor for incremental reads. reset=true means replacement/truncation/compaction changed the observed content; output restarts at beginning. Cursors are opaque and instance-specific.")]
+    public Task<LogChunk> ReadLogs(string run_id, string instance, CancellationToken cancellationToken, string cursor = null, int max_bytes = 16384) =>
+        runs.ReadLogsAsync(run_id, instance, cursor, max_bytes, cancellationToken);
+
+    [McpServerTool(Name = "screenshot", UseStructuredContent = true), Description("Request BMP screenshot in the run artifact directory. This is asynchronous; poll screenshot_status with returned captureId until complete. No automatic retry.")]
+    public Task<LiveTestResponse> Screenshot(string run_id, string instance, CancellationToken cancellationToken) =>
+        runs.RequestAsync(run_id, instance, "screenshot", new { path = runs.ScreenshotPath(run_id, instance) }, true, cancellationToken);
+
+    [McpServerTool(Name = "screenshot_status", ReadOnly = true, UseStructuredContent = true), Description("Check an existing screenshot captureId; complete=true means the bridge observed a stable BMP file. Returns a local artifact path, not image bytes.")]
+    public Task<LiveTestResponse> ScreenshotStatus(string run_id, string instance, string capture_id, CancellationToken cancellationToken) =>
+        runs.RequestAsync(run_id, instance, "screenshot-status", new { captureId = capture_id }, false, cancellationToken);
+
+    [McpServerTool(Name = "stop_run", UseStructuredContent = true), Description("Shutdown only owned processes, then force-stop those still alive after bounded grace. Archive endpoint-reported logs and retain all run artifacts. Idempotent; cleanup failures remain inspectable and can be retried.")]
+    public Task<RunView> StopRun(string run_id) => runs.StopAsync(run_id);
+}

--- a/tools/CoopMcpServer/InGameProcessLauncher.cs
+++ b/tools/CoopMcpServer/InGameProcessLauncher.cs
@@ -1,0 +1,80 @@
+﻿using System.Diagnostics;
+
+namespace CoopMcpServer;
+
+public interface IOwnedProcess : IDisposable
+{
+    int Pid { get; }
+    DateTime StartedUtc { get; }
+    bool IsAlive { get; }
+    Task StopAsync(TimeSpan grace);
+}
+
+public interface IGameProcessLauncher
+{
+    IOwnedProcess Launch(LaunchProfile profile, string role, string platformId, string runToken);
+}
+
+public sealed class InGameProcessLauncher : IGameProcessLauncher
+{
+    public IOwnedProcess Launch(LaunchProfile profile, string role, string platformId, string runToken)
+    {
+        var process = Process.Start(CreateStartInfo(profile, role, platformId, runToken));
+        if (process == null) throw new InvalidOperationException("Bannerlord did not start.");
+        try
+        {
+            return new OwnedProcess(process);
+        }
+        catch
+        {
+            // Only the process just created by this launcher can be cleaned up here.
+            try { if (!process.HasExited) process.Kill(); }
+            finally { process.Dispose(); }
+            throw;
+        }
+    }
+
+    public ProcessStartInfo CreateStartInfo(LaunchProfile profile, string role, string platformId, string runToken)
+    {
+        var info = new ProcessStartInfo(profile.Executable)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(profile.Executable),
+        };
+        foreach (string argument in new[] { "/singleplayer", "/" + role, "/autoconnect",
+            "/platformId", platformId, "/cooptestrun", runToken })
+            info.ArgumentList.Add(argument);
+        if (role == "client") info.ArgumentList.Add("/cooptestmanualjoin");
+        info.ArgumentList.Add("_MODULES_*" + string.Join("*", profile.Modules) + "*_MODULES_");
+        return info;
+    }
+
+    private sealed class OwnedProcess : IOwnedProcess
+    {
+        private readonly Process process;
+        public int Pid { get; }
+        public DateTime StartedUtc { get; }
+        public bool IsAlive => !process.HasExited && process.StartTime.ToUniversalTime() == StartedUtc;
+
+        public OwnedProcess(Process process)
+        {
+            this.process = process;
+            Pid = process.Id;
+            StartedUtc = process.StartTime.ToUniversalTime();
+        }
+
+        public async Task StopAsync(TimeSpan grace)
+        {
+            if (!IsAlive) return;
+            using var timeout = new CancellationTokenSource(grace);
+            try { await process.WaitForExitAsync(timeout.Token); }
+            catch (OperationCanceledException) { }
+            if (!IsAlive) return;
+            process.Kill();
+            using var killTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await process.WaitForExitAsync(killTimeout.Token);
+        }
+
+        public void Dispose() => process.Dispose();
+    }
+}

--- a/tools/CoopMcpServer/IncrementalLogReader.cs
+++ b/tools/CoopMcpServer/IncrementalLogReader.cs
@@ -1,0 +1,72 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace CoopMcpServer;
+
+public interface IIncrementalLogReader
+{
+    LogChunk Read(string path, string cursor, int maxBytes);
+}
+
+public sealed record LogChunk(string Text, string Cursor, bool Reset, bool HasMore, long Length);
+
+public sealed class IncrementalLogReader : IIncrementalLogReader
+{
+    private const int ProbeLimit = (1024 * 1024) + 512;
+    private sealed record CursorState(string Path, long CreatedTicks, long Offset, int ProbeLength,
+        string ProbeHash, string BoundaryHash);
+
+    public LogChunk Read(string path, string cursor, int maxBytes)
+    {
+        if (maxBytes < 4 || maxBytes > 65536) throw new ArgumentOutOfRangeException(nameof(maxBytes), "max_bytes must be 4..65536.");
+        CursorState previous = null;
+        if (cursor != null)
+        {
+            if (cursor.Length > 8192) throw new ArgumentException("Invalid log cursor.");
+            try { previous = JsonSerializer.Deserialize<CursorState>(Convert.FromBase64String(cursor)); }
+            catch (Exception e) when (e is FormatException || e is JsonException)
+            { throw new ArgumentException("Invalid log cursor.", e); }
+            if (previous == null || previous.Offset < 0 || previous.ProbeLength < 0 || previous.ProbeLength > ProbeLimit)
+                throw new ArgumentException("Invalid log cursor.");
+        }
+        path = System.IO.Path.GetFullPath(path);
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        long created = File.GetCreationTimeUtc(path).Ticks;
+        long length = stream.Length;
+        bool reset = previous != null && (previous.Path != path || previous.CreatedTicks != created ||
+            previous.Offset > length || previous.ProbeLength > length ||
+            previous.ProbeHash != Hash(stream, 0, previous.ProbeLength) ||
+            previous.BoundaryHash != Hash(stream, Math.Max(0, previous.Offset - 256), (int)Math.Min(256, previous.Offset)));
+        long offset = previous == null || reset ? 0 : previous.Offset;
+        int probeLength = (int)Math.Min(length, ProbeLimit);
+        string probeHash = Hash(stream, 0, probeLength);
+        stream.Position = offset;
+        var buffer = new byte[(int)Math.Min(maxBytes, length - offset)];
+        int count = stream.ReadAtLeast(buffer, buffer.Length, throwOnEndOfStream: false);
+        bool reachedEnd = offset + count >= length;
+        // Leave incomplete trailing UTF-8 characters for the next read.
+        if (count > 0)
+        {
+            int start = count - 1;
+            while (start > 0 && (buffer[start] & 0xC0) == 0x80) start--;
+            int expected = buffer[start] >= 0xF0 ? 4 : buffer[start] >= 0xE0 ? 3 : buffer[start] >= 0xC0 ? 2 : 1;
+            if (count - start < expected) count = start;
+        }
+        offset += count;
+        string boundaryHash = Hash(stream, Math.Max(0, offset - 256), (int)Math.Min(256, offset));
+        if (stream.Length < length || probeHash != Hash(stream, 0, probeLength) || File.GetCreationTimeUtc(path).Ticks != created)
+            throw new IOException("Log changed while reading; retry read_logs with the same cursor.");
+        var next = new CursorState(path, created, offset, probeLength, probeHash, boundaryHash);
+        return new LogChunk(Encoding.UTF8.GetString(buffer, 0, count),
+            Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(next)), reset, !reachedEnd && offset < length, length);
+    }
+
+    private string Hash(Stream stream, long offset, int count)
+    {
+        stream.Position = offset;
+        var bytes = new byte[count];
+        int read = stream.ReadAtLeast(bytes, count, throwOnEndOfStream: false);
+        return Convert.ToHexString(SHA256.HashData(bytes.AsSpan(0, read)));
+    }
+}

--- a/tools/CoopMcpServer/LiveTestPipeClient.cs
+++ b/tools/CoopMcpServer/LiveTestPipeClient.cs
@@ -1,0 +1,99 @@
+﻿using Common.LiveTesting;
+using System.IO.Pipes;
+using System.Text;
+using System.Text.Json;
+
+namespace CoopMcpServer;
+
+public interface ILiveTestPipeClient
+{
+    Task<LiveTestResponse> SendAsync(InstanceIdentity identity, string method, object parameters,
+        bool mutation, CancellationToken cancellationToken);
+}
+
+public sealed record InstanceIdentity(int Pid, DateTime StartedUtc, string Role, string PlatformId, string RunToken);
+
+public sealed class LiveTestPipeClient : ILiveTestPipeClient
+{
+    public async Task<LiveTestResponse> SendAsync(InstanceIdentity identity, string method, object parameters,
+        bool mutation, CancellationToken cancellationToken)
+    {
+        string id = Guid.NewGuid().ToString("N");
+        bool writeStarted = false;
+        var process = new LiveTestProcessInfo
+        {
+            Pid = identity.Pid, ProcessStartedUtc = identity.StartedUtc, Role = identity.Role,
+            PlatformId = identity.PlatformId, RunToken = identity.RunToken,
+        };
+        try
+        {
+            var request = new LiveTestRequest
+            {
+                Version = LiveTestProtocol.Version, Id = id, Method = method,
+                Parameters = JsonSerializer.SerializeToElement(parameters),
+            };
+            byte[] payload = Encoding.UTF8.GetBytes(LiveTestProtocol.SerializeRequest(request) + "\n");
+            ValidateRegistration(identity);
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(35));
+            using var pipe = new NamedPipeClientStream(".", LiveTestProtocol.GetPipeName(identity.Pid),
+                PipeDirection.InOut, PipeOptions.Asynchronous);
+            await pipe.ConnectAsync(1500, timeout.Token);
+            writeStarted = true;
+            await pipe.WriteAsync(payload, timeout.Token);
+            await pipe.FlushAsync(timeout.Token);
+            string json = await ReadResponseAsync(pipe, timeout.Token);
+            if (!LiveTestProtocol.TryDeserializeResponse(json, out var response, out var error))
+                throw new IOException(error.Message);
+            if (response.Id != id || response.Process.Pid != identity.Pid ||
+                response.Process.ProcessStartedUtc != identity.StartedUtc ||
+                response.Process.Role != identity.Role || response.Process.PlatformId != identity.PlatformId ||
+                response.Process.RunToken != identity.RunToken)
+                throw new IOException("Response identity or request id mismatch.");
+            return response;
+        }
+        catch (Exception exception) when (exception is IOException || exception is TimeoutException ||
+            exception is OperationCanceledException || exception is JsonException ||
+            exception is UnauthorizedAccessException || exception is InvalidOperationException ||
+            exception is KeyNotFoundException || exception is FormatException || exception is ArgumentException)
+        {
+            return LiveTestResponse.Failure(id, process,
+                new LiveTestError("transport_failed", exception.Message, mutation && writeStarted));
+        }
+    }
+
+    private void ValidateRegistration(InstanceIdentity identity)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "BannerlordCoop.LiveTest.v1", identity.RunToken,
+            identity.Pid + ".json");
+        using var file = File.OpenRead(path);
+        if (file.Length > 16384) throw new IOException("Endpoint registration is too large.");
+        using var document = JsonDocument.Parse(file);
+        var root = document.RootElement;
+        if (root.GetProperty("version").GetInt32() != LiveTestProtocol.Version ||
+            root.GetProperty("pid").GetInt32() != identity.Pid ||
+            root.GetProperty("processStartedUtc").GetDateTime() != identity.StartedUtc ||
+            root.GetProperty("role").GetString() != identity.Role ||
+            root.GetProperty("platformId").GetString() != identity.PlatformId ||
+            root.GetProperty("runToken").GetString() != identity.RunToken ||
+            root.GetProperty("pipeName").GetString() != LiveTestProtocol.GetPipeName(identity.Pid))
+            throw new IOException("Endpoint registration does not match the owned process.");
+    }
+
+    public async Task<string> ReadResponseAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var bytes = new MemoryStream();
+        var buffer = new byte[4096];
+        while (true)
+        {
+            int count = await stream.ReadAsync(buffer, cancellationToken);
+            if (count == 0) throw new IOException("Pipe closed before a complete response.");
+            int newline = Array.IndexOf(buffer, (byte)'\n', 0, count);
+            int length = newline >= 0 ? newline : count;
+            if (bytes.Length + length > LiveTestProtocol.MaximumMessageBytes)
+                throw new IOException("Live-test response exceeds the protocol limit.");
+            bytes.Write(buffer, 0, length);
+            if (newline >= 0) return new UTF8Encoding(false, true).GetString(bytes.ToArray()).TrimEnd('\r');
+        }
+    }
+}

--- a/tools/CoopMcpServer/Program.cs
+++ b/tools/CoopMcpServer/Program.cs
@@ -1,0 +1,28 @@
+﻿using CoopMcpServer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+if (!OperatingSystem.IsWindows()) throw new PlatformNotSupportedException("CoopMcpServer requires Windows.");
+if (args.Length != 2 || args[0] != "--config")
+    throw new ArgumentException("Usage: CoopMcpServer --config C:\\absolute\\profiles.json");
+var settings = CoopMcpServerSettings.Load(args[1]);
+var builder = Host.CreateApplicationBuilder();
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+builder.Services.AddSingleton(settings);
+builder.Services.AddTransient<IGameProcessLauncher, InGameProcessLauncher>();
+builder.Services.AddTransient<ILiveTestPipeClient, LiveTestPipeClient>();
+builder.Services.AddTransient<IIncrementalLogReader, IncrementalLogReader>();
+// Run ownership must outlive individual MCP tool invocations.
+builder.Services.AddSingleton<IRunOrchestrator, RunOrchestrator>();
+builder.Services.AddTransient<IDebugTools, DebugTools>();
+builder.Services.AddMcpServer().WithStdioServerTransport().WithTools<DebugTools>();
+using var host = builder.Build();
+var runs = host.Services.GetRequiredService<IRunOrchestrator>();
+try
+{
+    await host.StartAsync();
+    await host.WaitForShutdownAsync();
+}
+finally { await runs.StopAllAsync(); }

--- a/tools/CoopMcpServer/README.md
+++ b/tools/CoopMcpServer/README.md
@@ -1,0 +1,73 @@
+# CoopMcpServer (V1, Windows)
+
+A standalone .NET 10 stdio MCP server using the official C# `ModelContextProtocol` SDK, pinned to 1.4.1. No Bannerlord DLLs are loaded into the MCP process. The shared V1 wire protocol is source-linked from `source/Common/LiveTesting/LiveTestProtocol.cs`.
+
+V1 starts **an in-game `/server` process**, plus configurable deferred `/client` processes. The host does not play: anyone playing, including the host operator, uses a client. `IGameProcessLauncher` is the replacement seam for a future dedicated-server launcher; no dedicated-server implementation is included.
+
+## Install
+
+1. Install the Windows .NET 10 SDK (or runtime for published framework-dependent output).
+2. Prepare a Bannerlord installation with a **matching DEBUG build** of Coop, Common, GameInterface and the other mod assemblies. The bridge is compiled out in Release. These tools do not build or deploy the mod, edit game configuration, or install game dependencies.
+3. From the repository root, publish only the MCP executable:
+
+   ```powershell
+   & 'C:\Program Files\dotnet\dotnet.exe' publish tools\CoopMcpServer\CoopMcpServer.csproj -c Release -o C:\CoopMcpServer\Server
+   Copy-Item tools\CoopMcpServer\profiles.example.json C:\CoopMcpServer\profiles.json
+   ```
+
+4. Edit `C:\CoopMcpServer\profiles.json` to select the existing `Bannerlord.exe` and modules for your installation. The working directory is the executable's directory. The example uses the standard Steam install location. `artifactDirectory` must be absolute. Selected platform IDs must be distinct (including the server), and contain only ASCII letters/digits, `-` or `_`. Add client IDs to allow more clients, up to 16. Zero clients is supported. Profiles are trusted local operator configuration; tools accept a profile name, never an executable, shell command or arbitrary launch arguments.
+5. Add this to an MCP client's configuration:
+
+   ```json
+   {
+     "mcpServers": {
+       "bannerlord-coop": {
+         "command": "C:\\CoopMcpServer\\Server\\CoopMcpServer.exe",
+         "args": ["--config", "C:\\CoopMcpServer\\profiles.json"]
+       }
+     }
+   }
+   ```
+
+Use one MCP server session and one co-op host at a time on the local game ports. The transport is stdio plus local Windows named pipes, not HTTP. The launcher explicitly opts each DEBUG game process in with `/autoconnect /cooptestrun` and a fresh run token. Clients additionally receive `/cooptestmanualjoin`. Ordinary game launches are unaffected. Use only trusted local MCP clients, since registered co-op commands can change the save/world. No new command-role bypass or `AllowedThread` scope is introduced.
+
+## Agent workflow
+
+Tool parameters below are JSON objects. After `start_run`, use the returned `runId` as `run_id` on subsequent calls. Instance names are `server`, `client1`, `client2`, etc.; never target by a discovered PID.
+
+1. `start_run`: `{"profile":"local","client_count":2}`. `state: "started"` means processes were launched, **not** that the server is ready or clients are connected. A partially failed launch is cleaned up and reported with its run/artifact identity.
+2. `wait_for_state` on `server`, `state: "readyForCampaignTests"`, `timeout_seconds: 300`. Check `reached`. A timeout does not end the run; use `get_run` for `activeState`, `coopState`, queue depth, registry readiness, loaded assembly identities, and errors. `processAlive` alone is never readiness.
+3. For each client, `wait_for_state` with `state: "readyToJoin"`, `timeout_seconds: 300`, then call `join_client` once. Joining is explicit so clients do not race server initialization. Check the response's `ok` and `result.started`.
+4. Wait for each client `readyForCampaignTests`. The server's `connectedPlayerCount` and `connectedControllerIds` provide additional join diagnostics. A join acknowledgment is not a completed connection.
+5. Call `list_commands` for each instance after `commandRegistryReady`. It includes **all registered framework commands**, such as `coop.unstuck`, not only debug commands. Legacy `coop.debug.*` commands remain supported. Unregistered `coop.*` names and arbitrary vanilla console commands are not exposed. Catalogs before session initialization can contain only legacy commands.
+6. Execute commands with a string-array `arguments`, without shell quoting. For a read-only Danustica inspection, use `name: "coop.debug.location.list_characters"`, `arguments: ["Location_town_ES1_lordshall"]` on a client after checking its catalog. `coop.debug.town.list_towns` with `[]` lists towns, including Danustica (`town_ES1`, town object `town_comp_ES1`, Southern Empire). Run authoritative state-changing cheats on `server` only; inspect the replicated result on clients. Existing command role and authority checks still apply.
+7. `read_logs`: use `max_bytes: 16384`, initially omit `cursor`. Pass the returned opaque `cursor` on subsequent reads of the same instance. Output is limited to 4..65536 UTF-8 bytes per call and preserves split UTF-8 characters. `hasMore` means the current read limit left more data to read. An incomplete UTF-8 tail returns `hasMore: false` without consuming it; keep the cursor and poll again for later appends. `reset: true` restarts from the beginning when replacement, truncation or observed compaction invalidates the cursor. The reader checks creation time, a bounded prefix including the sink's compaction marker, and the cursor boundary. A concurrent rewrite can return an error; retry this **read** with the same cursor. This is not a lossless log subscription: the game sink can already have removed old middle entries before polling.
+8. Optional `screenshot`, then `screenshot_status` with the returned `captureId` as `capture_id`. Wait for `result.complete`; the initial request is not a finished image. Unique BMP paths are allocated inside the run's artifact directory. MCP returns the path, not inline image data.
+9. Always `stop_run` before closing the MCP client. It requests bridge shutdown, allows bounded grace, then kills only still-alive process handles created by this session. No process-name scans, PID adoption, process-tree kills, or cleanup of unrelated games. Cleanup failure is reported as `cleanup_failed`; inspect errors and retry `stop_run`. Starting another run is blocked until cleanup completes.
+
+`wait_for_state` accepts `controlReady`, `readyToJoin`, `commandRegistryReady`, `readyForCampaignTests`, `readyForMissionTests`, and `exited`, with a 1..300-second budget. `get_run` probes instances in parallel with a three-second status budget per instance. Command calls have a 35-second pipe budget; calls on one instance are serialized. Waiting for another command's instance gate can add latency to other tools, while `wait_for_state` includes gate waiting in its deadline. Configure the MCP client's tool timeout above the requested wait budget.
+
+### Failures and artifacts
+
+- Each endpoint registration and reply must match the owned PID, UTC process start time, role, platform ID and run token. Reply request IDs must match too. A stale registration or mismatched bridge version/identity is not adopted. Both protocol peers must include the new `processStartedUtc` envelope field; older DEBUG deployments will not work with this tool.
+- Inspect `ok`, `error`, `error.outcomeUncertain`, and command `result.output`. Framework output can report an argument/role failure even when the bridge successfully dispatched the command. Structured `LIVE_TEST_JSON` output is preserved in the bridge result.
+- **Never blindly retry a mutation with `outcomeUncertain: true`.** A game-thread timeout, lost reply, or cancellation after sending can leave the operation queued or applied. There is no automatic mutation retry, including joins and screenshots. Inspect state/logs before deciding what to do next.
+- Each run retains `run.json`, per-request response JSON, requested screenshots and copies of endpoint-reported logs at stop. The actual path comes from a validated status response, not guessed `Coop_client.log` names. If the process dies before any successful status, no log path is available and no guessed log is copied. Passing a live-file cursor after stop can reset because the archive path changed.
+- Completed runs remain accessible in the same MCP session. Restarted MCP sessions do not adopt old runs or processes; inspect retained files directly. Normal stdin EOF/host shutdown attempts owned-process cleanup, but force-killing the MCP process or a short client shutdown timeout can interrupt it. Always explicitly stop runs first. A machine crash cannot guarantee artifact archival or orphan cleanup. Preserve the recorded run manifest for manual inspection in that case.
+- V1 uses the game's existing auto-start and connection configuration. It does not select saves, change ports/passwords, bypass startup errors, run builds/deployments, or coordinate background joins.
+
+## Checks without launching Bannerlord
+
+```powershell
+& 'C:\Program Files\dotnet\dotnet.exe' test tools\CoopMcpServer.Tests\CoopMcpServer.Tests.csproj
+```
+
+The suite uses fake launchers/processes, temporary log files and local test pipes. The stdio tests start **only this MCP executable**, initialize an official SDK client, list all ten tools, check an unknown-run error, and verify stdin EOF exits cleanly. Source-linked dispatcher tests use game-thread/vanilla-registry fakes; the existing `source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs` covers the real referenced game assembly seam too.
+
+For a compile-only game check, clearing `PostBuildEvent` alone is insufficient: current `Deploy.targets` also runs after Build. Set the **global** `ModName` property empty as well, which disables its deployment condition:
+
+```powershell
+& 'C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\MSBuild.exe' source\Coop\Coop.csproj -t:Build -p:Configuration=Debug -p:Platform=AnyCPU -p:PostBuildEvent= -p:ModName= -p:NuGetAudit=false
+```
+
+A real server/two-client run, command replication and screenshot completion still require a separately authorized live validation using the workflow above.

--- a/tools/CoopMcpServer/RunOrchestrator.cs
+++ b/tools/CoopMcpServer/RunOrchestrator.cs
@@ -1,0 +1,313 @@
+﻿using Common.LiveTesting;
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace CoopMcpServer;
+
+public interface IRunOrchestrator
+{
+    Task<RunView> StartAsync(string profile, int clientCount, CancellationToken cancellationToken);
+    Task<RunView> GetAsync(string runId, CancellationToken cancellationToken);
+    Task<object> WaitAsync(string runId, string instance, string state, int timeoutSeconds, CancellationToken cancellationToken);
+    Task<LiveTestResponse> RequestAsync(string runId, string instance, string method, object parameters, bool mutation, CancellationToken cancellationToken);
+    Task<LogChunk> ReadLogsAsync(string runId, string instance, string cursor, int maxBytes, CancellationToken cancellationToken);
+    Task<RunView> StopAsync(string runId);
+    Task StopAllAsync();
+    string ScreenshotPath(string runId, string instance);
+}
+
+public sealed record InstanceView(string Name, InstanceIdentity Identity, bool ProcessAlive, JsonElement? Status, LiveTestError Error);
+public sealed record RunView(string RunId, string Profile, string ArtifactDirectory, string State, string Error, InstanceView[] Instances);
+
+public sealed class RunOrchestrator : IRunOrchestrator
+{
+    private readonly CoopMcpServerSettings settings;
+    private readonly IGameProcessLauncher launcher;
+    private readonly ILiveTestPipeClient pipe;
+    private readonly IIncrementalLogReader logs;
+    private readonly SemaphoreSlim lifecycle = new(1, 1);
+    private readonly ConcurrentDictionary<string, Run> runs = new();
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
+
+    private sealed class Instance
+    {
+        public string Name;
+        public IOwnedProcess Process;
+        public InstanceIdentity Identity;
+        public SemaphoreSlim Gate = new(1, 1);
+        public JsonElement? Status;
+        public LiveTestError Error;
+        public string LogPath;
+        public string ArchivedLogPath;
+        public bool Stopped;
+        public bool CleanupComplete;
+    }
+
+    private sealed class Run
+    {
+        public string Id;
+        public string Profile;
+        public string Directory;
+        public string State = "started";
+        public object ArtifactGate = new();
+        public string Error;
+        public List<Instance> Instances = new();
+    }
+
+    public RunOrchestrator(CoopMcpServerSettings settings, IGameProcessLauncher launcher,
+        ILiveTestPipeClient pipe, IIncrementalLogReader logs)
+    {
+        this.settings = settings;
+        this.launcher = launcher;
+        this.pipe = pipe;
+        this.logs = logs;
+    }
+
+    public async Task<RunView> StartAsync(string profile, int clientCount, CancellationToken cancellationToken)
+    {
+        await lifecycle.WaitAsync(cancellationToken);
+        try
+        {
+            if (runs.Values.Any(r => r.State != "stopped" && r.State != "launch_failed"))
+                throw new InvalidOperationException("Stop the active run before starting another run.");
+            if (!settings.Profiles.TryGetValue(profile, out var launchProfile))
+                throw new ArgumentException("Unknown configured profile.");
+            launchProfile.Validate(clientCount);
+            var run = new Run { Id = Guid.NewGuid().ToString("N"), Profile = profile };
+            run.Directory = Path.Combine(settings.ArtifactDirectory, run.Id);
+            Directory.CreateDirectory(run.Directory);
+            runs[run.Id] = run;
+            try
+            {
+                Save(run);
+                for (int index = 0; index <= clientCount; index++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    string role = index == 0 ? "server" : "client";
+                    string platformId = index == 0 ? launchProfile.ServerPlatformId : launchProfile.ClientPlatformIds[index - 1];
+                    IOwnedProcess process = launcher.Launch(launchProfile, role, platformId, run.Id);
+                    run.Instances.Add(new Instance
+                    {
+                        Name = index == 0 ? "server" : "client" + index,
+                        Process = process,
+                        Identity = new InstanceIdentity(process.Pid, process.StartedUtc, role, platformId, run.Id),
+                    });
+                    Save(run);
+                }
+            }
+            catch (Exception exception)
+            {
+                run.Error = exception.Message;
+                await StopInstancesAsync(run);
+                run.State = run.Instances.All(i => i.CleanupComplete) ? "launch_failed" : "cleanup_failed";
+                Save(run);
+            }
+            return View(run);
+        }
+        finally { lifecycle.Release(); }
+    }
+
+    public async Task<RunView> GetAsync(string runId, CancellationToken cancellationToken)
+    {
+        Run run = FindRun(runId);
+        await Task.WhenAll(run.Instances.Select(i => RefreshAsync(run, i, cancellationToken)));
+        Save(run);
+        return View(run);
+    }
+
+    public async Task<object> WaitAsync(string runId, string instance, string state, int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        string[] states = { "controlReady", "readyToJoin", "commandRegistryReady", "readyForCampaignTests", "readyForMissionTests", "exited" };
+        if (!states.Contains(state)) throw new ArgumentException("state must be one of: " + string.Join(", ", states));
+        if (timeoutSeconds < 1 || timeoutSeconds > 300) throw new ArgumentOutOfRangeException(nameof(timeoutSeconds), "timeout_seconds must be 1..300.");
+        var run = FindRun(runId);
+        var target = FindInstance(run, instance);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+        bool reached = false;
+        try
+        {
+            do
+            {
+                await RefreshAsync(run, target, timeout.Token);
+                reached = Matches(target, state);
+                if (reached || !Alive(target)) break;
+                await Task.Delay(500, timeout.Token);
+            } while (true);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) { }
+        return new { reached, state, instance = View(target) };
+    }
+
+    public async Task<LiveTestResponse> RequestAsync(string runId, string instance, string method, object parameters,
+        bool mutation, CancellationToken cancellationToken)
+    {
+        var run = FindRun(runId);
+        var target = FindInstance(run, instance);
+        await target.Gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!Alive(target)) throw new InvalidOperationException("The owned process has exited.");
+            var response = await pipe.SendAsync(target.Identity, method, parameters, mutation, cancellationToken);
+            // Write each result before returning it so uncertain mutations remain inspectable after MCP disconnects.
+            try
+            {
+                File.WriteAllText(Path.Combine(run.Directory, instance + "-" + response.Id + ".json"),
+                    LiveTestProtocol.SerializeResponse(response));
+            }
+            catch (Exception exception) when (exception is IOException || exception is UnauthorizedAccessException)
+            {
+                return LiveTestResponse.Failure(response.Id, response.Process,
+                    new LiveTestError("artifact_write_failed", exception.Message, mutation || (response.Error?.OutcomeUncertain ?? false)));
+            }
+            return response;
+        }
+        finally { target.Gate.Release(); }
+    }
+
+    public async Task<LogChunk> ReadLogsAsync(string runId, string instance, string cursor, int maxBytes, CancellationToken cancellationToken)
+    {
+        var run = FindRun(runId);
+        var target = FindInstance(run, instance);
+        if (target.LogPath == null && !target.Stopped) await RefreshAsync(run, target, cancellationToken);
+        await target.Gate.WaitAsync(cancellationToken);
+        try
+        {
+            string path = target.ArchivedLogPath ?? (Alive(target) ? target.LogPath : null);
+            if (path == null) throw new InvalidOperationException("No endpoint-reported log path is available. Query status while the endpoint is alive first.");
+            return logs.Read(path, cursor, maxBytes);
+        }
+        finally { target.Gate.Release(); }
+    }
+
+    public string ScreenshotPath(string runId, string instance)
+    {
+        var run = FindRun(runId);
+        FindInstance(run, instance);
+        return Path.Combine(run.Directory, instance + "-" + Guid.NewGuid().ToString("N") + ".bmp");
+    }
+
+    public async Task<RunView> StopAsync(string runId)
+    {
+        await lifecycle.WaitAsync();
+        try
+        {
+            var run = FindRun(runId);
+            await StopInstancesAsync(run);
+            run.State = run.Instances.All(i => i.CleanupComplete) ? "stopped" : "cleanup_failed";
+            if (run.State == "stopped") run.Error = null;
+            Save(run);
+            return View(run);
+        }
+        finally { lifecycle.Release(); }
+    }
+
+    public async Task StopAllAsync()
+    {
+        var failures = new List<Exception>();
+        foreach (var run in runs.Values)
+        {
+            try { await StopAsync(run.Id); }
+            catch (Exception exception) { failures.Add(exception); }
+        }
+        if (failures.Count > 0) throw new AggregateException("One or more runs failed cleanup.", failures);
+    }
+
+    private async Task StopInstancesAsync(Run run)
+    {
+        await Task.WhenAll(run.Instances.Select(async target =>
+        {
+            await target.Gate.WaitAsync();
+            try
+            {
+                if (target.CleanupComplete) return;
+                if (Alive(target))
+                {
+                    try
+                    {
+                        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                        var status = await pipe.SendAsync(target.Identity, "status", new { }, false, timeout.Token);
+                        ApplyStatus(target, status);
+                        using var shutdownTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                        await pipe.SendAsync(target.Identity, "shutdown", new { }, true, shutdownTimeout.Token);
+                    }
+                    catch (Exception exception)
+                    {
+                        target.Error = new LiveTestError("shutdown_failed", exception.Message, true);
+                    }
+                }
+                if (!target.Stopped)
+                {
+                    await target.Process.StopAsync(TimeSpan.FromSeconds(3));
+                    target.Stopped = !target.Process.IsAlive;
+                    if (!target.Stopped) throw new IOException("Owned process is still alive after stopping.");
+                    target.Process.Dispose();
+                }
+                if (target.LogPath != null)
+                {
+                    string archive = Path.Combine(run.Directory, target.Name + ".log");
+                    File.Copy(target.LogPath, archive, overwrite: true);
+                    target.ArchivedLogPath = archive;
+                }
+                target.CleanupComplete = true;
+                target.Status = null;
+                target.Error = null;
+            }
+            catch (Exception exception)
+            {
+                target.Error = new LiveTestError("cleanup_failed", exception.Message, false);
+                run.Error = "One or more instances could not be stopped or archived; inspect instance errors and retry stop_run.";
+            }
+            finally { target.Gate.Release(); }
+        }));
+    }
+
+    private async Task RefreshAsync(Run run, Instance target, CancellationToken cancellationToken)
+    {
+        await target.Gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (!Alive(target)) { target.Status = null; return; }
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(TimeSpan.FromSeconds(3));
+            var response = await pipe.SendAsync(target.Identity, "status", new { }, false, timeout.Token);
+            ApplyStatus(target, response);
+        }
+        finally { target.Gate.Release(); }
+    }
+
+    private void ApplyStatus(Instance target, LiveTestResponse response)
+    {
+        target.Error = response.Error;
+        target.Status = response.Ok && response.Result is JsonElement status ? status : null;
+        if (target.Status is JsonElement value && value.TryGetProperty("logPath", out var path) &&
+            path.ValueKind == JsonValueKind.String && Path.IsPathFullyQualified(path.GetString()))
+            target.LogPath = path.GetString();
+    }
+
+    private bool Matches(Instance target, string state)
+    {
+        if (state == "exited") return !Alive(target);
+        if (!Alive(target) || target.Status is not JsonElement status || target.Error != null) return false;
+        if (state == "controlReady") return true;
+        bool Flag(string name) => status.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.True;
+        if (state == "readyToJoin") return Flag("readyForClientJoin");
+        return Flag(state);
+    }
+
+    private bool Alive(Instance target) => !target.Stopped && target.Process.IsAlive;
+    private Run FindRun(string id) => runs.TryGetValue(id, out var run) ? run : throw new ArgumentException("Unknown run_id in this MCP session.");
+    private Instance FindInstance(Run run, string name)
+    {
+        var instance = run.Instances.SingleOrDefault(i => i.Name == name);
+        if (instance == null) throw new ArgumentException("Unknown instance; use server, client1, client2, etc. from get_run.");
+        return instance;
+    }
+    private InstanceView View(Instance i) => new(i.Name, i.Identity, Alive(i), i.Status, i.Error);
+    private RunView View(Run run) => new(run.Id, run.Profile, run.Directory, run.State, run.Error, run.Instances.Select(View).ToArray());
+    private void Save(Run run)
+    {
+        lock (run.ArtifactGate)
+            File.WriteAllText(Path.Combine(run.Directory, "run.json"), JsonSerializer.Serialize(View(run), JsonOptions));
+    }
+}

--- a/tools/CoopMcpServer/profiles.example.json
+++ b/tools/CoopMcpServer/profiles.example.json
@@ -1,0 +1,11 @@
+{
+  "artifactDirectory": "C:\\CoopMcpServer\\Runs",
+  "profiles": {
+    "local": {
+      "executable": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Mount & Blade II Bannerlord\\bin\\Win64_Shipping_Client\\Bannerlord.exe",
+      "modules": ["Native", "SandBoxCore", "SandBox", "StoryMode", "Coop"],
+      "serverPlatformId": "testserver",
+      "clientPlatformIds": ["testclient1", "testclient2", "testclient3", "testclient4"]
+    }
+  }
+}


### PR DESCRIPTION
## What is the current behavior?

agents can use the local live-test pipe bridge, but there is no MCP server to launch and manage a server/client run, execute commands, or collect logs.

## What is the new behavior?

adds `CoopMcpServer`, a standalone Windows .NET 10 stdio MCP server using the official C# SDK. it starts an in-game `/server` plus configurable clients, supports explicit client joins and readiness checks, exposes all registered co-op commands plus legacy debug commands, reads incremental logs, requests screenshots, and stops only its own processes.

uses the existing named-pipe bridge with run/process identity checks. timed-out mutations are not automatically retried. setup and tool usage are in `tools/CoopMcpServer/README.md`.

requires matching DEBUG mod assemblies. dedicated-server launching, builds/deployment and save selection are not included. the force-relay work is separate.

## How to test

50 MCP tests, 29 live-test protocol tests and 6 dispatcher tests passed. the DEBUG mod compile-only build passed. MCP tests include real stdio SDK initialization, tool discovery, pipe calls, process cleanup and incremental logs.

live game testing not run. follow the README to publish `CoopMcpServer`, configure a local profile, and start one server with two clients. wait for server readiness, join each client explicitly, check the command catalog, read logs, request a screenshot, then stop the run. confirm both clients connect and only the launched processes stop.

## Bot Changelog Entry

- Added an MCP server for agent-driven local co-op testing.
