### PR TITLE
Add dedicated-server Steam ID ban list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ For the best performance and stability, we strongly recommend hosting campaigns 
 
 Steam hosting does not require traditional port forwarding in most cases. Manual network hosting options are also available.
 
+Dedicated-server operators can block Steam64 identities with a [server-side ban list](doc/SteamBans.md).
+
 Server setup walkthrough: https://www.youtube.com/watch?v=laZM967Eals
 
 ## Current Features

--- a/doc/SteamBans.md
+++ b/doc/SteamBans.md
@@ -1,0 +1,31 @@
+# Steam bans
+
+Dedicated servers can refuse a player before their character is resolved or restored. Create `steam-bans.json` in the directory named by `COOP_DATA_DIR`:
+
+```json
+{
+  "steamIds": [
+    "76561198000000042"
+  ]
+}
+```
+
+Only numeric Steam64 identities between 5 and 20 digits are loaded. The file is checked on each join and reloaded when it changes, so adding or removing a ban does not require a server restart. If an edit contains malformed JSON, the server logs the error and keeps the last valid list.
+
+The dedicated-server layout also supports `server-data/steam-bans.json` beside the engine directory. Set `COOP_STEAM_BAN_FILE` to an absolute path to choose a different location.
+
+An optional `entries` array can retain display names for administration tools:
+
+```json
+{
+  "steamIds": [
+    "76561198000000042"
+  ],
+  "entries": [
+    {
+      "steamId": "76561198000000042",
+      "heroName": "Example player"
+    }
+  ]
+}
+```

--- a/source/Coop.Core/Server/Connections/ConnectionContext.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionContext.cs
@@ -36,6 +36,7 @@ public class ConnectionContext
         ISendCoalescer coalescer,
         IAttachmentIdMapper attachmentIdMapper,
         IExistingPlayerSender existingPlayerSender,
+        ISteamBanList steamBanList,
         IServerOptionsProvider serverOptionsProvider,
         IJoinCampaignBaselineSender joinCampaignBaselineSender,
         IJoinCampaignKingdomBaseLineSender joinCampaignKingdomBaseLineSender)
@@ -55,6 +56,7 @@ public class ConnectionContext
         Coalescer = coalescer;
         AttachmentIdMapper = attachmentIdMapper;
         ExistingPlayerSender = existingPlayerSender;
+        SteamBanList = steamBanList;
         ServerOptionsProvider = serverOptionsProvider;
         JoinCampaignBaselineSender = joinCampaignBaselineSender;
         JoinCampaignKingdomBaseLineSender = joinCampaignKingdomBaseLineSender;
@@ -75,6 +77,7 @@ public class ConnectionContext
     public ISendCoalescer Coalescer { get; }
     public IAttachmentIdMapper AttachmentIdMapper { get; }
     public IExistingPlayerSender ExistingPlayerSender { get; }
+    public ISteamBanList SteamBanList { get; }
     public IServerOptionsProvider ServerOptionsProvider { get; }
     public IJoinCampaignBaselineSender JoinCampaignBaselineSender { get; }
     public IJoinCampaignKingdomBaseLineSender JoinCampaignKingdomBaseLineSender { get; }

--- a/source/Coop.Core/Server/Connections/ConnectionLogic.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionLogic.cs
@@ -80,7 +80,7 @@ public class ConnectionLogic : IConnectionLogic
     private IReadOnlyDictionary<Type, Func<IConnectionState>> CreateStateFactories() =>
         new Dictionary<Type, Func<IConnectionState>>
         {
-            [typeof(ResolveCharacterState)] = () => new ResolveCharacterState(this, context.MessageBroker, context.Network, context.ModuleValidator, context.PlayerManager, context.PlayerPartyRestorer, context.ObjectManager, context.ModuleInfoProvider, context.ExistingPlayerSender),
+            [typeof(ResolveCharacterState)] = () => new ResolveCharacterState(this, context.MessageBroker, context.Network, context.ModuleValidator, context.PlayerManager, context.PlayerPartyRestorer, context.ObjectManager, context.ModuleInfoProvider, context.ExistingPlayerSender, context.SteamBanList),
             [typeof(CreateCharacterState)] = () => new CreateCharacterState(this, context.ObjectManager, context.MessageBroker, context.Network, context.HeroInterface, context.PlayerManager, context.PlayerCreationRollback, context.ExistingPlayerSender),
             [typeof(TransferSaveState)] = () => new TransferSaveState(this, context.MessageBroker, context.Network, context.CoopSessionProvider, context.SaveInterface, context.ConnectionMessageQueue, context.Coalescer, context.AttachmentIdMapper, context.ServerOptionsProvider),
             [typeof(LoadingState)] = () => new LoadingState(this, context.MessageBroker, context.Network, context.JoinCampaignBaselineSender, context.JoinCampaignKingdomBaseLineSender, context.ConnectionMessageQueue, context.Coalescer),

--- a/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
+++ b/source/Coop.Core/Server/Connections/States/ResolveCharacterState.cs
@@ -33,6 +33,7 @@ public class ResolveCharacterState : ConnectionStateBase
     private readonly IObjectManager objectManager;
     private readonly IModuleInfoProvider moduleInfoProvider;
     private readonly IExistingPlayerSender existingPlayerSender;
+    private readonly ISteamBanList steamBanList;
 
     public ResolveCharacterState(IConnectionLogic connectionLogic,
         IMessageBroker messageBroker,
@@ -42,7 +43,8 @@ public class ResolveCharacterState : ConnectionStateBase
         IPlayerPartyRestorer playerPartyRestorer,
         IObjectManager objectManager,
         IModuleInfoProvider moduleInfoProvider,
-        IExistingPlayerSender existingPlayerSender)
+        IExistingPlayerSender existingPlayerSender,
+        ISteamBanList steamBanList)
         : base(connectionLogic)
     {
         this.messageBroker = messageBroker;
@@ -53,6 +55,7 @@ public class ResolveCharacterState : ConnectionStateBase
         this.objectManager = objectManager;
         this.moduleInfoProvider = moduleInfoProvider;
         this.existingPlayerSender = existingPlayerSender;
+        this.steamBanList = steamBanList;
 
         messageBroker.Subscribe<NetworkClientValidate>(Handle_ClientValidate);
         messageBroker.Subscribe<NetworkModuleVersionsValidate>(Handle_ModuleVersionsValidate);
@@ -129,6 +132,15 @@ public class ResolveCharacterState : ConnectionStateBase
 
         try
         {
+            if (steamBanList.IsBanned(obj.What.PlayerId))
+            {
+                Logger.Warning(
+                    "Controller {ControllerId} is banned; disconnecting the joining peer",
+                    obj.What.PlayerId);
+                peer.Disconnect();
+                return;
+            }
+
             ResolveCharacter(peer, obj.What.PlayerId);
         }
         catch (Exception e)

--- a/source/Coop.Core/Server/Connections/SteamBanList.cs
+++ b/source/Coop.Core/Server/Connections/SteamBanList.cs
@@ -1,0 +1,198 @@
+﻿using Common.Logging;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Coop.Core.Server.Connections;
+
+/// <summary>Checks server-managed Steam64 identities before player resolution.</summary>
+public interface ISteamBanList
+{
+    bool IsBanned(string controllerId);
+}
+
+/// <summary>
+/// Reads the host's Steam64 ban list and refreshes it when the file changes.
+/// </summary>
+internal sealed class SteamBanList : ISteamBanList
+{
+    private const string FileName = "steam-bans.json";
+    private const string BanFileEnvironmentVariable = "COOP_STEAM_BAN_FILE";
+
+    private static readonly ILogger Logger = LogManager.GetLogger<SteamBanList>();
+
+    private readonly object sync = new object();
+    private readonly Func<string> resolvePath;
+    private HashSet<string> bannedIds = new HashSet<string>(StringComparer.Ordinal);
+    private string loadedPath = string.Empty;
+    private DateTime loadedWriteTimeUtc = DateTime.MinValue;
+    private bool fileWasPresent;
+
+    public SteamBanList() : this(ResolvePath)
+    {
+    }
+
+    internal SteamBanList(string path) : this(() => path)
+    {
+    }
+
+    private SteamBanList(Func<string> resolvePath)
+    {
+        if (resolvePath == null) throw new ArgumentNullException(nameof(resolvePath));
+        this.resolvePath = resolvePath;
+    }
+
+    public bool IsBanned(string controllerId)
+    {
+        string normalized = Normalize(controllerId);
+        if (normalized == null) return false;
+
+        ReloadIfChanged();
+
+        lock (sync)
+        {
+            return bannedIds.Contains(normalized);
+        }
+    }
+
+    internal static string? Normalize(string? steamId)
+    {
+        if (string.IsNullOrWhiteSpace(steamId)) return null;
+
+        string trimmed = steamId.Trim();
+        if (trimmed.Length < 5 || trimmed.Length > 20) return null;
+        return trimmed.All(char.IsDigit) ? trimmed : null;
+    }
+
+    private void ReloadIfChanged()
+    {
+        string path = resolvePath();
+
+        try
+        {
+            try
+            {
+                File.GetAttributes(path);
+            }
+            catch (FileNotFoundException)
+            {
+                ClearMissingFile(path);
+                return;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                ClearMissingFile(path);
+                return;
+            }
+
+            DateTime writeTimeUtc = File.GetLastWriteTimeUtc(path);
+            lock (sync)
+            {
+                if (path == loadedPath && fileWasPresent && writeTimeUtc == loadedWriteTimeUtc) return;
+            }
+
+            HashSet<string> next = Read(path);
+            lock (sync)
+            {
+                bannedIds = next;
+                loadedPath = path;
+                loadedWriteTimeUtc = writeTimeUtc;
+                fileWasPresent = true;
+            }
+
+            Logger.Information("Steam ban list loaded from {Path} ({Count} id(s))", path, next.Count);
+        }
+        catch (Exception exception) when (
+            exception is IOException ||
+            exception is UnauthorizedAccessException ||
+            exception is JsonException)
+        {
+            Logger.Error(exception, "Steam ban list could not be reloaded from {Path}; keeping the previous list", path);
+        }
+    }
+
+    private void ClearMissingFile(string path)
+    {
+        lock (sync)
+        {
+            if (path == loadedPath && !fileWasPresent) return;
+
+            bannedIds = new HashSet<string>(StringComparer.Ordinal);
+            loadedPath = path;
+            loadedWriteTimeUtc = DateTime.MinValue;
+            fileWasPresent = false;
+        }
+    }
+
+    private static HashSet<string> Read(string path)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+        if (document.RootElement.ValueKind != JsonValueKind.Object) return result;
+
+        if (document.RootElement.TryGetProperty("steamIds", out JsonElement steamIds) &&
+            steamIds.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement entry in steamIds.EnumerateArray())
+            {
+                AddNormalized(result, entry.ValueKind == JsonValueKind.String ? entry.GetString() : null);
+            }
+        }
+
+        if (document.RootElement.TryGetProperty("entries", out JsonElement entries) &&
+            entries.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement entry in entries.EnumerateArray())
+            {
+                if (entry.ValueKind != JsonValueKind.Object ||
+                    !entry.TryGetProperty("steamId", out JsonElement steamId) ||
+                    steamId.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                AddNormalized(result, steamId.GetString());
+            }
+        }
+
+        return result;
+    }
+
+    private static void AddNormalized(HashSet<string> result, string? steamId)
+    {
+        string normalized = Normalize(steamId);
+        if (normalized != null) result.Add(normalized);
+    }
+
+    private static string ResolvePath()
+    {
+        string? configuredPath = Environment.GetEnvironmentVariable(BanFileEnvironmentVariable);
+        string? coopDataDirectory = Environment.GetEnvironmentVariable("COOP_DATA_DIR");
+        return ResolvePath(configuredPath, coopDataDirectory, AppContext.BaseDirectory);
+    }
+
+    internal static string ResolvePath(
+        string? configuredPath,
+        string? coopDataDirectory,
+        string applicationBaseDirectory)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredPath)) return Path.GetFullPath(configuredPath);
+
+        if (!string.IsNullOrWhiteSpace(coopDataDirectory))
+        {
+            return Path.Combine(coopDataDirectory, FileName);
+        }
+
+        string deploymentPath = Path.GetFullPath(Path.Combine(
+            applicationBaseDirectory,
+            "..",
+            "..",
+            "..",
+            "server-data",
+            FileName));
+        return deploymentPath;
+    }
+}

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -81,6 +81,7 @@ public class ServerModule : CommonModule
         // Withholds world broadcasts from a peer until it has the transfer save and has entered the
         // campaign. AutoActivate so it subscribes to connection lifecycle events before any peer joins.
         builder.RegisterType<ConnectionMessageQueue>().As<IConnectionMessageQueue>().InstancePerLifetimeScope().AutoActivate();
+        builder.RegisterType<SteamBanList>().As<ISteamBanList>().InstancePerDependency();
 
         builder.RegisterType<MissionManager>()
             .As<IMissionManager>()

--- a/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/ResolveCharacterStateTests.cs
@@ -288,6 +288,30 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
+        public void NetworkClientValidate_BannedSteamId_DisconnectsBeforePlayerResolution()
+        {
+            var currentState = connectionLogic.SetState<ResolveCharacterState>();
+            const string steamId = "76561198000000042";
+            var banList = serverComponent.Container.Resolve<Mock<ISteamBanList>>();
+            banList.Setup(list => list.IsBanned(steamId)).Returns(true);
+            var playerManager = serverComponent.Container.Resolve<Mock<IPlayerManager>>();
+
+            currentState.Handle_ClientValidate(new MessagePayload<NetworkClientValidate>(
+                playerPeer,
+                new NetworkClientValidate(steamId)));
+
+            banList.Verify(list => list.IsBanned(steamId), Times.Once);
+            playerManager.Verify(
+                manager => manager.TryGetPlayer(It.IsAny<string>(), out It.Ref<Player>.IsAny),
+                Times.Never);
+            var messages = serverComponent.TestNetwork.SentNetworkMessages
+                .GetValueOrDefault(playerPeer.Id) ?? Enumerable.Empty<IMessage>();
+            Assert.Empty(messages);
+            Assert.IsType<ResolveCharacterState>(connectionLogic.State);
+            Assert.Equal(ConnectionState.ShutdownRequested, playerPeer.ConnectionState);
+        }
+
+        [Fact]
         public void NetworkClientValidate_RegisteredHeroWithStaleParty_RepairsWithoutCreatingCharacter()
         {
             var currentState = connectionLogic.SetState<ResolveCharacterState>();

--- a/source/Coop.Tests/Server/Connections/SteamBanListTests.cs
+++ b/source/Coop.Tests/Server/Connections/SteamBanListTests.cs
@@ -1,0 +1,110 @@
+﻿using Coop.Core.Server.Connections;
+using System;
+using System.IO;
+using Xunit;
+
+namespace Coop.Tests.Server.Connections;
+
+/// <summary>Tests the dedicated-server Steam ban list.</summary>
+public sealed class SteamBanListTests : IDisposable
+{
+    private readonly string directory = Path.Combine(
+        Path.GetTempPath(),
+        "BannerlordCoop-SteamBanListTests-" + Guid.NewGuid().ToString("N"));
+
+    private string BanFilePath => Path.Combine(directory, "steam-bans.json");
+
+    [Fact]
+    public void IsBanned_ReadsIdsAndNamedEntries()
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(BanFilePath,
+            "{\"steamIds\":[\"76561198000000042\"]," +
+            "\"entries\":[{\"steamId\":\"76561198000000043\",\"heroName\":\"Player\"}]}");
+        var banList = new SteamBanList(BanFilePath);
+
+        Assert.True(banList.IsBanned("76561198000000042"));
+        Assert.True(banList.IsBanned("76561198000000043"));
+        Assert.False(banList.IsBanned("76561198000000044"));
+    }
+
+    [Fact]
+    public void IsBanned_ReloadsChangedFileAndClearsDeletedFile()
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(BanFilePath, "{\"steamIds\":[\"76561198000000042\"]}");
+        var banList = new SteamBanList(BanFilePath);
+        Assert.True(banList.IsBanned("76561198000000042"));
+
+        File.WriteAllText(BanFilePath, "{\"steamIds\":[\"76561198000000043\"]}");
+        File.SetLastWriteTimeUtc(BanFilePath, DateTime.UtcNow.AddSeconds(2));
+        Assert.False(banList.IsBanned("76561198000000042"));
+        Assert.True(banList.IsBanned("76561198000000043"));
+
+        File.Delete(BanFilePath);
+        Assert.False(banList.IsBanned("76561198000000043"));
+    }
+
+    [Fact]
+    public void IsBanned_MalformedReloadKeepsLastValidList()
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(BanFilePath, "{\"steamIds\":[\"76561198000000042\"]}");
+        var banList = new SteamBanList(BanFilePath);
+        Assert.True(banList.IsBanned("76561198000000042"));
+
+        File.WriteAllText(BanFilePath, "{");
+        File.SetLastWriteTimeUtc(BanFilePath, DateTime.UtcNow.AddSeconds(2));
+
+        Assert.True(banList.IsBanned("76561198000000042"));
+    }
+
+    [Fact]
+    public void IsBanned_UnreadableReplacementKeepsLastValidList()
+    {
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(BanFilePath, "{\"steamIds\":[\"76561198000000042\"]}");
+        var banList = new SteamBanList(BanFilePath);
+        Assert.True(banList.IsBanned("76561198000000042"));
+
+        File.Delete(BanFilePath);
+        Directory.CreateDirectory(BanFilePath);
+
+        Assert.True(banList.IsBanned("76561198000000042"));
+    }
+
+    [Fact]
+    public void ResolvePath_ConfiguredDataDirectoryWinsOverDeploymentFallback()
+    {
+        string applicationDirectory = Path.Combine(directory, "engine", "bin", "server");
+        string deploymentDataDirectory = Path.Combine(directory, "server-data");
+        string configuredDataDirectory = Path.Combine(directory, "configured-data");
+        Directory.CreateDirectory(applicationDirectory);
+        Directory.CreateDirectory(deploymentDataDirectory);
+        Directory.CreateDirectory(configuredDataDirectory);
+        File.WriteAllText(Path.Combine(deploymentDataDirectory, "steam-bans.json"), "{}");
+        File.WriteAllText(Path.Combine(configuredDataDirectory, "steam-bans.json"), "{}");
+
+        string path = SteamBanList.ResolvePath(
+            null,
+            configuredDataDirectory,
+            applicationDirectory);
+
+        Assert.Equal(Path.Combine(configuredDataDirectory, "steam-bans.json"), path);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Server")]
+    [InlineData("76561198000000abc")]
+    public void Normalize_RejectsNonSteamIdentities(string? value)
+    {
+        Assert.Null(SteamBanList.Normalize(value));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(directory)) Directory.Delete(directory, true);
+    }
+}

--- a/source/Coop.Tests/TestComponentBase.cs
+++ b/source/Coop.Tests/TestComponentBase.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Network;
 using Common.Serialization;
 using Common.Tests.Utils;
+using Coop.Core.Server.Connections;
 using Coop.Core.Server.Services.Kingdoms;
 using Coop.Core.Server.Services.MobileParties;
 using Coop.Tests.Mocks;
@@ -136,6 +137,7 @@ internal abstract class TestComponentBase
         RegisterMock<ITacticalUnitSymbolsConfigInterface>(builder);
         RegisterMock<IVillageHostileActionInterface>(builder);
         RegisterMock<IServerOptionsProvider>(builder);
+        RegisterMock<ISteamBanList>(builder);
         RegisterMock<ISaveNotificationInterface>(builder);
 
         // ISaveInterface is consumed by TransferSaveState's constructor, which packages a save the


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments, if there are any at all
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation update
- [ ] Other... Please describe:

## What is the current behavior?

Dedicated servers cannot deny a joining player by Steam64 identity.

## What is the new behavior?

Dedicated servers load `steam-bans.json` and disconnect a listed Steam64 identity before its character is resolved or restored. The list reloads when it changes, keeps the last valid data after a read failure, and supports `COOP_STEAM_BAN_FILE`, `COOP_DATA_DIR`, and the standard dedicated-server data layout.

## Bot Changelog Entry

- Dedicated servers can block Steam64 identities with a live-reloading ban list.

## Other information

`dotnet test source\Coop.Tests\Coop.Tests.csproj -c Release --no-restore` (780 passed, 1 skipped)
