### PR TITLE
Fix CI checkout mismatch on older PR branches

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,8 @@ concurrency:
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
+# Use the event's merge commit in every job so scripts, sources, and build artifacts
+# match the workflow, even when the PR branch is behind development.
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - name: Link Game Assemblies Folder
         run: ln -s /home/mb2 mb2
@@ -66,7 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - name: Link Game Assemblies Folder
         run: ln -s /home/mb2 mb2
@@ -107,7 +109,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - name: Set up .NET 10
         uses: actions/setup-dotnet@v5
@@ -143,7 +145,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.sha }}
 
       - name: Link Game Assemblies Folder
         run: ln -s /home/mb2 mb2


### PR DESCRIPTION
## What is the current behavior?

The [failed run on #3515](https://github.com/Bannerlord-Coop-Team/BannerlordCoop/actions/runs/34005673742) passed the unit tests and all eight E2E shards. The verification job failed because the workflow included changes from development but checked out the older PR head, which had neither `run-verification-plan.sh` nor the harness projects.

## What is the new behavior?

All four jobs check out the event merge commit so the workflow, scripts, source, and shared build artifacts use the same revision.

## How to test

- Parsed the workflow and checked that all four checkouts use `github.sha`, with full history retained for verification planning.
- Confirmed the missing script and harness projects are absent from #3515 head and present in its merged tree.
- `git diff --check` passed.
- Run the Build and Test workflow on this PR.