### PR TITLE
Prune dead broker subscriptions on subscribe and unsubscribe

### DIFF
--- a/source/Common.Tests/Messaging/MessageBrokerTests.cs
+++ b/source/Common.Tests/Messaging/MessageBrokerTests.cs
@@ -18,6 +18,13 @@ public class MessageBrokerTests
     }
 
     /// <summary>
+    /// Second message type, so a test can publish one type while another type is subscribed to.
+    /// </summary>
+    private sealed class OtherProbeMessage : IMessage
+    {
+    }
+
+    /// <summary>
     /// Subscriber whose instance method records what it received.
     /// </summary>
     private sealed class Subscriber
@@ -38,6 +45,12 @@ public class MessageBrokerTests
         public int Received { get; private set; }
 
         public void Handle(MessagePayload<ProbeMessage> payload)
+        {
+            Received++;
+            log?.Add(name);
+        }
+
+        public void HandleOther(MessagePayload<OtherProbeMessage> payload)
         {
             Received++;
             log?.Add(name);
@@ -91,6 +104,48 @@ public class MessageBrokerTests
             earlier[0] = null;
             Collect();
             broker.Subscribe<ProbeMessage>(joiner.Handle);
+        }
+    }
+
+    /// <summary>
+    /// Subscriber that subscribes a listener for a second message type while the first type is being published.
+    /// </summary>
+    private sealed class ForeignTypeSubscriber
+    {
+        private readonly MessageBroker broker;
+        private readonly Subscriber joiner;
+
+        public ForeignTypeSubscriber(MessageBroker broker, Subscriber joiner)
+        {
+            this.broker = broker;
+            this.joiner = joiner;
+        }
+
+        public void Handle(MessagePayload<ProbeMessage> payload)
+        {
+            broker.Subscribe<OtherProbeMessage>(joiner.HandleOther);
+        }
+    }
+
+    /// <summary>
+    /// Subscriber that unsubscribes itself from inside its own callback, the way a state drops its
+    /// subscriptions while handling the message that ends it.
+    /// </summary>
+    private sealed class SelfUnsubscribingSubscriber
+    {
+        private readonly MessageBroker broker;
+        private readonly List<string> log;
+
+        public SelfUnsubscribingSubscriber(MessageBroker broker, List<string> log)
+        {
+            this.broker = broker;
+            this.log = log;
+        }
+
+        public void Handle(MessagePayload<ProbeMessage> payload)
+        {
+            log.Add("teardown");
+            broker.Unsubscribe<ProbeMessage>(Handle);
         }
     }
 
@@ -239,6 +294,64 @@ public class MessageBrokerTests
     }
 
     [Fact]
+    public void Subscribe_ForAnotherTypeWhileAPublishRuns_RemovesThatTypesDeadEntry()
+    {
+        var broker = new ProbeBroker();
+        var collected = SubscribeCollectableOtherSubscriber(broker);
+        Collect();
+        Assert.False(collected.IsAlive);
+        var joiner = new Subscriber();
+        var driver = new ForeignTypeSubscriber(broker, joiner);
+        broker.Subscribe<ProbeMessage>(driver.Handle);
+
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(1, broker.EntryCountFor<OtherProbeMessage>());
+        GC.KeepAlive(joiner);
+        GC.KeepAlive(driver);
+    }
+
+    [Fact]
+    public void Unsubscribe_FromInsideAPublishOfThatType_RemovesTheDeadEntryOnceThePublishEnds()
+    {
+        var broker = new ProbeBroker();
+        var order = new List<string>();
+        var live = new Subscriber("live", order);
+        broker.Subscribe<ProbeMessage>(live.Handle);
+        var teardown = new SelfUnsubscribingSubscriber(broker, order);
+        broker.Subscribe<ProbeMessage>(teardown.Handle);
+        var collected = SubscribeCollectableSubscriber(broker);
+        Collect();
+        Assert.False(collected.IsAlive);
+        Assert.Equal(3, broker.EntryCountFor<ProbeMessage>());
+
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(new[] { "live", "teardown" }, order);
+        Assert.Equal(1, broker.EntryCountFor<ProbeMessage>());
+        GC.KeepAlive(live);
+        GC.KeepAlive(teardown);
+    }
+
+    [Fact]
+    public void Unsubscribe_FromInsideAPublishThatLeavesOnlyDeadEntries_RemovesTheMessageTypeKey()
+    {
+        var broker = new ProbeBroker();
+        var order = new List<string>();
+        var teardown = new SelfUnsubscribingSubscriber(broker, order);
+        broker.Subscribe<ProbeMessage>(teardown.Handle);
+        var collected = SubscribeCollectableSubscriber(broker);
+        Collect();
+        Assert.False(collected.IsAlive);
+
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(0, broker.EntryCountFor<ProbeMessage>());
+        Assert.False(broker.HasEntriesFor<ProbeMessage>());
+        GC.KeepAlive(teardown);
+    }
+
+    [Fact]
     public void Unsubscribe_RemovesOnlyTheGivenTargetAndMethod()
     {
         var broker = new ProbeBroker();
@@ -319,6 +432,15 @@ public class MessageBrokerTests
     {
         var subscriber = new Subscriber();
         broker.Subscribe<ProbeMessage>(subscriber.Handle);
+        return new WeakReference(subscriber);
+    }
+
+    // Subscribes for the second message type from its own stack frame, so nothing roots the target.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference SubscribeCollectableOtherSubscriber(MessageBroker broker)
+    {
+        var subscriber = new Subscriber();
+        broker.Subscribe<OtherProbeMessage>(subscriber.HandleOther);
         return new WeakReference(subscriber);
     }
 

--- a/source/Common.Tests/Messaging/MessageBrokerTests.cs
+++ b/source/Common.Tests/Messaging/MessageBrokerTests.cs
@@ -68,6 +68,33 @@ public class MessageBrokerTests
     }
 
     /// <summary>
+    /// Subscriber that lets an earlier subscriber die and then subscribes another one, all from inside a publish.
+    /// </summary>
+    private sealed class PruneTriggeringSubscriber
+    {
+        private readonly MessageBroker broker;
+        private readonly Subscriber?[] earlier;
+        private readonly Subscriber joiner;
+        private readonly List<string> log;
+
+        public PruneTriggeringSubscriber(MessageBroker broker, Subscriber?[] earlier, Subscriber joiner, List<string> log)
+        {
+            this.broker = broker;
+            this.earlier = earlier;
+            this.joiner = joiner;
+            this.log = log;
+        }
+
+        public void Handle(MessagePayload<ProbeMessage> payload)
+        {
+            log.Add("trigger");
+            earlier[0] = null;
+            Collect();
+            broker.Subscribe<ProbeMessage>(joiner.Handle);
+        }
+    }
+
+    /// <summary>
     /// Broker that exposes its own subscription table, because the entry and key counts are what these tests assert.
     /// </summary>
     private sealed class ProbeBroker : MessageBroker
@@ -188,6 +215,30 @@ public class MessageBrokerTests
     }
 
     [Fact]
+    public void Publish_WhenPruningIsTriggeredMidCallback_DoesNotSkipALiveSubscriber()
+    {
+        var broker = new ProbeBroker();
+        var order = new List<string>();
+        var earlier = new Subscriber?[1];
+        var joiner = new Subscriber("joiner", order);
+        var trigger = new PruneTriggeringSubscriber(broker, earlier, joiner, order);
+        var middle = new Subscriber("middle", order);
+        var last = new Subscriber("last", order);
+        SubscribeIntoSlot(broker, earlier, "earlier", order);
+        broker.Subscribe<ProbeMessage>(trigger.Handle);
+        broker.Subscribe<ProbeMessage>(middle.Handle);
+        broker.Subscribe<ProbeMessage>(last.Handle);
+
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(new[] { "earlier", "trigger", "middle", "last", "joiner" }, order);
+        GC.KeepAlive(joiner);
+        GC.KeepAlive(trigger);
+        GC.KeepAlive(middle);
+        GC.KeepAlive(last);
+    }
+
+    [Fact]
     public void Unsubscribe_RemovesOnlyTheGivenTargetAndMethod()
     {
         var broker = new ProbeBroker();
@@ -252,6 +303,15 @@ public class MessageBrokerTests
     }
 
     private static void HandleTargetless(MessagePayload<ProbeMessage> payload) => targetlessReceived++;
+
+    // Keeps the new subscriber out of the calling frame so the array slot stays its only root.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SubscribeIntoSlot(MessageBroker broker, Subscriber?[] slot, string name, List<string> log)
+    {
+        var subscriber = new Subscriber(name, log);
+        slot[0] = subscriber;
+        broker.Subscribe<ProbeMessage>(subscriber.Handle);
+    }
 
     // Subscribes from its own stack frame so nothing roots the target once it returns.
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/source/Common.Tests/Messaging/MessageBrokerTests.cs
+++ b/source/Common.Tests/Messaging/MessageBrokerTests.cs
@@ -1,0 +1,278 @@
+﻿using Common.Messaging;
+using System.Runtime.CompilerServices;
+
+namespace Common.Tests.Messaging;
+
+/// <summary>
+/// Covers how the broker keeps, invokes and drops its weak subscriptions.
+/// </summary>
+public class MessageBrokerTests
+{
+    private static int targetlessReceived;
+
+    /// <summary>
+    /// Message type used only by these tests.
+    /// </summary>
+    private sealed class ProbeMessage : IMessage
+    {
+    }
+
+    /// <summary>
+    /// Subscriber whose instance method records what it received.
+    /// </summary>
+    private sealed class Subscriber
+    {
+        private readonly string name;
+        private readonly List<string>? log;
+
+        public Subscriber() : this("subscriber", null)
+        {
+        }
+
+        public Subscriber(string name, List<string>? log)
+        {
+            this.name = name;
+            this.log = log;
+        }
+
+        public int Received { get; private set; }
+
+        public void Handle(MessagePayload<ProbeMessage> payload)
+        {
+            Received++;
+            log?.Add(name);
+        }
+    }
+
+    /// <summary>
+    /// Subscriber that adds another subscriber for the same message type while that type is being published.
+    /// </summary>
+    private sealed class ReentrantSubscriber
+    {
+        private readonly MessageBroker broker;
+        private readonly Subscriber joiner;
+        private readonly List<string> log;
+
+        public ReentrantSubscriber(MessageBroker broker, Subscriber joiner, List<string> log)
+        {
+            this.broker = broker;
+            this.joiner = joiner;
+            this.log = log;
+        }
+
+        public void Handle(MessagePayload<ProbeMessage> payload)
+        {
+            log.Add("reentrant");
+            broker.Subscribe<ProbeMessage>(joiner.Handle);
+        }
+    }
+
+    /// <summary>
+    /// Broker that exposes its own subscription table, because the entry and key counts are what these tests assert.
+    /// </summary>
+    private sealed class ProbeBroker : MessageBroker
+    {
+        public bool HasEntriesFor<T>() => subscribers.ContainsKey(typeof(T));
+
+        public int EntryCountFor<T>() => subscribers.ContainsKey(typeof(T)) ? subscribers[typeof(T)].Count : 0;
+    }
+
+    [Fact]
+    public void Subscribe_WhenAnEarlierTargetWasCollected_RemovesTheDeadEntry()
+    {
+        var broker = new ProbeBroker();
+        var collected = SubscribeCollectableSubscriber(broker);
+        Collect();
+        Assert.False(collected.IsAlive);
+
+        var live = new Subscriber();
+        broker.Subscribe<ProbeMessage>(live.Handle);
+
+        Assert.Equal(1, broker.EntryCountFor<ProbeMessage>());
+        GC.KeepAlive(live);
+    }
+
+    [Fact]
+    public void Unsubscribe_WhenOnlyDeadEntriesRemain_RemovesTheMessageTypeKey()
+    {
+        var broker = new ProbeBroker();
+        var collected = SubscribeCollectableSubscriber(broker);
+        var live = new Subscriber();
+        broker.Subscribe<ProbeMessage>(live.Handle);
+        Collect();
+        Assert.False(collected.IsAlive);
+
+        broker.Unsubscribe<ProbeMessage>(live.Handle);
+
+        Assert.False(broker.HasEntriesFor<ProbeMessage>());
+        GC.KeepAlive(live);
+    }
+
+    [Fact]
+    public void Subscribe_WithRepeatedShortLivedSubscribers_DoesNotGrowTheEntryCount()
+    {
+        var broker = new ProbeBroker();
+        WeakReference? last = null;
+
+        for (int round = 0; round < 10; round++)
+        {
+            last = SubscribeCollectableSubscriber(broker);
+            Collect();
+        }
+
+        Assert.NotNull(last);
+        Assert.False(last!.IsAlive);
+        Assert.Equal(1, broker.EntryCountFor<ProbeMessage>());
+    }
+
+    [Fact]
+    public void Subscribe_WhenAnEarlierTargetWasCollected_KeepsLiveSubscribersReceiving()
+    {
+        var broker = new ProbeBroker();
+        var first = new Subscriber();
+        broker.Subscribe<ProbeMessage>(first.Handle);
+        var collected = SubscribeCollectableSubscriber(broker);
+        Collect();
+        Assert.False(collected.IsAlive);
+
+        var second = new Subscriber();
+        broker.Subscribe<ProbeMessage>(second.Handle);
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(1, first.Received);
+        Assert.Equal(1, second.Received);
+        GC.KeepAlive(first);
+        GC.KeepAlive(second);
+    }
+
+    [Fact]
+    public void Publish_WithADeadEntryBetweenLiveSubscribers_InvokesBothInRegistrationOrder()
+    {
+        var broker = new ProbeBroker();
+        var order = new List<string>();
+        var first = new Subscriber("first", order);
+        broker.Subscribe<ProbeMessage>(first.Handle);
+        var collected = SubscribeCollectableSubscriber(broker);
+        var last = new Subscriber("last", order);
+        broker.Subscribe<ProbeMessage>(last.Handle);
+        Collect();
+        Assert.False(collected.IsAlive);
+
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(new[] { "first", "last" }, order);
+        GC.KeepAlive(first);
+        GC.KeepAlive(last);
+    }
+
+    [Fact]
+    public void Publish_WhenAHandlerSubscribesForTheSameType_DoesNotSkipTheNextLiveSubscriber()
+    {
+        var broker = new ProbeBroker();
+        var order = new List<string>();
+        var joiner = new Subscriber("joiner", order);
+        var reentrant = new ReentrantSubscriber(broker, joiner, order);
+        broker.Subscribe<ProbeMessage>(reentrant.Handle);
+        var collected = SubscribeCollectableSubscriber(broker);
+        var last = new Subscriber("last", order);
+        broker.Subscribe<ProbeMessage>(last.Handle);
+        Collect();
+        Assert.False(collected.IsAlive);
+
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(new[] { "reentrant", "last", "joiner" }, order);
+        GC.KeepAlive(joiner);
+        GC.KeepAlive(reentrant);
+        GC.KeepAlive(last);
+    }
+
+    [Fact]
+    public void Unsubscribe_RemovesOnlyTheGivenTargetAndMethod()
+    {
+        var broker = new ProbeBroker();
+        var order = new List<string>();
+        var first = new Subscriber("first", order);
+        var second = new Subscriber("second", order);
+        broker.Subscribe<ProbeMessage>(first.Handle);
+        broker.Subscribe<ProbeMessage>(second.Handle);
+
+        broker.Unsubscribe<ProbeMessage>(first.Handle);
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Equal(1, broker.EntryCountFor<ProbeMessage>());
+        Assert.Equal(new[] { "second" }, order);
+        GC.KeepAlive(first);
+        GC.KeepAlive(second);
+    }
+
+    [Fact]
+    public void Subscribe_WithTheSameTargetAndMethodTwice_KeepsOneEntry()
+    {
+        var broker = new ProbeBroker();
+        var live = new Subscriber();
+
+        broker.Subscribe<ProbeMessage>(live.Handle);
+        broker.Subscribe<ProbeMessage>(live.Handle);
+
+        Assert.Equal(1, broker.EntryCountFor<ProbeMessage>());
+        GC.KeepAlive(live);
+    }
+
+    [Fact]
+    public void Publish_WithAnUnrootedLambdaSubscription_DoesNotReachItAfterCollection()
+    {
+        var broker = new ProbeBroker();
+        var received = new List<string>();
+        SubscribeUnrootedLambda(broker, received);
+        Assert.Equal(1, broker.EntryCountFor<ProbeMessage>());
+        Collect();
+
+        broker.Publish(this, new ProbeMessage());
+
+        Assert.Empty(received);
+        Assert.Equal(0, broker.EntryCountFor<ProbeMessage>());
+    }
+
+    [Fact]
+    public void Subscribe_WithATargetlessDelegate_TreatsItAsDeadAndNeverInvokesIt()
+    {
+        var broker = new ProbeBroker();
+        targetlessReceived = 0;
+        broker.Subscribe<ProbeMessage>(HandleTargetless);
+        var live = new Subscriber();
+
+        broker.Subscribe<ProbeMessage>(live.Handle);
+
+        Assert.Equal(1, broker.EntryCountFor<ProbeMessage>());
+        broker.Publish(this, new ProbeMessage());
+        Assert.Equal(0, targetlessReceived);
+        Assert.Equal(1, live.Received);
+        GC.KeepAlive(live);
+    }
+
+    private static void HandleTargetless(MessagePayload<ProbeMessage> payload) => targetlessReceived++;
+
+    // Subscribes from its own stack frame so nothing roots the target once it returns.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference SubscribeCollectableSubscriber(MessageBroker broker)
+    {
+        var subscriber = new Subscriber();
+        broker.Subscribe<ProbeMessage>(subscriber.Handle);
+        return new WeakReference(subscriber);
+    }
+
+    // The lambda's closure is the subscription target, and nothing roots it once this frame returns.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SubscribeUnrootedLambda(MessageBroker broker, List<string> received)
+    {
+        broker.Subscribe<ProbeMessage>(payload => received.Add("lambda"));
+    }
+
+    private static void Collect()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+}

--- a/source/Common/Messaging/MessageBroker.cs
+++ b/source/Common/Messaging/MessageBroker.cs
@@ -2,7 +2,6 @@
 using Serilog;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace Common.Messaging;
 
@@ -20,8 +19,11 @@ public class MessageBroker : IMessageBroker
     private static readonly ILogger Logger = LogManager.GetLogger<MessageBroker>();
     protected static MessageBroker instance;
     protected readonly Dictionary<Type, List<WeakDelegate>> subscribers;
-    // Publishes currently running on this broker, counted with Interlocked because the network thread and the game thread both publish
-    private int publishDepth;
+    // Subscriber lists a publish is currently walking, one entry per running publish, so pruning a
+    // list holds off while a loop is stepping through it by index
+    private readonly List<List<WeakDelegate>> walkedByPublish = new List<List<WeakDelegate>>();
+    // Lists whose pruning was skipped for that reason, caught up by the publish that leaves last
+    private readonly List<List<WeakDelegate>> prunePending = new List<List<WeakDelegate>>();
     public static MessageBroker Instance { 
         get
         {
@@ -48,7 +50,7 @@ public class MessageBroker : IMessageBroker
         var delegates = subscribers[typeof(T)];
         if (delegates == null || delegates.Count == 0) return;
         var payload = new MessagePayload<T>(source, message);
-        Interlocked.Increment(ref publishDepth);
+        walkedByPublish.Add(delegates);
         try
         {
             for (int i = 0; i < delegates.Count; i++)
@@ -79,7 +81,13 @@ public class MessageBroker : IMessageBroker
         }
         finally
         {
-            Interlocked.Decrement(ref publishDepth);
+            walkedByPublish.Remove(delegates);
+            if (!walkedByPublish.Contains(delegates) && prunePending.Remove(delegates))
+            {
+                delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
+                if (delegates.Count == 0 && subscribers.TryGetValue(typeof(T), out var current) && current == delegates)
+                    subscribers.Remove(typeof(T));
+            }
         }
     }
 
@@ -108,11 +116,16 @@ public class MessageBroker : IMessageBroker
     }
 
     // Entries whose target was collected otherwise sit here until this message type is published again.
-    // A running publish walks its list by index, so removing an entry it already passed would make it
-    // skip the next live subscriber; that list is left alone until the publish is done.
+    // Pruning a list that a publish is stepping through by index would move entries past its position,
+    // so that list is noted here and pruned in the finally of that publish instead.
     private void RemoveDeadSubscribers(List<WeakDelegate> delegates)
     {
-        if (publishDepth > 0) return;
+        if (walkedByPublish.Contains(delegates))
+        {
+            if (!prunePending.Contains(delegates))
+                prunePending.Add(delegates);
+            return;
+        }
         delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
     }
 

--- a/source/Common/Messaging/MessageBroker.cs
+++ b/source/Common/Messaging/MessageBroker.cs
@@ -19,6 +19,10 @@ public class MessageBroker : IMessageBroker
     private static readonly ILogger Logger = LogManager.GetLogger<MessageBroker>();
     protected static MessageBroker instance;
     protected readonly Dictionary<Type, List<WeakDelegate>> subscribers;
+    // Guards the two lists below. They replace an Interlocked counter, and a counter cannot be left
+    // unbalanced by an interleaving, while a lost list update would mark a list as walked for good
+    // and stop pruning it for the lifetime of the broker
+    private readonly object bookkeepingLock = new object();
     // Subscriber lists a publish is currently walking, one entry per running publish, so pruning a
     // list holds off while a loop is stepping through it by index
     private readonly List<List<WeakDelegate>> walkedByPublish = new List<List<WeakDelegate>>();
@@ -50,7 +54,10 @@ public class MessageBroker : IMessageBroker
         var delegates = subscribers[typeof(T)];
         if (delegates == null || delegates.Count == 0) return;
         var payload = new MessagePayload<T>(source, message);
-        walkedByPublish.Add(delegates);
+        lock (bookkeepingLock)
+        {
+            walkedByPublish.Add(delegates);
+        }
         try
         {
             for (int i = 0; i < delegates.Count; i++)
@@ -81,12 +88,15 @@ public class MessageBroker : IMessageBroker
         }
         finally
         {
-            walkedByPublish.Remove(delegates);
-            if (!walkedByPublish.Contains(delegates) && prunePending.Remove(delegates))
+            lock (bookkeepingLock)
             {
-                delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
-                if (delegates.Count == 0 && subscribers.TryGetValue(typeof(T), out var current) && current == delegates)
-                    subscribers.Remove(typeof(T));
+                walkedByPublish.Remove(delegates);
+                if (!walkedByPublish.Contains(delegates) && prunePending.Remove(delegates))
+                {
+                    delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
+                    if (delegates.Count == 0 && subscribers.TryGetValue(typeof(T), out var current) && current == delegates)
+                        subscribers.Remove(typeof(T));
+                }
             }
         }
     }
@@ -120,13 +130,16 @@ public class MessageBroker : IMessageBroker
     // so that list is noted here and pruned in the finally of that publish instead.
     private void RemoveDeadSubscribers(List<WeakDelegate> delegates)
     {
-        if (walkedByPublish.Contains(delegates))
+        lock (bookkeepingLock)
         {
-            if (!prunePending.Contains(delegates))
-                prunePending.Add(delegates);
-            return;
+            if (walkedByPublish.Contains(delegates))
+            {
+                if (!prunePending.Contains(delegates))
+                    prunePending.Add(delegates);
+                return;
+            }
+            delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
         }
-        delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
     }
 
     public virtual void Dispose()

--- a/source/Common/Messaging/MessageBroker.cs
+++ b/source/Common/Messaging/MessageBroker.cs
@@ -2,6 +2,7 @@
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Common.Messaging;
 
@@ -19,6 +20,8 @@ public class MessageBroker : IMessageBroker
     private static readonly ILogger Logger = LogManager.GetLogger<MessageBroker>();
     protected static MessageBroker instance;
     protected readonly Dictionary<Type, List<WeakDelegate>> subscribers;
+    // Publishes currently running on this broker, counted with Interlocked because the network thread and the game thread both publish
+    private int publishDepth;
     public static MessageBroker Instance { 
         get
         {
@@ -45,30 +48,38 @@ public class MessageBroker : IMessageBroker
         var delegates = subscribers[typeof(T)];
         if (delegates == null || delegates.Count == 0) return;
         var payload = new MessagePayload<T>(source, message);
-        for (int i = 0; i < delegates.Count; i++)
+        Interlocked.Increment(ref publishDepth);
+        try
         {
-            // TODO this might be slow
-            var weakDelegate = delegates[i];
-            if (weakDelegate.IsAlive == false)
+            for (int i = 0; i < delegates.Count; i++)
             {
-                // Subscriptions are weak by design, but a collected target means this message is
-                // silently not handled — name it, because a lost handler is otherwise invisible
-                // (the classic trap: a closure/lambda subscription nothing kept alive).
-                Logger.Warning("Dropping dead subscriber {Method} for {MessageType}: its target was garbage collected",
-                    weakDelegate.Method?.Name ?? "<unknown>", typeof(T).Name);
-                delegates.RemoveAt(i--);
-                continue;
-            }
+                // TODO this might be slow
+                var weakDelegate = delegates[i];
+                if (weakDelegate.IsAlive == false)
+                {
+                    // Subscriptions are weak by design, but a collected target means this message is
+                    // silently not handled — name it, because a lost handler is otherwise invisible
+                    // (the classic trap: a closure/lambda subscription nothing kept alive).
+                    Logger.Warning("Dropping dead subscriber {Method} for {MessageType}: its target was garbage collected",
+                        weakDelegate.Method?.Name ?? "<unknown>", typeof(T).Name);
+                    delegates.RemoveAt(i--);
+                    continue;
+                }
 
-            try
-            {
-                // Making synchronous to maintain sequencing of packets
-                weakDelegate.Invoke(new object[] { payload });
+                try
+                {
+                    // Making synchronous to maintain sequencing of packets
+                    weakDelegate.Invoke(new object[] { payload });
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Failed to run {Method}", (weakDelegate.Instance as WeakDelegate)?.Method.Name ?? "<null>");
+                }
             }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to run {Method}", (weakDelegate.Instance as WeakDelegate)?.Method.Name ?? "<null>");
-            }
+        }
+        finally
+        {
+            Interlocked.Decrement(ref publishDepth);
         }
     }
 
@@ -96,9 +107,12 @@ public class MessageBroker : IMessageBroker
             subscribers.Remove(typeof(T));
     }
 
-    // Entries whose target was collected otherwise sit here until this message type is published again
-    private static void RemoveDeadSubscribers(List<WeakDelegate> delegates)
+    // Entries whose target was collected otherwise sit here until this message type is published again.
+    // A running publish walks its list by index, so removing an entry it already passed would make it
+    // skip the next live subscriber; that list is left alone until the publish is done.
+    private void RemoveDeadSubscribers(List<WeakDelegate> delegates)
     {
+        if (publishDepth > 0) return;
         delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
     }
 

--- a/source/Common/Messaging/MessageBroker.cs
+++ b/source/Common/Messaging/MessageBroker.cs
@@ -76,6 +76,7 @@ public class MessageBroker : IMessageBroker
     {
         var delegates = subscribers.ContainsKey(typeof(T)) ?
                         subscribers[typeof(T)] : new List<WeakDelegate>();
+        RemoveDeadSubscribers(delegates);
         if (!delegates.Contains(subscription))
         {
             delegates.Add(subscription);
@@ -90,8 +91,15 @@ public class MessageBroker : IMessageBroker
         var delegates = subscribers[typeof(T)];
         if (delegates.Contains(new WeakDelegate(subscription)))
             delegates.Remove(subscription);
+        RemoveDeadSubscribers(delegates);
         if (delegates.Count == 0)
             subscribers.Remove(typeof(T));
+    }
+
+    // Entries whose target was collected otherwise sit here until this message type is published again
+    private static void RemoveDeadSubscribers(List<WeakDelegate> delegates)
+    {
+        delegates.RemoveAll(weakDelegate => !weakDelegate.IsAlive);
     }
 
     public virtual void Dispose()


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?

`MessageBroker` keeps subscriptions in a dictionary keyed by message type
(`MessageBroker.cs:21`) holding `WeakDelegate` entries, so a subscriber target is
not rooted. A collected target is dropped only while that same message type is
published (`MessageBroker.cs:59`). `Subscribe` (`MessageBroker.cs:75`) and
`Unsubscribe` (`MessageBroker.cs:86`) never look at `IsAlive`, so a message type
that is not published again keeps its dictionary key, its list, the
`WeakDelegate`, its `WeakReference` and its `MethodInfo`. `Unsubscribe` removes
the type key only on an empty list (`MessageBroker.cs:93`), and a dead entry
keeps that count above zero.

#1758 disposes a named set of per-mission handlers at mission teardown, so those
unsubscribe deterministically. Anything outside that set still waits for a later
`Publish<T>` of the same type.

## What is the new behavior?

Resolves #3115

`Subscribe` and `Unsubscribe` drop entries whose target was collected, so a dead
entry goes away on the next subscribe or unsubscribe for that message type, and an
empty list removes its dictionary key.

`Publish` walks its list by index and only checks each entry as it reaches it, so an
entry it already passed can still die during a later callback of the same publish.
Removing that entry shifts the rest down and the next live subscriber is never
invoked. `Publish` therefore records the list it is walking (`MessageBroker.cs:59`),
one entry per running publish, and `RemoveDeadSubscribers` notes that list instead of
pruning it (`MessageBroker.cs:135`). The publish that leaves that list last catches
the pruning up in its `finally` (`MessageBroker.cs:96`).

The record is per list rather than per broker, because most subscribe and unsubscribe
calls here run inside a callback: the state machines switch from a handler, and the
old state unsubscribes while the new one subscribes. A broker-wide guard would skip
pruning on exactly those paths, and a publish of one message type would also block
pruning of an unrelated one.

`Unsubscribe` already removed the message type key once its list ran empty, so the
deferred prune removes that key as well; otherwise `Count` never reaches zero and an
empty list is left under a live key.

The two lists are guarded by a lock of their own (`MessageBroker.cs:25`), because they
replace an `Interlocked` counter and a counter cannot be left unbalanced by an
interleaving. Two threads do publish here: the poller task reaches `Publish` through
`CoopClient.cs:232` and `:243`, and the game thread through `CoopClient.cs:129`. A
lost list update would mark a list as walked for good and stop pruning that message
type for the lifetime of the broker. No lock is held while a subscriber runs, and
nothing else is guarded by it: every other access to the subscriber lists and the
dictionary stays outside the lock, exactly as on `development`.

The delivery loop is unchanged apart from indentation, weak ownership stays as it is,
and no strong root is added. The publish warning at `MessageBroker.cs:72` fires less
often, because an entry can be gone before the next publish of that type.

`Unsubscribe` still removes its own entry directly (`MessageBroker.cs:122`) and
`Publish` still removes entries it walks past (`MessageBroker.cs:74`), so a handler
that unsubscribes itself, and a nested publish of the same type, can still make a
running loop skip the next entry. Both predate this change and behave the same on
`development`. The broker is not thread safe before or after this change; the lock
covers only the bookkeeping this change introduces.

`MessageBrokerTests` compiles against `development`, where seven of its fourteen
tests fail.

## Bot Changelog Entry

## Other information
