### PR TITLE
Prevent duplicate poller loops after a restart

### DIFF
--- a/source/Common.Tests/Utils/PollerTests.cs
+++ b/source/Common.Tests/Utils/PollerTests.cs
@@ -169,6 +169,10 @@ public sealed class PollerTests
     [Fact]
     public async Task RepeatedRestarts_KeepASingleTickInFlightAndStopCompletely()
     {
+        const int restarts = 20;
+        using var tickEntered = new SemaphoreSlim(0);
+        using var releaseTick = new SemaphoreSlim(0);
+        using var stopStarted = new ManualResetEventSlim(false);
         var sync = new object();
         int ticksEntered = 0;
         int ticksInFlight = 0;
@@ -182,33 +186,57 @@ public sealed class PollerTests
                 if (ticksInFlight > mostTicksInFlight) mostTicksInFlight = ticksInFlight;
             }
 
-            Thread.Sleep(1);
+            tickEntered.Release();
+            releaseTick.Wait();
 
             lock (sync) ticksInFlight--;
         }, TimeSpan.FromMilliseconds(1));
 
         try
         {
-            for (int restart = 0; restart < 200; restart++)
+            poller.Start();
+            Assert.True(tickEntered.Wait(TimeSpan.FromSeconds(5)));
+
+            for (int restart = 1; restart <= restarts; restart++)
             {
                 poller.Start();
+
+                // The replacement loop has to wait out the tick that is still running, so nothing enters here.
+                Assert.False(tickEntered.Wait(TimeSpan.FromMilliseconds(100)), $"restart {restart} started a second tick next to the one in flight");
+
+                releaseTick.Release();
+
+                // A restart only counts as a handoff once the replacement loop has run a tick of its own.
+                Assert.True(tickEntered.Wait(TimeSpan.FromSeconds(5)), $"restart {restart} never reached its replacement tick");
             }
 
-            Assert.True(poller.StopAndWait(TimeSpan.FromSeconds(10)));
+            Task<bool> stopTask = Task.Run(() =>
+            {
+                stopStarted.Set();
+                return poller.StopAndWait(TimeSpan.FromSeconds(10));
+            });
+            Assert.True(stopStarted.Wait(TimeSpan.FromSeconds(5)));
+            Task firstCompleted = await Task.WhenAny(stopTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+            Assert.NotSame(stopTask, firstCompleted);
 
-            int ticksWhenStopped;
-            lock (sync) ticksWhenStopped = ticksEntered;
+            releaseTick.Release();
+
+            Assert.True(await stopTask);
 
             await Task.Delay(TimeSpan.FromMilliseconds(200));
 
             lock (sync)
             {
-                Assert.Equal(ticksWhenStopped, ticksEntered);
-                Assert.True(mostTicksInFlight <= 1, $"{mostTicksInFlight} ticks ran at the same time");
+                // Every restart handed over to exactly one replacement tick, and nothing ticked after the stop.
+                Assert.Equal(restarts + 1, ticksEntered);
+                Assert.Equal(1, mostTicksInFlight);
             }
         }
         finally
         {
+            // Cancel before releasing, so the freed ticks end their loops instead of starting another round.
+            poller.Stop();
+            releaseTick.Release(restarts + 2);
             poller.StopAndWait(TimeSpan.FromSeconds(5));
         }
     }

--- a/source/Common.Tests/Utils/PollerTests.cs
+++ b/source/Common.Tests/Utils/PollerTests.cs
@@ -265,4 +265,58 @@ public sealed class PollerTests
             poller.StopAndWait(TimeSpan.FromSeconds(5));
         }
     }
+
+    [Fact]
+    public void Start_CalledFromThePollingFunction_RunsTheReplacementLoopOnItsOwn()
+    {
+        using var restartRequested = new ManualResetEventSlim(false);
+        using var releaseFirstTick = new ManualResetEventSlim(false);
+        using var laterTickEntered = new ManualResetEventSlim(false);
+        var sync = new object();
+        int ticksEntered = 0;
+        int ticksInFlight = 0;
+        int mostTicksInFlight = 0;
+        Poller poller = null!;
+        poller = new Poller(_ =>
+        {
+            bool isFirstTick;
+            lock (sync)
+            {
+                isFirstTick = ++ticksEntered == 1;
+                ticksInFlight++;
+                if (ticksInFlight > mostTicksInFlight) mostTicksInFlight = ticksInFlight;
+            }
+
+            if (isFirstTick)
+            {
+                poller.Start();
+                restartRequested.Set();
+                releaseFirstTick.Wait();
+            }
+            else
+            {
+                laterTickEntered.Set();
+            }
+
+            lock (sync) ticksInFlight--;
+        }, TimeSpan.FromSeconds(1));
+
+        try
+        {
+            poller.Start();
+            Assert.True(restartRequested.Wait(TimeSpan.FromSeconds(5)));
+
+            Assert.False(laterTickEntered.Wait(TimeSpan.FromSeconds(1)));
+
+            releaseFirstTick.Set();
+
+            Assert.True(laterTickEntered.Wait(TimeSpan.FromSeconds(5)));
+            lock (sync) Assert.Equal(1, mostTicksInFlight);
+        }
+        finally
+        {
+            releaseFirstTick.Set();
+            poller.StopAndWait(TimeSpan.FromSeconds(5));
+        }
+    }
 }

--- a/source/Common.Tests/Utils/PollerTests.cs
+++ b/source/Common.Tests/Utils/PollerTests.cs
@@ -69,4 +69,200 @@ public sealed class PollerTests
             poller.StopAndWait(TimeSpan.FromSeconds(5));
         }
     }
+
+    [Fact]
+    public void Start_WhileATickIsInFlight_RunsTheReplacementLoopOnlyAfterThatTickReturns()
+    {
+        using var firstTickEntered = new ManualResetEventSlim(false);
+        using var releaseFirstTick = new ManualResetEventSlim(false);
+        using var laterTickEntered = new ManualResetEventSlim(false);
+        var sync = new object();
+        int ticksEntered = 0;
+        int ticksInFlight = 0;
+        int mostTicksInFlight = 0;
+        var poller = new Poller(_ =>
+        {
+            bool isFirstTick;
+            lock (sync)
+            {
+                isFirstTick = ++ticksEntered == 1;
+                ticksInFlight++;
+                if (ticksInFlight > mostTicksInFlight) mostTicksInFlight = ticksInFlight;
+            }
+
+            if (isFirstTick)
+            {
+                firstTickEntered.Set();
+                releaseFirstTick.Wait();
+            }
+            else
+            {
+                laterTickEntered.Set();
+            }
+
+            lock (sync) ticksInFlight--;
+        }, TimeSpan.FromSeconds(1));
+
+        try
+        {
+            poller.Start();
+            Assert.True(firstTickEntered.Wait(TimeSpan.FromSeconds(5)));
+
+            poller.Start();
+
+            Assert.False(laterTickEntered.Wait(TimeSpan.FromSeconds(1)));
+
+            releaseFirstTick.Set();
+
+            Assert.True(laterTickEntered.Wait(TimeSpan.FromSeconds(5)));
+            lock (sync) Assert.Equal(1, mostTicksInFlight);
+        }
+        finally
+        {
+            releaseFirstTick.Set();
+            poller.StopAndWait(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
+    public async Task StopAndWait_AfterARestart_StillWaitsForTheReplacedLoop()
+    {
+        using var firstTickEntered = new ManualResetEventSlim(false);
+        using var releaseFirstTick = new ManualResetEventSlim(false);
+        using var stopStarted = new ManualResetEventSlim(false);
+        int ticksEntered = 0;
+        var poller = new Poller(_ =>
+        {
+            if (Interlocked.Increment(ref ticksEntered) > 1) return;
+
+            firstTickEntered.Set();
+            releaseFirstTick.Wait();
+        }, TimeSpan.FromSeconds(1));
+
+        try
+        {
+            poller.Start();
+            Assert.True(firstTickEntered.Wait(TimeSpan.FromSeconds(5)));
+
+            poller.Start();
+
+            Task<bool> stopTask = Task.Run(() =>
+            {
+                stopStarted.Set();
+                return poller.StopAndWait(TimeSpan.FromSeconds(5));
+            });
+            Assert.True(stopStarted.Wait(TimeSpan.FromSeconds(5)));
+            Task firstCompleted = await Task.WhenAny(stopTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+            Assert.NotSame(stopTask, firstCompleted);
+
+            releaseFirstTick.Set();
+
+            Assert.True(await stopTask);
+        }
+        finally
+        {
+            releaseFirstTick.Set();
+            poller.StopAndWait(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
+    public async Task RepeatedRestarts_KeepASingleTickInFlightAndStopCompletely()
+    {
+        var sync = new object();
+        int ticksEntered = 0;
+        int ticksInFlight = 0;
+        int mostTicksInFlight = 0;
+        var poller = new Poller(_ =>
+        {
+            lock (sync)
+            {
+                ticksEntered++;
+                ticksInFlight++;
+                if (ticksInFlight > mostTicksInFlight) mostTicksInFlight = ticksInFlight;
+            }
+
+            Thread.Sleep(1);
+
+            lock (sync) ticksInFlight--;
+        }, TimeSpan.FromMilliseconds(1));
+
+        try
+        {
+            for (int restart = 0; restart < 200; restart++)
+            {
+                poller.Start();
+            }
+
+            Assert.True(poller.StopAndWait(TimeSpan.FromSeconds(10)));
+
+            int ticksWhenStopped;
+            lock (sync) ticksWhenStopped = ticksEntered;
+
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+            lock (sync)
+            {
+                Assert.Equal(ticksWhenStopped, ticksEntered);
+                Assert.True(mostTicksInFlight <= 1, $"{mostTicksInFlight} ticks ran at the same time");
+            }
+        }
+        finally
+        {
+            poller.StopAndWait(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
+    public async Task Stop_DoesNotWaitForTheInFlightTick()
+    {
+        using var tickEntered = new ManualResetEventSlim(false);
+        using var releaseTick = new ManualResetEventSlim(false);
+        using var tickFinished = new ManualResetEventSlim(false);
+        var poller = new Poller(_ =>
+        {
+            tickEntered.Set();
+            releaseTick.Wait();
+            tickFinished.Set();
+        }, TimeSpan.FromSeconds(1));
+
+        try
+        {
+            poller.Start();
+            Assert.True(tickEntered.Wait(TimeSpan.FromSeconds(5)));
+
+            Task stopTask = Task.Run(() => poller.Stop());
+            Task firstCompleted = await Task.WhenAny(stopTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(stopTask, firstCompleted);
+            Assert.False(tickFinished.IsSet);
+        }
+        finally
+        {
+            releaseTick.Set();
+            poller.StopAndWait(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
+    public void IsRunning_FollowsStartAndStop()
+    {
+        using var tickEntered = new ManualResetEventSlim(false);
+        var poller = new Poller(_ => tickEntered.Set(), TimeSpan.FromMilliseconds(1));
+
+        try
+        {
+            Assert.False(poller.IsRunning);
+
+            poller.Start();
+            Assert.True(tickEntered.Wait(TimeSpan.FromSeconds(5)));
+            Assert.True(poller.IsRunning);
+
+            Assert.True(poller.StopAndWait(TimeSpan.FromSeconds(5)));
+            Assert.False(poller.IsRunning);
+        }
+        finally
+        {
+            poller.StopAndWait(TimeSpan.FromSeconds(5));
+        }
+    }
 }

--- a/source/Common/Util/Poller.cs
+++ b/source/Common/Util/Poller.cs
@@ -24,14 +24,16 @@ public class Poller
     private TimeSpan pollingInterval;
 
     /// <summary>
-    /// Guards the loop ownership below, so Start, Stop and StopAndWait never interleave
+    /// Serializes Start, Stop and StopAndWait so they never see a half-swapped source and task
     /// </summary>
     private readonly object lifecycleLock = new object();
 
     /// <summary>
-    /// The loop this poller owns right now, or null while nothing is polling
+    /// A cancellation token source to stop the polling
     /// </summary>
-    private PollLoop currentLoop;
+    private CancellationTokenSource cts;
+
+    private Task pollingTask;
 
     [ThreadStatic]
     private static Poller activePoller;
@@ -39,17 +41,7 @@ public class Poller
     /// <summary>
     /// Returns true if task is running otherwise false
     /// </summary>
-    public bool IsRunning
-    {
-        get
-        {
-            lock (lifecycleLock)
-            {
-                return currentLoop != null && !currentLoop.Token.IsCancellationRequested;
-            }
-        }
-    }
-
+    public bool IsRunning => !cts?.IsCancellationRequested ?? false;
     public bool IsPollingThread => ReferenceEquals(activePoller, this);
 
     /// <summary>
@@ -70,31 +62,30 @@ public class Poller
     }
 
     /// <summary>
-    /// Starts the polling task in the background. On an already started poller this cancels the running loop and
-    /// queues the replacement behind it, because both loops would otherwise call the polling function at the same time.
+    /// Starts the polling task in the background. Restarting cancels the current source and queues the replacement
+    /// behind the running task, because both loops would otherwise call the polling function at the same time.
     /// </summary>
     public void Start()
     {
         lock (lifecycleLock)
         {
-            // Read the task before cancelling: cancellation can finish the loop right here, which clears currentLoop.
-            var previous = currentLoop?.Task;
-            currentLoop?.Cancellation.Cancel();
+            var previousTask = pollingTask;
+            cts?.Cancel();
 
-            var loop = new PollLoop(new CancellationTokenSource());
-            currentLoop = loop;
-            loop.Task = Task.Run(() => RunLoopAsync(loop, previous));
+            var source = new CancellationTokenSource();
+            cts = source;
+            pollingTask = Task.Run(() => RunAsync(previousTask, source));
         }
     }
 
-    private async Task RunLoopAsync(PollLoop loop, Task previous)
+    private async Task RunAsync(Task previousTask, CancellationTokenSource source)
     {
-        if (previous != null)
+        if (previousTask != null)
         {
             try
             {
-                // Let the loop this one replaces finish first, otherwise two loops poll the same state side by side.
-                await previous;
+                // Wait out the loop this one replaces, otherwise both poll the same state side by side.
+                await previousTask;
             }
             catch (Exception ex)
             {
@@ -104,24 +95,24 @@ public class Poller
 
         try
         {
-            await PollAsync(loop);
+            await PollAsync(source.Token);
         }
         finally
         {
             lock (lifecycleLock)
             {
-                if (ReferenceEquals(currentLoop, loop))
+                // Only clear the field when a restart hasn't already put a newer source there.
+                if (ReferenceEquals(cts, source))
                 {
-                    currentLoop = null;
+                    cts = null;
                 }
-            }
 
-            // Nothing can reach this source once the loop above has given up ownership, so its handles can go.
-            loop.Cancellation.Dispose();
+                source.Dispose();
+            }
         }
     }
 
-    private async Task PollAsync(PollLoop loop)
+    private async Task PollAsync(CancellationToken token)
     {
         // Setup initial start time
         var startTime = DateTime.Now;
@@ -130,7 +121,7 @@ public class Poller
         string lastError = null;
         long repeatCount = 0;
 
-        while (loop.Token.IsCancellationRequested == false)
+        while (token.IsCancellationRequested == false)
         {
             // Calculate the delta time span
             var delta = DateTime.Now - startTime;
@@ -166,7 +157,7 @@ public class Poller
             // Wait for the specified interval to elapse before continuing the loop
             try
             {
-                await Task.Delay(pollingInterval, loop.Token);
+                await Task.Delay(pollingInterval, token);
             }
             catch (OperationCanceledException)
             {
@@ -183,7 +174,7 @@ public class Poller
     public void Stop()
     {
         // Cancel the cancellation token
-        CancelCurrentLoop();
+        CancelAndCaptureTask();
     }
 
     /// <summary>
@@ -198,7 +189,7 @@ public class Poller
     /// </returns>
     public bool StopAndWait(TimeSpan timeout)
     {
-        var task = CancelCurrentLoop();
+        var task = CancelAndCaptureTask();
 
         if (IsPollingThread)
         {
@@ -222,41 +213,14 @@ public class Poller
     }
 
     /// <summary>
-    /// Cancels the loop this poller owns and hands its task back, so the caller can wait outside the lifecycle lock.
+    /// Cancels the current source and hands back the tracked task, so the caller waits outside the lifecycle lock.
     /// </summary>
-    private Task CancelCurrentLoop()
+    private Task CancelAndCaptureTask()
     {
         lock (lifecycleLock)
         {
-            var loop = currentLoop;
-            if (loop == null)
-            {
-                return null;
-            }
-
-            // Read the task before cancelling: cancellation can finish the loop right here, which clears currentLoop.
-            var task = loop.Task;
-            loop.Cancellation.Cancel();
-            return task;
+            cts?.Cancel();
+            return pollingTask;
         }
-    }
-
-    /// <summary>
-    /// One polling loop and the cancellation it owns. A loop only ever reads its own token, so a restart cannot
-    /// hand the previous loop the new loop's cancellation and leave it running.
-    /// </summary>
-    private sealed class PollLoop
-    {
-        public PollLoop(CancellationTokenSource cancellation)
-        {
-            Cancellation = cancellation;
-            Token = cancellation.Token;
-        }
-
-        public CancellationTokenSource Cancellation { get; }
-
-        public CancellationToken Token { get; }
-
-        public Task Task { get; set; }
     }
 }

--- a/source/Common/Util/Poller.cs
+++ b/source/Common/Util/Poller.cs
@@ -24,11 +24,14 @@ public class Poller
     private TimeSpan pollingInterval;
 
     /// <summary>
-    /// A cancellation token source to stop the polling
+    /// Guards the loop ownership below, so Start, Stop and StopAndWait never interleave
     /// </summary>
-    private CancellationTokenSource cts;
+    private readonly object lifecycleLock = new object();
 
-    private Task pollingTask;
+    /// <summary>
+    /// The loop this poller owns right now, or null while nothing is polling
+    /// </summary>
+    private PollLoop currentLoop;
 
     [ThreadStatic]
     private static Poller activePoller;
@@ -36,7 +39,17 @@ public class Poller
     /// <summary>
     /// Returns true if task is running otherwise false
     /// </summary>
-    public bool IsRunning => !cts?.IsCancellationRequested ?? false;
+    public bool IsRunning
+    {
+        get
+        {
+            lock (lifecycleLock)
+            {
+                return currentLoop != null && !currentLoop.Token.IsCancellationRequested;
+            }
+        }
+    }
+
     public bool IsPollingThread => ReferenceEquals(activePoller, this);
 
     /// <summary>
@@ -57,20 +70,58 @@ public class Poller
     }
 
     /// <summary>
-    /// Starts the polling task in the background
+    /// Starts the polling task in the background. On an already started poller this cancels the running loop and
+    /// queues the replacement behind it, because both loops would otherwise call the polling function at the same time.
     /// </summary>
     public void Start()
     {
-        if (pollingTask != null)
+        lock (lifecycleLock)
         {
-            Stop();
-        }
+            // Read the task before cancelling: cancellation can finish the loop right here, which clears currentLoop.
+            var previous = currentLoop?.Task;
+            currentLoop?.Cancellation.Cancel();
 
-        cts = new CancellationTokenSource();
-        pollingTask = Task.Run(PollAsync);
+            var loop = new PollLoop(new CancellationTokenSource());
+            currentLoop = loop;
+            loop.Task = Task.Run(() => RunLoopAsync(loop, previous));
+        }
     }
 
-    private async Task PollAsync()
+    private async Task RunLoopAsync(PollLoop loop, Task previous)
+    {
+        if (previous != null)
+        {
+            try
+            {
+                // Let the loop this one replaces finish first, otherwise two loops poll the same state side by side.
+                await previous;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Replaced polling loop ended with an exception");
+            }
+        }
+
+        try
+        {
+            await PollAsync(loop);
+        }
+        finally
+        {
+            lock (lifecycleLock)
+            {
+                if (ReferenceEquals(currentLoop, loop))
+                {
+                    currentLoop = null;
+                }
+            }
+
+            // Nothing can reach this source once the loop above has given up ownership, so its handles can go.
+            loop.Cancellation.Dispose();
+        }
+    }
+
+    private async Task PollAsync(PollLoop loop)
     {
         // Setup initial start time
         var startTime = DateTime.Now;
@@ -79,7 +130,7 @@ public class Poller
         string lastError = null;
         long repeatCount = 0;
 
-        while (cts.IsCancellationRequested == false)
+        while (loop.Token.IsCancellationRequested == false)
         {
             // Calculate the delta time span
             var delta = DateTime.Now - startTime;
@@ -115,7 +166,7 @@ public class Poller
             // Wait for the specified interval to elapse before continuing the loop
             try
             {
-                await Task.Delay(pollingInterval, cts.Token);
+                await Task.Delay(pollingInterval, loop.Token);
             }
             catch (OperationCanceledException)
             {
@@ -132,7 +183,7 @@ public class Poller
     public void Stop()
     {
         // Cancel the cancellation token
-        cts?.Cancel();
+        CancelCurrentLoop();
     }
 
     /// <summary>
@@ -147,14 +198,13 @@ public class Poller
     /// </returns>
     public bool StopAndWait(TimeSpan timeout)
     {
-        cts?.Cancel();
+        var task = CancelCurrentLoop();
 
         if (IsPollingThread)
         {
             return false;
         }
 
-        var task = pollingTask;
         if (task == null)
         {
             return true;
@@ -169,5 +219,44 @@ public class Poller
             // The loop faulted; it is no longer running, which is all the caller needs.
             return true;
         }
+    }
+
+    /// <summary>
+    /// Cancels the loop this poller owns and hands its task back, so the caller can wait outside the lifecycle lock.
+    /// </summary>
+    private Task CancelCurrentLoop()
+    {
+        lock (lifecycleLock)
+        {
+            var loop = currentLoop;
+            if (loop == null)
+            {
+                return null;
+            }
+
+            // Read the task before cancelling: cancellation can finish the loop right here, which clears currentLoop.
+            var task = loop.Task;
+            loop.Cancellation.Cancel();
+            return task;
+        }
+    }
+
+    /// <summary>
+    /// One polling loop and the cancellation it owns. A loop only ever reads its own token, so a restart cannot
+    /// hand the previous loop the new loop's cancellation and leave it running.
+    /// </summary>
+    private sealed class PollLoop
+    {
+        public PollLoop(CancellationTokenSource cancellation)
+        {
+            Cancellation = cancellation;
+            Token = cancellation.Token;
+        }
+
+        public CancellationTokenSource Cancellation { get; }
+
+        public CancellationToken Token { get; }
+
+        public Task Task { get; set; }
     }
 }


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

`Poller.Start()` cancels the running loop and then replaces the `cts` field, and
`PollAsync` re-reads that field in its loop condition (`Poller.cs:82`) and in
`Task.Delay` (`Poller.cs:118`). A loop that sits in its callback while the swap
happens comes back to the new, uncancelled source and keeps polling next to the
replacement, because it never owned the token it was cancelled with. Only the
newest `pollingTask` is tracked, so `StopAndWait` reports success while the older
loop still calls the polling function.

`AGENTS.md:23` states that the single `Poller` task drives
`netManager.PollEvents()` so receive callbacks fire one at a time, never
concurrently. The mission client sends and receives on that path
(`LiteNetP2PClient.cs:724` wraps an `IMessage` in a `MessagePacket`, `:1020`
publishes what arrives), and it is the one that restarts: its `Poller` is built per
client instance (`LiteNetP2PClient.cs:127`) and the client is registered per
lifetime scope (`MissionModule.cs:58`), the `Start`/`Stop` pair runs on every
mission change (`BattleInstanceLifecycle.cs:102` and `:121`,
`CoopLocationsController.cs:424` and `:507`, `CoopTournamentController.Initialize`
and `OnLeaving`), and `LiteNetP2PClient.cs:164` only cancels. Two loops then call
`netManager.PollEvents()` (`LiteNetP2PClient.cs:237`) at the same time.

That does not deliver a message twice. `PollEvents` detaches the whole pending
chain under `_eventLock` and processes it outside the lock, so the two loops split
the queue between them. What breaks is the ordering and the
one-at-a-time property `AGENTS.md:23` describes: a loop held up inside a receive
callback lets the other loop take everything that arrived after it and publish that
to the `MessageBroker` first, and receive callbacks of both loops run at the same
time.

The four other pollers do not restart, so they are unaffected.
`CoopNetworkBase.StartNetworkPoller()` (`CoopNetworkBase.cs:92`) allows a single
start through a `CompareExchange`, `PacketProfiler` starts once in its constructor
(`PacketProfiler.cs:45`), and `SteamTunnelClient.cs:62` and `SteamTunnelHost.cs:99`
build a fresh `Poller` on every start. `LiteNetP2PClient.cs:164` is also the only
teardown that stops on cancellation alone, because `CoopNetworkBase.cs:112`,
`PacketProfiler.cs:147`, `SteamTunnelClient.cs:152` and `SteamTunnelHost.cs:138`
already use `StopAndWait`.

## What is the new behavior?

Resolves #3114

`Start` cancels the current source and schedules `RunAsync(previousTask, source)`,
which waits for its predecessor, polls with `source.Token` instead of re-reading
the field, and in its `finally` clears `cts` only when no restart has already put
a newer source there, then disposes its own source under the lock. The completed
task stays tracked until the next start. `Stop` and `StopAndWait` share
`CancelAndCaptureTask`, so the cancel and the capture happen under the lock while
the wait and the self-wait check stay outside it. The api is unchanged, and `Stop`
still only cancels, so the teardown at `LiteNetP2PClient.cs:164` keeps the
behavior it has today.

The trade is that a restart waits for the tick in flight, so a polling function
that hangs now stops the replacement from starting while `IsRunning` still
reports true. It is the same callback that would have hung before, without a
second loop next to it. Note that the `StopAndWait` timeout now also covers a
queued successor, not just the loop being stopped.

Two requirements from the issue are not covered. There is no disposal api, so the
task, the source and the callback reference are not released on a final teardown,
and `IsRunning` still reports the state of the current source rather than of the
loop. Neither is added here, because this change keeps the existing api.

`PollerTests` keeps the restart cases and adds a restart started from inside the
polling function, which cancels the very loop it is called from.

## Bot Changelog Entry

- Fixed a second background loop polling mission network events after leaving and
  re-entering a battle, tavern or tournament, which delivered messages out of send
  order and ran receive callbacks at the same time.

## Other information
