### PR TITLE
Add server/client availability to co-op commands

### DIFF
--- a/source/Common.Tests/Commands/CoopCommandRegistryTests.cs
+++ b/source/Common.Tests/Commands/CoopCommandRegistryTests.cs
@@ -4,8 +4,135 @@ using Serilog;
 
 namespace Common.Tests.Commands;
 
-public class CoopCommandRegistryTests
+[CollectionDefinition("ModInformation", DisableParallelization = true)]
+public class ModInformationCollection
 {
+}
+
+[Collection("ModInformation")]
+public class CoopCommandRegistryTests : IDisposable
+{
+    private readonly bool originalIsServer = ModInformation.IsServer;
+
+    public void Dispose()
+    {
+        ModInformation.IsServer = originalIsServer;
+    }
+
+    [Theory]
+    [InlineData(CoopCommandSide.Both, false, true, "")]
+    [InlineData(CoopCommandSide.Both, true, true, "")]
+    [InlineData(CoopCommandSide.Server, false, false, "This command is only available on the server")]
+    [InlineData(CoopCommandSide.Server, true, true, "")]
+    [InlineData(CoopCommandSide.Client, false, true, "")]
+    [InlineData(CoopCommandSide.Client, true, false, "This command is only available on the client")]
+    public void ProcessCommand_EnforcesCommandSide(
+        CoopCommandSide side, bool isServer, bool shouldSucceed, string expectedOutput)
+    {
+        ModInformation.IsServer = isServer;
+        var command = new TestCommand("coop.debug.test", "capture", "Captures values.", side: side);
+        var registry = CreateRegistry(command);
+        var args = new CoopCommandArgsFactory().FromValues(Array.Empty<string>());
+
+        CoopCommandResult result = registry.ProcessCommand("coop.debug.test.capture", args);
+
+        Assert.Equal(shouldSucceed, result.Succeeded);
+        Assert.Equal(expectedOutput, result.Output);
+        Assert.Equal(shouldSucceed ? null : "command_wrong_side", result.ErrorCode);
+        Assert.Equal(shouldSucceed ? 1 : 0, command.ProcessCount);
+    }
+
+    [Theory]
+    [InlineData(CoopCommandSide.Server, false, "This command is only available on the server")]
+    [InlineData(CoopCommandSide.Client, true, "This command is only available on the client")]
+    public void ProcessCommand_WhenArgumentsAreInvalidOnWrongSide_ReturnsSideRejection(
+        CoopCommandSide side, bool isServer, string expectedOutput)
+    {
+        ModInformation.IsServer = isServer;
+        var command = new TestCommand(
+            "coop.debug.test", "capture", "Captures one value.", side: side,
+            expectedArgs: new IExpectedArgs[] { new ExpectedArgs("value", "The value to capture.") });
+        var registry = CreateRegistry(command);
+        var argsFactory = new CoopCommandArgsFactory();
+        ICoopCommandArgs[] invalidArguments =
+        {
+            argsFactory.FromValues(Array.Empty<string>()),
+            argsFactory.FromValues(new[] { string.Empty }),
+            argsFactory.FromValues(new[] { "   " }),
+            argsFactory.FromValues(new[] { "first", "second" }),
+        };
+
+        foreach (ICoopCommandArgs args in invalidArguments)
+        {
+            CoopCommandResult result = registry.ProcessCommand("coop.debug.test.capture", args);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_wrong_side", result.ErrorCode);
+            Assert.Equal(expectedOutput, result.Output);
+        }
+
+        Assert.Equal(0, command.ProcessCount);
+    }
+
+    [Theory]
+    [InlineData(CoopCommandSide.Server, true)]
+    [InlineData(CoopCommandSide.Client, false)]
+    public void ProcessCommand_WhenRuntimeRoleChanges_UsesCurrentRole(CoopCommandSide side, bool allowedIsServer)
+    {
+        ModInformation.IsServer = allowedIsServer;
+        var command = new TestCommand("coop.debug.test", "capture", "Captures values.", side: side);
+        var registry = CreateRegistry(command);
+        var args = new CoopCommandArgsFactory().FromValues(Array.Empty<string>());
+
+        Assert.True(registry.ProcessCommand("coop.debug.test.capture", args).Succeeded);
+        ModInformation.IsServer = !allowedIsServer;
+        Assert.Equal("command_wrong_side", registry.ProcessCommand("coop.debug.test.capture", args).ErrorCode);
+        Assert.Equal(1, command.ProcessCount);
+        ModInformation.IsServer = allowedIsServer;
+        Assert.True(registry.ProcessCommand("coop.debug.test.capture", args).Succeeded);
+        Assert.Equal(2, command.ProcessCount);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(3)]
+    public void Constructor_WhenCommandSideIsUndefined_Throws(int side)
+    {
+        var command = new TestCommand(
+            "coop.debug.test", "capture", "Captures values.", side: (CoopCommandSide)side);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => CreateRegistry(command));
+
+        Assert.Contains("coop.debug.test.capture", exception.Message);
+        Assert.Contains("invalid command side", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(CoopCommandSide.Both)]
+    [InlineData(CoopCommandSide.Server)]
+    [InlineData(CoopCommandSide.Client)]
+    public void Constructor_SnapshotsCommandSideMetadata(CoopCommandSide side)
+    {
+        var command = new TestCommand("coop.debug.test", "capture", "Captures values.", side: side);
+        var registry = CreateRegistry(command);
+        CoopCommandDescriptor descriptor = Assert.Single(registry.Commands);
+        command.Side = side == CoopCommandSide.Server ? CoopCommandSide.Client : CoopCommandSide.Server;
+        ModInformation.IsServer = side != CoopCommandSide.Client;
+
+        Assert.Equal(side, descriptor.Side);
+        Assert.True(registry.ProcessCommand(
+            descriptor.FullName, new CoopCommandArgsFactory().FromValues(Array.Empty<string>())).Succeeded);
+    }
+
+    [Fact]
+    public void DescriptorConstructor_WithoutSide_DefaultsToBoth()
+    {
+        var descriptor = new CoopCommandDescriptor("coop.debug.test", "capture", "Captures values.", Array.Empty<IExpectedArgs>());
+
+        Assert.Equal(CoopCommandSide.Both, descriptor.Side);
+        Assert.Equal(0, (int)CoopCommandSide.Both);
+    }
+
     [Fact]
     public void Constructor_ExposesCommandMetadataAndBuildsUsage()
     {
@@ -237,11 +364,13 @@ public class CoopCommandRegistryTests
             string name,
             string description,
             bool throwOnProcess = false,
+            CoopCommandSide side = CoopCommandSide.Both,
             params IExpectedArgs[] expectedArgs)
         {
             Prefix = prefix;
             Name = name;
             Description = description;
+            Side = side;
             ExpectedArgs = expectedArgs;
             this.throwOnProcess = throwOnProcess;
         }
@@ -251,6 +380,8 @@ public class CoopCommandRegistryTests
         public string Name { get; }
 
         public string Description { get; }
+
+        public CoopCommandSide Side { get; set; }
 
         public IExpectedArgs[] ExpectedArgs { get; }
 

--- a/source/Common/Commands/CoopCommandDescriptor.cs
+++ b/source/Common/Commands/CoopCommandDescriptor.cs
@@ -12,6 +12,16 @@ public sealed class CoopCommandDescriptor
         string name,
         string description,
         IExpectedArgs[] expectedArgs)
+        : this(prefix, name, description, expectedArgs, CoopCommandSide.Both)
+    {
+    }
+
+    internal CoopCommandDescriptor(
+        string prefix,
+        string name,
+        string description,
+        IExpectedArgs[] expectedArgs,
+        CoopCommandSide side)
     {
         if (expectedArgs == null) throw new ArgumentNullException(nameof(expectedArgs));
 
@@ -19,6 +29,7 @@ public sealed class CoopCommandDescriptor
         Name = name;
         FullName = $"{prefix}.{name}";
         Description = description;
+        Side = side;
         this.expectedArgs = (IExpectedArgs[])expectedArgs.Clone();
         Usage = BuildUsage();
     }
@@ -32,6 +43,8 @@ public sealed class CoopCommandDescriptor
     public string Usage { get; }
 
     public string Description { get; }
+
+    public CoopCommandSide Side { get; }
 
     public IExpectedArgs[] ExpectedArgs => (IExpectedArgs[])expectedArgs.Clone();
 

--- a/source/Common/Commands/CoopCommandRegistry.cs
+++ b/source/Common/Commands/CoopCommandRegistry.cs
@@ -36,13 +36,15 @@ public sealed class CoopCommandRegistry : ICoopCommandRegistry
                 throw new ArgumentException("The command collection cannot contain null values.", nameof(commands));
 
             IExpectedArgs[] expectedArgs = command.ExpectedArgs;
-            ValidateCommand(command, expectedArgs);
+            CoopCommandSide side = command.Side;
+            ValidateCommand(command, expectedArgs, side);
 
             var descriptor = new CoopCommandDescriptor(
                 command.Prefix,
                 command.Name,
                 command.Description,
-                expectedArgs);
+                expectedArgs,
+                side);
             if (commandMap.ContainsKey(descriptor.FullName))
                 throw new InvalidOperationException($"The command '{descriptor.FullName}' is registered more than once.");
 
@@ -65,7 +67,6 @@ public sealed class CoopCommandRegistry : ICoopCommandRegistry
     {
         return fullName != null && commandsByName.ContainsKey(fullName);
     }
-
     public CoopCommandResult ProcessCommand(string fullName, ICoopCommandArgs args)
     {
         if (args == null) throw new ArgumentNullException(nameof(args));
@@ -79,6 +80,11 @@ public sealed class CoopCommandRegistry : ICoopCommandRegistry
         }
 
         CoopCommandDescriptor descriptor = descriptorsByName[fullName];
+        if (descriptor.Side == CoopCommandSide.Server && ModInformation.IsClient)
+            return new CoopCommandResult(false, "This command is only available on the server", "command_wrong_side");
+        if (descriptor.Side == CoopCommandSide.Client && ModInformation.IsServer)
+            return new CoopCommandResult(false, "This command is only available on the client", "command_wrong_side");
+
         if (!ArgumentsAreValid(descriptor.ExpectedArgs, args))
             return new CoopCommandResult(false, descriptor.Usage, "invalid_arguments");
 
@@ -101,8 +107,11 @@ public sealed class CoopCommandRegistry : ICoopCommandRegistry
         }
     }
 
-    private void ValidateCommand(ICoopCommand command, IExpectedArgs[] expectedArgs)
+    private void ValidateCommand(ICoopCommand command, IExpectedArgs[] expectedArgs, CoopCommandSide side)
     {
+        if (!Enum.IsDefined(typeof(CoopCommandSide), side))
+            throw new InvalidOperationException($"The command '{command.Prefix}.{command.Name}' has an invalid command side '{side}'.");
+
         if (string.IsNullOrWhiteSpace(command.Prefix))
             throw new InvalidOperationException($"{command.GetType().Name} has no command prefix.");
         if (!string.Equals(command.Prefix, "coop", StringComparison.Ordinal) &&

--- a/source/Common/Commands/CoopCommandSide.cs
+++ b/source/Common/Commands/CoopCommandSide.cs
@@ -1,0 +1,8 @@
+﻿namespace Common.Commands;
+
+public enum CoopCommandSide
+{
+    Both = 0,
+    Server,
+    Client,
+}

--- a/source/Common/Commands/ICoopCommand.cs
+++ b/source/Common/Commands/ICoopCommand.cs
@@ -8,6 +8,8 @@ public interface ICoopCommand
 
     string Description { get; }
 
+    CoopCommandSide Side { get; }
+
     IExpectedArgs[] ExpectedArgs { get; }
 
     CoopCommandResult ProcessCommand(ICoopCommandArgs args);

--- a/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
+++ b/source/Coop.Core/Common/Commands/JoinDebugCommands.cs
@@ -44,6 +44,8 @@ public static class JoinDebugCommands
 
         public string Description => "Reports the current campaign join state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -87,6 +89,8 @@ public static class JoinDebugCommands
 
         public string Description => "Arms the next client join baseline to omit an inactive party.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_string_id", "The inactive party StringId."),
@@ -114,6 +118,8 @@ public static class JoinDebugCommands
         public string Name => "stage_inactive_party";
 
         public string Description => "Stages an isolated server party as inactive for join testing.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -162,6 +168,8 @@ public static class JoinDebugCommands
 
         public string Description => "Restores the staged inactive server party.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -191,6 +199,8 @@ public static class JoinDebugCommands
         public string Name => "disconnect";
 
         public string Description => "Disconnects the active client session.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface.Tests/Services/Commands/CharacterFactionCoopCommandTests.cs
+++ b/source/GameInterface.Tests/Services/Commands/CharacterFactionCoopCommandTests.cs
@@ -132,18 +132,27 @@ public class CharacterFactionCoopCommandTests
     [Fact]
     public void Registry_RejectsInvalidArgumentCountBeforeCommandLogic()
     {
-        ICoopCommand command = CreateCommand("coop.debug.hero", "set_gold");
-        var registry = new CoopCommandRegistry(
-            new[] { command },
-            new LoggerConfiguration().CreateLogger());
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            ICoopCommand command = CreateCommand("coop.debug.hero", "set_gold");
+            var registry = new CoopCommandRegistry(
+                new[] { command },
+                new LoggerConfiguration().CreateLogger());
 
-        CoopCommandResult result = registry.ProcessCommand(
-            $"{command.Prefix}.{command.Name}",
-            new TestArgs(Array.Empty<string>()));
+            CoopCommandResult result = registry.ProcessCommand(
+                $"{command.Prefix}.{command.Name}",
+                new TestArgs(Array.Empty<string>()));
 
-        Assert.False(result.Succeeded);
-        Assert.Equal("invalid_arguments", result.ErrorCode);
-        Assert.Contains("<hero_name>", result.Output);
+            Assert.False(result.Succeeded);
+            Assert.Equal("invalid_arguments", result.ErrorCode);
+            Assert.Contains("<hero_name>", result.Output);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
     }
 
     [Theory]

--- a/source/GameInterface.Tests/Services/Commands/CoopCommandSideRegressionTests.cs
+++ b/source/GameInterface.Tests/Services/Commands/CoopCommandSideRegressionTests.cs
@@ -1,0 +1,128 @@
+﻿using Common;
+using Common.Commands;
+#if DEBUG
+using Coop.Core.Common.Commands;
+#endif
+using GameInterface;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Commands;
+
+[Collection(global::GameInterface.Tests.ModInformationRoleCollection.Name)]
+public class CoopCommandSideRegressionTests
+{
+    [Theory]
+    [MemberData(nameof(CorrectedCommandSides))]
+    public void CorrectedCommands_ExposeExpectedSide(string outerTypeName, string typeName, CoopCommandSide expectedSide)
+    {
+        ICoopCommand command = CreateCommand(outerTypeName, typeName);
+
+        Assert.Equal(expectedSide, command.Side);
+    }
+
+    [Theory]
+    [InlineData(false, "HeroDeveloperCommands", "HeroDeveloperAddAttributePointsCoopCommand", "This command is only available on the server")]
+    [InlineData(true, "UnstuckCommand", "UnstuckCoopCommand", "This command is only available on the client")]
+    public void Registry_RejectsWrongSideForRealCommands(
+        bool isServer,
+        string outerTypeName,
+        string typeName,
+        string expectedOutput)
+    {
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = isServer;
+            ICoopCommand command = CreateCommand(outerTypeName, typeName);
+            var registry = new CoopCommandRegistry(new[] { command }, new LoggerConfiguration().CreateLogger());
+            ICoopCommandArgs args = new CoopCommandArgsFactory().FromValues(Array.Empty<string>());
+
+            CoopCommandResult result = registry.ProcessCommand($"{command.Prefix}.{command.Name}", args);
+
+            Assert.False(result.Succeeded);
+            Assert.Equal("command_wrong_side", result.ErrorCode);
+            Assert.Equal(expectedOutput, result.Output);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
+    }
+
+    public static IEnumerable<object[]> CorrectedCommandSides()
+    {
+#if DEBUG
+        yield return new object[] { "JoinDebugCommands", "JoinStateCoopCommand", CoopCommandSide.Both };
+#endif
+        yield return new object[] { "ArenaMasterCommands", "ViewArenaMasterInteractionsCommandCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "CaravansCommands", "CaravansViewProhibitedKingdomsCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "CaravansCommands", "CaravansViewInteractedCaravansCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "CaravansCommands", "CaravansViewTakenTradeRumorsCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "TradeSkillCommands", "InventoryViewPlayerTradeDataCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "TradeSkillCommands", "InventoryViewPlayerTradeRumorsCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "TradeSkillCommands", "InventoryViewEnteredSettlementsCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "SmithingCommands", "CraftingCraftedItemHistoryCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "SmithingCommands", "CraftingCraftingPiecesXpCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "SmithingCommands", "CraftingUnlockedCraftingPiecesCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "VillagerPartiesCommands", "ViewInteractedVillagersCommandCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "WorkshopDebugCommand", "ViewWarehouseRostersCommandCoopCommand", CoopCommandSide.Both };
+        yield return new object[] { "HeroDebugCommand", "HeroAddPowerCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "HeroDebugCommand", "HeroSetGoldCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "HeroDebugCommand", "HeroSetGoldStateCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "HeroDebugCommand", "HeroSetHitpointsCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "HeroDebugCommand", "HeroSetBannerItemCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "HeroDebugCommand", "HeroSetIssueCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "HeroDebugCommand", "HeroRefreshVolunteersCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "IssuesDebugCommand", "IssuesGiveCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "IssuesDebugCommand", "IssuesCompleteCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "TacticalUnitSymbolsDebugCommand", "UiTacticalSymbolsCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityRandomCapturePlayerCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityCapturePlayerCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityCapturePlayerFixtureCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityRestoreRosterFixtureCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityReleasePlayerCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityPrepareVisualTestFixtureCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityRestoreVisualTestFixtureCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityRansomPlayerAtSettlementCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "PlayerCaptivityCommands", "PlayerCaptivityRestorePartyFixtureStateCoopCommand", CoopCommandSide.Server };
+#if DEBUG
+        yield return new object[] { "AiLordPeaceReleaseFixtureCommands", "PlayerCaptivityCaptureAiLordFixtureCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "LargeBattleRosterFixtureCommands", "LargeBattleRosterStatusCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "LargeBattleRosterFixtureCommands", "ExactBattleRosterStatusCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "LargeBattleRosterFixtureCommands", "LargeBattleRosterRestoreCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "LargeBattleRosterFixtureCommands", "ExactBattleRosterRestoreCoopCommand", CoopCommandSide.Server };
+#endif
+        yield return new object[] { "PartyCommands", "RestorePositionCoopCommand", CoopCommandSide.Server };
+#if DEBUG
+        yield return new object[] { "MapEventDebugCommands", "LateJoinModeExitMissionsCoopCommand", CoopCommandSide.Server };
+        yield return new object[] { "MapEventDebugCommands", "LateJoinModeCleanupCoopCommand", CoopCommandSide.Server };
+#endif
+        yield return new object[] { "MapEventDebugCommands", "StartAttackMissionCoopCommand", CoopCommandSide.Client };
+        yield return new object[] { "CampaignOptionsCommands", "CampaignOptionsIsIronmanModeCoopCommand", CoopCommandSide.Both };
+    }
+
+    private static ICoopCommand CreateCommand(string outerTypeName, string typeName)
+    {
+        Type commandType = GetCommandType(outerTypeName, typeName);
+        return (ICoopCommand)Activator.CreateInstance(commandType)!;
+    }
+
+    private static Type GetCommandType(string outerTypeName, string typeName)
+    {
+        return GetCommandAssemblies()
+            .SelectMany(assembly => assembly.GetTypes())
+            .Single(type => type.Name == typeName && type.DeclaringType != null && type.DeclaringType.Name == outerTypeName);
+    }
+
+    private static IEnumerable<System.Reflection.Assembly> GetCommandAssemblies()
+    {
+        yield return typeof(GameInterfaceModule).Assembly;
+#if DEBUG
+        yield return typeof(JoinDebugCommands).Assembly;
+#endif
+    }
+}

--- a/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
+++ b/source/GameInterface.Tests/Services/LiveTesting/LiveTestCommandDispatcherTests.cs
@@ -122,6 +122,8 @@ public class LiveTestCommandDispatcherTests
 
         public string Description => "Captures structured live-test arguments.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs => new IExpectedArgs[]
         {
             new ExpectedArgs("first", "The first value to capture."),

--- a/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/CoopCommandLineRegistrarTests.cs
@@ -171,6 +171,8 @@ public class CoopCommandLineRegistrarTests
 
         public string Description => "Captures arguments for the command framework test.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs => new IExpectedArgs[]
         {
             new ExpectedArgs("first", "The first value."),

--- a/source/GameInterface.Tests/Utils/Commands/DirectMigratedCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/DirectMigratedCommandTests.cs
@@ -102,20 +102,29 @@ public class DirectMigratedCommandTests
     [Fact]
     public void Registry_RejectsInvalidArgumentCountBeforeCommandLogic()
     {
-        ICoopCommand command = Assert.Single(
-            CreateCommands(),
-            candidate => candidate.Name == "set_troop_state");
-        var registry = new CoopCommandRegistry(
-            new[] { command },
-            new LoggerConfiguration().CreateLogger());
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            ICoopCommand command = Assert.Single(
+                CreateCommands(),
+                candidate => candidate.Name == "set_troop_state");
+            var registry = new CoopCommandRegistry(
+                new[] { command },
+                new LoggerConfiguration().CreateLogger());
 
-        CoopCommandResult result = registry.ProcessCommand(
-            $"{command.Prefix}.{command.Name}",
-            new TestArgs(Array.Empty<string>()));
+            CoopCommandResult result = registry.ProcessCommand(
+                $"{command.Prefix}.{command.Name}",
+                new TestArgs(Array.Empty<string>()));
 
-        Assert.False(result.Succeeded);
-        Assert.Equal("invalid_arguments", result.ErrorCode);
-        Assert.Contains("<party_id>", result.Output);
+            Assert.False(result.Succeeded);
+            Assert.Equal("invalid_arguments", result.ErrorCode);
+            Assert.Contains("<party_id>", result.Output);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
     }
 
     [Theory]

--- a/source/GameInterface.Tests/Utils/Commands/SystemDeveloperDirectCommandTests.cs
+++ b/source/GameInterface.Tests/Utils/Commands/SystemDeveloperDirectCommandTests.cs
@@ -132,17 +132,26 @@ public class SystemDeveloperDirectCommandTests
     [Fact]
     public void Registry_RejectsInvalidArgumentCountBeforeCommandLogic()
     {
-        ICoopCommand command = Assert.Single(
-            CreateCommands(),
-            candidate => candidate.Name == "add_attribute_points");
-        var registry = new CoopCommandRegistry(new[] { command }, new LoggerConfiguration().CreateLogger());
+        bool originalIsServer = ModInformation.IsServer;
+        try
+        {
+            ModInformation.IsServer = true;
+            ICoopCommand command = Assert.Single(
+                CreateCommands(),
+                candidate => candidate.Name == "add_attribute_points");
+            var registry = new CoopCommandRegistry(new[] { command }, new LoggerConfiguration().CreateLogger());
 
-        CoopCommandResult result = registry.ProcessCommand(
-            $"{command.Prefix}.{command.Name}",
-            new TestArgs(new[] { "Hero", "With", "Spaces", "2" }));
+            CoopCommandResult result = registry.ProcessCommand(
+                $"{command.Prefix}.{command.Name}",
+                new TestArgs(new[] { "Hero", "With", "Spaces", "2" }));
 
-        Assert.False(result.Succeeded);
-        Assert.Equal("invalid_arguments", result.ErrorCode);
+            Assert.False(result.Succeeded);
+            Assert.Equal("invalid_arguments", result.ErrorCode);
+        }
+        finally
+        {
+            ModInformation.IsServer = originalIsServer;
+        }
     }
 
     [Fact]

--- a/source/GameInterface/Services/Alleys/Commands/AlleyDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyDebugCommand.cs
@@ -59,6 +59,8 @@ public class AlleyDebugCommand
 
         public string Description => "Lists alleys in a settlement.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlement_id", "The settlement StringId."),
@@ -90,6 +92,8 @@ public class AlleyDebugCommand
 
         public string Description => "Reports the local main hero registry id.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -109,6 +113,8 @@ public class AlleyDebugCommand
         public string Name => "set_owner";
 
         public string Description => "Sets an alley owner on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -155,6 +161,8 @@ public class AlleyDebugCommand
 
         public string Description => "Abandons a player-owned alley on the server.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlement_id", "The settlement StringId."),
@@ -186,6 +194,8 @@ public class AlleyDebugCommand
 
         public string Description => "Runs one authoritative alley daily tick.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -206,6 +216,8 @@ public class AlleyDebugCommand
         public string Name => "attack";
 
         public string Description => "Starts an AI attack against a player-owned alley.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -234,6 +246,8 @@ public class AlleyDebugCommand
         public string Name => "info";
 
         public string Description => "Reports state for an alley.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
+++ b/source/GameInterface/Services/Alleys/Commands/AlleyRecruitDebugCommand.cs
@@ -49,6 +49,8 @@ public class AlleyRecruitDebugCommand
 
         public string Description => "Starts the alley recruitment fixture.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlement_id", "The settlement StringId."),
@@ -122,6 +124,8 @@ public class AlleyRecruitDebugCommand
 
         public string Description => "Reports alley recruitment fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -142,6 +146,8 @@ public class AlleyRecruitDebugCommand
         public string Name => "recruit_roster";
 
         public string Description => "Reports the recruit roster for a hero party.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -179,6 +185,8 @@ public class AlleyRecruitDebugCommand
         public string Name => "recruit_fixture_restore";
 
         public string Description => "Restores the alley recruitment fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -406,6 +414,8 @@ public class AlleyRecruitDebugCommand
 
         public string Description => "Reports the alley overseer mission state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlement_id", "The settlement StringId."),
@@ -437,6 +447,8 @@ public class AlleyRecruitDebugCommand
         public string Name => "recruit_conversation_start";
 
         public string Description => "Starts a conversation with the alley overseer.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -476,6 +488,8 @@ public class AlleyRecruitDebugCommand
         public string Name => "recruit_conversation";
 
         public string Description => "Drives or inspects the alley recruitment conversation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -517,6 +531,8 @@ public class AlleyRecruitDebugCommand
         public string Name => "recruit_inventory";
 
         public string Description => "Drives or inspects the alley recruitment inventory screen.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -565,6 +581,8 @@ public class AlleyRecruitDebugCommand
         public string Name => "recruit_start_looter_battle";
 
         public string Description => "Starts the alley recruitment looter battle fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Arenas/Commands/ArenaMasterCommands.cs
+++ b/source/GameInterface/Services/Arenas/Commands/ArenaMasterCommands.cs
@@ -26,6 +26,8 @@ internal class ArenaMasterCommands
 
         public string Description => "Lists interactions for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)

--- a/source/GameInterface/Services/Armies/Commands/ArmyDebugCommand.cs
+++ b/source/GameInterface/Services/Armies/Commands/ArmyDebugCommand.cs
@@ -38,6 +38,8 @@ public class ArmyDebugCommand
 
         public string Description => "Lists registered armies.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -80,6 +82,8 @@ public class ArmyDebugCommand
         public string Name => "create";
 
         public string Description => "Creates an army on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -163,6 +167,8 @@ public class ArmyDebugCommand
 
         public string Description => "Destroys an army on the server.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("army_id", "The registered army id."),
@@ -230,6 +236,8 @@ public class ArmyDebugCommand
 
         public string Description => "Lists parties in an army.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("army_id", "The registered army id."),
@@ -273,6 +281,8 @@ public class ArmyDebugCommand
         public string Name => "mobile_party_add";
 
         public string Description => "Adds a mobile party to an army.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -324,6 +334,8 @@ public class ArmyDebugCommand
 
         public string Description => "Removes a mobile party from an army.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("army_id", "The registered army id."),
@@ -372,6 +384,8 @@ public class ArmyDebugCommand
         public string Name => "info";
 
         public string Description => "Reports state for an army.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/BesiegerCamps/Commands/BesiegerCampDebugCommand.cs
+++ b/source/GameInterface/Services/BesiegerCamps/Commands/BesiegerCampDebugCommand.cs
@@ -43,6 +43,8 @@ public class BesiegerCampDebugCommand
 
         public string Description => "Sets number of troops killed on side for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("besiegerCampId", "The besieger camp id."),
@@ -91,6 +93,8 @@ public class BesiegerCampDebugCommand
 
         public string Description => "Sets progress for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("besiegerCampId", "The besieger camp id."),
@@ -138,6 +142,8 @@ public class BesiegerCampDebugCommand
         public string Name => "set_siege_strategy";
 
         public string Description => "Sets siege strategy for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -193,6 +199,8 @@ public class BesiegerCampDebugCommand
 
         public string Description => "Sets leader party for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("besiegerCampId", "The besieger camp id."),
@@ -241,6 +249,8 @@ public class BesiegerCampDebugCommand
 
         public string Description => "Adds besieger party for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("besiegerCampId", "The besieger camp id."),
@@ -288,6 +298,8 @@ public class BesiegerCampDebugCommand
         public string Name => "remove_party";
 
         public string Description => "Removes party for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/CampaignOptionsCommands.cs
@@ -32,6 +32,8 @@ internal class CampaignOptionsCommands
 
         public string Description => "Reports list.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -64,6 +66,8 @@ internal class CampaignOptionsCommands
 
         public string Description => "Runs the auto allocate clan member perks debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("value", "The option value.", isRequired: false),
@@ -86,6 +90,8 @@ internal class CampaignOptionsCommands
         public string Name => "player_troops_received_damage";
 
         public string Description => "Runs the player troops received damage debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -110,6 +116,8 @@ internal class CampaignOptionsCommands
 
         public string Description => "Runs the recruitment difficulty debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("value", "The option value.", isRequired: false),
@@ -132,6 +140,8 @@ internal class CampaignOptionsCommands
         public string Name => "player_map_movement_speed";
 
         public string Description => "Runs the player map movement speed debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -156,6 +166,8 @@ internal class CampaignOptionsCommands
 
         public string Description => "Runs the stealth and disguise difficulty debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("value", "The option value.", isRequired: false),
@@ -178,6 +190,8 @@ internal class CampaignOptionsCommands
         public string Name => "combat_ai_difficulty";
 
         public string Description => "Runs the combat ai difficulty debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -202,6 +216,8 @@ internal class CampaignOptionsCommands
 
         public string Description => "Runs the is life death cycle disabled debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("value", "The option value.", isRequired: false),
@@ -224,6 +240,8 @@ internal class CampaignOptionsCommands
         public string Name => "persuasion_success_chance";
 
         public string Description => "Runs the persuasion success chance debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -248,6 +266,8 @@ internal class CampaignOptionsCommands
 
         public string Description => "Runs the clan member death chance debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("value", "The option value.", isRequired: false),
@@ -270,6 +290,8 @@ internal class CampaignOptionsCommands
         public string Name => "is_ironman_mode";
 
         public string Description => "Runs the is ironman mode debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -296,6 +318,8 @@ internal class CampaignOptionsCommands
 
         public string Description => "Runs the battle death debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("value", "The option value.", isRequired: false),
@@ -318,6 +342,8 @@ internal class CampaignOptionsCommands
         public string Name => "player_received_damage_difficulty";
 
         public string Description => "Runs the player received damage difficulty debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
+++ b/source/GameInterface/Services/CampaignService/Commands/ModOptionsCommands.cs
@@ -24,6 +24,8 @@ internal class ModOptionsCommands
 
         public string Description => "Reports list.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)

--- a/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
+++ b/source/GameInterface/Services/Caravans/Commands/CaravansCommands.cs
@@ -47,6 +47,8 @@ internal class CaravansCommands
 
         public string Description => "Reports view prohibited kingdoms.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -95,6 +97,8 @@ internal class CaravansCommands
         public string Name => "view_interacted_caravans";
 
         public string Description => "Reports view interacted caravans.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -145,6 +149,8 @@ internal class CaravansCommands
 
         public string Description => "Reports view taken trade rumors.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -191,6 +197,8 @@ internal class CaravansCommands
 
         public string Description => "Reports view trade action logs.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -230,6 +238,8 @@ internal class CaravansCommands
         public string Name => "view_looted_caravans";
 
         public string Description => "Reports view looted caravans.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
+++ b/source/GameInterface/Services/CharacterDevelopers/Commands/CharacterDeveloperCommands.cs
@@ -32,6 +32,8 @@ internal class CharacterDeveloperCommands
 
         public string Description => "Reports stats.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),

--- a/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
+++ b/source/GameInterface/Services/CharacterObjects/Commands/CharacterObjectCommands.cs
@@ -31,6 +31,8 @@ internal class CharacterObjectCommands
 
         public string Description => "Reports info.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("character_id", "The registered character id.", isRequired: true),
@@ -61,6 +63,8 @@ internal class CharacterObjectCommands
         public string Name => "list";
 
         public string Description => "Reports list.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
+++ b/source/GameInterface/Services/Clans/Commands/ClanDebugCommands.cs
@@ -49,6 +49,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Opens the clan screen on a client.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -73,6 +75,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Closes the clan screen on a client.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -93,6 +97,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "screen_state";
 
         public string Description => "Reports clan screen state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -117,6 +123,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Selects the parties tab on the clan screen.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -138,6 +146,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "wage_state";
 
         public string Description => "Reports clan party wage state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -249,6 +259,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Sends repeated party role refresh messages.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The registered mobile party id."),
@@ -290,6 +302,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Lists campaign clans.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -320,6 +334,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "field_dump";
 
         public string Description => "Dumps every field of a registered clan.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -354,6 +370,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Adds influence to a registered clan.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("clan_id", "The registered clan id."),
@@ -381,6 +399,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "change_clan_leader";
 
         public string Description => "Changes the leader of a registered clan.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -425,6 +445,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Moves a registered clan to a kingdom.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("clan_id", "The registered clan id."),
@@ -468,6 +490,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Destroys a registered clan.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("clan_id", "The registered clan id."),
@@ -503,6 +527,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "add_companion";
 
         public string Description => "Adds a registered companion to a clan.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -547,6 +573,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Removes a registered companion from a clan.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered companion hero id."),
@@ -585,6 +613,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "add_renown";
 
         public string Description => "Adds renown to a registered clan.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -634,6 +664,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "economy";
 
         public string Description => "Reports battle-economy values for a clan.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -708,6 +740,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Joins a registered clan to a kingdom.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("clan_id", "The registered clan id."),
@@ -743,6 +777,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "leave_kingdom";
 
         public string Description => "Removes a registered clan from its kingdom.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -794,6 +830,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Reports kingdom membership for a clan.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("clan_id", "The registered clan id."),
@@ -827,6 +865,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "give_influence";
 
         public string Description => "Gives influence to a registered clan.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -863,6 +903,8 @@ namespace GameInterface.Services.GameDebug.Commands
 
         public string Description => "Reports a curated summary for a registered clan.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("clan_id", "The registered clan id."),
@@ -897,6 +939,8 @@ namespace GameInterface.Services.GameDebug.Commands
         public string Name => "daily_gold_change";
 
         public string Description => "Reports predicted daily gold changes for a clan.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Companions/Commands/CompanionsCommands.cs
+++ b/source/GameInterface/Services/Companions/Commands/CompanionsCommands.cs
@@ -70,6 +70,8 @@ internal class CompanionsCommands
 
         public string Description => "Lists available wanderer heroes.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -112,6 +114,8 @@ internal class CompanionsCommands
 
         public string Description => "Clears available wanderer heroes.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -137,6 +141,8 @@ internal class CompanionsCommands
         public string Name => "role_fixture_setup";
 
         public string Description => "Starts the companion-role fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -195,6 +201,8 @@ internal class CompanionsCommands
 
         public string Description => "Opens the companion-role fixture conversation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -239,6 +247,8 @@ internal class CompanionsCommands
 
         public string Description => "Reports companion-role conversation state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -262,6 +272,8 @@ internal class CompanionsCommands
         public string Name => "role_fixture_prepare_client";
 
         public string Description => "Prepares the client for the companion-role fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -293,6 +305,8 @@ internal class CompanionsCommands
         public string Name => "role_fixture_assign_scout";
 
         public string Description => "Assigns the fixture companion as scout.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -330,6 +344,8 @@ internal class CompanionsCommands
 
         public string Description => "Reports companion-role fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The registered mobile party id."),
@@ -363,6 +379,8 @@ internal class CompanionsCommands
 
         public string Description => "Reports the scout assigned to a party.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The registered mobile party id."),
@@ -390,6 +408,8 @@ internal class CompanionsCommands
         public string Name => "role_fixture_restore";
 
         public string Description => "Restores the companion-role fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -447,6 +467,8 @@ internal class CompanionsCommands
         public string Name => "dismissal_fixture_setup";
 
         public string Description => "Starts the companion-dismissal fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -506,6 +528,8 @@ internal class CompanionsCommands
 
         public string Description => "Prepares the fixture companion dismissal.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The player controller id."),
@@ -542,6 +566,8 @@ internal class CompanionsCommands
         public string Name => "dismissal_fixture_trigger_consequence";
 
         public string Description => "Triggers the companion dismissal consequence.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -626,6 +652,8 @@ internal class CompanionsCommands
 
         public string Description => "Reports companion dismissal completion.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("dismissed_hero_id", "The registered dismissed hero id."),
@@ -659,6 +687,8 @@ internal class CompanionsCommands
 
         public string Description => "Releases the dismissal fixture encounter.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("dismissed_hero_id", "The registered dismissed hero id."),
@@ -687,6 +717,8 @@ internal class CompanionsCommands
 
         public string Description => "Requests the dismissal fixture replacement.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("replacement_hero_id", "The registered replacement hero id."),
@@ -714,6 +746,8 @@ internal class CompanionsCommands
 
         public string Description => "Reports companion dismissal fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The registered mobile party id."),
@@ -740,6 +774,8 @@ internal class CompanionsCommands
         public string Name => "dismissal_fixture_restore";
 
         public string Description => "Restores the companion-dismissal fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -793,6 +829,8 @@ internal class CompanionsCommands
 
         public string Description => "Opens the companion party screen.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -813,6 +851,8 @@ internal class CompanionsCommands
 
         public string Description => "Closes the companion party screen.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -831,6 +871,8 @@ internal class CompanionsCommands
         public string Name => "commit_party_screen";
 
         public string Description => "Commits changes on the companion party screen.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/CameraReset.cs
@@ -23,6 +23,8 @@ internal class CameraReset
 
         public string Description => "Runs the fix camera debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -39,6 +41,8 @@ internal class CameraReset
         public string Name => "focus_main_party";
 
         public string Description => "Runs the focus main party debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -63,6 +67,8 @@ internal class CameraReset
         public string Name => "state";
 
         public string Description => "Reports state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/GameThreadDebugCommand.cs
@@ -32,6 +32,8 @@ public class GameThreadDebugCommand
 
         public string Description => "Runs the instrument debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: false),
@@ -74,6 +76,8 @@ public class GameThreadDebugCommand
         public string Name => "stall";
 
         public string Description => "Runs the stall debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/PartySyncPerformanceLogsCommand.cs
@@ -25,6 +25,8 @@ public class PartySyncPerformanceLogsCommand
 
         public string Description => "Runs the party sync performance logs debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mode", "on, off, or status.", isRequired: true),

--- a/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UiDebugCommands.cs
@@ -44,6 +44,8 @@ internal class UiDebugCommands
 
         public string Description => "Runs the close screen debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -71,6 +73,8 @@ internal class UiDebugCommands
         public string Name => "prepare_evidence_map";
 
         public string Description => "Runs the prepare evidence map debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -110,6 +114,8 @@ internal class UiDebugCommands
         public string Name => "evidence_map_state";
 
         public string Description => "Reports evidence map state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -160,6 +166,8 @@ internal class UiDebugCommands
 
         public string Description => "Runs the leave settlement encounter debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -206,6 +214,8 @@ internal class UiDebugCommands
         public string Name => "map_click_offset";
 
         public string Description => "Runs the map click offset debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -275,6 +285,8 @@ internal class UiDebugCommands
 
         public string Description => "Reports map movement state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -303,6 +315,8 @@ internal class UiDebugCommands
         public string Name => "switch_menu";
 
         public string Description => "Runs the switch menu debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -339,6 +353,8 @@ internal class UiDebugCommands
 
         public string Description => "Reports pop state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -364,6 +380,8 @@ internal class UiDebugCommands
 
         public string Description => "Reports active state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -381,6 +399,8 @@ internal class UiDebugCommands
 
         public string Description => "Reports loading window state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -397,6 +417,8 @@ internal class UiDebugCommands
         public string Name => "saving_overlay_state";
 
         public string Description => "Reports saving overlay state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
+++ b/source/GameInterface/Services/GameDebug/Commands/UnstuckCommand.cs
@@ -30,6 +30,8 @@ public class UnstuckCommand
 
         public string Description => "Runs the unstuck debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)

--- a/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
+++ b/source/GameInterface/Services/HeroDevelopers/Commands/HeroDeveloperCommands.cs
@@ -35,6 +35,8 @@ internal class HeroDeveloperCommands
 
         public string Description => "Runs the add skill xp debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
@@ -81,6 +83,8 @@ internal class HeroDeveloperCommands
 
         public string Description => "Runs the add attribute points debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
@@ -124,6 +128,8 @@ internal class HeroDeveloperCommands
 
         public string Description => "Runs the add focus points debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name_or_id", "The hero display name or StringId.", isRequired: true),
@@ -166,6 +172,8 @@ internal class HeroDeveloperCommands
         public string Name => "reset_skills";
 
         public string Description => "Runs the reset skills debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Heroes/Commands/HeroBoostFighterDebugCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/HeroBoostFighterDebugCommand.cs
@@ -43,6 +43,8 @@ public class HeroBoostFighterDebugCommand
 
         public string Description => "Boosts a registered hero for fighter fixture testing.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_registry_id", "The registered hero id to boost."),

--- a/source/GameInterface/Services/Heroes/Commands/HeroConversationDebugCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/HeroConversationDebugCommand.cs
@@ -33,6 +33,8 @@ internal class HeroConversationDebugCommand
 
         public string Description => "Opens a conversation with a registered hero.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered hero id to converse with."),
@@ -67,6 +69,8 @@ internal class HeroConversationDebugCommand
 
         public string Description => "Reports the current hero conversation state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The optional registered hero id to compare with the active conversation.", false),
@@ -100,6 +104,8 @@ internal class HeroConversationDebugCommand
 
         public string Description => "Closes the active hero conversation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -122,6 +128,8 @@ internal class HeroConversationDebugCommand
         public string Name => "set_has_met";
 
         public string Description => "Sets whether the local player has met a hero.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -153,6 +161,8 @@ internal class HeroConversationDebugCommand
         public string Name => "meeting_state";
 
         public string Description => "Reports cached meeting state for two heroes.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Heroes/Commands/HeroDebugCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/HeroDebugCommand.cs
@@ -48,6 +48,8 @@ public class HeroDebugCommand
 
         public string Description => "Lists registered heroes, optionally filtered by display-name prefix.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("name_prefix", "The optional display-name prefix. Quote multi-word values.", false),
@@ -96,6 +98,8 @@ public class HeroDebugCommand
         public string Name => "home_settlement_snapshot";
 
         public string Description => "Reports registered hero home-settlement state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -171,6 +175,8 @@ public class HeroDebugCommand
 
         public string Description => "Dumps fields for a registered hero.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered hero id."),
@@ -214,6 +220,8 @@ public class HeroDebugCommand
         public string Name => "create_hero";
 
         public string Description => "Creates a hero from a character template on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -262,6 +270,8 @@ public class HeroDebugCommand
 
         public string Description => "Audits registered hero state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -282,6 +292,8 @@ public class HeroDebugCommand
         public string Name => "add_power";
 
         public string Description => "Adds power to a registered hero on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -324,6 +336,8 @@ public class HeroDebugCommand
         public string Name => "set_gold";
 
         public string Description => "Sets gold for every hero with an exact display name on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -368,6 +382,8 @@ public class HeroDebugCommand
 
         public string Description => "Reports gold for a registered hero.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered hero id."),
@@ -391,6 +407,8 @@ public class HeroDebugCommand
         public string Name => "set_gold_state";
 
         public string Description => "Sets non-negative gold for a registered hero on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -429,6 +447,8 @@ public class HeroDebugCommand
         public string Name => "set_hitpoints";
 
         public string Description => "Sets hit points for a registered hero on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -478,6 +498,8 @@ public class HeroDebugCommand
 
         public string Description => "Sets the banner item for a registered hero on the server.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered hero id."),
@@ -526,6 +548,8 @@ public class HeroDebugCommand
 
         public string Description => "Lists available banner items.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -554,6 +578,8 @@ public class HeroDebugCommand
         public string Name => "get_banneritem";
 
         public string Description => "Reports the banner item for a registered hero.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -590,6 +616,8 @@ public class HeroDebugCommand
 
         public string Description => "Lists heroes with active issues.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -625,6 +653,8 @@ public class HeroDebugCommand
         public string Name => "set_issue";
 
         public string Description => "Sets an issue for a registered hero on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -676,6 +706,8 @@ public class HeroDebugCommand
 
         public string Description => "Reports the issue for a registered hero.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered hero id."),
@@ -708,6 +740,8 @@ public class HeroDebugCommand
         public string Name => "volunteers";
 
         public string Description => "Lists volunteers for a hero.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -755,6 +789,8 @@ public class HeroDebugCommand
 
         public string Description => "Refreshes volunteers for a settlement on the server.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlement_id", "The optional settlement StringId; defaults to town_ES1.", false),
@@ -785,6 +821,8 @@ public class HeroDebugCommand
         public string Name => "set_relation";
 
         public string Description => "Sets the base relation between two registered heroes.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -841,6 +879,8 @@ public class HeroDebugCommand
 
         public string Description => "Reports the base relation between two registered heroes.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero1_id", "The first registered hero id."),
@@ -875,6 +915,8 @@ public class HeroDebugCommand
         public string Name => "get_effective_relation";
 
         public string Description => "Reports the effective relation between two registered heroes.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -927,6 +969,8 @@ public class HeroDebugCommand
         public string Name => "set_effective_relation";
 
         public string Description => "Sets effective relation between two registered heroes.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Heroes/Commands/HeroIdCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/HeroIdCommand.cs
@@ -29,6 +29,8 @@ public sealed class HeroIdCommand : IHeroIdCommand
 
     public string Description => "Finds registered ids for heroes with an exact display name.";
 
+    public CoopCommandSide Side => CoopCommandSide.Both;
+
     public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
     {
         new ExpectedArgs(

--- a/source/GameInterface/Services/Heroes/Commands/RomanceDebugCommand.cs
+++ b/source/GameInterface/Services/Heroes/Commands/RomanceDebugCommand.cs
@@ -32,6 +32,8 @@ internal class RomanceDebugCommand
 
         public string Description => "Lists current romance states.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -65,6 +67,8 @@ internal class RomanceDebugCommand
 
         public string Description => "Describes the romance debug commands.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -83,6 +87,8 @@ internal class RomanceDebugCommand
         public string Name => "status";
 
         public string Description => "Reports romance state for a player and NPC.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = CreatePairArguments();
 
@@ -112,6 +118,8 @@ internal class RomanceDebugCommand
         public string Name => "start";
 
         public string Description => "Starts courtship between a player and NPC.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = CreatePairArguments();
 
@@ -150,6 +158,8 @@ internal class RomanceDebugCommand
 
         public string Description => "Marks a romance pair as compatible.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = CreatePairArguments();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -186,6 +196,8 @@ internal class RomanceDebugCommand
         public string Name => "agree";
 
         public string Description => "Marks a romance pair as agreed on marriage.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = CreatePairArguments();
 
@@ -224,6 +236,8 @@ internal class RomanceDebugCommand
 
         public string Description => "Marries a player hero and NPC hero.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = CreatePairArguments();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -255,6 +269,8 @@ internal class RomanceDebugCommand
         public string Name => "divorce";
 
         public string Description => "Divorces a player hero and NPC hero.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = CreatePairArguments();
 

--- a/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
+++ b/source/GameInterface/Services/Inventory/Commands/InventoryCommands.cs
@@ -44,6 +44,8 @@ internal class InventoryCommands
 
         public string Description => "Runs the item ids debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
@@ -85,6 +87,8 @@ internal class InventoryCommands
 
         public string Description => "Runs the item values debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
@@ -125,6 +129,8 @@ internal class InventoryCommands
         public string Name => "hero_equipment";
 
         public string Description => "Runs the hero equipment debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -171,6 +177,8 @@ internal class InventoryCommands
         public string Name => "give_animals";
 
         public string Description => "Runs the give animals debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -235,6 +243,8 @@ internal class InventoryCommands
         public string Name => "give_warhorses";
 
         public string Description => "Runs the give warhorses debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
+++ b/source/GameInterface/Services/Inventory/TradeSkills/Commands/TradeSkillCommands.cs
@@ -30,6 +30,8 @@ internal class TradeSkillCommands
 
         public string Description => "Reports view player trade data.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -78,6 +80,8 @@ internal class TradeSkillCommands
         public string Name => "view_player_trade_rumors";
 
         public string Description => "Reports view player trade rumors.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -131,6 +135,8 @@ internal class TradeSkillCommands
         public string Name => "view_entered_settlements";
 
         public string Description => "Reports view entered settlements.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
+++ b/source/GameInterface/Services/Issues/Commands/IssuesDebugCommand.cs
@@ -27,6 +27,8 @@ public static class IssuesDebugCommand
 
         public string Description => "Runs the give debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
@@ -129,6 +131,8 @@ public static class IssuesDebugCommand
 
         public string Description => "Runs the complete debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered issue owner hero id.", isRequired: true),
@@ -198,6 +202,8 @@ public static class IssuesDebugCommand
         public string Name => "list_types";
 
         public string Description => "Reports list types.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
+++ b/source/GameInterface/Services/ItemObjects/Commands/ItemObjectCommands.cs
@@ -35,6 +35,8 @@ namespace GameInterface.Services.ItemObjects.Commands
 
             public string Description => "Reports data.";
 
+            public CoopCommandSide Side => CoopCommandSide.Both;
+
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
                 new ExpectedArgs("item_id", "The registered item object id.", isRequired: true),

--- a/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
+++ b/source/GameInterface/Services/ItemRosters/Commands/ItemRosterDebugCommands.cs
@@ -32,6 +32,8 @@ namespace GameInterface.Services.ItemRosters.Commands
 
             public string Description => "Runs the add random item debug operation.";
 
+            public CoopCommandSide Side => CoopCommandSide.Both;
+
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
                 new ExpectedArgs("settlement_id", "The settlement StringId.", isRequired: true),
@@ -64,6 +66,8 @@ namespace GameInterface.Services.ItemRosters.Commands
             public string Name => "add_item_burst";
 
             public string Description => "Runs the add item burst debug operation.";
+
+            public CoopCommandSide Side => CoopCommandSide.Server;
 
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
@@ -116,6 +120,8 @@ namespace GameInterface.Services.ItemRosters.Commands
 
             public string Description => "Reports info.";
 
+            public CoopCommandSide Side => CoopCommandSide.Both;
+
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
                 new ExpectedArgs("party_or_settlement_id", "The party or settlement StringId.", isRequired: true),
@@ -143,6 +149,8 @@ namespace GameInterface.Services.ItemRosters.Commands
             public string Name => "export";
 
             public string Description => "Runs the export debug operation.";
+
+            public CoopCommandSide Side => CoopCommandSide.Both;
 
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {

--- a/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
+++ b/source/GameInterface/Services/Kingdoms/Commands/KingdomDebugCommand.cs
@@ -143,6 +143,8 @@ public class KingdomDebugCommand
 
         public string Description => "Opens the kingdom screen on a client.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -166,6 +168,8 @@ public class KingdomDebugCommand
         public string Name => "open_decision";
 
         public string Description => "Opens one queued kingdom decision.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -232,6 +236,8 @@ public class KingdomDebugCommand
 
         public string Description => "Closes the kingdom screen on a client.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -252,6 +258,8 @@ public class KingdomDebugCommand
         public string Name => "screen_state";
 
         public string Description => "Reports kingdom screen state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -276,6 +284,8 @@ public class KingdomDebugCommand
         public string Name => "policy_timeout_capture";
 
         public string Description => "Captures the kingdom policy-timeout fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -326,6 +336,8 @@ public class KingdomDebugCommand
         public string Name => "policy_timeout_stage";
 
         public string Description => "Stages the kingdom policy-timeout fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -386,6 +398,8 @@ public class KingdomDebugCommand
 
         public string Description => "Reports kingdom policy-timeout fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -416,6 +430,8 @@ public class KingdomDebugCommand
         public string Name => "policy_timeout_restore";
 
         public string Description => "Restores the kingdom policy-timeout fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -467,6 +483,8 @@ public class KingdomDebugCommand
         public string Name => "policy_timeout_verify";
 
         public string Description => "Verifies the kingdom policy-timeout fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -577,6 +595,8 @@ public class KingdomDebugCommand
 
         public string Description => "Creates a kingdom for a clan leader on the server.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("leader_hero_name", "The exact leader display name or id. Quote multi-word names."),
@@ -656,6 +676,8 @@ public class KingdomDebugCommand
 
         public string Description => "Lists campaign kingdoms.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -683,6 +705,8 @@ public class KingdomDebugCommand
         public string Name => "info";
 
         public string Description => "Reports state for a registered kingdom.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -716,6 +740,8 @@ public class KingdomDebugCommand
         public string Name => "force_player_join_kingdom";
 
         public string Description => "Moves a player clan into a kingdom.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -803,6 +829,8 @@ public class KingdomDebugCommand
 
         public string Description => "Requests player vassalage in a kingdom.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The player controller id."),
@@ -863,6 +891,8 @@ public class KingdomDebugCommand
 
         public string Description => "Lists supported kingdom decision arguments.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -900,6 +930,8 @@ public class KingdomDebugCommand
 
         public string Description => "Describes kingdom decision removal arguments.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -925,6 +957,8 @@ public class KingdomDebugCommand
         public string Name => "list_kingdom_decisions";
 
         public string Description => "Lists queued decisions for a kingdom.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -970,6 +1004,8 @@ public class KingdomDebugCommand
         public string Name => "decisions";
 
         public string Description => "Lists queued decisions and client votes for a kingdom.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1057,6 +1093,8 @@ public class KingdomDebugCommand
 
         public string Description => "Lists possible outcomes for a kingdom decision.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("kingdom_id", "The registered kingdom id."),
@@ -1102,6 +1140,8 @@ public class KingdomDebugCommand
         public string Name => "vote_decision";
 
         public string Description => "Requests a client vote on a kingdom decision.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1171,6 +1211,8 @@ public class KingdomDebugCommand
 
         public string Description => "Resolves a queued kingdom decision.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("kingdom_id", "The registered kingdom id."),
@@ -1209,6 +1251,8 @@ public class KingdomDebugCommand
         public string Name => "list_policies";
 
         public string Description => "Lists active policies for a kingdom.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1259,6 +1303,8 @@ public class KingdomDebugCommand
         public string Name => "collection_list";
 
         public string Description => "Lists a synced kingdom collection.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1321,6 +1367,8 @@ public class KingdomDebugCommand
         public string Name => "collection_add";
 
         public string Description => "Adds a value to a synced kingdom collection.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1412,6 +1460,8 @@ public class KingdomDebugCommand
 
         public string Description => "Removes a value from a synced kingdom collection.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("collection", "The kingdom collection name."),
@@ -1490,6 +1540,8 @@ public class KingdomDebugCommand
 
         public string Description => "Declares war between two factions on the server.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("faction1_id", "The first registered faction id."),
@@ -1531,6 +1583,8 @@ public class KingdomDebugCommand
         public string Name => "make_peace";
 
         public string Description => "Makes peace between two factions on the server.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -2071,6 +2125,8 @@ public class KingdomDebugCommand
 
         public string Description => "Adds a supported decision to a kingdom.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("kingdom_id", "The registered kingdom id."),
@@ -2136,6 +2192,8 @@ public class KingdomDebugCommand
         public string Name => "remove_decision";
 
         public string Description => "Removes a queued decision from a kingdom.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Locations/Commands/LocationDebugCommand.cs
+++ b/source/GameInterface/Services/Locations/Commands/LocationDebugCommand.cs
@@ -34,6 +34,8 @@ public class LocationDebugCommand
 
         public string Description => "Enters the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("locationId", "The location id."),
@@ -90,6 +92,8 @@ public class LocationDebugCommand
 
         public string Description => "Leaves the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -118,6 +122,8 @@ public class LocationDebugCommand
         public string Name => "list";
 
         public string Description => "Lists the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -159,6 +165,8 @@ public class LocationDebugCommand
 
         public string Description => "Shows the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("locationId", "The location id."),
@@ -190,6 +198,8 @@ public class LocationDebugCommand
         public string Name => "list_characters";
 
         public string Description => "Lists characters for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -225,6 +235,8 @@ public class LocationDebugCommand
 
         public string Description => "Lists special items for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("locationId", "The location id."),
@@ -258,6 +270,8 @@ public class LocationDebugCommand
         public string Name => "add_character";
 
         public string Description => "Adds character for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -307,6 +321,8 @@ public class LocationDebugCommand
 
         public string Description => "Removes character for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("locationId", "The location id."),
@@ -349,6 +365,8 @@ public class LocationDebugCommand
 
         public string Description => "Removes all characters for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("locationId", "The location id."),
@@ -382,6 +400,8 @@ public class LocationDebugCommand
         public string Name => "add_special_item";
 
         public string Description => "Adds special item for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -419,6 +439,8 @@ public class LocationDebugCommand
         public string Name => "remove_special_item";
 
         public string Description => "Removes special item for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -465,6 +487,8 @@ public class LocationDebugCommand
         public string Name => "populate";
 
         public string Description => "Runs the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/BattleTeamKillCommands.cs
@@ -47,6 +47,8 @@ internal class BattleTeamKillCommands
 
         public string Description => "Runs the click deployment ready debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -78,6 +80,8 @@ internal class BattleTeamKillCommands
 
         public string Description => "Reports deployment state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -100,6 +104,8 @@ internal class BattleTeamKillCommands
         public string Name => "finish_deployment";
 
         public string Description => "Runs the finish deployment debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -131,6 +137,8 @@ internal class BattleTeamKillCommands
         public string Name => "toggle_scoreboard";
 
         public string Description => "Runs the toggle scoreboard debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -164,6 +172,8 @@ internal class BattleTeamKillCommands
         public string Name => "collapse_scoreboard_parties";
 
         public string Description => "Runs the collapse scoreboard parties debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -201,6 +211,8 @@ internal class BattleTeamKillCommands
         public string Name => "scoreboard_state";
 
         public string Description => "Reports scoreboard state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -349,6 +361,8 @@ internal class BattleTeamKillCommands
 
         public string Description => "Runs the leave battle debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -372,6 +386,8 @@ internal class BattleTeamKillCommands
         public string Name => "kill_enemy";
 
         public string Description => "Runs the kill enemy debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -408,6 +424,8 @@ internal class BattleTeamKillCommands
 
         public string Description => "Runs the kill enemy team debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -433,6 +451,8 @@ internal class BattleTeamKillCommands
         public string Name => "kill_own_team";
 
         public string Description => "Runs the kill own team debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/MapEvents/Commands/KillPlayerAgentCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/KillPlayerAgentCommands.cs
@@ -27,6 +27,8 @@ internal class KillPlayerAgentCommands
 
         public string Description => "Runs the kms debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)

--- a/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/MapEventDebugCommands.cs
@@ -74,6 +74,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports prisoner prompt state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -90,6 +92,8 @@ public class MapEventDebugCommands
         public string Name => "prisoner_prompt";
 
         public string Description => "Runs the prisoner prompt debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -292,6 +296,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the start player field battle debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("attacker_mobile_party_id", "The attacker mobile party id.", true),
@@ -405,6 +411,8 @@ public class MapEventDebugCommands
 
         public string Description => "Restores or clears restore player field battle.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -443,6 +451,8 @@ public class MapEventDebugCommands
         public string Name => "request_player_field_battle";
 
         public string Description => "Runs the request player field battle debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -511,6 +521,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports player interaction state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -531,6 +543,8 @@ public class MapEventDebugCommands
         public string Name => "submit_player_interaction";
 
         public string Description => "Runs the submit player interaction debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -580,6 +594,8 @@ public class MapEventDebugCommands
         public string Name => "start_attack_mission";
 
         public string Description => "Runs the start attack mission debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -637,6 +653,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the start looter debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -670,6 +688,8 @@ public class MapEventDebugCommands
         public string Name => "start_nearest_looter";
 
         public string Description => "Runs the start nearest looter debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -718,6 +738,8 @@ public class MapEventDebugCommands
         public string Name => "start_nearest_bandit_attack";
 
         public string Description => "Runs the start nearest bandit attack debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -805,6 +827,8 @@ public class MapEventDebugCommands
         public string Name => "bandit_attack_fixture_prepare";
 
         public string Description => "Runs the bandit attack fixture prepare debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -944,6 +968,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the bandit attack fixture start debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -1026,6 +1052,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports bandit attack fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -1078,6 +1106,8 @@ public class MapEventDebugCommands
         public string Name => "bandit_attack_fixture_restore";
 
         public string Description => "Restores or clears bandit attack fixture restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1162,6 +1192,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the finish non battle encounter debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1187,6 +1219,8 @@ public class MapEventDebugCommands
         public string Name => "join_existing";
 
         public string Description => "Runs the join existing debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1254,6 +1288,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the battle reward fixture prepare debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("initiator_controller_id", "The initiator controller id.", true),
@@ -1319,6 +1355,8 @@ public class MapEventDebugCommands
         public string Name => "battle_reward_fixture_start";
 
         public string Description => "Runs the battle reward fixture start debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1529,6 +1567,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the battle reward fixture reinforce debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1579,6 +1619,8 @@ public class MapEventDebugCommands
         public string Name => "battle_reward_fixture_join";
 
         public string Description => "Runs the battle reward fixture join debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -1641,6 +1683,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the battle reward fixture begin rout debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1680,6 +1724,8 @@ public class MapEventDebugCommands
         public string Name => "battle_reward_fixture_route_enemies";
 
         public string Description => "Runs the battle reward fixture route enemies debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -1721,6 +1767,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports battle reward fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1761,6 +1809,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports battle reward client state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1798,6 +1848,8 @@ public class MapEventDebugCommands
         public string Name => "battle_reward_fixture_restore";
 
         public string Description => "Restores or clears battle reward fixture restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -2035,6 +2087,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the wounded allied fixture start debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -2155,6 +2209,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports wounded allied fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -2211,6 +2267,8 @@ public class MapEventDebugCommands
         public string Name => "wounded_allied_fixture_restore";
 
         public string Description => "Restores or clears wounded allied fixture restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -2351,6 +2409,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the leave settlement debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -2392,6 +2452,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the finish current encounter debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -2415,6 +2477,8 @@ public class MapEventDebugCommands
         public string Name => "enter_current_battle";
 
         public string Description => "Runs the enter current battle debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -2454,6 +2518,8 @@ public class MapEventDebugCommands
         public string Name => "finish_player_encounter";
 
         public string Description => "Runs the finish player encounter debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -2503,6 +2569,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports conversation hold state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_base_id", "The party base id.", true),
@@ -2533,6 +2601,8 @@ public class MapEventDebugCommands
         public string Name => "late_join_mode_fixture";
 
         public string Description => "Runs the late join mode fixture debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -2683,6 +2753,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the late join mode join debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -2745,6 +2817,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the late join mode enter debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -2793,6 +2867,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the late join mode begin field battle debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -2830,6 +2906,8 @@ public class MapEventDebugCommands
         public string Name => "late_join_mode_disable_dying";
 
         public string Description => "Runs the late join mode disable dying debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -2870,6 +2948,8 @@ public class MapEventDebugCommands
         public string Name => "late_join_mode_exit_missions";
 
         public string Description => "Runs the late join mode exit missions debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -2920,6 +3000,8 @@ public class MapEventDebugCommands
 
         public string Description => "Restores or clears late join mode restore.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -2949,6 +3031,8 @@ public class MapEventDebugCommands
         public string Name => "late_join_mode_state";
 
         public string Description => "Reports late join mode state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -3007,6 +3091,8 @@ public class MapEventDebugCommands
         public string Name => "late_join_mode_cleanup";
 
         public string Description => "Runs the late join mode cleanup debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -3112,6 +3198,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the peace pursuit fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -3152,6 +3240,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports peace pursuit state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -3186,6 +3276,8 @@ public class MapEventDebugCommands
         public string Name => "test_peace_stops_pursuit";
 
         public string Description => "Runs the test peace stops pursuit debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -3349,6 +3441,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the kill random troop debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -3420,6 +3514,8 @@ public class MapEventDebugCommands
         public string Name => "kill_all_but_one";
 
         public string Description => "Runs the kill all but one debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -3512,6 +3608,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports player encounter.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -3548,6 +3646,8 @@ public class MapEventDebugCommands
         public string Name => "encounter_state";
 
         public string Description => "Reports encounter state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -3595,6 +3695,8 @@ public class MapEventDebugCommands
         public string Name => "retreat_confirmation";
 
         public string Description => "Runs the retreat confirmation debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -3650,6 +3752,8 @@ public class MapEventDebugCommands
 
         public string Description => "Runs the complete encounter meeting debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -3678,6 +3782,8 @@ public class MapEventDebugCommands
         public string Name => "choose_battle_mode";
 
         public string Description => "Runs the choose battle mode debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -3730,6 +3836,8 @@ public class MapEventDebugCommands
 
         public string Description => "Reports events.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -3776,6 +3884,8 @@ public class MapEventDebugCommands
         public string Name => "get_event";
 
         public string Description => "Reports event.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/MapEvents/Commands/PostBattleFreezeFixtureCommands.cs
+++ b/source/GameInterface/Services/MapEvents/Commands/PostBattleFreezeFixtureCommands.cs
@@ -55,6 +55,8 @@ internal class PostBattleFreezeFixtureCommands
 
         public string Description => "Runs the post battle freeze fixture start debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("first_controller_id", "The first controller id.", true),
@@ -215,6 +217,8 @@ internal class PostBattleFreezeFixtureCommands
 
         public string Description => "Runs the post battle freeze fixture open debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -259,6 +263,8 @@ internal class PostBattleFreezeFixtureCommands
 
         public string Description => "Reports post battle freeze fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -281,6 +287,8 @@ internal class PostBattleFreezeFixtureCommands
         public string Name => "post_battle_freeze_fixture_unpause";
 
         public string Description => "Runs the post battle freeze fixture unpause debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -309,6 +317,8 @@ internal class PostBattleFreezeFixtureCommands
         public string Name => "post_battle_freeze_fixture_restore";
 
         public string Description => "Restores or clears post battle freeze fixture restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/MobileParties/Commands/FollowPartyFixtureCommands.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/FollowPartyFixtureCommands.cs
@@ -31,6 +31,8 @@ internal static class FollowPartyFixtureCommands
 
         public string Description => "Runs fixture setup for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("playerPartyId", "The player party id."),
@@ -101,6 +103,8 @@ internal static class FollowPartyFixtureCommands
 
         public string Description => "Runs fixture follow for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("targetPartyId", "The target party id."),
@@ -136,6 +140,8 @@ internal static class FollowPartyFixtureCommands
         public string Name => "follow_fixture_move_target";
 
         public string Description => "Runs fixture move target for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -174,6 +180,8 @@ internal static class FollowPartyFixtureCommands
 
         public string Description => "Runs fixture state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("playerPartyId", "The player party id."),
@@ -209,6 +217,8 @@ internal static class FollowPartyFixtureCommands
         public string Name => "follow_fixture_restore";
 
         public string Description => "Runs fixture restore for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/MobileParties/Commands/MercenaryStockDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MercenaryStockDebugCommand.cs
@@ -39,6 +39,8 @@ internal class MercenaryStockDebugCommand
 
         public string Description => "Refreshes mercenary stocks for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townName", "The exact town name; quote values containing spaces."),
@@ -94,6 +96,8 @@ internal class MercenaryStockDebugCommand
         public string Name => "request_mercenary_stock";
 
         public string Description => "Requests mercenary stock for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
+++ b/source/GameInterface/Services/MobileParties/Commands/MobilePartyDebugCommand.cs
@@ -36,6 +36,8 @@ internal class MobilePartyDebugCommand
 
         public string Description => "Shows the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("partyStringId", "The party string id."),
@@ -89,6 +91,8 @@ internal class MobilePartyDebugCommand
 
         public string Description => "Runs info for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("partyStringId", "The party string id."),
@@ -123,6 +127,8 @@ internal class MobilePartyDebugCommand
         public string Name => "attachment_ids";
 
         public string Description => "Runs ids for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -168,6 +174,8 @@ internal class MobilePartyDebugCommand
         public string Name => "verify_ai_authority";
 
         public string Description => "Verifies ai authority for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -362,6 +370,8 @@ internal class MobilePartyDebugCommand
 
         public string Description => "Creates party for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("heroId", "The hero id."),
@@ -411,6 +421,8 @@ internal class MobilePartyDebugCommand
         public string Name => "spawn_test_parties";
 
         public string Description => "Spawns test parties for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -481,6 +493,8 @@ internal class MobilePartyDebugCommand
 
         public string Description => "Destroys party for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mobilePartyId", "The mobile party id."),
@@ -523,6 +537,8 @@ internal class MobilePartyDebugCommand
 
         public string Description => "Destroys all bandit parties for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -564,6 +580,8 @@ internal class MobilePartyDebugCommand
 
         public string Description => "Lists the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -595,6 +613,8 @@ internal class MobilePartyDebugCommand
         public string Name => "set_wage_limit_updated";
 
         public string Description => "Sets wage limit updated for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -647,6 +667,8 @@ internal class MobilePartyDebugCommand
 
         public string Description => "Sets wage unlimited for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("partyStringId", "The party string id."),
@@ -691,6 +713,8 @@ internal class MobilePartyDebugCommand
         public string Name => "audit";
 
         public string Description => "Audits the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/Party/Commands/GarrisonTroopXpFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/GarrisonTroopXpFixtureCommands.cs
@@ -51,6 +51,8 @@ internal static class GarrisonTroopXpFixtureCommands
 
         public string Description => "Runs the garrison xp fixture capture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -128,6 +130,8 @@ internal static class GarrisonTroopXpFixtureCommands
         public string Name => "garrison_xp_fixture_setup";
 
         public string Description => "Runs the garrison xp fixture setup debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -260,6 +264,8 @@ internal static class GarrisonTroopXpFixtureCommands
 
         public string Description => "Reports garrison xp fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("player_party_id", "The player party id.", true),
@@ -317,6 +323,8 @@ internal static class GarrisonTroopXpFixtureCommands
 
         public string Description => "Runs the open garrison xp fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
@@ -348,6 +356,8 @@ internal static class GarrisonTroopXpFixtureCommands
         public string Name => "garrison_xp_fixture_screen_state";
 
         public string Description => "Reports garrison xp fixture screen state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -424,6 +434,8 @@ internal static class GarrisonTroopXpFixtureCommands
 
         public string Description => "Runs the stage garrison xp withdrawal debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("garrison_party_id", "The garrison party id.", true),
@@ -462,6 +474,8 @@ internal static class GarrisonTroopXpFixtureCommands
 
         public string Description => "Runs the commit garrison xp withdrawal debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -487,6 +501,8 @@ internal static class GarrisonTroopXpFixtureCommands
         public string Name => "garrison_xp_fixture_restore";
 
         public string Description => "Restores or clears garrison xp fixture restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -547,6 +563,8 @@ internal static class GarrisonTroopXpFixtureCommands
         public string Name => "garrison_xp_fixture_verify_restore";
 
         public string Description => "Restores or clears garrison xp fixture verify restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/LargeBattleRosterFixtureCommands.cs
@@ -59,6 +59,8 @@ internal static class LargeBattleRosterFixtureCommands
 
         public string Description => "Runs the large battle roster begin debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
@@ -133,6 +135,8 @@ internal static class LargeBattleRosterFixtureCommands
 
         public string Description => "Runs the exact battle roster begin debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
@@ -161,6 +165,8 @@ internal static class LargeBattleRosterFixtureCommands
         public string Name => "battle_size_roster_begin";
 
         public string Description => "Runs the battle size roster begin debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -299,6 +305,8 @@ internal static class LargeBattleRosterFixtureCommands
 
         public string Description => "Reports large battle roster status.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
@@ -350,6 +358,8 @@ internal static class LargeBattleRosterFixtureCommands
 
         public string Description => "Reports exact battle roster status.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("first_party_or_controller_id", "The first party or controller id.", true),
@@ -369,6 +379,8 @@ internal static class LargeBattleRosterFixtureCommands
         public string Name => "large_battle_roster_restore";
 
         public string Description => "Restores or clears large battle roster restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -453,6 +465,8 @@ internal static class LargeBattleRosterFixtureCommands
         public string Name => "exact_battle_roster_restore";
 
         public string Description => "Restores or clears exact battle roster restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/Party/Commands/PartyCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/PartyCommands.cs
@@ -88,6 +88,8 @@ internal class PartyCommands
 
         public string Description => "Runs the whoami debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -113,6 +115,8 @@ internal class PartyCommands
         public string Name => "position";
 
         public string Description => "Runs the position debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -149,6 +153,8 @@ internal class PartyCommands
         public string Name => "move_offset";
 
         public string Description => "Runs the move offset debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -189,6 +195,8 @@ internal class PartyCommands
         public string Name => "restore_position";
 
         public string Description => "Restores a party to a campaign-map position and hold state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -237,6 +245,8 @@ internal class PartyCommands
         public string Name => "move_to_settlement";
 
         public string Description => "Runs the move to settlement debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -288,6 +298,8 @@ internal class PartyCommands
         public string Name => "character_ids";
 
         public string Description => "Runs the characterids debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -355,6 +367,8 @@ internal class PartyCommands
 
         public string Description => "Runs the set troop wounded debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The party id.", true),
@@ -399,6 +413,8 @@ internal class PartyCommands
         public string Name => "set_troop_state";
 
         public string Description => "Reports set troop state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -496,6 +512,8 @@ internal class PartyCommands
 
         public string Description => "Runs the select party screen troop debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("character_id", "The character id.", true),
@@ -533,6 +551,8 @@ internal class PartyCommands
         public string Name => "upgrade_party_screen_troop";
 
         public string Description => "Runs the upgrade party screen troop debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -594,6 +614,8 @@ internal class PartyCommands
 
         public string Description => "Runs the stage party screen transfer debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("character_id", "The character id.", true),
@@ -631,6 +653,8 @@ internal class PartyCommands
         public string Name => "party_screen_troop_state";
 
         public string Description => "Reports party screen troop state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -687,6 +711,8 @@ internal class PartyCommands
 
         public string Description => "Runs the addtroopxp debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name", "The hero name.", true),
@@ -728,6 +754,8 @@ internal class PartyCommands
         public string Name => "add_troops";
 
         public string Description => "Runs the addtroops debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -790,6 +818,8 @@ internal class PartyCommands
 
         public string Description => "Runs the siege buff debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The party id.", true),
@@ -837,6 +867,8 @@ internal class PartyCommands
 
         public string Description => "Runs the declare war debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The party id.", true),
@@ -871,6 +903,8 @@ internal class PartyCommands
         public string Name => "add_prisoners";
 
         public string Description => "Runs the addprisoners debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -930,6 +964,8 @@ internal class PartyCommands
 
         public string Description => "Runs the removeprisoners debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name", "The hero name.", true),
@@ -975,6 +1011,8 @@ internal class PartyCommands
         public string Name => "imprison_companion";
 
         public string Description => "Runs the imprison companion debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1024,6 +1062,8 @@ internal class PartyCommands
         public string Name => "snapshot_prison";
 
         public string Description => "Runs the snapshot prison debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
+++ b/source/GameInterface/Services/Party/Commands/TroopXpTransferFixtureCommands.cs
@@ -49,6 +49,8 @@ internal static class TroopXpTransferFixtureCommands
 
         public string Description => "Runs the clan party xp fixture capture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controller_id", "The controller id.", true),
@@ -94,6 +96,8 @@ internal static class TroopXpTransferFixtureCommands
         public string Name => "clan_party_xp_fixture_setup";
 
         public string Description => "Runs the clan party xp fixture setup debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -227,6 +231,8 @@ internal static class TroopXpTransferFixtureCommands
 
         public string Description => "Reports clan party xp fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("player_party_id", "The player party id.", true),
@@ -276,6 +282,8 @@ internal static class TroopXpTransferFixtureCommands
 
         public string Description => "Runs the open clan party transfer debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("clan_party_id", "The clan party id.", true),
@@ -305,6 +313,8 @@ internal static class TroopXpTransferFixtureCommands
         public string Name => "stage_clan_party_transfer";
 
         public string Description => "Runs the stage clan party transfer debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -343,6 +353,8 @@ internal static class TroopXpTransferFixtureCommands
         public string Name => "clan_party_transfer_screen_state";
 
         public string Description => "Reports clan party transfer screen state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -410,6 +422,8 @@ internal static class TroopXpTransferFixtureCommands
 
         public string Description => "Runs the commit clan party transfer debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -437,6 +451,8 @@ internal static class TroopXpTransferFixtureCommands
         public string Name => "clan_party_xp_fixture_restore";
 
         public string Description => "Restores or clears clan party xp fixture restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -527,6 +543,8 @@ internal static class TroopXpTransferFixtureCommands
         public string Name => "clan_party_xp_fixture_verify_restore";
 
         public string Description => "Restores or clears clan party xp fixture verify restore.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
+++ b/source/GameInterface/Services/PartyVisuals/Commands/PartyVisualDebugCommands.cs
@@ -36,6 +36,8 @@ internal class PartyVisualDebugCommands
 
         public string Description => "Reports buffer state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -85,6 +87,8 @@ internal class PartyVisualDebugCommands
 
         public string Description => "Reports fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -100,6 +104,8 @@ internal class PartyVisualDebugCommands
         public string Name => "stage_over_limit_fixture";
 
         public string Description => "Runs the stage over limit fixture debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -168,6 +174,8 @@ internal class PartyVisualDebugCommands
         public string Name => "restore_over_limit_fixture";
 
         public string Description => "Restores or clears restore over limit fixture.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/AiLordPeaceReleaseFixtureCommands.cs
@@ -44,6 +44,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
 
         public string Description => "Runs the observe ai lord pair debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
@@ -99,6 +101,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
 
         public string Description => "Runs the focus hero party debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered hero id.", isRequired: true),
@@ -131,6 +135,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
 
         public string Description => "Runs the snapshot ai lord diplomacy fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("prisoner_hero_id", "The registered prisoner hero id.", isRequired: true),
@@ -161,6 +167,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
 
         public string Description => "Runs the restore ai lord diplomacy fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -188,6 +196,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
         public string Name => "capture_ai_lord_fixture";
 
         public string Description => "Runs the capture ai lord fixture debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -301,6 +311,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
 
         public string Description => "Runs the observe ai lord fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -320,6 +332,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
         public string Name => "focus_party";
 
         public string Description => "Runs the focus party debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -349,6 +363,8 @@ internal static class AiLordPeaceReleaseFixtureCommands
         public string Name => "restore_ai_lord_fixture";
 
         public string Description => "Runs the restore ai lord fixture debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
+++ b/source/GameInterface/Services/PlayerCaptivityService/Commands/PlayerCaptivityCommands.cs
@@ -56,6 +56,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Runs the random capture player debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
@@ -95,6 +97,8 @@ internal class PlayerCaptivityCommands
         public string Name => "capture_player";
 
         public string Description => "Runs the capture player debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -140,6 +144,8 @@ internal class PlayerCaptivityCommands
         public string Name => "capture_player_fixture";
 
         public string Description => "Runs the capture player fixture debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -236,6 +242,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Runs the restore roster fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
@@ -324,6 +332,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Runs the release player debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
@@ -378,6 +388,8 @@ internal class PlayerCaptivityCommands
         public string Name => "prepare_visual_test_fixture";
 
         public string Description => "Runs the prepare visual test fixture debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -478,6 +490,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Runs the restore visual test fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -555,6 +569,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Runs the liberate prisoner debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
@@ -613,6 +629,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Reports status.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
@@ -650,6 +668,8 @@ internal class PlayerCaptivityCommands
         public string Name => "discard_player_from_party_screen";
 
         public string Description => "Runs the discard player from party screen debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -770,6 +790,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Runs the observe player debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
@@ -838,6 +860,8 @@ internal class PlayerCaptivityCommands
         public string Name => "ransom_player_at_settlement";
 
         public string Description => "Runs the ransom player at settlement debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -917,6 +941,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Reports captivity state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_id", "The registered player hero id.", isRequired: true),
@@ -963,6 +989,8 @@ internal class PlayerCaptivityCommands
 
         public string Description => "Reports party fixture state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("party_id", "The registered mobile party id.", isRequired: true),
@@ -988,6 +1016,8 @@ internal class PlayerCaptivityCommands
         public string Name => "restore_party_fixture_state";
 
         public string Description => "Reports restore party fixture state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Players/Commands/DeletePlayerCommand.cs
+++ b/source/GameInterface/Services/Players/Commands/DeletePlayerCommand.cs
@@ -34,6 +34,8 @@ public class DeletePlayerCommand
 
         public string Description => "Requests deletion of the local player from the server.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)

--- a/source/GameInterface/Services/Players/Commands/PlayerDebugCommands.cs
+++ b/source/GameInterface/Services/Players/Commands/PlayerDebugCommands.cs
@@ -31,6 +31,8 @@ internal class PlayerDebugCommands
 
         public string Description => "Lists registered co-op players.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -76,6 +78,8 @@ internal class PlayerDebugCommands
         public string Name => "party_state";
 
         public string Description => "Reports replicated party state for a player.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
+++ b/source/GameInterface/Services/Save/Commands/SaveDebugCommand.cs
@@ -31,6 +31,8 @@ namespace GameInterface.Services.Save.Commands
 
             public string Description => "Runs the save as debug operation.";
 
+            public CoopCommandSide Side => CoopCommandSide.Server;
+
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
                 new ExpectedArgs("save_name", "A save name using 1 through 64 letters, digits, underscores, or hyphens.", isRequired: true),
@@ -62,6 +64,8 @@ namespace GameInterface.Services.Save.Commands
 
             public string Description => "Reports state.";
 
+            public CoopCommandSide Side => CoopCommandSide.Both;
+
             public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
             public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -86,6 +90,8 @@ namespace GameInterface.Services.Save.Commands
             public string Name => "force_autosave";
 
             public string Description => "Runs the force autosave debug operation.";
+
+            public CoopCommandSide Side => CoopCommandSide.Server;
 
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {

--- a/source/GameInterface/Services/Settlements/Commands/SettlementAuditorCommand.cs
+++ b/source/GameInterface/Services/Settlements/Commands/SettlementAuditorCommand.cs
@@ -21,6 +21,8 @@ internal class SettlementAuditorCommand
 
         public string Description => "Audits the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)

--- a/source/GameInterface/Services/Settlements/Commands/SettlementCommands.cs
+++ b/source/GameInterface/Services/Settlements/Commands/SettlementCommands.cs
@@ -52,6 +52,8 @@ internal class SettlementCommands
 
         public string Description => "Enters random castle for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("castleId", "The castle id.", isRequired: false),
@@ -84,6 +86,8 @@ internal class SettlementCommands
         public string Name => "teleport_main_party_to_castle";
 
         public string Description => "Runs main party to castle for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -140,6 +144,8 @@ internal class SettlementCommands
         public string Name => "restore_main_party_castle_teleport";
 
         public string Description => "Restores main party castle teleport for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -207,6 +213,8 @@ internal class SettlementCommands
 
         public string Description => "Gets town name for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -244,6 +252,8 @@ internal class SettlementCommands
         public string Name => "set_enemies_spotted";
 
         public string Description => "Sets enemies spotted for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -293,6 +303,8 @@ internal class SettlementCommands
 
         public string Description => "Sets allies spotted for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -337,6 +349,8 @@ internal class SettlementCommands
         public string Name => "set_bribe_paid";
 
         public string Description => "Sets bribe paid for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -383,6 +397,8 @@ internal class SettlementCommands
 
         public string Description => "Sets hit points for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -427,6 +443,8 @@ internal class SettlementCommands
         public string Name => "last_attacker";
 
         public string Description => "Runs attacker for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -475,6 +493,8 @@ internal class SettlementCommands
 
         public string Description => "Lists siege state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -503,6 +523,8 @@ internal class SettlementCommands
         public string Name => "set_siege_state";
 
         public string Description => "Sets siege state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -553,6 +575,8 @@ internal class SettlementCommands
 
         public string Description => "Sets militia for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -600,6 +624,8 @@ internal class SettlementCommands
         public string Name => "set_garrison_pay_limit";
 
         public string Description => "Sets garrison pay limit for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -649,6 +675,8 @@ internal class SettlementCommands
 
         public string Description => "Collects cache notables for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -694,6 +722,8 @@ internal class SettlementCommands
         public string Name => "info";
 
         public string Description => "Shows the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -753,6 +783,8 @@ internal class SettlementCommands
 
         public string Description => "Sets owner for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementComponentId", "The settlement component id."),
@@ -806,6 +838,8 @@ internal class SettlementCommands
         public string Name => "capture_by_siege";
 
         public string Description => "Captures by siege for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -870,6 +904,8 @@ internal class SettlementCommands
 
         public string Description => "Shows state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementNameOrId", "The exact settlement name or id; quote names containing spaces."),
@@ -920,6 +956,8 @@ internal class SettlementCommands
 
         public string Description => "Sets gold for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementComponentId", "The settlement component id."),
@@ -963,6 +1001,8 @@ internal class SettlementCommands
 
         public string Description => "Sets is owner unassigned for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementComponentId", "The settlement component id."),
@@ -1003,6 +1043,8 @@ internal class SettlementCommands
         public string Name => "set_owner_clan";
 
         public string Description => "Sets owner clan for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
+++ b/source/GameInterface/Services/SiegeEvents/Commands/SiegeDebugCommand.cs
@@ -127,6 +127,8 @@ public class SiegeDebugCommand
 
         public string Description => "Runs prompt fixture start for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controllerId", "The controller id."),
@@ -275,6 +277,8 @@ public class SiegeDebugCommand
 
         public string Description => "Runs prompt fixture state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controllerId", "The controller id."),
@@ -326,6 +330,8 @@ public class SiegeDebugCommand
         public string Name => "prisoner_prompt_fixture_restore";
 
         public string Description => "Runs prompt fixture restore for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -856,6 +862,8 @@ public class SiegeDebugCommand
 
         public string Description => "Starts army relief for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controllerId", "The controller id."),
@@ -977,6 +985,8 @@ public class SiegeDebugCommand
 
         public string Description => "Runs relief state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("controllerId", "The controller id."),
@@ -1021,6 +1031,8 @@ public class SiegeDebugCommand
 
         public string Description => "Requests besiege for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -1054,6 +1066,8 @@ public class SiegeDebugCommand
 
         public string Description => "Requests assault for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -1086,6 +1100,8 @@ public class SiegeDebugCommand
         public string Name => "join_active_assault";
 
         public string Description => "Joins active assault for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1161,6 +1177,8 @@ public class SiegeDebugCommand
         public string Name => "assault_entry_state";
 
         public string Description => "Runs entry state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -1259,6 +1277,8 @@ public class SiegeDebugCommand
 
         public string Description => "Leaves the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1287,6 +1307,8 @@ public class SiegeDebugCommand
         public string Name => "leave_settlement";
 
         public string Description => "Leaves settlement for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -1330,6 +1352,8 @@ public class SiegeDebugCommand
         public string Name => "start";
 
         public string Description => "Starts the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1446,6 +1470,8 @@ public class SiegeDebugCommand
 
         public string Description => "Stops the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -1538,6 +1564,8 @@ public class SiegeDebugCommand
         public string Name => "join_players";
 
         public string Description => "Joins players for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1641,6 +1669,8 @@ public class SiegeDebugCommand
 
         public string Description => "Runs state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("partyId", "The party id."),
@@ -1681,6 +1711,8 @@ public class SiegeDebugCommand
         public string Name => "prepare_ladders_only";
 
         public string Description => "Prepares ladders only for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1771,6 +1803,8 @@ public class SiegeDebugCommand
         public string Name => "stage_machines";
 
         public string Description => "Stages machines for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1868,6 +1902,8 @@ public class SiegeDebugCommand
 
         public string Description => "Runs the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -1942,6 +1978,8 @@ public class SiegeDebugCommand
 
         public string Description => "Runs status for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -2012,6 +2050,8 @@ public class SiegeDebugCommand
 
         public string Description => "Resolves starvation for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -2064,6 +2104,8 @@ public class SiegeDebugCommand
 
         public string Description => "Lists the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -2100,6 +2142,8 @@ public class SiegeDebugCommand
         public string Name => "graph";
 
         public string Description => "Runs the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -2167,6 +2211,8 @@ public class SiegeDebugCommand
 
         public string Description => "Focuses the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("settlementId", "The settlement id."),
@@ -2218,6 +2264,8 @@ public class SiegeDebugCommand
         public string Name => "dump_party";
 
         public string Description => "Dumps party for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -2288,6 +2336,8 @@ public class SiegeDebugCommand
         public string Name => "dump_engines";
 
         public string Description => "Dumps engines for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -2372,6 +2422,8 @@ public class SiegeDebugCommand
         public string Name => "dump_machines";
 
         public string Description => "Dumps machines for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
+++ b/source/GameInterface/Services/Smithing/Commands/SmithingCommands.cs
@@ -50,6 +50,8 @@ internal class SmithingCommands
 
         public string Description => "Runs the give supplies debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
@@ -120,6 +122,8 @@ internal class SmithingCommands
 
         public string Description => "Runs the unlock all crafting pieces debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -157,6 +161,8 @@ internal class SmithingCommands
         public string Name => "town_orders";
 
         public string Description => "Runs the town orders debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -202,6 +208,8 @@ internal class SmithingCommands
 
         public string Description => "Runs the add town order debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("hero_name", "The exact hero display name.", isRequired: true),
@@ -246,6 +254,8 @@ internal class SmithingCommands
         public string Name => "add_crafted_items";
 
         public string Description => "Runs the add crafted items debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -303,6 +313,8 @@ internal class SmithingCommands
 
         public string Description => "Runs the stamina debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -337,6 +349,8 @@ internal class SmithingCommands
         public string Name => "crafted_item_history";
 
         public string Description => "Runs the crafted item history debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
@@ -385,6 +399,8 @@ internal class SmithingCommands
 
         public string Description => "Runs the crafting pieces xp debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -431,6 +447,8 @@ internal class SmithingCommands
         public string Name => "unlocked_crafting_pieces";
 
         public string Description => "Runs the unlocked crafting pieces debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
+++ b/source/GameInterface/Services/Template/Commands/TemplateCommands.cs
@@ -27,6 +27,9 @@ internal class TemplateCommands
 
         public string Description => "Runs the template debug operation.";
 
+        /// Use Both unless the command is truly server-only or client-only.
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)

--- a/source/GameInterface/Services/Time/Commands/TimeCommands.cs
+++ b/source/GameInterface/Services/Time/Commands/TimeCommands.cs
@@ -28,6 +28,8 @@ internal class TimeCommands
 
         public string Description => "Reports get time mode.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -48,6 +50,8 @@ internal class TimeCommands
             public string Name => "set_time_mode";
 
             public string Description => "Runs the set time mode debug operation.";
+
+            public CoopCommandSide Side => CoopCommandSide.Server;
 
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
@@ -101,6 +105,8 @@ internal class TimeCommands
 
         public string Description => "Runs the request time mode debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("time_mode", "Pause, Play_1x, or Play_2x.", isRequired: true),
@@ -126,6 +132,8 @@ internal class TimeCommands
         public string Name => "advance_time";
 
         public string Description => "Runs the advance time debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Tournaments/Commands/TournamentDebugCommand.cs
+++ b/source/GameInterface/Services/Tournaments/Commands/TournamentDebugCommand.cs
@@ -46,6 +46,8 @@ public class TournamentDebugCommand
 
         public string Description => "Adds tournament to town for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townNameOrId", "The exact town name or id; quote names containing spaces."),
@@ -91,6 +93,8 @@ public class TournamentDebugCommand
         public string Name => "danustica_fixture_begin";
 
         public string Description => "Runs fixture begin for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -147,6 +151,8 @@ public class TournamentDebugCommand
 
         public string Description => "Runs fixture state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -185,6 +191,8 @@ public class TournamentDebugCommand
         public string Name => "danustica_fixture_restore";
 
         public string Description => "Runs fixture restore for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -232,6 +240,8 @@ public class TournamentDebugCommand
         public string Name => "danustica_fixture_abort";
 
         public string Description => "Runs fixture abort for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -281,6 +291,8 @@ public class TournamentDebugCommand
 
         public string Description => "Runs request join for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -315,6 +327,8 @@ public class TournamentDebugCommand
 
         public string Description => "Runs request start for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -341,6 +355,8 @@ public class TournamentDebugCommand
         public string Name => "danustica_request_choice";
 
         public string Description => "Runs request choice for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Client;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -382,6 +398,8 @@ public class TournamentDebugCommand
 
         public string Description => "Runs request leave for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -407,6 +425,8 @@ public class TournamentDebugCommand
         public string Name => "danustica_observe";
 
         public string Description => "Runs observe for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/Towns/Commands/TownAuditorDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownAuditorDebugCommand.cs
@@ -47,6 +47,8 @@ public class TownAuditorDebugCommand
 
         public string Description => "Runs the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Client;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)

--- a/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
+++ b/source/GameInterface/Services/Towns/Commands/TownDebugCommand.cs
@@ -51,6 +51,8 @@ public class TownDebugCommand
 
         public string Description => "Lists towns for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -85,6 +87,8 @@ public class TownDebugCommand
 
         public string Description => "Lists items for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -115,6 +119,8 @@ public class TownDebugCommand
         public string Name => "info";
 
         public string Description => "Shows the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -172,6 +178,8 @@ public class TownDebugCommand
 
         public string Description => "Runs backlink for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -202,6 +210,8 @@ public class TownDebugCommand
         public string Name => "focus_garrison";
 
         public string Description => "Focuses garrison for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -250,6 +260,8 @@ public class TownDebugCommand
         public string Name => "apply_garrison_lifecycle";
 
         public string Description => "Applies garrison lifecycle for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -352,6 +364,8 @@ public class TownDebugCommand
 
         public string Description => "Lists buildings for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -387,6 +401,8 @@ public class TownDebugCommand
 
         public string Description => "Lists workshops for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -419,6 +435,8 @@ public class TownDebugCommand
         public string Name => "set_food_stocks";
 
         public string Description => "Sets food stocks for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -469,6 +487,8 @@ public class TownDebugCommand
 
         public string Description => "Sets governor for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -517,6 +537,8 @@ public class TownDebugCommand
 
         public string Description => "Sets last captured by for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -564,6 +586,8 @@ public class TownDebugCommand
         public string Name => "add_item_to_sold_items";
 
         public string Description => "Adds item to sold items for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -639,6 +663,8 @@ public class TownDebugCommand
 
         public string Description => "Sets prosperity for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -686,6 +712,8 @@ public class TownDebugCommand
 
         public string Description => "Sets loyalty for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -732,6 +760,8 @@ public class TownDebugCommand
         public string Name => "set_security";
 
         public string Description => "Sets security for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -781,6 +811,8 @@ public class TownDebugCommand
 
         public string Description => "Sets in rebellious state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -822,6 +854,8 @@ public class TownDebugCommand
 
         public string Description => "Starts rebellion for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -859,6 +893,8 @@ public class TownDebugCommand
         public string Name => "set_garrison_auto_recruitment";
 
         public string Description => "Sets garrison auto recruitment for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -907,6 +943,8 @@ public class TownDebugCommand
 
         public string Description => "Sets trade tax acc for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -954,6 +992,8 @@ public class TownDebugCommand
 
         public string Description => "Changes current building for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -991,6 +1031,8 @@ public class TownDebugCommand
 
         public string Description => "Changes current building queue for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("townId", "The town id."),
@@ -1024,6 +1066,8 @@ public class TownDebugCommand
         public string Name => "management_data";
 
         public string Description => "Runs data for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/SteamDebugCommand.cs
@@ -48,6 +48,8 @@ public class SteamDebugCommand
 
         public string Description => "Runs the host lobby debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -78,6 +80,8 @@ public class SteamDebugCommand
         public string Name => "invite";
 
         public string Description => "Runs the invite debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
+++ b/source/GameInterface/Services/UI/Commands/TacticalUnitSymbolsDebugCommand.cs
@@ -24,6 +24,8 @@ public class TacticalUnitSymbolsDebugCommand
 
         public string Description => "Runs the tactical symbols debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mode", "on, off, toggle, or status.", isRequired: true),

--- a/source/GameInterface/Services/Villages/Commands/RaidDebugCommands.cs
+++ b/source/GameInterface/Services/Villages/Commands/RaidDebugCommands.cs
@@ -24,6 +24,8 @@ public class RaidDebugCommands
 
         public string Description => "Controls raid ai intervention for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mode", "The mode."),

--- a/source/GameInterface/Services/Villages/Commands/VillageDebugCommand.cs
+++ b/source/GameInterface/Services/Villages/Commands/VillageDebugCommand.cs
@@ -43,6 +43,8 @@ internal class VillageDebugCommand
 
         public string Description => "Lists the relevant state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -77,6 +79,8 @@ internal class VillageDebugCommand
         public string Name => "info";
 
         public string Description => "Shows the relevant state for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -123,6 +127,8 @@ internal class VillageDebugCommand
 
         public string Description => "Sets state for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Server;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("villageId", "The village id."),
@@ -168,6 +174,8 @@ internal class VillageDebugCommand
         public string Name => "set_hearth";
 
         public string Description => "Sets hearth for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -217,6 +225,8 @@ internal class VillageDebugCommand
         public string Name => "set_trade_tax_acc";
 
         public string Description => "Sets trade tax acc for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -268,6 +278,8 @@ internal class VillageDebugCommand
         public string Name => "set_demand_time";
 
         public string Description => "Sets demand time for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Server;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {

--- a/source/GameInterface/Services/Villages/Commands/VillagerPartiesCommands.cs
+++ b/source/GameInterface/Services/Villages/Commands/VillagerPartiesCommands.cs
@@ -30,6 +30,8 @@ internal class VillagerPartiesCommands
 
         public string Description => "Shows interacted villagers for co-op debugging.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs strings)
@@ -76,6 +78,8 @@ internal class VillagerPartiesCommands
         public string Name => "view_looted_villagers";
 
         public string Description => "Shows looted villagers for co-op debugging.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 

--- a/source/GameInterface/Services/Workshops/Commands/WorkshopDebugCommand.cs
+++ b/source/GameInterface/Services/Workshops/Commands/WorkshopDebugCommand.cs
@@ -70,6 +70,8 @@ namespace GameInterface.Services.Workshops.Commands
 
             public string Description => "Sets workshop custom name for co-op debugging.";
 
+            public CoopCommandSide Side => CoopCommandSide.Both;
+
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
                 new ExpectedArgs("settlementId", "The settlement id."),
@@ -117,6 +119,8 @@ namespace GameInterface.Services.Workshops.Commands
             public string Name => "set_workshop_owner";
 
             public string Description => "Sets workshop owner for co-op debugging.";
+
+            public CoopCommandSide Side => CoopCommandSide.Both;
 
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
@@ -186,6 +190,8 @@ namespace GameInterface.Services.Workshops.Commands
 
             public string Description => "Runs in settlement for co-op debugging.";
 
+            public CoopCommandSide Side => CoopCommandSide.Both;
+
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
                 new ExpectedArgs("settlementId", "The settlement id."),
@@ -228,6 +234,8 @@ namespace GameInterface.Services.Workshops.Commands
 
             public string Description => "Runs owned workshops for co-op debugging.";
 
+            public CoopCommandSide Side => CoopCommandSide.Both;
+
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {
                 new ExpectedArgs("heroId", "The hero id."),
@@ -269,6 +277,8 @@ namespace GameInterface.Services.Workshops.Commands
             public string Name => "view_warehouse_rosters";
 
             public string Description => "Shows warehouse rosters for co-op debugging.";
+
+            public CoopCommandSide Side => CoopCommandSide.Both;
 
             public IExpectedArgs[] ExpectedArgs { get; } = System.Array.Empty<IExpectedArgs>();
 
@@ -332,6 +342,8 @@ namespace GameInterface.Services.Workshops.Commands
             public string Name => "workshop_info";
 
             public string Description => "Runs info for co-op debugging.";
+
+            public CoopCommandSide Side => CoopCommandSide.Both;
 
             public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
             {

--- a/source/Missions/Agents/Handlers/MovementDebugCommands.cs
+++ b/source/Missions/Agents/Handlers/MovementDebugCommands.cs
@@ -24,6 +24,8 @@ internal static class MovementDebugCommands
 
         public string Description => "Reports state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -87,6 +89,8 @@ internal static class MovementDebugCommands
 
         public string Description => "Runs the force rate debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("rate", "The rate.", true),
@@ -118,6 +122,8 @@ internal static class MovementDebugCommands
         public string Name => "force_receiver_cap";
 
         public string Description => "Runs the force receiver cap debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -152,6 +158,8 @@ internal static class MovementDebugCommands
         public string Name => "simulate_receive_pressure";
 
         public string Description => "Runs the simulate receive pressure debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -201,6 +209,8 @@ internal static class MovementDebugCommands
         public string Name => "clear_receive_pressure";
 
         public string Description => "Restores or clears clear receive pressure.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 

--- a/source/Missions/Battles/BattleDebugCommands.cs
+++ b/source/Missions/Battles/BattleDebugCommands.cs
@@ -140,6 +140,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the replication fixture debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mode", "The mode.", true),
@@ -282,6 +284,8 @@ internal static class BattleDebugCommands
         public string Name => "column_reinforcement_fixture";
 
         public string Description => "Runs the column reinforcement fixture debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -500,6 +504,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the action performance debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("action", "The action.", true),
@@ -539,6 +545,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the animation trace debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("action", "The action.", true),
@@ -577,6 +585,8 @@ internal static class BattleDebugCommands
         public string Name => "wield_test";
 
         public string Description => "Runs the wield test debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -693,6 +703,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Reports item modifier state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -785,6 +797,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Reports state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -856,6 +870,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Reports size state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -903,6 +919,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the charge owned formations debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -943,6 +961,8 @@ internal static class BattleDebugCommands
         public string Name => "mount_state";
 
         public string Description => "Reports mount state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1045,6 +1065,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the capture mount pose debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
@@ -1089,6 +1111,8 @@ internal static class BattleDebugCommands
         public string Name => "mount_pose_samples";
 
         public string Description => "Runs the mount pose samples debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1194,6 +1218,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the move cavalry debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("distance", "The distance.", true),
@@ -1269,6 +1295,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the hold cavalry debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1321,6 +1349,8 @@ internal static class BattleDebugCommands
         public string Name => "turn_cavalry";
 
         public string Description => "Runs the turn cavalry debug operation.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1494,6 +1524,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the focus mount debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("mount_agent_id", "The mount agent id.", true),
@@ -1565,6 +1597,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Reports mount camera state.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1631,6 +1665,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Restores or clears release mount camera.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 
         public CoopCommandResult ProcessCommand(ICoopCommandArgs args)
@@ -1669,6 +1705,8 @@ internal static class BattleDebugCommands
         public string Name => "ladder_state";
 
         public string Description => "Reports ladder state.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
@@ -1753,6 +1791,8 @@ internal static class BattleDebugCommands
 
         public string Description => "Runs the focus ladder debug operation.";
 
+        public CoopCommandSide Side => CoopCommandSide.Both;
+
         public IExpectedArgs[] ExpectedArgs { get; } = new IExpectedArgs[]
         {
             new ExpectedArgs("machine_id", "The machine id.", true),
@@ -1801,6 +1841,8 @@ internal static class BattleDebugCommands
         public string Name => "release_ladder_camera";
 
         public string Description => "Restores or clears release ladder camera.";
+
+        public CoopCommandSide Side => CoopCommandSide.Both;
 
         public IExpectedArgs[] ExpectedArgs { get; } = Array.Empty<IExpectedArgs>();
 


### PR DESCRIPTION
## Summary
- Add required `ICoopCommand.Side` metadata (`Server`, `Client`, or `Both`) and expose it through command descriptors.
- Reject wrong-side commands centrally before argument validation or execution, returning `command_wrong_side` with exactly `This command is only available on the server` / `This command is only available on the client`.
- Update every command and test implementation. Preserve dual-role diagnostics and conditional read/write commands; retain helper guards for direct callers.
- Add role-matrix, role-change, metadata-validation, production classification, and wrong-side regression tests.

## Verification
- Full solution builds in Release and Debug (`dotnet build source/Coop.sln -c <configuration> -p:Platform=x64 -p:ModName=`); deployment disabled.
- Common.Tests Release: **164 passed**.
- GameInterface.Tests filtered to `FullyQualifiedName~Commands|FullyQualifiedName~LiveTestCommandDispatcherTests`: **78 passed Release**, **90 passed Debug**.
- `git diff --check` passed.
- Existing dependency/framework/analyzer warnings remain. No in-game smoke test or deployment performed.
