### PR TITLE
Log missing co-op session JSON paths

### DIFF
--- a/source/Coop.Core/Server/Services/Save/CoopSaveManager.cs
+++ b/source/Coop.Core/Server/Services/Save/CoopSaveManager.cs
@@ -1,5 +1,7 @@
-﻿using Common.Serialization;
+﻿using Common.Logging;
+using Common.Serialization;
 using GameInterface.CoopSessionData.Save.Data;
+using Serilog;
 using System;
 using System.IO;
 using TaleWorlds.Library;
@@ -17,6 +19,8 @@ namespace Coop.Core.Server.Services.Save
 
     internal class CoopSaveManager : ICoopSaveManager
     {
+        private static readonly ILogger Logger = LogManager.GetLogger<CoopSaveManager>();
+
         public string DefaultPath { get; } = ResolveDefaultPath();
         public string FileType { get; } = ".json";
 
@@ -72,6 +76,8 @@ namespace Coop.Core.Server.Services.Save
                 }
             }
 
+            Logger.Warning("Co-op session JSON was not found at {FilePath}; saved player registrations will not be restored",
+                Path.GetFullPath(filePath));
             return null;
         }
 


### PR DESCRIPTION
## What is the current behavior?
missing session JSON files return null without a log, making lost player registrations hard to diagnose. related to #3534.

## What is the new behavior?
log a warning with the full attempted JSON path when the file is missing. save loading behavior is unchanged.

## How to test
- compile-only Release build of Coop.Core passed (49 warnings, 0 errors).
- manual, not run: in a disposable copy of the Server-Raichs save, move Server-Raichs.json aside and load Server-Raichs.sav on the server. check the warning includes the full path to Server-Raichs.json. restore the JSON before saving.