### PR TITLE
Add Discord rich presence for co-op sessions

### DIFF
--- a/doc/DiscordRichPresence.md
+++ b/doc/DiscordRichPresence.md
@@ -1,0 +1,67 @@
+# Discord Rich Presence
+
+## Portal setup
+
+1. Open application **1546158363480690738** in the [Discord Developer Portal](https://discord.com/developers/applications).
+2. Set its application name to **Bannerlord Coop**. Discord supplies the activity title from this name, not the executable name.
+3. Under Rich Presence assets, upload the supplied Bannerlord Coop artwork with key **`bannerlord_coop`**. This is a manual portal step; the mod does not upload artwork. Use the portal's supported image dimensions and crop/resize the supplied wide image if needed.
+4. Run the Discord desktop app and enable activity sharing in its settings.
+
+The mod publishes `In a co-op campaign` or `Fighting a battle`, `1 player` / `N players`, and a start timestamp. Discord renders the elapsed timer and controls the exact layout. There are no join buttons, invites, bot credentials, server endpoints, or player names in the activity.
+
+## Behavior and implementation
+
+Presence starts only after the local client's campaign join catch-up completes. Its timestamp starts at network connection and stays unchanged across battle entry/exit and player-count updates. Disconnect, returning to the main menu, session disposal, or module shutdown clears it. A new connection gets a new timestamp. Dedicated servers never register the presence service.
+
+The count comes from `NetworkConnectedPlayersChanged`: the server's `ConnectionCollection` counts connected client peers, including the local client and clients still loading, but not the server. Do not add one for self or host. Until a count arrives, a connected client knows about one player: itself.
+
+`CampaignState.CompleteCampaignEntry` publishes `ClientCampaignReady` after join synchronization. Local `CoopBattleController.AfterStart` already publishes `BattleMissionReady`; controller disposal now publishes `BattleMissionEnded`, including normal retreats/aborts. A mission that fails before readiness never advertises battle status. Settlement visits and other players' battles do not change the local status. Disconnect clears status even when mission teardown does not finish.
+
+`DiscordPresenceHandler` is autoactivated through the client module's existing `IHandler` registration. Its state is locked because network and game events run on different threads; it reads no game objects. It suppresses duplicate updates. `DiscordPresenceClient` serializes library calls on the thread pool, including cleanup, and retains its own latest activity. The library's READY callback runs after automatic synchronization; it queues a reapply of the latest activity (including a clear), otherwise a concurrent library sync could restore stale status. `DiscordRpcConnection` exposes that callback through a fakeable seam and is disposed only by the adapter's queue. Lachee's [DiscordRichPresence](https://github.com/Lachee/discord-rpc-csharp) **1.6.1.70** handles local IPC, background retries and reconnect state synchronization. Routine pipe failures use its silent default logger; unexpected adapter failures log once per session.
+
+The package targets .NET Standard 2.0, compatible with `Coop.Core` and the .NET Framework 4.7.2 mod. `CopyLocalLockFileAssemblies` and project-reference copying put `DiscordRPC.dll` and its transitive dependencies in the Coop output. The existing `Deploy.targets` DLL glob includes them; no custom deployment step is needed.
+
+```mermaid
+classDiagram
+    class IHandler
+    class IDiscordPresenceClient {
+        SetPresence(details, state, startedAtUtc)
+        ClearPresence()
+        Dispose()
+    }
+    IHandler <|.. DiscordPresenceHandler
+    IDiscordPresenceClient <|.. DiscordPresenceClient
+    DiscordPresenceHandler --> IDiscordPresenceClient
+    DiscordPresenceClient --> IDiscordRpcConnection
+    IDiscordRpcConnection <|.. DiscordRpcConnection
+    DiscordRpcConnection --> DiscordRpcClient
+```
+
+```mermaid
+flowchart LR
+    Coop --> Core[Coop.Core]
+    Core --> Missions
+    Core --> Common
+    Core --> RPC[DiscordRichPresence]
+    RPC --> Desktop[Local Discord desktop IPC]
+```
+
+## Checks
+
+- Start a dedicated server with Discord open: it must not publish this activity. Join from a client: no campaign activity during save transfer/catch-up, then `In a co-op campaign`, `1 player`, and elapsed time.
+- Connect two more clients: the count becomes `3 players`. Disconnect one: it becomes `2 players`. Hosting through the menu still counts the launcher only as its playing client, not the separate server.
+- Enter a co-op field or siege battle: `Fighting a battle`, without resetting elapsed time. Retreat or finish: campaign status returns with the same timer. Another client's battle must not change the observing campaign client's status.
+- Visit Danustica (`town_ES1`) and its tavern: keep campaign status, not battle status.
+- Disconnect during campaign and during battle, return to the main menu, and exit the game: presence clears. Rejoin: a fresh timer. Cancel or fail a join: no campaign presence.
+- Start a session with Discord closed, then open Discord. Close and restart Discord during campaign and during battle. Presence should recover without gameplay stalls; allow up to about a minute for the library's retry backoff and Discord's own display delay. Check `Coop_client.log` for repeated failures.
+- Verify uploaded artwork, title and formatting in another Discord user's view, including interaction with automatic vanilla Bannerlord detection. Activity sharing settings may hide the activity.
+
+Compile without deployment from a Windows shell (set `SolutionDir` to the worktree's `source` directory when restoring this legacy project):
+
+```powershell
+$solutionDir = (Join-Path (Get-Location) 'source') + '\'
+MSBuild.exe source\Coop\Coop.csproj -restore -p:RestorePackagesConfig=true "-p:SolutionDir=$solutionDir" -p:Configuration=Release -p:Platform=AnyCPU -p:PostBuildEvent= -p:ModName=
+dotnet test source\Coop.Tests\Coop.Tests.csproj -c Release --filter "FullyQualifiedName~DiscordPresenceClientTests|FullyQualifiedName~DiscordPresenceHandlerTests|FullyQualifiedName~CampaignStateTests|FullyQualifiedName~ConnectedPlayerCountServerHandlerTests"
+```
+
+`PostBuildEvent=` alone does not suppress the current deployment target; `ModName=` also disables `DeployToGame`.

--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -6,6 +6,7 @@ using Common.Network;
 using Common.Network.Session;
 using Common.PacketHandlers;
 using Coop.Core.Client.Policies;
+using Coop.Core.Client.Services.Discord;
 using Coop.Core.Client.Services.Kingdoms;
 using Coop.Core.Client.Services.MobileParties;
 using Coop.Core.Client.Services.Session;
@@ -41,6 +42,9 @@ public class ClientModule : CommonModule
         builder.RegisterType<JoinDebugCommands.DisconnectCoopCommand>().As<ICoopCommand>().InstancePerDependency();
 #endif
 
+        // The presence adapter owns connection disposal on its serialized worker queue.
+        builder.RegisterType<DiscordRpcConnection>().As<IDiscordRpcConnection>().InstancePerDependency().ExternallyOwned();
+        builder.RegisterType<DiscordPresenceClient>().As<IDiscordPresenceClient>().InstancePerLifetimeScope();
         builder.RegisterType<ClientContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ClientLogic>().As<ILogic>().As<IClientLogic>().InstancePerLifetimeScope();
         builder.RegisterType<CoopClient>().As<ICoopClient>().As<INetwork>().As<IRelayNetwork>().As<INetEventListener>().InstancePerLifetimeScope();

--- a/source/Coop.Core/Client/Messages/ClientCampaignReady.cs
+++ b/source/Coop.Core/Client/Messages/ClientCampaignReady.cs
@@ -1,0 +1,6 @@
+﻿using Common.Messaging;
+
+namespace Coop.Core.Client.Messages;
+
+/// <summary>The local client has completed campaign join synchronization.</summary>
+public record ClientCampaignReady : IEvent;

--- a/source/Coop.Core/Client/Services/Discord/DiscordPresenceClient.cs
+++ b/source/Coop.Core/Client/Services/Discord/DiscordPresenceClient.cs
@@ -1,0 +1,118 @@
+﻿using Common.Logging;
+using DiscordRPC;
+using Serilog;
+using System;
+using System.Threading.Tasks;
+
+namespace Coop.Core.Client.Services.Discord;
+
+public interface IDiscordPresenceClient : IDisposable
+{
+    void SetPresence(string details, string state, DateTime startedAtUtc);
+    void ClearPresence();
+}
+
+/// <summary>Serializes optional Discord work away from the game and network threads.</summary>
+public sealed class DiscordPresenceClient : IDiscordPresenceClient
+{
+    public const string ApplicationId = "1546158363480690738";
+    public const string ArtworkKey = "bannerlord_coop";
+    private static readonly ILogger Logger = LogManager.GetLogger<DiscordPresenceClient>();
+    private readonly object gate = new object();
+    private readonly IDiscordRpcConnection connection;
+    private Task pending = Task.CompletedTask;
+    private RichPresence latestPresence;
+    private bool initialized;
+    private bool disposed;
+    private bool failed;
+
+    public DiscordPresenceClient(IDiscordRpcConnection connection)
+    {
+        if (connection == null) throw new ArgumentNullException(nameof(connection));
+        this.connection = connection;
+        connection.Ready += Handle_Ready;
+    }
+
+    internal Task PendingWork
+    {
+        get { lock (gate) return pending; }
+    }
+
+    public void SetPresence(string details, string state, DateTime startedAtUtc)
+    {
+        Enqueue(() =>
+        {
+            if (failed) return;
+            latestPresence = new RichPresence
+            {
+                Details = details,
+                State = state,
+                Timestamps = new Timestamps(startedAtUtc),
+                Assets = new Assets { LargeImageKey = ArtworkKey, LargeImageText = "Bannerlord Coop" },
+            };
+            if (!initialized)
+            {
+                if (!connection.Initialize())
+                    throw new InvalidOperationException("Discord RPC could not initialize");
+                initialized = true;
+            }
+            ApplyLatestPresence();
+        });
+    }
+
+    public void ClearPresence() => Enqueue(() =>
+    {
+        latestPresence = null;
+        ApplyLatestPresence();
+    });
+
+    // Automatic READY synchronization can race our writes; reapply our own snapshot after it completes.
+    private void Handle_Ready() => Enqueue(ApplyLatestPresence);
+
+    private void ApplyLatestPresence()
+    {
+        if (initialized && (!failed || latestPresence == null)) connection.SetPresence(latestPresence);
+    }
+
+    private void Enqueue(Action action)
+    {
+        lock (gate)
+        {
+            if (disposed) return;
+            QueueCore(action);
+        }
+    }
+
+    private void QueueCore(Action action)
+    {
+        pending = pending.ContinueWith(_ =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception exception)
+            {
+                if (!failed)
+                    Logger.Warning(exception, "Discord presence disabled for this session");
+                failed = true;
+            }
+        }, TaskScheduler.Default);
+    }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (disposed) return;
+            disposed = true;
+            QueueCore(() =>
+            {
+                latestPresence = null;
+                connection.Ready -= Handle_Ready;
+                // The library's graceful shutdown clears presence and closes its background pipe.
+                connection.Dispose();
+            });
+        }
+    }
+}

--- a/source/Coop.Core/Client/Services/Discord/DiscordPresenceHandler.cs
+++ b/source/Coop.Core/Client/Services/Discord/DiscordPresenceHandler.cs
@@ -1,0 +1,149 @@
+﻿using Common.Messaging;
+using Common.Network.Messages;
+using Coop.Core.Client.Messages;
+using Coop.Core.Common.Services.Connection.Messages;
+using GameInterface.Services.GameState.Messages;
+using Missions.Messages;
+using System;
+using System.Globalization;
+
+namespace Coop.Core.Client.Services.Discord;
+
+/// <summary>Tracks only this client's playable session, not remote players' battles.</summary>
+internal sealed class DiscordPresenceHandler : IHandler
+{
+    private readonly IMessageBroker messageBroker;
+    private readonly IDiscordPresenceClient presenceClient;
+    private readonly Func<DateTime> getUtcNow;
+    private readonly object gate = new object();
+    private DateTime? connectedAtUtc;
+    private bool campaignReady;
+    private string battleId;
+    private int playerCount = 1;
+    private string lastDetails;
+    private string lastState;
+    private bool disposed;
+
+    public DiscordPresenceHandler(IMessageBroker messageBroker, IDiscordPresenceClient presenceClient)
+        : this(messageBroker, presenceClient, () => DateTime.UtcNow)
+    {
+    }
+
+    internal DiscordPresenceHandler(
+        IMessageBroker messageBroker, IDiscordPresenceClient presenceClient, Func<DateTime> getUtcNow)
+    {
+        if (messageBroker == null) throw new ArgumentNullException(nameof(messageBroker));
+        if (presenceClient == null) throw new ArgumentNullException(nameof(presenceClient));
+        if (getUtcNow == null) throw new ArgumentNullException(nameof(getUtcNow));
+        this.messageBroker = messageBroker;
+        this.presenceClient = presenceClient;
+        this.getUtcNow = getUtcNow;
+
+        messageBroker.Subscribe<NetworkConnected>(Handle_Connected);
+        messageBroker.Subscribe<ClientCampaignReady>(Handle_CampaignReady);
+        messageBroker.Subscribe<NetworkConnectedPlayersChanged>(Handle_PlayerCount);
+        messageBroker.Subscribe<BattleMissionReady>(Handle_BattleReady);
+        messageBroker.Subscribe<BattleMissionEnded>(Handle_BattleEnded);
+        messageBroker.Subscribe<NetworkDisconnected>(Handle_Disconnected);
+        messageBroker.Subscribe<EndCoopMode>(Handle_EndCoopMode);
+        messageBroker.Subscribe<MainMenuEntered>(Handle_MainMenuEntered);
+    }
+
+    private void Handle_Connected(MessagePayload<NetworkConnected> _)
+    {
+        lock (gate)
+        {
+            if (disposed || connectedAtUtc.HasValue) return;
+            connectedAtUtc = getUtcNow();
+        }
+    }
+
+    private void Handle_CampaignReady(MessagePayload<ClientCampaignReady> _)
+    {
+        lock (gate)
+        {
+            if (disposed || !connectedAtUtc.HasValue) return;
+            campaignReady = true;
+            PublishPresence();
+        }
+    }
+
+    private void Handle_PlayerCount(MessagePayload<NetworkConnectedPlayersChanged> payload)
+    {
+        lock (gate)
+        {
+            if (disposed || !connectedAtUtc.HasValue) return;
+            // The server counts client connections, including this client; never add a host player.
+            playerCount = Math.Max(1, payload.What.ConnectedPlayers);
+            PublishPresence();
+        }
+    }
+
+    private void Handle_BattleReady(MessagePayload<BattleMissionReady> payload)
+    {
+        lock (gate)
+        {
+            if (disposed || !campaignReady) return;
+            battleId = payload.What.MapEventId;
+            PublishPresence();
+        }
+    }
+
+    private void Handle_BattleEnded(MessagePayload<BattleMissionEnded> payload)
+    {
+        lock (gate)
+        {
+            if (disposed || battleId != payload.What.MapEventId) return;
+            battleId = null;
+            PublishPresence();
+        }
+    }
+
+    private void PublishPresence()
+    {
+        if (!campaignReady || !connectedAtUtc.HasValue) return;
+        string details = battleId == null ? "In a co-op campaign" : "Fighting a battle";
+        string state = playerCount.ToString(CultureInfo.InvariantCulture) +
+            (playerCount == 1 ? " player" : " players");
+        if (details == lastDetails && state == lastState) return;
+        presenceClient.SetPresence(details, state, connectedAtUtc.Value);
+        lastDetails = details;
+        lastState = state;
+    }
+
+    private void Handle_Disconnected(MessagePayload<NetworkDisconnected> _) => ClearSession();
+    private void Handle_EndCoopMode(MessagePayload<EndCoopMode> _) => ClearSession();
+    private void Handle_MainMenuEntered(MessagePayload<MainMenuEntered> _) => ClearSession();
+
+    private void ClearSession()
+    {
+        lock (gate)
+        {
+            if (lastDetails != null) presenceClient.ClearPresence();
+            connectedAtUtc = null;
+            campaignReady = false;
+            battleId = null;
+            playerCount = 1;
+            lastDetails = null;
+            lastState = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (gate)
+        {
+            if (disposed) return;
+            disposed = true;
+            ClearSession();
+        }
+        messageBroker.Unsubscribe<NetworkConnected>(Handle_Connected);
+        messageBroker.Unsubscribe<ClientCampaignReady>(Handle_CampaignReady);
+        messageBroker.Unsubscribe<NetworkConnectedPlayersChanged>(Handle_PlayerCount);
+        messageBroker.Unsubscribe<BattleMissionReady>(Handle_BattleReady);
+        messageBroker.Unsubscribe<BattleMissionEnded>(Handle_BattleEnded);
+        messageBroker.Unsubscribe<NetworkDisconnected>(Handle_Disconnected);
+        messageBroker.Unsubscribe<EndCoopMode>(Handle_EndCoopMode);
+        messageBroker.Unsubscribe<MainMenuEntered>(Handle_MainMenuEntered);
+    }
+}

--- a/source/Coop.Core/Client/Services/Discord/DiscordRpcConnection.cs
+++ b/source/Coop.Core/Client/Services/Discord/DiscordRpcConnection.cs
@@ -1,0 +1,37 @@
+﻿using DiscordRPC;
+using DiscordRPC.Message;
+using System;
+
+namespace Coop.Core.Client.Services.Discord;
+
+public interface IDiscordRpcConnection : IDisposable
+{
+    event Action Ready;
+    bool Initialize();
+    void SetPresence(RichPresence presence);
+}
+
+/// <summary>Exposes the library's post-synchronization READY callback.</summary>
+public sealed class DiscordRpcConnection : IDiscordRpcConnection
+{
+    private DiscordRpcClient client;
+    public event Action Ready;
+
+    public bool Initialize()
+    {
+        client = new DiscordRpcClient(DiscordPresenceClient.ApplicationId) { SkipIdenticalPresence = false };
+        client.OnReady += Handle_Ready;
+        return client.Initialize();
+    }
+
+    private void Handle_Ready(object sender, ReadyMessage message) => Ready?.Invoke();
+
+    public void SetPresence(RichPresence presence) => client.SetPresence(presence);
+
+    public void Dispose()
+    {
+        if (client == null) return;
+        client.OnReady -= Handle_Ready;
+        client.Dispose();
+    }
+}

--- a/source/Coop.Core/Client/States/CampaignState.cs
+++ b/source/Coop.Core/Client/States/CampaignState.cs
@@ -265,6 +265,7 @@ public class CampaignState : ClientStateBase
     {
         messageBroker.Publish(this, new PlayerKillFeedColorResendRequested());
         loadingInterface.HideLoadingScreen();
+        messageBroker.Publish(this, new ClientCampaignReady());
     }
 
     internal void Handle_MissionStateEntered(MessagePayload<MissionStateEntered> obj)

--- a/source/Coop.Core/Coop.Core.csproj
+++ b/source/Coop.Core/Coop.Core.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="8.2.0" />
+    <PackageReference Include="DiscordRichPresence" Version="1.6.1.70" />
     <PackageReference Include="Krafs.Publicizer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Coop.Tests/Client/Services/Discord/DiscordPresenceClientTests.cs
+++ b/source/Coop.Tests/Client/Services/Discord/DiscordPresenceClientTests.cs
@@ -1,0 +1,173 @@
+﻿using Coop.Core.Client.Services.Discord;
+using DiscordRPC;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Coop.Tests.Client.Services.Discord;
+
+public class DiscordPresenceClientTests : IAsyncLifetime
+{
+    private readonly FakeDiscordRpcConnection connection = new FakeDiscordRpcConnection();
+    private readonly DiscordPresenceClient client;
+    private readonly DateTime startedAt = new DateTime(2026, 9, 7, 12, 0, 0, DateTimeKind.Utc);
+
+    public DiscordPresenceClientTests()
+    {
+        client = new DiscordPresenceClient(connection);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReadyOverlappingUpdate_ReappliesLatestInsteadOfInitialNullOrStaleCampaign(bool reconnect)
+    {
+        if (reconnect)
+        {
+            client.SetPresence("In a co-op campaign", "1 player", startedAt);
+            await Drain();
+        }
+        var capturedByReady = connection.CurrentPresence;
+
+        client.SetPresence("Fighting a battle", "3 players", startedAt);
+        await Drain();
+        connection.CompleteReady(capturedByReady);
+        await Drain();
+
+        Assert.Equal("Fighting a battle", connection.CurrentPresence!.Details);
+        Assert.Equal("3 players", connection.CurrentPresence.State);
+        Assert.Equal(startedAt, connection.CurrentPresence.Timestamps.Start);
+        Assert.Equal(DiscordPresenceClient.ArtworkKey, connection.CurrentPresence.Assets.LargeImageKey);
+        Assert.Equal(1, connection.InitializeCalls);
+    }
+
+    [Fact]
+    public async Task ReadyOverlappingClear_ReappliesNullInsteadOfStaleActivity()
+    {
+        client.SetPresence("Fighting a battle", "3 players", startedAt);
+        await Drain();
+        var capturedByReady = connection.CurrentPresence;
+
+        client.ClearPresence();
+        await Drain();
+        connection.CompleteReady(capturedByReady);
+        await Drain();
+
+        Assert.Null(connection.CurrentPresence);
+    }
+
+    [Fact]
+    public async Task ReadyQueuedBehindClear_ReadsSnapshotWhenItsActionRuns()
+    {
+        client.SetPresence("In a co-op campaign", "1 player", startedAt);
+        await Drain();
+        var capturedByReady = connection.CurrentPresence;
+        var enteredWrite = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseWrite = new ManualResetEventSlim();
+        connection.BeforeNextWrite = () =>
+        {
+            enteredWrite.SetResult(true);
+            if (!releaseWrite.Wait(TimeSpan.FromSeconds(10))) throw new TimeoutException();
+        };
+
+        client.SetPresence("Fighting a battle", "3 players", startedAt);
+        try
+        {
+            await enteredWrite.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            client.ClearPresence();
+            connection.CompleteReady(capturedByReady);
+        }
+        finally
+        {
+            releaseWrite.Set();
+        }
+        await Drain();
+
+        Assert.Null(connection.CurrentPresence);
+    }
+
+    [Fact]
+    public async Task DisposeAfterReady_ClearsAndIgnoresInFlightCallbacksAndLaterRequests()
+    {
+        client.SetPresence("Fighting a battle", "3 players", startedAt);
+        await Drain();
+        var inFlightReady = connection.CaptureReadyCallback();
+        connection.CompleteReady(null);
+        client.Dispose();
+        await Drain();
+        int writes = connection.WriteCalls;
+
+        inFlightReady();
+        client.SetPresence("In a co-op campaign", "1 player", startedAt);
+        client.ClearPresence();
+        client.Dispose();
+        await Drain();
+
+        Assert.Null(connection.CurrentPresence);
+        Assert.Equal(writes, connection.WriteCalls);
+        Assert.Equal(1, connection.DisposeCalls);
+        Assert.Equal(0, connection.ReadySubscriberCount);
+    }
+
+    [Fact]
+    public async Task ClearAndDisposeBeforeFirstActivity_DoNotInitializeDiscord()
+    {
+        client.ClearPresence();
+        client.Dispose();
+        await Drain();
+
+        Assert.Equal(0, connection.InitializeCalls);
+        Assert.Equal(0, connection.WriteCalls);
+        Assert.Equal(1, connection.DisposeCalls);
+    }
+
+    private Task Drain() => client.PendingWork.WaitAsync(TimeSpan.FromSeconds(10));
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        client.Dispose();
+        await Drain();
+    }
+
+    private sealed class FakeDiscordRpcConnection : IDiscordRpcConnection
+    {
+        public event Action? Ready;
+        public RichPresence? CurrentPresence;
+        public Action? BeforeNextWrite;
+        public int InitializeCalls;
+        public int WriteCalls;
+        public int DisposeCalls;
+        public int ReadySubscriberCount => Ready?.GetInvocationList().Length ?? 0;
+
+        public bool Initialize()
+        {
+            InitializeCalls++;
+            return true;
+        }
+
+        public void SetPresence(RichPresence? presence)
+        {
+            Interlocked.Exchange(ref BeforeNextWrite, null)?.Invoke();
+            CurrentPresence = presence;
+            WriteCalls++;
+        }
+
+        public Action CaptureReadyCallback() => Ready!;
+
+        public void CompleteReady(RichPresence? capturedPresence)
+        {
+            // DiscordRPC 1.6.1.70 synchronizes its captured value before invoking OnReady.
+            CurrentPresence = capturedPresence;
+            Ready?.Invoke();
+        }
+
+        public void Dispose()
+        {
+            DisposeCalls++;
+            CurrentPresence = null;
+        }
+    }
+}

--- a/source/Coop.Tests/Client/Services/Discord/DiscordPresenceHandlerTests.cs
+++ b/source/Coop.Tests/Client/Services/Discord/DiscordPresenceHandlerTests.cs
@@ -1,0 +1,156 @@
+﻿using Common.Messaging;
+using Common.Network.Messages;
+using Coop.Core.Client.Messages;
+using Coop.Core.Client.Services.Discord;
+using Coop.Core.Common.Services.Connection.Messages;
+using GameInterface.Services.GameState.Messages;
+using Missions.Messages;
+using Moq;
+using System;
+using Xunit;
+
+namespace Coop.Tests.Client.Services.Discord;
+
+public class DiscordPresenceHandlerTests : IDisposable
+{
+    private readonly MessageBroker broker = new MessageBroker();
+    private readonly Mock<IDiscordPresenceClient> client = new Mock<IDiscordPresenceClient>();
+    private readonly DiscordPresenceHandler handler;
+    private readonly DateTime startedAt = new DateTime(2026, 9, 7, 12, 0, 0, DateTimeKind.Utc);
+    private DateTime now;
+
+    public DiscordPresenceHandlerTests()
+    {
+        now = startedAt;
+        handler = new DiscordPresenceHandler(broker, client.Object, () => now);
+    }
+
+    [Fact]
+    public void ConnectionAndLoading_DoNotAdvertiseUntilCampaignJoinCompletes()
+    {
+        broker.Publish(this, new ClientCampaignReady());
+        broker.Publish(this, new BattleMissionReady("battle"));
+        broker.Publish(this, new NetworkConnected());
+        broker.Publish(this, new NetworkConnectedPlayersChanged(3));
+        client.VerifyNoOtherCalls();
+
+        broker.Publish(this, new ClientCampaignReady());
+
+        client.Verify(c => c.SetPresence("In a co-op campaign", "3 players", startedAt), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1, "1 player")]
+    [InlineData(3, "3 players")]
+    [InlineData(0, "1 player")]
+    [InlineData(-1, "1 player")]
+    public void PlayerCount_UsesServerClientCountWithoutAddingSelfOrHost(int count, string text)
+    {
+        broker.Publish(this, new NetworkConnected());
+        broker.Publish(this, new NetworkConnectedPlayersChanged(count));
+        broker.Publish(this, new ClientCampaignReady());
+
+        client.Verify(c => c.SetPresence("In a co-op campaign", text, startedAt), Times.Once);
+    }
+
+    [Fact]
+    public void BattleTransitionsAndRosterChanges_KeepConnectionTimestamp()
+    {
+        EnterCampaign();
+        now = startedAt.AddMinutes(10);
+        broker.Publish(this, new NetworkConnected());
+        broker.Publish(this, new BattleMissionReady("battle"));
+        broker.Publish(this, new NetworkConnectedPlayersChanged(3));
+        broker.Publish(this, new BattleMissionEnded("battle"));
+
+        client.Verify(c => c.SetPresence("Fighting a battle", "1 player", startedAt), Times.Once);
+        client.Verify(c => c.SetPresence("Fighting a battle", "3 players", startedAt), Times.Once);
+        client.Verify(c => c.SetPresence("In a co-op campaign", "3 players", startedAt), Times.Once);
+    }
+
+    [Fact]
+    public void DuplicateEventsAndUnrelatedBattleEnd_DoNotRepublish()
+    {
+        EnterCampaign();
+        broker.Publish(this, new ClientCampaignReady());
+        broker.Publish(this, new NetworkConnectedPlayersChanged(1));
+        broker.Publish(this, new BattleMissionReady("battle"));
+        broker.Publish(this, new BattleMissionReady("battle"));
+        broker.Publish(this, new BattleMissionEnded("old-battle"));
+
+        client.Verify(c => c.SetPresence("In a co-op campaign", "1 player", startedAt), Times.Once);
+        client.Verify(c => c.SetPresence("Fighting a battle", "1 player", startedAt), Times.Once);
+        client.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("disconnect")]
+    [InlineData("end")]
+    [InlineData("menu")]
+    public void SessionEnd_ClearsBattleAndIgnoresLateEventsUntilNewConnection(string reason)
+    {
+        EnterCampaign();
+        broker.Publish(this, new BattleMissionReady("battle"));
+        switch (reason)
+        {
+            case "disconnect": broker.Publish(this, new NetworkDisconnected(default)); break;
+            case "end": broker.Publish(this, new EndCoopMode()); break;
+            case "menu": broker.Publish(this, new MainMenuEntered()); break;
+        }
+        client.Verify(c => c.ClearPresence(), Times.Once);
+        client.Invocations.Clear();
+        broker.Publish(this, new NetworkConnectedPlayersChanged(8));
+        broker.Publish(this, new BattleMissionEnded("battle"));
+        broker.Publish(this, new ClientCampaignReady());
+        broker.Publish(this, new BattleMissionReady("late-battle"));
+        client.VerifyNoOtherCalls();
+
+        now = startedAt.AddHours(1);
+        EnterCampaign();
+        client.Verify(c => c.SetPresence("In a co-op campaign", "1 player", now), Times.Once);
+    }
+
+    [Fact]
+    public void DisconnectAndDispose_ClearOnlyOnceAndUnsubscribe()
+    {
+        EnterCampaign();
+        broker.Publish(this, new NetworkDisconnected(default));
+        broker.Publish(this, new EndCoopMode());
+        handler.Dispose();
+        handler.Dispose();
+        EnterCampaign();
+        broker.Publish(this, new BattleMissionReady("battle"));
+
+        client.Verify(c => c.ClearPresence(), Times.Once);
+        client.Verify(c => c.SetPresence("In a co-op campaign", "1 player", startedAt), Times.Once);
+        client.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void DisposeActiveSession_ClearsPresence()
+    {
+        EnterCampaign();
+        handler.Dispose();
+        client.Verify(c => c.ClearPresence(), Times.Once);
+    }
+
+    [Fact]
+    public void DisposeFailedJoin_DoesNotStartDiscord()
+    {
+        broker.Publish(this, new NetworkConnected());
+        handler.Dispose();
+        client.VerifyNoOtherCalls();
+    }
+
+    private void EnterCampaign()
+    {
+        broker.Publish(this, new NetworkConnected());
+        broker.Publish(this, new ClientCampaignReady());
+    }
+
+    public void Dispose()
+    {
+        handler.Dispose();
+        broker.Dispose();
+    }
+}

--- a/source/Coop.Tests/Client/States/CampaignStateTests.cs
+++ b/source/Coop.Tests/Client/States/CampaignStateTests.cs
@@ -174,6 +174,7 @@ public class CampaignStateTests
 
         loadingInterface.Verify(m => m.HideLoadingScreen(), Times.Once);
         Assert.Single(TestMessageBroker.GetMessagesFromType<PlayerKillFeedColorResendRequested>());
+        Assert.Single(TestMessageBroker.GetMessagesFromType<ClientCampaignReady>());
         Assert.Equal(1, JoinSignalCount(JoinSyncSignal.CatchUpApplied));
     }
 
@@ -297,6 +298,7 @@ public class CampaignStateTests
     {
         loadingInterface.Verify(m => m.HideLoadingScreen(), Times.Never);
         Assert.Empty(TestMessageBroker.GetMessagesFromType<PlayerKillFeedColorResendRequested>());
+        Assert.Empty(TestMessageBroker.GetMessagesFromType<ClientCampaignReady>());
         Assert.Equal(0, JoinSignalCount(JoinSyncSignal.CatchUpApplied));
     }
 

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -613,6 +613,7 @@ namespace Coop
         protected override void OnSubModuleUnloaded()
         {
             CrashDiagnostics.SetPhase("module-unloading");
+            Coop?.Dispose();
 #if DEBUG
             liveTestControlServer?.Dispose();
             liveTestControlServer = null;

--- a/source/Missions/Battles/CoopBattleController.cs
+++ b/source/Missions/Battles/CoopBattleController.cs
@@ -199,6 +199,7 @@ public class CoopBattleController : CoopMissionController
 
     public override void Dispose()
     {
+        messageBroker.Publish(this, new BattleMissionEnded(Session.InstanceId));
         lifecycle.Dispose();
         replicator.Dispose();
         deathReporter.Dispose();

--- a/source/Missions/Messages/BattleMissionEnded.cs
+++ b/source/Missions/Messages/BattleMissionEnded.cs
@@ -1,0 +1,6 @@
+﻿using Common.Messaging;
+
+namespace Missions.Messages;
+
+/// <summary>The local battle controller is being disposed, including aborted missions.</summary>
+public record BattleMissionEnded(string MapEventId) : IEvent;


### PR DESCRIPTION
## What is the current behavior?

discord has no co-op-specific activity, only the detected Bannerlord game.

## What is the new behavior?

adds client-only Discord presence with `In a co-op campaign` / `Fighting a battle`, connected-player count and elapsed session time. clears on disconnect and restores the latest activity when Discord reconnects.

application `1546158363480690738` needs the name **Bannerlord Coop** and the supplied artwork uploaded as `bannerlord_coop`.

## How to test

- targeted tests: 35 passed, 1 pre-existing skip. Release compile-only build passed, no deployment.
- live Discord checks are still pending. follow `doc/DiscordRichPresence.md` for player joins/leaves, battle transitions, disconnect/rejoin and Discord restart.

## Bot Changelog Entry

- Discord can now show your co-op campaign or battle, player count and elapsed session time.
