### PR TITLE
Fix getting captured during sneak in

### DIFF
--- a/source/GameInterface.Tests/Services/Settlements/SettlementSneakInTests.cs
+++ b/source/GameInterface.Tests/Services/Settlements/SettlementSneakInTests.cs
@@ -1,0 +1,164 @@
+﻿using Common;
+using Autofac;
+using Common.Messaging;
+using Common.Network;
+using Common.Util;
+using GameInterface.Policies;
+using GameInterface.Services.MapEvents.Patches;
+using GameInterface.Services.MobileParties.Extensions;
+using GameInterface.Services.MobileParties.Interfaces;
+using GameInterface.Services.ObjectManager;
+using GameInterface.Services.PlayerCaptivityService.Handlers;
+using GameInterface.Services.Players;
+using GameInterface.Services.Settlements.Handlers;
+using GameInterface.Services.Settlements.Messages;
+using GameInterface.Tests.Bootstrap;
+using HarmonyLib;
+using Moq;
+using System;
+using System.Runtime.CompilerServices;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Party;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.CampaignSystem.Settlements;
+using TaleWorlds.Core;
+using Xunit;
+
+namespace GameInterface.Tests.Services.Settlements;
+
+[Collection(ModInformationRoleCollection.Name)]
+public class SettlementSneakInTests
+{
+    public SettlementSneakInTests()
+    {
+        // Needed for test environment to have Campaign models
+        GameBootStrap.Initialize();
+
+        RuntimeHelpers.RunModuleConstructor(typeof(Coop.Tests.Mocks.TestNetwork).Module.ModuleHandle);
+    }
+
+    [Fact]
+    public void SettlementSneakInPlayerCaptured_DoesntRemoveCompanionsAndTroops()
+    {
+        var playerHero = ObjectHelper.SkipConstructor<Hero>();
+        var playerCharacter = ObjectHelper.SkipConstructor<CharacterObject>();
+        playerHero._heroState = Hero.CharacterStates.Active;
+        playerCharacter.HeroObject = playerHero;
+        playerHero._characterObject = playerCharacter;
+
+        var companion = ObjectHelper.SkipConstructor<Hero>();
+        var companionCharacter = ObjectHelper.SkipConstructor<CharacterObject>();
+        companion._heroState = Hero.CharacterStates.Active;
+        companionCharacter.HeroObject = companion;
+        companion._characterObject = companionCharacter;
+
+        var troop = ObjectHelper.SkipConstructor<CharacterObject>();
+        var vanillaPlayerCharacter = ObjectHelper.SkipConstructor<CharacterObject>();
+
+        var playerParty = ObjectHelper.SkipConstructor<MobileParty>();
+        var playerPartyBase = ObjectHelper.SkipConstructor<PartyBase>();
+        playerParty.Party = playerPartyBase;
+        playerParty.IsActive = true;
+        playerPartyBase.MobileParty = playerParty;
+        playerPartyBase.MemberRoster = new TroopRoster(playerPartyBase);
+        playerPartyBase.PrisonRoster = new TroopRoster(playerPartyBase);
+        playerPartyBase.MemberRoster.AddToCounts(playerCharacter, 1);
+        playerPartyBase.MemberRoster.AddToCounts(companionCharacter, 1);
+        playerPartyBase.MemberRoster.AddToCounts(troop, 10);
+
+        var playerObjects = (ConditionalWeakTable<object, ControlledObjectInfo>)AccessTools
+            .Field(typeof(PlayerManager), "PlayerObjects")
+            .GetValue(null)!;
+
+        var settlement = ObjectHelper.SkipConstructor<Settlement>();
+
+        var settlementParty = ObjectHelper.SkipConstructor<PartyBase>();
+        settlement.Party = settlementParty;
+        settlementParty.PrisonRoster = new TroopRoster(settlementParty);
+
+        var messageBroker = MessageBroker.Instance;
+        var objectManager = new Mock<IObjectManager>();
+        var network = new Mock<INetwork>();
+        var sessionInteractionsInterface = new Mock<ISessionInteractionsPlayerDataInterface>();
+        var playerManager = new Mock<IPlayerManager>();
+
+        var syncPolicy = new Mock<ISyncPolicy>();
+        syncPolicy.Setup(policy => policy.AllowOriginal()).Returns(false);
+        var containerBuilder = new ContainerBuilder();
+        containerBuilder.RegisterInstance(syncPolicy.Object).As<ISyncPolicy>();
+        using var container = containerBuilder.Build();
+
+        var harmony = new Harmony(nameof(SettlementSneakInPlayerCaptured_DoesntRemoveCompanionsAndTroops));
+        bool wasServer = ModInformation.IsServer;
+        bool hadContainer = ContainerProvider.TryGetContainer(out var previousContainer);
+        var eventDispatcher = CampaignEventDispatcher.Instance;
+        var previousEventReceivers = eventDispatcher._eventReceivers;
+        var previousPlayerTroop = Game.Current.PlayerTroop;
+
+        SetupObject(objectManager, "hero-1", playerHero);
+        SetupObject(objectManager, "settlement-1", settlement);
+        var message = new NetworkTakenPrisonerDuringSneakIn("hero-1", "settlement-1");
+
+        try
+        {
+            playerObjects.Add(playerParty, new ControlledObjectInfo("TestPlayer", null!));
+            // Vanilla reads both globals while TakePrisonerAction completes.
+            eventDispatcher._eventReceivers = Array.Empty<CampaignEventReceiver>();
+            Game.Current.PlayerTroop = vanillaPlayerCharacter;
+            harmony.CreateClassProcessor(typeof(TakePrisonerActionPatches)).Patch();
+            ModInformation.IsServer = true;
+
+            Assert.True(playerParty.IsPlayerParty());
+            Assert.Same(playerParty, playerHero.PartyBelongedTo);
+
+            using var sneakInHandler = new SettlementSneakInHandler(
+                messageBroker,
+                objectManager.Object,
+                network.Object,
+                sessionInteractionsInterface.Object);
+
+            using var captivityHandler = new PlayerCaptivityServerHandler(
+                objectManager.Object,
+                network.Object,
+                messageBroker,
+                playerManager.Object);
+
+            using (ContainerProvider.UseContainerThreadSafe(container))
+            {
+                messageBroker.Publish(this, message);
+                GameThread.Run(() => { }, blocking: true);
+            }
+
+            Assert.True(playerParty.IsActive);
+            Assert.Equal(11, playerPartyBase.MemberRoster.TotalManCount);
+            Assert.False(playerPartyBase.MemberRoster.Contains(playerCharacter));
+            Assert.Equal(1, playerPartyBase.MemberRoster.GetElementNumber(companionCharacter));
+            Assert.Equal(10, playerPartyBase.MemberRoster.GetElementNumber(troop));
+            Assert.Equal(1, settlementParty.PrisonRoster.TotalManCount);
+            Assert.True(settlementParty.PrisonRoster.Contains(playerCharacter));
+            Assert.Same(settlementParty, playerHero.PartyBelongedToAsPrisoner);
+            Assert.Null(playerHero.PartyBelongedTo);
+            Assert.Equal(Hero.CharacterStates.Prisoner, playerHero.HeroState);
+            Assert.Same(playerParty, companion.PartyBelongedTo);
+        }
+        finally
+        {
+            harmony.UnpatchAll(harmony.Id);
+            playerObjects.Remove(playerParty);
+            eventDispatcher._eventReceivers = previousEventReceivers;
+            Game.Current.PlayerTroop = previousPlayerTroop;
+            ModInformation.IsServer = wasServer;
+
+            if (hadContainer)
+                ContainerProvider.SetContainer(previousContainer);
+            else
+                ContainerProvider.Clear();
+        }
+    }
+
+    private static void SetupObject<T>(Mock<IObjectManager> objectManager, string id, T instance)
+        where T : class
+    {
+        objectManager.Setup(manager => manager.TryGetObjectWithLogging(id, out instance)).Returns(true);
+    }
+}

--- a/source/GameInterface/Services/Settlements/Handlers/SettlementSneakInHandler.cs
+++ b/source/GameInterface/Services/Settlements/Handlers/SettlementSneakInHandler.cs
@@ -7,6 +7,7 @@ using GameInterface.Services.ObjectManager;
 using GameInterface.Services.Settlements.Messages;
 using Serilog;
 using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Actions;
 using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Settlements.Handlers;
@@ -33,12 +34,18 @@ internal class SettlementSneakInHandler : IHandler
 
         messageBroker.Subscribe<AddSettlementAsSneakedIn>(Handle_AddSettlementAsSneakedIn);
         messageBroker.Subscribe<NetworkAddSettlementAsSneakedIn>(Handle_NetworkAddSettlementAsSneakedIn);
+
+        messageBroker.Subscribe<TakenPrisonerDuringSneakIn>(Handle_TakenPrisonerDuringSneakIn);
+        messageBroker.Subscribe<NetworkTakenPrisonerDuringSneakIn>(Handle_NetworkTakenPrisonerDuringSneakIn);
     }
 
     public void Dispose()
     {
         messageBroker.Unsubscribe<AddSettlementAsSneakedIn>(Handle_AddSettlementAsSneakedIn);
         messageBroker.Unsubscribe<NetworkAddSettlementAsSneakedIn>(Handle_NetworkAddSettlementAsSneakedIn);
+
+        messageBroker.Unsubscribe<TakenPrisonerDuringSneakIn>(Handle_TakenPrisonerDuringSneakIn);
+        messageBroker.Unsubscribe<NetworkTakenPrisonerDuringSneakIn>(Handle_NetworkTakenPrisonerDuringSneakIn);
     }
 
     private void Handle_AddSettlementAsSneakedIn(MessagePayload<AddSettlementAsSneakedIn> obj)
@@ -63,6 +70,30 @@ internal class SettlementSneakInHandler : IHandler
             if (!objectManager.TryGetObjectWithLogging<Settlement>(data.CurrentSettlementId, out var _)) return;
 
             sessionInteractionsPlayerDataInterface.AddSettlementSneakedIn(data.MainHeroId, data.CurrentSettlementId);
+        });
+    }
+
+    private void Handle_TakenPrisonerDuringSneakIn(MessagePayload<TakenPrisonerDuringSneakIn> obj)
+    {
+        var data = obj.What;
+
+        if (!objectManager.TryGetIdWithLogging(data.MainHero, out var mainHeroId)) return;
+        if (!objectManager.TryGetIdWithLogging(data.CurrentSettlement, out var currentSettlementId)) return;
+
+        var message = new NetworkTakenPrisonerDuringSneakIn(mainHeroId, currentSettlementId);
+        network.SendAll(message);
+    }
+
+    private void Handle_NetworkTakenPrisonerDuringSneakIn(MessagePayload<NetworkTakenPrisonerDuringSneakIn> obj)
+    {
+        var data = obj.What;
+
+        GameThread.RunSafe(() =>
+        {
+            if (!objectManager.TryGetObjectWithLogging<Hero>(data.MainHeroId, out var mainHero)) return;
+            if (!objectManager.TryGetObjectWithLogging<Settlement>(data.CurrentSettlementId, out var currentSettlement)) return;
+
+            TakePrisonerAction.Apply(currentSettlement.Party, mainHero);
         });
     }
 }

--- a/source/GameInterface/Services/Settlements/Handlers/SettlementSneakInHandler.cs
+++ b/source/GameInterface/Services/Settlements/Handlers/SettlementSneakInHandler.cs
@@ -93,6 +93,7 @@ internal class SettlementSneakInHandler : IHandler
             if (!objectManager.TryGetObjectWithLogging<Hero>(data.MainHeroId, out var mainHero)) return;
             if (!objectManager.TryGetObjectWithLogging<Settlement>(data.CurrentSettlementId, out var currentSettlement)) return;
 
+            mainHero.PartyBelongedTo?.Party.AddElementToMemberRoster(mainHero.CharacterObject, -1, true);
             TakePrisonerAction.Apply(currentSettlement.Party, mainHero);
         });
     }

--- a/source/GameInterface/Services/Settlements/Messages/NetworkTakenPrisonerDuringSneakIn.cs
+++ b/source/GameInterface/Services/Settlements/Messages/NetworkTakenPrisonerDuringSneakIn.cs
@@ -1,0 +1,22 @@
+﻿using Common.Messaging;
+using ProtoBuf;
+
+namespace GameInterface.Services.Settlements.Messages;
+
+[ProtoContract(SkipConstructor = true)]
+internal readonly struct NetworkTakenPrisonerDuringSneakIn : ICommand
+{
+    [ProtoMember(1)]
+    public readonly string MainHeroId;
+
+    [ProtoMember(2)]
+    public readonly string CurrentSettlementId;
+
+    public NetworkTakenPrisonerDuringSneakIn(
+        string mainHeroId,
+        string currentSettlementId)
+    {
+        MainHeroId = mainHeroId;
+        CurrentSettlementId = currentSettlementId;
+    }
+}

--- a/source/GameInterface/Services/Settlements/Messages/TakenPrisonerDuringSneakIn.cs
+++ b/source/GameInterface/Services/Settlements/Messages/TakenPrisonerDuringSneakIn.cs
@@ -1,0 +1,19 @@
+﻿using Common.Messaging;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Settlements;
+
+namespace GameInterface.Services.Settlements.Messages;
+
+public readonly struct TakenPrisonerDuringSneakIn : IEvent
+{
+    public readonly Hero MainHero;
+    public readonly Settlement CurrentSettlement;
+
+    public TakenPrisonerDuringSneakIn(
+        Hero mainHero,
+        Settlement currentSettlement)
+    {
+        MainHero = mainHero;
+        CurrentSettlement = currentSettlement;
+    }
+}

--- a/source/GameInterface/Services/Settlements/Patches/SneakedInSettlementsPatch.cs
+++ b/source/GameInterface/Services/Settlements/Patches/SneakedInSettlementsPatch.cs
@@ -4,6 +4,7 @@ using GameInterface.Services.Settlements.Messages;
 using HarmonyLib;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.CampaignBehaviors;
+using TaleWorlds.CampaignSystem.GameMenus;
 using TaleWorlds.CampaignSystem.Settlements;
 
 namespace GameInterface.Services.Settlements.Patches;
@@ -20,5 +21,18 @@ internal class SneakedInSettlementsPatch
         // Send to server to persist in CoopSession
         var message = new AddSettlementAsSneakedIn(Hero.MainHero, Settlement.CurrentSettlement);
         MessageBroker.Instance.Publish(__instance, message);
+    }
+
+    [HarmonyPatch(nameof(EncounterGameMenuBehavior.game_menu_captivity_castle_taken_prisoner_cont_on_consequence))]
+    [HarmonyPrefix]
+    public static bool GameMenuCaptivityCastleTakenPrisonerContonConsequencePrefix(EncounterGameMenuBehavior __instance)
+    {
+        GameMenu.ExitToLast();
+
+        // Send to server to start player captivity
+        var message = new TakenPrisonerDuringSneakIn(Hero.MainHero, Settlement.CurrentSettlement);
+        MessageBroker.Instance.Publish(__instance, message);
+
+        return false;
     }
 }


### PR DESCRIPTION
## PR Checklist
<!-- Insert "x" inside square brackets to check item. -->

Please check if your PR fulfills the following requirements:

- [ ] All new classes have class-level documentation comments, if there are any at all
- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR. -->

- [x] Bug fix (non-breaking change that fixes an issue)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a player sneaks into a settlement they can get spotted and captured by the guards. The method that handles this isn't patched so the consequence only runs client-side, leaving the caught player without a party.

## What is the new behavior?
<!-- Insert issue id after hashtag. -->
Resolves #3508
<!-- Describe functionality added. Add images or videos to show how it works if applies -->
Send message to server to start player captivity instead of on the client.

## Bot Changelog Entry
<!-- The bot publishes these entries verbatim in the nightly release changelog. Add concise, nontechnical bullet points for tester-visible changes. Prefer one bullet unless this PR has multiple distinct tester-visible changes. Leave this section empty when there is no useful tester-facing entry. -->
Fixed not getting captured properly when caught sneaking into a settlement.