### PR TITLE
reduce campaign join replay stalls

### DIFF
--- a/source/Common.Tests/GameThreadDrainBudgetTests.cs
+++ b/source/Common.Tests/GameThreadDrainBudgetTests.cs
@@ -1,0 +1,117 @@
+﻿using Xunit;
+using Common;
+
+namespace Common.Tests;
+
+/// <summary>Verifies frame budgets preserve queue order, cancellation and runtime ownership.</summary>
+public class GameThreadDrainBudgetTests : IDisposable
+{
+    private readonly int previousGameThreadId = GameThread.Instance.GameThreadId;
+
+    public void Dispose() => GameThread.Instance.RestoreGameThread(previousGameThreadId);
+
+    [Fact]
+    public void BudgetDefersRemainingWorkAndPreservesOrder()
+    {
+        var queue = new GameThread.QueueContext();
+        using var active = GameThread.ActivateQueue(queue);
+        GameThread.Instance.MarkGameThread();
+        var applied = new List<int>();
+        using var budget = GameThread.Instance.LimitFrameDrain(TimeSpan.FromTicks(1));
+        GameThread.EnqueueSafe(() => applied.Add(1));
+        GameThread.EnqueueSafe(() => applied.Add(2));
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.Equal(new[] { 1 }, applied);
+        Assert.Equal(1, GameThread.Instance.QueueLength);
+        budget.Dispose();
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.Equal(new[] { 1, 2 }, applied);
+    }
+
+    [Fact]
+    public void BudgetAndTimeoutBelongToTheirOriginalRuntime()
+    {
+        var first = new GameThread.QueueContext();
+        var second = new GameThread.QueueContext();
+        using var active = GameThread.ActivateQueue(first);
+        using var budget = GameThread.Instance.LimitFrameDrain(TimeSpan.FromMilliseconds(8), TimeSpan.FromMinutes(5));
+        Assert.Equal(1, GameThread.Instance.FrameDrainLimitCount);
+        Assert.Equal(TimeSpan.FromMinutes(5), GameThread.Instance.EffectiveBlockingTimeout);
+        using (GameThread.ActivateQueue(second))
+        {
+            Assert.Equal(0, GameThread.Instance.FrameDrainLimitCount);
+            Assert.Equal(GameThread.BlockingTimeout, GameThread.Instance.EffectiveBlockingTimeout);
+            budget.Dispose();
+            Assert.Equal(0, GameThread.Instance.FrameDrainLimitCount);
+        }
+        Assert.Equal(0, GameThread.Instance.FrameDrainLimitCount);
+        Assert.Equal(GameThread.BlockingTimeout, GameThread.Instance.EffectiveBlockingTimeout);
+    }
+
+    [Fact]
+    public void NestedPumpDoesNotRunNewWorkAsPartOfOuterFrame()
+    {
+        var queue = new GameThread.QueueContext();
+        using var active = GameThread.ActivateQueue(queue);
+        GameThread.Instance.MarkGameThread();
+        using var budget = GameThread.Instance.LimitFrameDrain(TimeSpan.FromSeconds(1));
+        var applied = new List<int>();
+        GameThread.EnqueueSafe(() =>
+        {
+            applied.Add(1);
+            GameThread.Instance.Update(TimeSpan.Zero);
+            GameThread.EnqueueSafe(() => applied.Add(3));
+        });
+        GameThread.EnqueueSafe(() => applied.Add(2));
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.Equal(new[] { 1, 2 }, applied);
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.Equal(new[] { 1, 2, 3 }, applied);
+    }
+
+    [Fact]
+    public void DiscardCancelsOldFrameWithoutConsumingReplacementWork()
+    {
+        var queue = new GameThread.QueueContext();
+        using var active = GameThread.ActivateQueue(queue);
+        GameThread.Instance.MarkGameThread();
+        using var budget = GameThread.Instance.LimitFrameDrain(TimeSpan.FromSeconds(1));
+        var applied = new List<int>();
+        GameThread.EnqueueSafe(() =>
+        {
+            applied.Add(1);
+            GameThread.Instance.DiscardQueuedActions();
+            GameThread.EnqueueSafe(() => applied.Add(3));
+        });
+        GameThread.EnqueueSafe(() => applied.Add(2));
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.Equal(new[] { 1 }, applied);
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.Equal(new[] { 1, 3 }, applied);
+    }
+
+    [Fact]
+    public void FailedActionCancelsOriginalWaitersButLeavesLaterWorkQueued()
+    {
+        var queue = new GameThread.QueueContext();
+        using var active = GameThread.ActivateQueue(queue);
+        GameThread.Instance.MarkGameThread();
+        using var budget = GameThread.Instance.LimitFrameDrain(TimeSpan.FromSeconds(1));
+        using var waiter = new EventWaitHandle(false, EventResetMode.ManualReset);
+        bool laterRan = false;
+        var failed = new GameThread.QueuedAction(() =>
+        {
+            GameThread.EnqueueSafe(() => laterRan = true);
+            throw new InvalidOperationException("failed application");
+        }, null, "failure", default);
+        var abandoned = new GameThread.QueuedAction(() => Assert.Fail("stale waiter ran"), waiter, "waiter", default);
+        queue.queue.Enqueue(failed);
+        queue.queue.Enqueue(abandoned);
+        Assert.Throws<InvalidOperationException>(() => GameThread.Instance.Update(TimeSpan.Zero));
+        Assert.True(waiter.WaitOne(TimeSpan.Zero));
+        Assert.Throws<OperationCanceledException>(abandoned.ThrowIfNotExecuted);
+        Assert.False(laterRan);
+        GameThread.Instance.Update(TimeSpan.Zero);
+        Assert.True(laterRan);
+    }
+}

--- a/source/Common/GameThread.cs
+++ b/source/Common/GameThread.cs
@@ -23,6 +23,11 @@ public class GameThread : IUpdateable
     {
         internal readonly Queue<QueuedAction> queue = new Queue<QueuedAction>();
         internal readonly object gate = new object();
+        internal long removedTaskCount;
+        internal long nextDrainBudgetId;
+        internal long activeDrainTicks;
+        internal long activeBlockingTimeoutTicks;
+        internal readonly Dictionary<long, (long DrainTicks, long TimeoutTicks)> drainBudgets = new();
         internal bool isClosed;
         internal int rejectedAfterCloseCount;
         private Action waitPump;
@@ -228,6 +233,14 @@ public class GameThread : IUpdateable
             throw new ArgumentException("Wrong thread!");
         }
 
+        QueueContext current = CurrentQueue;
+        long budget = Interlocked.Read(ref current.activeDrainTicks);
+        if (budget > 0)
+        {
+            DrainLimitedFrame(current, budget);
+            return;
+        }
+
         List<QueuedAction> toBeRun = new List<QueuedAction>();
 
         int backlog;
@@ -238,6 +251,7 @@ public class GameThread : IUpdateable
             while (queueContext.queue.Count > 0)
             {
                 toBeRun.Add(queueContext.queue.Dequeue());
+                queueContext.removedTaskCount++;
             }
         }
 
@@ -307,6 +321,141 @@ public class GameThread : IUpdateable
         if (m_ReportTimer.Elapsed >= ReportInterval)
         {
             ReportAndReset();
+        }
+    }
+
+    /// <summary>Limits queued join work per frame while preserving the runtime's FIFO queue.</summary>
+    public IDisposable LimitFrameDrain(TimeSpan maximumDrainTime, TimeSpan? blockingTimeout = null)
+    {
+        if (maximumDrainTime <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(maximumDrainTime));
+        TimeSpan timeout = blockingTimeout ?? BlockingTimeout;
+        if (timeout <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(blockingTimeout));
+        QueueContext queue = CurrentQueue;
+        lock (queue.gate)
+        {
+            if (queue.isClosed) throw new OperationCanceledException("The game-thread queue is closed.");
+            long id = ++queue.nextDrainBudgetId;
+            queue.drainBudgets.Add(id, (Math.Max(1L,
+                (long)(maximumDrainTime.TotalSeconds * Stopwatch.Frequency)), timeout.Ticks));
+            RefreshDrainLimits(queue);
+            return new FrameDrainBudgetScope(queue, id);
+        }
+    }
+
+    /// <summary>Number of active drain limits in this runtime.</summary>
+    public int FrameDrainLimitCount
+    {
+        get
+        {
+            QueueContext queue = CurrentQueue;
+            lock (queue.gate) return queue.drainBudgets.Count;
+        }
+    }
+
+    /// <summary>Timeout applied to newly queued blocking work in this runtime.</summary>
+    public TimeSpan EffectiveBlockingTimeout
+    {
+        get
+        {
+            long ticks = Interlocked.Read(ref CurrentQueue.activeBlockingTimeoutTicks);
+            return ticks > 0 ? TimeSpan.FromTicks(ticks) : BlockingTimeout;
+        }
+    }
+
+    private void DrainLimitedFrame(QueueContext queue, long budgetTicks)
+    {
+        int backlog;
+        long frameEnd;
+        lock (queue.gate)
+        {
+            backlog = queue.queue.Count;
+            frameEnd = queue.removedTaskCount + backlog;
+        }
+
+        long started = Stopwatch.GetTimestamp();
+        int actionsRun = 0;
+        while (actionsRun < backlog)
+        {
+            QueuedAction task;
+            lock (queue.gate)
+            {
+                // Nested pumps and queue discards consume this frame's original work too.
+                if (queue.queue.Count == 0 || queue.removedTaskCount >= frameEnd) break;
+                task = queue.queue.Dequeue();
+                queue.removedTaskCount++;
+            }
+            long actionStart = Stopwatch.GetTimestamp();
+            try
+            {
+                RunQueuedTask(task);
+            }
+            catch
+            {
+                var abandoned = new List<QueuedAction>();
+                lock (queue.gate)
+                {
+                    while (queue.queue.Count > 0 && queue.removedTaskCount < frameEnd)
+                    {
+                        abandoned.Add(queue.queue.Dequeue());
+                        queue.removedTaskCount++;
+                    }
+                }
+                CancelUnrunBatch(abandoned, 0);
+                throw;
+            }
+            if (Instrument && !task.Cancellation.IsCancellationRequested)
+            {
+                string label = task.Label ?? "(unlabeled)";
+                m_PerLabel.TryGetValue(label, out var aggregate);
+                m_PerLabel[label] = (aggregate.Ticks + Stopwatch.GetTimestamp() - actionStart, aggregate.Count + 1);
+            }
+            actionsRun++;
+            if (Stopwatch.GetTimestamp() - started >= budgetTicks) break;
+        }
+
+        if (!Instrument) return;
+        long elapsed = Stopwatch.GetTimestamp() - started;
+        m_WindowFrames++;
+        m_WindowActions += actionsRun;
+        m_WindowTicks += elapsed;
+        if (elapsed > m_WorstFrameTicks)
+        {
+            m_WorstFrameTicks = elapsed;
+            m_WorstFrameActions = actionsRun;
+        }
+        m_WorstBacklog = Math.Max(m_WorstBacklog, backlog);
+        if (m_ReportTimer.Elapsed >= ReportInterval) ReportAndReset();
+    }
+
+    private static void RefreshDrainLimits(QueueContext queue)
+    {
+        Interlocked.Exchange(ref queue.activeDrainTicks,
+            queue.drainBudgets.Count == 0 ? 0 : queue.drainBudgets.Values.Min(value => value.DrainTicks));
+        Interlocked.Exchange(ref queue.activeBlockingTimeoutTicks,
+            queue.drainBudgets.Count == 0 ? 0 : queue.drainBudgets.Values.Max(value => value.TimeoutTicks));
+    }
+
+    /// <summary>Releases the limit on its owning queue even after the ambient runtime changes.</summary>
+    private sealed class FrameDrainBudgetScope : IDisposable
+    {
+        private QueueContext queue;
+        private readonly long id;
+
+        public FrameDrainBudgetScope(QueueContext queue, long id)
+        {
+            this.queue = queue;
+            this.id = id;
+        }
+
+        public void Dispose()
+        {
+            QueueContext owner = Interlocked.Exchange(ref queue, null);
+            if (owner == null) return;
+            lock (owner.gate)
+            {
+                owner.drainBudgets.Remove(id);
+                RefreshDrainLimits(owner);
+            }
         }
     }
 
@@ -433,16 +582,17 @@ public class GameThread : IUpdateable
 
             if (ewh == null) return;
 
+            TimeSpan waitTimeout = Instance.EffectiveBlockingTimeout;
             int waitResult = !cancellation.CanBeCanceled
-                ? (ewh.WaitOne(BlockingTimeout) ? 0 : WaitHandle.WaitTimeout)
+                ? (ewh.WaitOne(waitTimeout) ? 0 : WaitHandle.WaitTimeout)
                 : WaitHandle.WaitAny(
                     new[] { ewh, cancellation.WaitHandle },
-                    BlockingTimeout);
+                    waitTimeout);
             if (waitResult == WaitHandle.WaitTimeout)
             {
                 throw new TimeoutException(
                     $"A blocking {nameof(Run)} action was not processed by the game loop " +
-                    $"within {BlockingTimeout.TotalSeconds:0} seconds. The game loop thread is not pumping " +
+                    $"within {waitTimeout.TotalSeconds:0} seconds. The game loop thread is not pumping " +
                     $"{nameof(GameThread)}.{nameof(Update)} (initialized: {Instance.IsInitialized}).");
             }
             if (waitResult == 1)
@@ -653,6 +803,7 @@ public class GameThread : IUpdateable
                 queueContext.WaitPump = null;
             }
             discarded = new List<QueuedAction>(queueContext.queue);
+            queueContext.removedTaskCount += queueContext.queue.Count;
             queueContext.queue.Clear();
         }
 

--- a/source/Common/Messaging/IJoinCatchUpMergeMessage.cs
+++ b/source/Common/Messaging/IJoinCatchUpMergeMessage.cs
@@ -1,0 +1,10 @@
+﻿namespace Common.Messaging;
+
+/// <summary>Opt-in combination of adjacent replay messages before the final join baseline.</summary>
+public interface IJoinCatchUpMergeMessage : IMessage
+{
+    // Only a lookup hint; TryMerge must check the complete identity and mutation semantics.
+    string JoinCatchUpMergeKey { get; }
+
+    bool TryMerge(IMessage next, out IMessage merged);
+}

--- a/source/Common/Network/IBufferedNetwork.cs
+++ b/source/Common/Network/IBufferedNetwork.cs
@@ -1,0 +1,9 @@
+﻿using LiteNetLib;
+
+namespace Common.Network;
+
+/// <summary>Optional cleanup for transports that aggregate unsent messages per peer.</summary>
+public interface IBufferedNetwork
+{
+    void DiscardPendingMessages(NetPeer peer);
+}

--- a/source/Common/Network/NetworkJoinLimits.cs
+++ b/source/Common/Network/NetworkJoinLimits.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace Common.Network;
+
+/// <summary>
+/// Shared safety limits for the dedicated server and the in-process client/server configuration.
+/// Keeping these values here prevents production from silently using a different join watchdog.
+/// </summary>
+public static class NetworkJoinLimits
+{
+    /// <summary>Maximum time to enter the campaign while the held replay remains backlogged.</summary>
+    public static readonly TimeSpan CampaignEntryTimeout = TimeSpan.FromMinutes(15);
+
+    /// <summary>Maximum held world-replay packets for one joining peer.</summary>
+    public const int MaxReplayPackets = 100_000;
+
+    /// <summary>
+    /// Maximum serialized world-replay memory retained for one joining peer. The packet ceiling
+    /// remains the primary gameplay guard; this prevents unusually large messages from making that
+    /// count an ineffective memory bound.
+    /// </summary>
+    public const long MaxReplayPendingBytes = 128L * 1024 * 1024;
+
+    /// <summary>Maximum logical messages emitted in one replay batch.</summary>
+    public const int MaxReplayBatchPackets = 512;
+
+    /// <summary>Maximum batches awaiting ordered client application, filled one per server frame.</summary>
+    public const int MaxReplayInFlightBatches = 4;
+
+    /// <summary>
+    /// Target serialized replay payload emitted per application acknowledgement. This fits within
+    /// LiteNetLib's reliable window when the existing 1,200-byte aggregation budget is used. One
+    /// individually larger message is allowed through alone so replay cannot deadlock.
+    /// </summary>
+    public const int MaxReplayBatchBytes = 64 * 1024;
+
+    /// <summary>Maximum server game-thread time spent filling one replay batch.</summary>
+    public static readonly TimeSpan ReplayBatchSendBudget = TimeSpan.FromMilliseconds(4);
+
+    /// <summary>
+    /// Maximum time without application progress during the replay and baseline handshake. Replay work is
+    /// frame-budgeted on the client, so slow machines need time to apply it without freezing a frame.
+    /// </summary>
+    public static readonly TimeSpan ReplayAppliedTimeout = TimeSpan.FromMinutes(5);
+}

--- a/source/Common/Network/ReferenceComparer.cs
+++ b/source/Common/Network/ReferenceComparer.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Common.Network;
+
+/// <summary>Compares reference types by object identity.</summary>
+public sealed class ReferenceComparer<T> : IEqualityComparer<T> where T : class
+{
+    public static readonly ReferenceComparer<T> Instance = new ReferenceComparer<T>();
+
+    private ReferenceComparer()
+    {
+    }
+
+    public bool Equals(T x, T y) => ReferenceEquals(x, y);
+
+    public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+}

--- a/source/Common/PacketHandlers/MessagePacketHandler.cs
+++ b/source/Common/PacketHandlers/MessagePacketHandler.cs
@@ -118,6 +118,7 @@ public class MessagePacketHandler : IMessagePacketHandler
 [ProtoContract(SkipConstructor = true)]
 public readonly struct MessagePacket : IPacket
 {
+    private const int MaxJoinCatchUpMergedBytes = 4096;
     public DeliveryMethod DeliveryMethod => DeliveryMethod.ReliableOrdered;
 
     public PacketType PacketType => PacketType.Message;
@@ -131,10 +132,41 @@ public readonly struct MessagePacket : IPacket
     /// </summary>
     public readonly Type MessageType;
 
-    private MessagePacket(byte[] data, Type messageType)
+    // Send-side metadata only; the packet wire format is unchanged.
+    public readonly string JoinCatchUpMergeKey;
+
+    private MessagePacket(byte[] data, Type messageType, string joinCatchUpMergeKey)
     {
         Data = data;
         MessageType = messageType;
+        JoinCatchUpMergeKey = joinCatchUpMergeKey;
+    }
+
+    public bool TryMergeForJoinCatchUp(
+        MessagePacket next,
+        ICommonSerializer serializer,
+        out MessagePacket merged)
+    {
+        merged = default;
+        if (string.IsNullOrEmpty(JoinCatchUpMergeKey) ||
+            MessageType != next.MessageType ||
+            JoinCatchUpMergeKey != next.JoinCatchUpMergeKey ||
+            Data.Length > MaxJoinCatchUpMergedBytes || next.Data.Length > MaxJoinCatchUpMergedBytes)
+            return false;
+
+        // Read the frozen wire payload, never a caller-owned message or mutable operation array.
+        if (serializer.Deserialize<IMessage>(Data) is not IJoinCatchUpMergeMessage previous ||
+            !previous.TryMerge(serializer.Deserialize<IMessage>(next.Data), out var combined))
+            return false;
+
+        var candidate = Create(combined, serializer);
+        // Bound receive work and never trade fewer queue entries for more retained bytes.
+        if (candidate.Data.Length > MaxJoinCatchUpMergedBytes ||
+            candidate.Data.Length > (long)Data.Length + next.Data.Length)
+            return false;
+
+        merged = candidate;
+        return true;
     }
 
     /// <summary>
@@ -149,6 +181,7 @@ public readonly struct MessagePacket : IPacket
             throw new ArgumentException($"Type {message.GetType().Name} is not serializable.");
         }
 
-        return new MessagePacket(serializer.Serialize(message), message.GetType());
+        return new MessagePacket(serializer.Serialize(message), message.GetType(),
+            (message as IJoinCatchUpMergeMessage)?.JoinCatchUpMergeKey);
     }
 }

--- a/source/Coop.Core/Client/CoopClient.cs
+++ b/source/Coop.Core/Client/CoopClient.cs
@@ -137,8 +137,9 @@ public class CoopClient : CoopNetworkBase, ICoopClient
         if (isConnected == true)
         {
             isConnected = false;
+            var serverReason = ReadDisconnectReason(disconnectInfo);
             messageBroker.Publish(this, new SendInformationMessage(disconnectInfo.Reason.ToString()));
-            messageBroker.Publish(this, new NetworkDisconnected(disconnectInfo));
+            messageBroker.Publish(this, new NetworkDisconnected(disconnectInfo, serverReason));
         }
         else
         {
@@ -147,6 +148,27 @@ public class CoopClient : CoopNetworkBase, ICoopClient
             Logger.Warning("Connection attempt failed ({Reason}), retrying in 3 seconds...", disconnectInfo.Reason);
             reconnectPending = true;
             reconnectAfter = DateTime.UtcNow.AddSeconds(3);
+        }
+    }
+
+    private static string ReadDisconnectReason(DisconnectInfo disconnectInfo)
+    {
+        var data = disconnectInfo.AdditionalData;
+        if (data == null || data.IsNull) return null;
+
+        try
+        {
+            if (disconnectInfo.Reason != DisconnectReason.RemoteConnectionClose) return null;
+            string reason = data.GetString(128);
+            return data.EndOfData ? reason : null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+        finally
+        {
+            data.Recycle();
         }
     }
 

--- a/source/Coop.Core/Client/Messages/NetworkDisconnected.cs
+++ b/source/Coop.Core/Client/Messages/NetworkDisconnected.cs
@@ -9,10 +9,12 @@ namespace Coop.Core.Client.Messages
     public record NetworkDisconnected : IEvent
     {
         public DisconnectInfo DisconnectInfo { get; }
+        public string ServerReason { get; }
 
-        public NetworkDisconnected(DisconnectInfo disconnectInfo)
+        public NetworkDisconnected(DisconnectInfo disconnectInfo, string serverReason = null)
         {
             DisconnectInfo = disconnectInfo;
+            ServerReason = serverReason;
         }
     }
 }

--- a/source/Coop.Core/Client/Services/Connection/Handlers/DisconnectHandler.cs
+++ b/source/Coop.Core/Client/Services/Connection/Handlers/DisconnectHandler.cs
@@ -28,11 +28,24 @@ internal class DisconnectHandler : IHandler
     private void Handle(MessagePayload<NetworkDisconnected> obj)
     {
         gameStateInterface.GoToMainMenu();
-        coopFinalizer.Finalize(GetDisconnectMessage(obj.What.DisconnectInfo.Reason));
+        coopFinalizer.Finalize(GetDisconnectMessage(obj.What.DisconnectInfo.Reason, obj.What.ServerReason));
     }
 
-    private static string GetDisconnectMessage(DisconnectReason reason)
+    private static string GetDisconnectMessage(DisconnectReason reason, string serverReason)
     {
+        switch (serverReason)
+        {
+            case "JoinReplayAppliedTimeout":
+                return "Joining the campaign timed out while synchronizing.\n" +
+                       "The server stopped this join to keep the campaign responsive. Please try again.";
+            case "JoinReplayQueueLimit":
+                return "Joining the campaign stopped because its synchronization queue exceeded the safety limit.\n" +
+                       "Please try again.";
+            case "JoinCampaignEntryTimeout":
+                return "Joining the campaign timed out while loading the transferred save.\n" +
+                       "The server stopped this join to keep the campaign responsive. Please try again.";
+        }
+
         return reason == DisconnectReason.Timeout
             ? "Connection to the co-op server timed out.\nCheck your internet connection and try joining again."
             : "You have been Disconnected";

--- a/source/Coop.Core/Client/States/CampaignState.cs
+++ b/source/Coop.Core/Client/States/CampaignState.cs
@@ -12,6 +12,8 @@ using GameInterface.Services.Time.Interfaces;
 using GameInterface.Services.UI.Interfaces;
 using GameInterface.Services.UI.Messages;
 using System.Globalization;
+using System;
+using System.Threading;
 
 namespace Coop.Core.Client.States;
 
@@ -28,6 +30,8 @@ public class CampaignState : ClientStateBase
     private readonly IMapTimeTrackerInterface mapTimeTrackerInterface;
     private readonly bool waitingForJoinCatchUp;
     private bool replayAppliedQueued;
+    private int lastReplayBatchId;
+    private IDisposable joinCatchUpDrainBudget;
     private volatile bool baselineResponseExpected;
     private volatile bool finalBaselineResponseExpected;
     private int successfulBaselines;
@@ -83,7 +87,18 @@ public class CampaignState : ClientStateBase
             "Loading Host Campaign",
             "Creating remote player heroes...");
 
-        network.SendAll(new NetworkPlayerCampaignEntered());
+        if (waitingForJoinCatchUp)
+            joinCatchUpDrainBudget = GameThread.Instance.LimitFrameDrain(
+                TimeSpan.FromMilliseconds(8), NetworkJoinLimits.ReplayAppliedTimeout);
+        try
+        {
+            network.SendAll(new NetworkPlayerCampaignEntered());
+        }
+        catch
+        {
+            ReleaseJoinCatchUpDrainBudget();
+            throw;
+        }
 
         if (!waitingForJoinCatchUp)
         {
@@ -93,6 +108,7 @@ public class CampaignState : ClientStateBase
 
     public override void Dispose()
     {
+        ReleaseJoinCatchUpDrainBudget();
         messageBroker.Unsubscribe<MainMenuEntered>(Handle_MainMenuEntered);
         messageBroker.Unsubscribe<MissionStateEntered>(Handle_MissionStateEntered);
         if (waitingForJoinCatchUp)
@@ -105,6 +121,20 @@ public class CampaignState : ClientStateBase
 
     internal void Handle_JoinSync(MessagePayload<NetworkJoinSync> obj)
     {
+        if (obj.What.Signal == JoinSyncSignal.ReplayBatchComplete)
+        {
+            int batchId = obj.What.ReplayBatchId;
+            if (batchId <= 0 || batchId <= lastReplayBatchId) return;
+            lastReplayBatchId = batchId;
+            // The acknowledgement runs after earlier queued applications, even in a nested pump.
+            GameThread.EnqueueSafe(() =>
+            {
+                if (!ReferenceEquals(Logic.State, this)) return;
+                SendJoinSignal(JoinSyncSignal.ReplayBatchApplied, batchId);
+            }, context: nameof(JoinSyncSignal.ReplayBatchComplete));
+            return;
+        }
+
         if (obj.What.Signal == JoinSyncSignal.ReplayComplete)
         {
             if (replayAppliedQueued) return;
@@ -258,11 +288,15 @@ public class CampaignState : ClientStateBase
         }, context: nameof(Handle_CampaignTimeSampleReceived));
     }
 
-    private void SendJoinSignal(JoinSyncSignal signal) =>
-        network.SendAll(new NetworkJoinSync(signal));
+    private void SendJoinSignal(JoinSyncSignal signal, int replayBatchId = 0) =>
+        network.SendAll(new NetworkJoinSync(signal, replayBatchId));
+
+    private void ReleaseJoinCatchUpDrainBudget() =>
+        Interlocked.Exchange(ref joinCatchUpDrainBudget, null)?.Dispose();
 
     private void CompleteCampaignEntry()
     {
+        ReleaseJoinCatchUpDrainBudget();
         messageBroker.Publish(this, new PlayerKillFeedColorResendRequested());
         loadingInterface.HideLoadingScreen();
         messageBroker.Publish(this, new ClientCampaignReady());

--- a/source/Coop.Core/Common/Network/CoopNetworkBase.cs
+++ b/source/Coop.Core/Common/Network/CoopNetworkBase.cs
@@ -17,7 +17,7 @@ using System.Threading;
 namespace Coop.Core.Common.Network;
 
 /// <inheritdoc cref="INetwork"/>
-public abstract class CoopNetworkBase : INetwork, INetEventListener
+public abstract class CoopNetworkBase : INetwork, IBufferedNetwork, INetEventListener
 {
     public INetworkConfig Config { get; }
     public abstract int Priority { get; }
@@ -243,6 +243,8 @@ public abstract class CoopNetworkBase : INetwork, INetEventListener
             peer => peer.ConnectionState == ConnectionState.Connected,
             SendReliableMessagePayload);
     }
+
+    public void DiscardPendingMessages(NetPeer peer) => reliableMessageBatcher.Remove(peer);
 
     private void RecordAggregateSent(AggregateMessagePacket packet, int framingOverhead)
     {

--- a/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
@@ -3,6 +3,7 @@ using Common.Messaging;
 using Common.Network;
 using Common.Network.Messages;
 using Common.PacketHandlers;
+using Common.Serialization;
 using Coop.Core.Common.Session.Messages;
 using Coop.Core.Server.Connections.Messages;
 using LiteNetLib;
@@ -10,7 +11,7 @@ using Serilog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using System.Diagnostics;
 using System.Threading;
 
 namespace Coop.Core.Server.Connections;
@@ -32,16 +33,21 @@ namespace Coop.Core.Server.Connections;
 /// <item><b>Live</b> (after <see cref="CompleteCatchUp"/>): the retained channel keeps passing broadcasts
 /// through until disconnect.</item>
 /// </list>
-/// A peer with no channel is treated as newly accepted and its world broadcasts are dropped. LiteNetLib
-/// exposes an accepted peer to fan-out before raising <see cref="PlayerConnected"/>, so treating an
-/// unknown peer as live can deliver campaign objects before its save loads.
+/// Unknown peers drop world broadcasts: LiteNetLib can expose an accepted peer to fan-out before
+/// raising <see cref="PlayerConnected"/>. Campaign time and lobby membership bypass this gate.
 /// The drop/queue cut is clean: the save runs in a blocking <c>GameThread.Run</c> on the network
-/// thread, so the poller is parked and nothing races the snapshot. Replay-before-live is held by the
-/// per-peer gate lock (across the whole flush, Open flipped last), not by thread identity or the
-/// non-thread-safe broker.
+/// thread while the network poller waits for the save capture to finish.
+/// Replay-before-live is held by the per-peer gate lock (across the whole flush, Open flipped last),
+/// not by thread identity or the non-thread-safe broker.
 /// </remarks>
 public interface IConnectionMessageQueue
 {
+    /// <summary>
+    /// Isolates a newly accepted peer before connection listeners can emit campaign traffic for it.
+    /// Idempotent with the normal <see cref="PlayerConnected"/> handler.
+    /// </summary>
+    void RegisterPeer(NetPeer peer);
+
     /// <summary>
     /// Consulted for every broadcast to a single peer. Returns <c>true</c> when the queue has taken
     /// responsibility for the packet (dropped while pre-save, or held while loading) and the caller
@@ -52,22 +58,71 @@ public interface IConnectionMessageQueue
     /// <summary>
     /// Moves a peer from <c>Dropping</c> to <c>Queueing</c>. Call on the main thread immediately after
     /// the transfer-save snapshot is taken. Because that save runs under a blocking GameThread.Run
-    /// call issued from the network thread the poller is parked, so the snapshot is not raced and this
-    /// cut cleanly separates "in the save" (dropped) from "after the save" (queued for replay).
+    /// call issued from the network thread the poller is parked, so world-history sends stay behind the
+    /// capture and this cut cleanly separates "in the save" (dropped) from "after the save" (queued).
     /// </summary>
     void BeginQueueing(NetPeer peer);
 
-    /// <summary>Replays held packets while keeping later broadcasts queued.</summary>
-    void Flush(NetPeer peer);
+    /// <summary>Replays one bounded batch while keeping later broadcasts queued.</summary>
+    JoinReplayBatchResult FlushBatch(NetPeer peer);
+
+    /// <summary>Defers an oversized singleton while earlier batches still await application.</summary>
+    JoinReplayBatchResult FlushBatch(NetPeer peer, bool allowOversized);
+
+    /// <summary>
+    /// Ends the period where current-state broadcasts are covered by the final authoritative
+    /// campaign baseline. Call immediately before that baseline is captured; later changes must
+    /// remain queued behind it.
+    /// </summary>
+    void EndFinalBaselineCoverage(NetPeer peer);
 
     /// <summary>Gets the gate and reliable-channel backlog while catch-up is active.</summary>
     bool TryGetCatchUpPacketsRemaining(NetPeer peer, out int packetsRemaining);
 
-    /// <summary>Replays held packets, appends a reliable marker, and opens the peer atomically.</summary>
-    void OpenWithTail(NetPeer peer, IMessage tailMarker);
+    /// <summary>Gets serialized replay bytes still retained by the gate.</summary>
+    bool TryGetCatchUpPendingBytes(NetPeer peer, out long pendingBytes);
+
+    /// <summary>Returns whether replay admission stopped before a configured safety limit.</summary>
+    bool HasCatchUpOverflowed(NetPeer peer);
+
+    /// <summary>Returns a compact queue breakdown for join diagnostics.</summary>
+    string DescribeCatchUp(NetPeer peer);
+
+    /// <summary>
+    /// Replays one bounded final batch. When it empties the gate, begins the terminal phase, appends
+    /// a reliable marker, and opens the peer atomically.
+    /// </summary>
+    JoinReplayBatchResult OpenWithTailBatch(
+        NetPeer peer,
+        IMessage tailMarker,
+        Func<bool> tryBeginOpen);
 
     /// <summary>Stops progress tracking after the client applies the ordered join tail.</summary>
     void CompleteCatchUp(NetPeer peer);
+
+    /// <summary>Clears a failed join's replay and keeps later broadcasts isolated until disconnect.</summary>
+    int AbortCatchUp(NetPeer peer);
+}
+
+/// <summary>Progress and admission status of one bounded replay batch.</summary>
+public readonly struct JoinReplayBatchResult
+{
+    public readonly int PacketsSent;
+    public readonly int BytesSent;
+    public readonly bool HasMore;
+    public readonly bool Overflowed;
+
+    public JoinReplayBatchResult(
+        int packetsSent,
+        int bytesSent,
+        bool hasMore,
+        bool overflowed = false)
+    {
+        PacketsSent = packetsSent;
+        BytesSent = bytesSent;
+        HasMore = hasMore;
+        Overflowed = overflowed;
+    }
 }
 
 /// <inheritdoc cref="IConnectionMessageQueue"/>
@@ -85,33 +140,54 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
     {
         public readonly object Gate = new object();
         public volatile Phase Phase = Phase.Dropping;
-        public readonly Queue<IPacket> Pending = new Queue<IPacket>();
+        public readonly LinkedList<IPacket> Pending = new LinkedList<IPacket>();
+        public LinkedListNode<IPacket> PendingMerge;
         public int PendingCount;
-    }
-
-    /// <summary>Keys connection generations by peer instance rather than reusable endpoint.</summary>
-    private sealed class NetPeerReferenceComparer : IEqualityComparer<NetPeer>
-    {
-        public static readonly NetPeerReferenceComparer Instance = new NetPeerReferenceComparer();
-
-        public bool Equals(NetPeer x, NetPeer y) => ReferenceEquals(x, y);
-        public int GetHashCode(NetPeer peer) => RuntimeHelpers.GetHashCode(peer);
+        public long PendingBytes;
+        public bool Overflowed;
+        public bool FinalBaselineCoverageActive = true;
+        public long MergedAdjacentTotal;
     }
 
     private static readonly ILogger Logger = LogManager.GetLogger<ConnectionMessageQueue>();
-
     // Lazy breaks the construction cycle: CoopServer (the INetwork) depends on this queue, and the
     // queue only needs INetwork later, at flush time, to replay held packets.
     private readonly Lazy<INetwork> network;
     private readonly IMessageBroker messageBroker;
+    private readonly ICommonSerializer serializer;
+    private readonly int maxPendingPackets;
+    private readonly long maxPendingBytes;
 
     private readonly ConcurrentDictionary<NetPeer, PeerChannel> channels =
-        new ConcurrentDictionary<NetPeer, PeerChannel>(NetPeerReferenceComparer.Instance);
-
-    public ConnectionMessageQueue(Lazy<INetwork> network, IMessageBroker messageBroker)
+        new ConcurrentDictionary<NetPeer, PeerChannel>(ReferenceComparer<NetPeer>.Instance);
+    public ConnectionMessageQueue(
+        Lazy<INetwork> network,
+        IMessageBroker messageBroker,
+        ICommonSerializer serializer)
+        : this(
+            network,
+            messageBroker,
+            serializer,
+            NetworkJoinLimits.MaxReplayPackets,
+            NetworkJoinLimits.MaxReplayPendingBytes)
     {
+    }
+
+    internal ConnectionMessageQueue(
+        Lazy<INetwork> network,
+        IMessageBroker messageBroker,
+        ICommonSerializer serializer,
+        int maxPendingPackets,
+        long maxPendingBytes)
+    {
+        if (maxPendingPackets <= 0) throw new ArgumentOutOfRangeException(nameof(maxPendingPackets));
+        if (maxPendingBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxPendingBytes));
+
         this.network = network;
         this.messageBroker = messageBroker;
+        this.serializer = serializer;
+        this.maxPendingPackets = maxPendingPackets;
+        this.maxPendingBytes = maxPendingBytes;
 
         messageBroker.Subscribe<PlayerConnected>(Handle_PlayerConnected);
         messageBroker.Subscribe<PlayerDisconnected>(Handle_PlayerDisconnected);
@@ -125,39 +201,56 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
 
     public bool TryHandleBroadcast(NetPeer peer, IPacket packet)
     {
-        if (ShouldBypassLoadingQueue(packet)) return false;
+        if (packet.PacketType == PacketType.CampaignTime ||
+            packet is MessagePacket lobby && lobby.MessageType == typeof(NetworkSessionLobbyChanged))
+            return false;
 
-        // LiteNetLib exposes an accepted peer to SendAll before OnPeerConnected installs its channel.
-        // Fail closed during that gap so world objects cannot reach a client before its transfer save.
-        if (channels.TryGetValue(peer, out var channel) == false) return true;
-
+        if (!channels.TryGetValue(peer, out var channel)) return true;
         lock (channel.Gate)
         {
-            switch (channel.Phase)
+            if (channel.Phase == Phase.Dropping) return true;
+            if (channel.Phase != Phase.Queueing) return false;
+
+            var mergeNode = channel.PendingMerge;
+            channel.PendingMerge = null;
+            if (channel.Overflowed) return true;
+
+            int bytes = GetReplayPacketSize(packet);
+            MessagePacket combined = default;
+            bool merged = channel.FinalBaselineCoverageActive && mergeNode != null &&
+                mergeNode.Value is MessagePacket previous && packet is MessagePacket next &&
+                previous.TryMergeForJoinCatchUp(next, serializer, out combined);
+            // Merge only the adjacent frozen payload; intervening world events are barriers.
+            if (merged)
             {
-                case Phase.Queueing:
-                    channel.Pending.Enqueue(packet);
-                    Interlocked.Increment(ref channel.PendingCount);
-                    return true;
-                case Phase.Dropping:
-                    // Already in the save the peer is about to load; discard.
-                    return true;
-                default:
-                    // Open and Live peers receive normal world traffic. Retaining the Live channel
-                    // lets an absent channel unambiguously mean a newly accepted peer.
-                    return false;
+                bytes = combined.Data.Length - ((MessagePacket)mergeNode.Value).Data.Length;
+                packet = combined;
             }
+
+            if ((!merged && channel.PendingCount >= maxPendingPackets) ||
+                channel.PendingBytes + bytes > maxPendingBytes)
+            {
+                channel.Overflowed = true;
+                return true;
+            }
+
+            LinkedListNode<IPacket> node;
+            if (merged)
+            {
+                node = mergeNode;
+                node.Value = packet;
+                channel.MergedAdjacentTotal++;
+            }
+            else
+            {
+                node = channel.Pending.AddLast(packet);
+                Interlocked.Increment(ref channel.PendingCount);
+            }
+            Interlocked.Add(ref channel.PendingBytes, bytes);
+            if (packet is MessagePacket candidate && !string.IsNullOrEmpty(candidate.JoinCatchUpMergeKey))
+                channel.PendingMerge = node;
+            return true;
         }
-    }
-
-    private static bool ShouldBypassLoadingQueue(IPacket packet)
-    {
-        // Campaign time is a periodic current-state sample, not history to replay after loading.
-        if (packet.PacketType == PacketType.CampaignTime) return true;
-
-        // Lobby membership is connection metadata, not campaign state contained in the save.
-        return packet is MessagePacket messagePacket &&
-               messagePacket.MessageType == typeof(NetworkSessionLobbyChanged);
     }
 
     public void BeginQueueing(NetPeer peer)
@@ -169,12 +262,21 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         lock (channel.Gate)
         {
             channel.Phase = Phase.Queueing;
+            channel.PendingMerge = null;
+            channel.FinalBaselineCoverageActive = true;
+            channel.Overflowed = false;
         }
+    }
+
+    public void RegisterPeer(NetPeer peer)
+    {
+        if (peer == null) throw new ArgumentNullException(nameof(peer));
+        channels.TryAdd(peer, new PeerChannel());
     }
 
     private void Handle_PlayerConnected(MessagePayload<PlayerConnected> payload)
     {
-        channels.TryAdd(payload.What.PlayerPeer, new PeerChannel());
+        RegisterPeer(payload.What.PlayerPeer);
     }
 
     private void Handle_PlayerDisconnected(MessagePayload<PlayerDisconnected> payload)
@@ -183,18 +285,39 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         channels.TryRemove(payload.What.PlayerId, out _);
     }
 
-    public void Flush(NetPeer peer)
+    public JoinReplayBatchResult FlushBatch(NetPeer peer) => FlushBatch(peer, allowOversized: true);
+
+    public JoinReplayBatchResult FlushBatch(NetPeer peer, bool allowOversized)
+    {
+        if (channels.TryGetValue(peer, out var channel) == false) return default;
+
+        JoinReplayBatchResult result;
+        lock (channel.Gate)
+        {
+            result = DrainBatch(peer, channel, allowOversized: allowOversized);
+        }
+
+        Logger.Debug(
+            "Flushed replay batch to peer {Peer}: packets={Packets} bytes={Bytes} more={HasMore}",
+            peer.Id,
+            result.PacketsSent,
+            result.BytesSent,
+            result.HasMore);
+        return result;
+    }
+
+    public void EndFinalBaselineCoverage(NetPeer peer)
     {
         if (channels.TryGetValue(peer, out var channel) == false) return;
 
-        int replayed;
         lock (channel.Gate)
         {
-            replayed = channel.Pending.Count;
-            Drain(peer, channel);
+            if (channel.Phase == Phase.Queueing)
+            {
+                channel.FinalBaselineCoverageActive = false;
+                channel.PendingMerge = null;
+            }
         }
-
-        Logger.Debug("Flushed {Count} queued packets to peer {Peer} while joining", replayed, peer.Id);
     }
 
     public bool TryGetCatchUpPacketsRemaining(NetPeer peer, out int packetsRemaining)
@@ -202,7 +325,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         packetsRemaining = 0;
         if (channels.TryGetValue(peer, out var channel) == false) return false;
 
-        if (channel.Phase == Phase.Dropping || channel.Phase == Phase.Live) return false;
+        if (channel.Phase is Phase.Dropping or Phase.Live) return false;
 
         packetsRemaining = Volatile.Read(ref channel.PendingCount) +
                            peer.GetPacketsCountInReliableQueue(0, true) +
@@ -210,18 +333,54 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         return true;
     }
 
-    public void OpenWithTail(NetPeer peer, IMessage tailMarker)
+    public bool TryGetCatchUpPendingBytes(NetPeer peer, out long pendingBytes)
     {
-        if (tailMarker == null) throw new ArgumentNullException(nameof(tailMarker));
+        pendingBytes = 0;
+        if (channels.TryGetValue(peer, out var channel) == false) return false;
+        if (channel.Phase is Phase.Dropping or Phase.Live) return false;
 
-        // Disconnect can remove the channel after the loading state checks that it is still current.
-        if (channels.TryGetValue(peer, out var channel) == false) return;
+        pendingBytes = Interlocked.Read(ref channel.PendingBytes);
+        return true;
+    }
 
-        int replayed;
+    public bool HasCatchUpOverflowed(NetPeer peer)
+    {
+        if (channels.TryGetValue(peer, out var channel) == false) return false;
+
         lock (channel.Gate)
         {
-            replayed = channel.Pending.Count;
-            Drain(peer, channel);
+            return channel.Overflowed;
+        }
+    }
+
+    public string DescribeCatchUp(NetPeer peer)
+    {
+        if (!channels.TryGetValue(peer, out var channel)) return "gate=none";
+        lock (channel.Gate)
+        {
+            return $"gate={channel.Phase} pending={channel.PendingCount} " +
+                $"pendingBytes={channel.PendingBytes} overflowed={channel.Overflowed} " +
+                $"mergedAdjacent={channel.MergedAdjacentTotal}";
+        }
+    }
+
+    public JoinReplayBatchResult OpenWithTailBatch(
+        NetPeer peer,
+        IMessage tailMarker,
+        Func<bool> tryBeginOpen)
+    {
+        if (tailMarker == null) throw new ArgumentNullException(nameof(tailMarker));
+        if (tryBeginOpen == null) throw new ArgumentNullException(nameof(tryBeginOpen));
+
+        if (!channels.TryGetValue(peer, out var channel)) return default;
+
+        JoinReplayBatchResult result;
+        lock (channel.Gate)
+        {
+            result = DrainBatch(peer, channel);
+            if (result.Overflowed) return result;
+            if (result.HasMore) return result;
+            if (!tryBeginOpen()) return result;
 
             // A racing broadcast is either drained before this marker or observes Open and is sent
             // after it. The client can therefore use the marker as the reliable world-stream barrier.
@@ -229,7 +388,12 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
             channel.Phase = Phase.Open;
         }
 
-        Logger.Debug("Opened peer {Peer} after {Count} queued packets and the join tail marker", peer.Id, replayed);
+        Logger.Debug(
+            "Opened peer {Peer} after final replay batch packets={Packets} bytes={Bytes}",
+            peer.Id,
+            result.PacketsSent,
+            result.BytesSent);
+        return result;
     }
 
     public void CompleteCatchUp(NetPeer peer)
@@ -243,13 +407,76 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
         }
     }
 
-    private void Drain(NetPeer peer, PeerChannel channel)
+    public int AbortCatchUp(NetPeer peer)
     {
-        while (channel.Pending.Count > 0)
+        if (channels.TryGetValue(peer, out var channel) == false)
         {
-            var packet = channel.Pending.Dequeue();
+            (network.Value as IBufferedNetwork)?.DiscardPendingMessages(peer);
+            return 0;
+        }
+
+        int cleared;
+        lock (channel.Gate)
+        {
+            cleared = channel.Pending.Count;
+            channel.Pending.Clear();
+            channel.PendingMerge = null;
+            Interlocked.Exchange(ref channel.PendingCount, 0);
+            Interlocked.Exchange(ref channel.PendingBytes, 0);
+            channel.Overflowed = false;
+            channel.Phase = Phase.Dropping;
+            channel.FinalBaselineCoverageActive = true;
+        }
+
+        // Replay Drain uses normal message aggregation. Remove anything it buffered before the
+        // watchdog was able to abort so the end-of-update aggregate flush cannot send stale replay.
+        (network.Value as IBufferedNetwork)?.DiscardPendingMessages(peer);
+        return cleared;
+    }
+
+    private JoinReplayBatchResult DrainBatch(
+        NetPeer peer,
+        PeerChannel channel,
+        bool allowOversized = true)
+    {
+        int drained = 0;
+        int drainedBytes = 0;
+        var stopwatch = Stopwatch.StartNew();
+        while (channel.Pending.Count > 0 &&
+               drained < NetworkJoinLimits.MaxReplayBatchPackets &&
+               (drained == 0 || stopwatch.Elapsed < NetworkJoinLimits.ReplayBatchSendBudget))
+        {
+            LinkedListNode<IPacket> node = channel.Pending.First;
+            var packet = node.Value;
+            int packetBytes = GetReplayPacketSize(packet);
+            if ((drained > 0 || !allowOversized) &&
+                drainedBytes + packetBytes > NetworkJoinLimits.MaxReplayBatchBytes)
+            {
+                break;
+            }
+
+            channel.Pending.RemoveFirst();
+            if (ReferenceEquals(node, channel.PendingMerge)) channel.PendingMerge = null;
+            drained++;
+            drainedBytes += packetBytes;
             Interlocked.Decrement(ref channel.PendingCount);
+            Interlocked.Add(ref channel.PendingBytes, -packetBytes);
             network.Value.SendImmediate(peer, packet);
         }
+
+        bool hasMore = channel.Pending.Count > 0;
+        return new JoinReplayBatchResult(
+            drained,
+            drainedBytes,
+            hasMore,
+            channel.Overflowed);
+    }
+
+    private int GetReplayPacketSize(IPacket packet)
+    {
+        if (packet is MessagePacket messagePacket && messagePacket.Data != null)
+            return messagePacket.Data.Length;
+
+        return serializer.Serialize(packet).Length;
     }
 }

--- a/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
+++ b/source/Coop.Core/Server/Connections/ConnectionMessageQueue.cs
@@ -1,4 +1,4 @@
-﻿using Common.Logging;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Network.Messages;
@@ -202,7 +202,7 @@ internal sealed class ConnectionMessageQueue : IConnectionMessageQueue, IDisposa
     public bool TryHandleBroadcast(NetPeer peer, IPacket packet)
     {
         if (packet.PacketType == PacketType.CampaignTime ||
-            packet is MessagePacket lobby && lobby.MessageType == typeof(NetworkSessionLobbyChanged))
+            (packet is MessagePacket lobby && lobby.MessageType == typeof(NetworkSessionLobbyChanged)))
             return false;
 
         if (!channels.TryGetValue(peer, out var channel)) return true;

--- a/source/Coop.Core/Server/Connections/JoinPeerTerminator.cs
+++ b/source/Coop.Core/Server/Connections/JoinPeerTerminator.cs
@@ -1,0 +1,15 @@
+﻿using LiteNetLib;
+
+namespace Coop.Core.Server.Connections;
+
+/// <summary>Disconnects a failed join after its replay has been made terminal.</summary>
+public interface IJoinPeerTerminator
+{
+    void Disconnect(NetPeer peer, string reason);
+}
+
+/// <inheritdoc cref="IJoinPeerTerminator"/>
+internal sealed class JoinPeerTerminator : IJoinPeerTerminator
+{
+    public void Disconnect(NetPeer peer, string reason) => peer.Disconnect();
+}

--- a/source/Coop.Core/Server/Connections/JoinPeerTerminator.cs
+++ b/source/Coop.Core/Server/Connections/JoinPeerTerminator.cs
@@ -1,4 +1,5 @@
 ﻿using LiteNetLib;
+using LiteNetLib.Utils;
 
 namespace Coop.Core.Server.Connections;
 
@@ -11,5 +12,10 @@ public interface IJoinPeerTerminator
 /// <inheritdoc cref="IJoinPeerTerminator"/>
 internal sealed class JoinPeerTerminator : IJoinPeerTerminator
 {
-    public void Disconnect(NetPeer peer, string reason) => peer.Disconnect();
+    public void Disconnect(NetPeer peer, string reason)
+    {
+        var data = new NetDataWriter();
+        data.Put(reason);
+        peer.Disconnect(data);
+    }
 }

--- a/source/Coop.Core/Server/Connections/Messages/NetworkJoinSync.cs
+++ b/source/Coop.Core/Server/Connections/Messages/NetworkJoinSync.cs
@@ -12,6 +12,8 @@ public enum JoinSyncSignal
     FinalBaselineApplied,
     WorldReady,
     CatchUpApplied,
+    ReplayBatchComplete,
+    ReplayBatchApplied,
 }
 
 /// <summary>Coordinates the ordered replay and baseline barriers for a joining client.</summary>
@@ -23,5 +25,12 @@ public readonly struct NetworkJoinSync : IMessage
     [ProtoMember(1)]
     public readonly JoinSyncSignal Signal;
 
-    public NetworkJoinSync(JoinSyncSignal signal) => Signal = signal;
+    [ProtoMember(2)]
+    public readonly int ReplayBatchId;
+
+    public NetworkJoinSync(JoinSyncSignal signal, int replayBatchId = 0)
+    {
+        Signal = signal;
+        ReplayBatchId = replayBatchId;
+    }
 }

--- a/source/Coop.Core/Server/Connections/States/LoadingState.cs
+++ b/source/Coop.Core/Server/Connections/States/LoadingState.cs
@@ -1,22 +1,32 @@
 ﻿using Common;
+using Common.Logging;
 using Common.Messaging;
 using Common.Network;
 using Common.Network.Coalescing;
 using Common.Network.Messages;
 using Coop.Core.Server.Connections.Messages;
-using Coop.Core.Server.Services.Kingdoms;
 using Coop.Core.Server.Services.MobileParties;
+using Coop.Core.Server.Services.Kingdoms;
 using LiteNetLib;
+using Serilog;
+using System.Collections.Generic;
+using System.Threading;
 
 namespace Coop.Core.Server.Connections.States;
 
 /// <summary>State representing a connection loading the campaign.</summary>
 public class LoadingState : ConnectionStateBase
 {
+    internal const int MaxBaselinesPerJoin = 16;
+
+    private static readonly ILogger Logger = LogManager.GetLogger<LoadingState>();
+
     private enum JoinPhase
     {
         WaitingForCampaignEntry,
         CampaignEntryQueued,
+        ReplayBatchQueued,
+        WaitingForReplayBatchApplied,
         WaitingForReplayApplied,
         InitialBaselineQueued,
         WaitingForInitialBaseline,
@@ -25,6 +35,15 @@ public class LoadingState : ConnectionStateBase
         WorldReadyQueued,
         WaitingForCatchUpApplied,
         CatchUpAppliedQueued,
+        Aborted,
+    }
+
+    private enum ReplayContinuation
+    {
+        InitialReplay,
+        InitialBaseline,
+        FinalBaseline,
+        WorldReady,
     }
 
     private readonly IMessageBroker messageBroker;
@@ -33,14 +52,22 @@ public class LoadingState : ConnectionStateBase
     private readonly IJoinCampaignKingdomBaseLineSender campaignKingdomBaselineSender;
     private readonly IConnectionMessageQueue connectionMessageQueue;
     private readonly ISendCoalescer coalescer;
-    private volatile JoinPhase phase;
+    private readonly object joinGate = new object();
+    private int phase = (int)JoinPhase.WaitingForCampaignEntry;
     private int initialBaselinesSent;
-#if DEBUG
     private int totalBaselinesSent;
+    private int baselineLimitLogged;
+    private int nextReplayBatchId;
+    private readonly Queue<(int Id, int Bytes)> replayBatches = new Queue<(int, int)>();
+    private bool replayDrainBlocked;
+    private long joinProgressVersion;
+    private ReplayContinuation replayContinuation;
+#if DEBUG
 
     internal string DebugJoinState =>
-        $"phase={phase} initialBaselinesSent={initialBaselinesSent} " +
-        $"totalBaselinesSent={totalBaselinesSent} joinCatchUpPending={IsJoinCatchUpPending}";
+        $"phase={CurrentPhase} initialBaselinesSent={initialBaselinesSent} " +
+        $"totalBaselinesSent={totalBaselinesSent} nextReplayBatchId={nextReplayBatchId} " +
+        $"joinProgressVersion={JoinProgressVersion} joinCatchUpPending={IsJoinCatchUpPending}";
 #endif
 
     public LoadingState(
@@ -66,14 +93,71 @@ public class LoadingState : ConnectionStateBase
 
     public override bool IsLoading => true;
 
-    internal bool IsJoinCatchUpPending =>
-        phase == JoinPhase.WaitingForReplayApplied ||
-        phase == JoinPhase.InitialBaselineQueued ||
-        phase == JoinPhase.WaitingForInitialBaseline ||
-        phase == JoinPhase.FinalBaselineQueued ||
-        phase == JoinPhase.WaitingForFinalBaseline ||
-        phase == JoinPhase.WorldReadyQueued ||
-        phase == JoinPhase.WaitingForCatchUpApplied;
+    internal bool IsJoinCatchUpPending => IsPendingJoinPhase(CurrentPhase);
+
+    internal bool IsPreEntryPending => CurrentPhase <= JoinPhase.CampaignEntryQueued;
+
+    internal bool IsWaitingForReplayApplied =>
+        CurrentPhase == JoinPhase.WaitingForReplayApplied;
+
+    internal bool IsAborted => CurrentPhase == JoinPhase.Aborted;
+
+    internal string JoinPhaseName => CurrentPhase.ToString();
+
+    internal long JoinProgressVersion => Interlocked.Read(ref joinProgressVersion);
+
+    internal bool TryAbortJoinCatchUp()
+    {
+        if (!Monitor.TryEnter(joinGate)) return false;
+        try
+        {
+            while (ReferenceEquals(ConnectionLogic.State, this))
+            {
+                JoinPhase current = CurrentPhase;
+                if (!IsPendingJoinPhase(current)) return false;
+                if (Interlocked.CompareExchange(
+                        ref phase,
+                        (int)JoinPhase.Aborted,
+                        (int)current) == (int)current)
+                {
+                    replayBatches.Clear();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            Monitor.Exit(joinGate);
+        }
+    }
+
+    internal bool TryAbortPreEntryJoin()
+    {
+        if (!Monitor.TryEnter(joinGate)) return false;
+        try
+        {
+            while (ReferenceEquals(ConnectionLogic.State, this))
+            {
+                JoinPhase current = CurrentPhase;
+                if (current > JoinPhase.CampaignEntryQueued) return false;
+                if (Interlocked.CompareExchange(
+                        ref phase,
+                        (int)JoinPhase.Aborted,
+                        (int)current) == (int)current)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            Monitor.Exit(joinGate);
+        }
+    }
 
     public override void Dispose()
     {
@@ -84,102 +168,299 @@ public class LoadingState : ConnectionStateBase
     internal void PlayerCampaignEnteredHandler(MessagePayload<NetworkPlayerCampaignEntered> payload)
     {
         var peer = (NetPeer)payload.Who;
-        if (peer != ConnectionLogic.Peer || phase != JoinPhase.WaitingForCampaignEntry) return;
+        if (!ReferenceEquals(peer, ConnectionLogic.Peer) ||
+            !TrySetPhase(JoinPhase.WaitingForCampaignEntry, JoinPhase.CampaignEntryQueued))
+        {
+            return;
+        }
 
-        phase = JoinPhase.CampaignEntryQueued;
         GameThread.RunSafe(() =>
         {
-            if (!IsCurrent(JoinPhase.CampaignEntryQueued)) return;
+            lock (joinGate)
+            {
+                if (!IsCurrent(JoinPhase.CampaignEntryQueued)) return;
 
-            messageBroker.Publish(this, new PlayerCampaignEntered(peer));
-            messageBroker.Publish(this, new PlayerConnectionStateChanged());
-            connectionMessageQueue.Flush(peer);
-            phase = JoinPhase.WaitingForReplayApplied;
-            network.SendImmediate(peer, new NetworkJoinSync(JoinSyncSignal.ReplayComplete));
+                messageBroker.Publish(this, new PlayerCampaignEntered(peer));
+                messageBroker.Publish(this, new PlayerConnectionStateChanged());
+                replayContinuation = ReplayContinuation.InitialReplay;
+                if (!TrySetPhase(JoinPhase.CampaignEntryQueued, JoinPhase.ReplayBatchQueued)) return;
+                PumpReplay(peer);
+            }
         }, context: nameof(PlayerCampaignEnteredHandler));
     }
 
     internal void JoinSyncHandler(MessagePayload<NetworkJoinSync> payload)
     {
         var peer = (NetPeer)payload.Who;
-        if (peer != ConnectionLogic.Peer) return;
+        if (!ReferenceEquals(peer, ConnectionLogic.Peer)) return;
 
         switch (payload.What.Signal)
         {
-            case JoinSyncSignal.ReplayApplied when phase == JoinPhase.WaitingForReplayApplied:
-                QueueBaseline(peer, isFinal: false, nameof(JoinSyncSignal.ReplayApplied));
+            case JoinSyncSignal.ReplayBatchApplied:
+                QueueNextReplayBatch(peer, payload.What.ReplayBatchId);
                 break;
-            case JoinSyncSignal.BaselineRequested when phase == JoinPhase.WaitingForInitialBaseline:
-                QueueBaseline(peer, isFinal: false, nameof(JoinSyncSignal.BaselineRequested));
+            case JoinSyncSignal.ReplayApplied:
+                QueueBaseline(
+                    peer,
+                    JoinPhase.WaitingForReplayApplied,
+                    isFinal: false,
+                    nameof(JoinSyncSignal.ReplayApplied));
                 break;
-            case JoinSyncSignal.BaselineRequested when phase == JoinPhase.WaitingForFinalBaseline:
-                QueueBaseline(peer, isFinal: true, nameof(JoinSyncSignal.BaselineRequested));
+            case JoinSyncSignal.BaselineRequested when CurrentPhase == JoinPhase.WaitingForInitialBaseline:
+                QueueBaseline(
+                    peer,
+                    JoinPhase.WaitingForInitialBaseline,
+                    isFinal: false,
+                    nameof(JoinSyncSignal.BaselineRequested));
+                break;
+            case JoinSyncSignal.BaselineRequested when CurrentPhase == JoinPhase.WaitingForFinalBaseline:
+                QueueBaseline(
+                    peer,
+                    JoinPhase.WaitingForFinalBaseline,
+                    isFinal: true,
+                    nameof(JoinSyncSignal.BaselineRequested));
                 break;
             case JoinSyncSignal.BaselineApplied
-                when phase == JoinPhase.WaitingForInitialBaseline && initialBaselinesSent >= 2:
-                QueueBaseline(peer, isFinal: true, nameof(JoinSyncSignal.BaselineApplied));
+                when CurrentPhase == JoinPhase.WaitingForInitialBaseline && initialBaselinesSent >= 2:
+                QueueBaseline(
+                    peer,
+                    JoinPhase.WaitingForInitialBaseline,
+                    isFinal: true,
+                    nameof(JoinSyncSignal.BaselineApplied));
                 break;
-            case JoinSyncSignal.FinalBaselineApplied when phase == JoinPhase.WaitingForFinalBaseline:
+            case JoinSyncSignal.FinalBaselineApplied when CurrentPhase == JoinPhase.WaitingForFinalBaseline:
                 QueueWorldReady(peer);
                 break;
-            case JoinSyncSignal.CatchUpApplied when phase == JoinPhase.WaitingForCatchUpApplied:
+            case JoinSyncSignal.CatchUpApplied when CurrentPhase == JoinPhase.WaitingForCatchUpApplied:
                 QueueCampaignEntry(peer);
                 break;
         }
     }
 
-    private void QueueBaseline(NetPeer peer, bool isFinal, string context)
+    private void QueueBaseline(
+        NetPeer peer,
+        JoinPhase expected,
+        bool isFinal,
+        string context)
     {
         JoinPhase queued = isFinal ? JoinPhase.FinalBaselineQueued : JoinPhase.InitialBaselineQueued;
         JoinPhase waiting = isFinal ? JoinPhase.WaitingForFinalBaseline : JoinPhase.WaitingForInitialBaseline;
-        phase = queued;
+        if (!TrySetPhase(expected, queued)) return;
 
         GameThread.RunSafe(() =>
         {
-            if (!IsCurrent(queued)) return;
+            lock (joinGate)
+            {
+                if (!IsCurrent(queued)) return;
 
-            coalescer.Flush(network);
-            connectionMessageQueue.Flush(peer);
-            if (!isFinal) initialBaselinesSent++;
-#if DEBUG
-            totalBaselinesSent++;
-#endif
-            phase = waiting;
-            campaignBaselineSender.Send(peer);
-            campaignKingdomBaselineSender.Send(peer);
+                if (totalBaselinesSent >= MaxBaselinesPerJoin)
+                {
+                    if (Interlocked.Exchange(ref baselineLimitLogged, 1) == 0)
+                    {
+                        Logger.Warning(
+                            "Ignored campaign baseline request from peer {PeerId} after {Limit} baselines; " +
+                            "the join watchdog will terminate the non-converging connection",
+                            peer.Id,
+                            MaxBaselinesPerJoin);
+                    }
+                    TrySetPhase(queued, waiting);
+                    return;
+                }
+
+                AdvanceJoinProgress();
+                totalBaselinesSent++;
+                replayContinuation = isFinal
+                    ? ReplayContinuation.FinalBaseline
+                    : ReplayContinuation.InitialBaseline;
+                if (!TrySetPhase(queued, JoinPhase.ReplayBatchQueued)) return;
+                PumpReplay(peer);
+            }
         }, context: context);
     }
 
     private void QueueWorldReady(NetPeer peer)
     {
-        phase = JoinPhase.WorldReadyQueued;
+        if (!TrySetPhase(JoinPhase.WaitingForFinalBaseline, JoinPhase.WorldReadyQueued)) return;
+        AdvanceJoinProgress();
         GameThread.RunSafe(() =>
         {
-            if (!IsCurrent(JoinPhase.WorldReadyQueued)) return;
+            lock (joinGate)
+            {
+                if (!IsCurrent(JoinPhase.WorldReadyQueued)) return;
 
-            coalescer.Flush(network);
-            phase = JoinPhase.WaitingForCatchUpApplied;
-            connectionMessageQueue.OpenWithTail(
-                peer,
-                new NetworkJoinSync(JoinSyncSignal.WorldReady));
+                replayContinuation = ReplayContinuation.WorldReady;
+                if (!TrySetPhase(JoinPhase.WorldReadyQueued, JoinPhase.ReplayBatchQueued)) return;
+                PumpReplay(peer);
+            }
         }, context: nameof(JoinSyncSignal.FinalBaselineApplied));
     }
 
     private void QueueCampaignEntry(NetPeer peer)
     {
-        phase = JoinPhase.CatchUpAppliedQueued;
+        if (!TrySetPhase(
+                JoinPhase.WaitingForCatchUpApplied,
+                JoinPhase.CatchUpAppliedQueued))
+        {
+            return;
+        }
+        AdvanceJoinProgress();
         GameThread.RunSafe(() =>
         {
-            if (!IsCurrent(JoinPhase.CatchUpAppliedQueued)) return;
+            lock (joinGate)
+            {
+                if (!IsCurrent(JoinPhase.CatchUpAppliedQueued)) return;
 
-            connectionMessageQueue.CompleteCatchUp(peer);
-            messageBroker.Publish(this, new PlayerCampaignSynchronized(peer));
-            ConnectionLogic.EnterCampaign();
+                connectionMessageQueue.CompleteCatchUp(peer);
+
+                messageBroker.Publish(this, new PlayerCampaignSynchronized(peer));
+
+                ConnectionLogic.EnterCampaign();
+            }
         }, context: nameof(JoinSyncSignal.CatchUpApplied));
     }
 
+    private void QueueNextReplayBatch(NetPeer peer, int replayBatchId)
+    {
+        lock (joinGate)
+        {
+            if ((!IsCurrent(JoinPhase.WaitingForReplayBatchApplied) &&
+                 !IsCurrent(JoinPhase.ReplayBatchQueued)) ||
+                replayBatches.Count == 0 || replayBatches.Peek().Id != replayBatchId)
+            {
+                return;
+            }
+
+            // Reliable ordered acknowledgements release only the oldest issued application credit.
+            replayBatches.Dequeue();
+            AdvanceJoinProgress();
+            QueueReplayPump(peer);
+        }
+    }
+
+    private void QueueReplayPump(NetPeer peer)
+    {
+        if (replayBatches.Count >= NetworkJoinLimits.MaxReplayInFlightBatches ||
+            (replayBatches.Count > 0 &&
+             (replayDrainBlocked || replayBatches.Peek().Bytes > NetworkJoinLimits.MaxReplayBatchBytes)) ||
+            !TrySetPhase(JoinPhase.WaitingForReplayBatchApplied, JoinPhase.ReplayBatchQueued)) return;
+
+        // The phase admits one queued pump, even when several acknowledgements arrive in one frame.
+        GameThread.EnqueueSafe(() =>
+        {
+            lock (joinGate)
+            {
+                if (!IsCurrent(JoinPhase.ReplayBatchQueued)) return;
+                PumpReplay(peer);
+            }
+        }, context: nameof(JoinSyncSignal.ReplayBatchApplied));
+    }
+
+    private void PumpReplay(NetPeer peer)
+    {
+        if (!IsCurrent(JoinPhase.ReplayBatchQueued)) return;
+
+        // Include coalesced world mutations in this cut before deciding whether the bounded batch is
+        // final. New mutations remain queued behind the application barrier.
+        coalescer.Flush(network);
+
+        JoinReplayBatchResult result;
+        if (replayContinuation == ReplayContinuation.WorldReady && replayBatches.Count == 0)
+        {
+            result = connectionMessageQueue.OpenWithTailBatch(
+                peer,
+                new NetworkJoinSync(JoinSyncSignal.WorldReady),
+                () => TrySetPhase(
+                    JoinPhase.ReplayBatchQueued,
+                    JoinPhase.WaitingForCatchUpApplied));
+            if (result.Overflowed) return;
+            if (!result.HasMore) return;
+        }
+        else
+        {
+            result = replayBatches.Count == 0
+                ? connectionMessageQueue.FlushBatch(peer)
+                : connectionMessageQueue.FlushBatch(peer, allowOversized: false);
+            if (result.Overflowed) return;
+            if (!result.HasMore && replayBatches.Count == 0)
+            {
+                CompleteReplayContinuation(peer);
+                return;
+            }
+        }
+
+        // Empty/oversized tails wait for all issued barriers before the next cut or baseline.
+        replayDrainBlocked = !result.HasMore || result.PacketsSent == 0;
+        if (!TrySetPhase(
+                JoinPhase.ReplayBatchQueued,
+                JoinPhase.WaitingForReplayBatchApplied))
+        {
+            return;
+        }
+
+        if (result.PacketsSent > 0)
+        {
+            int replayBatchId = ++nextReplayBatchId;
+            replayBatches.Enqueue((replayBatchId, result.BytesSent));
+            network.SendImmediate(
+                peer,
+                new NetworkJoinSync(JoinSyncSignal.ReplayBatchComplete, replayBatchId));
+        }
+        QueueReplayPump(peer);
+    }
+
+    private void CompleteReplayContinuation(NetPeer peer)
+    {
+        switch (replayContinuation)
+        {
+            case ReplayContinuation.InitialReplay:
+                if (!TrySetPhase(
+                        JoinPhase.ReplayBatchQueued,
+                        JoinPhase.WaitingForReplayApplied))
+                {
+                    return;
+                }
+                network.SendImmediate(peer, new NetworkJoinSync(JoinSyncSignal.ReplayComplete));
+                return;
+            case ReplayContinuation.InitialBaseline:
+                if (!TrySetPhase(
+                        JoinPhase.ReplayBatchQueued,
+                        JoinPhase.WaitingForInitialBaseline))
+                {
+                    return;
+                }
+                initialBaselinesSent++;
+                campaignBaselineSender.Send(peer);
+                campaignKingdomBaselineSender.Send(peer);
+                return;
+            case ReplayContinuation.FinalBaseline:
+                if (!TrySetPhase(
+                        JoinPhase.ReplayBatchQueued,
+                        JoinPhase.WaitingForFinalBaseline))
+                {
+                    return;
+                }
+                connectionMessageQueue.EndFinalBaselineCoverage(peer);
+                campaignBaselineSender.Send(peer);
+                campaignKingdomBaselineSender.Send(peer);
+                return;
+        }
+    }
+
+    private void AdvanceJoinProgress() => Interlocked.Increment(ref joinProgressVersion);
+
+    private JoinPhase CurrentPhase => (JoinPhase)Volatile.Read(ref phase);
+
+    private static bool IsPendingJoinPhase(JoinPhase current) =>
+        current >= JoinPhase.ReplayBatchQueued &&
+        current != JoinPhase.CatchUpAppliedQueued &&
+        current != JoinPhase.Aborted;
+
+    private bool TrySetPhase(JoinPhase expected, JoinPhase next) =>
+        ReferenceEquals(ConnectionLogic.State, this) &&
+        Interlocked.CompareExchange(ref phase, (int)next, (int)expected) == (int)expected;
+
     private bool IsCurrent(JoinPhase expected) =>
-        ReferenceEquals(ConnectionLogic.State, this) && phase == expected;
+        ReferenceEquals(ConnectionLogic.State, this) && CurrentPhase == expected;
 
     public override void CreateCharacter()
     {

--- a/source/Coop.Core/Server/ServerModule.cs
+++ b/source/Coop.Core/Server/ServerModule.cs
@@ -93,6 +93,7 @@ public class ServerModule : CommonModule
             .InstancePerDependency();
         // Pauses time while a peer's packet queue is overloaded (slow client catching up). Constructed
         // as a CoopServer dependency, so it registers its unpause policy when the server is built.
+        builder.RegisterType<JoinPeerTerminator>().As<IJoinPeerTerminator>().InstancePerDependency();
         builder.RegisterType<OverloadedPeerManager>().As<IOverloadedPeerManager>().InstancePerLifetimeScope().AutoActivate();
 
         builder.RegisterType<ServerTelemetryUploader>()

--- a/source/Coop.Core/Server/Services/ItemRosters/Messages/NetworkItemRosterUpdate.cs
+++ b/source/Coop.Core/Server/Services/ItemRosters/Messages/NetworkItemRosterUpdate.cs
@@ -7,7 +7,7 @@ namespace Coop.Core.Server.Services.ItemRosters.Messages;
 /// Sent to the client by the server when an ItemRoster is updated.
 /// </summary>
 [ProtoContract(SkipConstructor = true)]
-public readonly struct NetworkItemRosterUpdate : IMessage
+public readonly struct NetworkItemRosterUpdate : IMessage, IJoinCatchUpMergeMessage
 {
     [ProtoMember(1)]
     public readonly string ItemRosterId;
@@ -20,6 +20,26 @@ public readonly struct NetworkItemRosterUpdate : IMessage
 
     [ProtoMember(4)]
     public readonly int Amount;
+
+    public string JoinCatchUpMergeKey => $"{ItemRosterId}:{ItemID}:{ItemModifierID}";
+
+    public bool TryMerge(IMessage next, out IMessage merged)
+    {
+        merged = null;
+        if (next is not NetworkItemRosterUpdate other ||
+            ItemRosterId != other.ItemRosterId || ItemID != other.ItemID ||
+            ItemModifierID != other.ItemModifierID ||
+            Amount <= 0 || other.Amount <= 0)
+            return false;
+
+        // Native removals can throw on underflow after updating caches. Preserve each removal
+        // and every sign change instead of combining their partial effects.
+        long total = (long)Amount + other.Amount;
+        if (total < int.MinValue || total > int.MaxValue) return false;
+
+        merged = new NetworkItemRosterUpdate(ItemRosterId, ItemID, ItemModifierID, (int)total);
+        return true;
+    }
 
     public NetworkItemRosterUpdate(string itemRosterId, string itemID, string itemModifierID, int amount)
     {

--- a/source/Coop.Core/Server/Services/Time/OverloadedPeerManager.cs
+++ b/source/Coop.Core/Server/Services/Time/OverloadedPeerManager.cs
@@ -1,4 +1,5 @@
 ﻿using Common.Logging;
+using Coop.Core.Server.Connections.Messages;
 using Common.Messaging;
 using Common.Network;
 using Coop.Core.Server.Connections;
@@ -21,6 +22,13 @@ public interface IOverloadedPeerManager : IDisposable
 
 internal class OverloadedPeerManager : IOverloadedPeerManager
 {
+    /// <summary>Tracks the last acknowledged application progress for one joining connection.</summary>
+    private sealed class JoinProgress
+    {
+        public long Version;
+        public DateTime LastProgressUtc;
+    }
+
     private static readonly ILogger Logger = LogManager.GetLogger<OverloadedPeerManager>();
     private readonly INetworkConfig config;
     private readonly IMessageBroker messageBroker;
@@ -31,16 +39,18 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     private readonly IConnectionCollection connectionCollection;
     private readonly IConnectionMessageQueue connectionMessageQueue;
 
+    private readonly IJoinPeerTerminator joinPeerTerminator;
+    private readonly Dictionary<NetPeer, JoinProgress> joinCatchUpProgress = new(ReferenceComparer<NetPeer>.Instance);
+    private readonly Dictionary<NetPeer, DateTime> preEntryBackpressureStartedUtc = new(ReferenceComparer<NetPeer>.Instance);
+
     private IAutomaticPauseLease automaticPauseLease;
     private volatile NetPeer[] cachedOverloadedPeers = Array.Empty<NetPeer>();
-    private readonly Dictionary<NetPeer, DateTime> joinCatchUpStartedUtc = new Dictionary<NetPeer, DateTime>();
 
     // Diagnostics for the catch-up pause: when it started and when depths were last logged, so a
     // long pause leaves periodic evidence in the log instead of only an in-game message.
     private DateTime pauseStartedUtc;
     private DateTime lastPauseDepthLogUtc;
     private static readonly TimeSpan PauseDepthLogInterval = TimeSpan.FromSeconds(5);
-    internal static readonly TimeSpan JoinCatchUpPauseDelay = TimeSpan.FromSeconds(20);
 
     public OverloadedPeerManager(
         INetworkConfig config,
@@ -48,7 +58,8 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         Lazy<INetwork> network,
         ITimeControlInterface timeControlInterface,
         IConnectionCollection connectionCollection,
-        IConnectionMessageQueue connectionMessageQueue
+        IConnectionMessageQueue connectionMessageQueue,
+        IJoinPeerTerminator joinPeerTerminator
     )
     {
         this.config = config;
@@ -57,6 +68,7 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         this.timeControlInterface = timeControlInterface;
         this.connectionCollection = connectionCollection;
         this.connectionMessageQueue = connectionMessageQueue;
+        this.joinPeerTerminator = joinPeerTerminator;
 
         timeControlInterface.AddUnpausePolicy(PlayersOverloadedPolicy);
     }
@@ -64,7 +76,8 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
     public void Dispose()
     {
         timeControlInterface.RemoveUnpausePolicy(PlayersOverloadedPolicy);
-        joinCatchUpStartedUtc.Clear();
+        joinCatchUpProgress.Clear();
+        preEntryBackpressureStartedUtc.Clear();
     }
 
     private static int GetQueueDepth(NetPeer peer)
@@ -85,34 +98,176 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
             .ToList();
     }
 
-    private List<NetPeer> UpdateJoinCatchUpPeers(DateTime utcNow)
+    private void AbortStalledJoiners(DateTime utcNow)
     {
-        var peers = connectionCollection
-            .Where(logic => logic.State is LoadingState { IsJoinCatchUpPending: true })
-            .Select(logic => logic.Peer)
-            .ToList();
-        var activePeers = new HashSet<NetPeer>(peers);
+        var joining = connectionCollection
+            .Select(logic => (logic.Peer, State: logic.State as LoadingState))
+            .Where(entry => entry.State?.IsJoinCatchUpPending == true)
+            .Select(entry => (entry.Peer, State: entry.State!))
+            .ToArray();
+        var activePeers = new HashSet<NetPeer>(
+            joining.Select(entry => entry.Peer),
+            ReferenceComparer<NetPeer>.Instance);
 
-        foreach (var peer in joinCatchUpStartedUtc.Keys.Where(peer => !activePeers.Contains(peer)).ToArray())
+        foreach (var peer in joinCatchUpProgress.Keys
+                     .Where(peer => !activePeers.Contains(peer))
+                     .ToArray())
         {
-            joinCatchUpStartedUtc.Remove(peer);
+            joinCatchUpProgress.Remove(peer);
         }
 
-        foreach (var peer in peers)
+        foreach (var entry in joining)
         {
-            if (!joinCatchUpStartedUtc.ContainsKey(peer))
+            long progressVersion = entry.State.JoinProgressVersion;
+            if (!joinCatchUpProgress.TryGetValue(entry.Peer, out var progress))
             {
-                joinCatchUpStartedUtc.Add(peer, utcNow);
+                progress = new JoinProgress
+                {
+                    Version = progressVersion,
+                    LastProgressUtc = utcNow,
+                };
+                joinCatchUpProgress.Add(entry.Peer, progress);
             }
-        }
+            else if (progress.Version != progressVersion)
+            {
+                progress.Version = progressVersion;
+                progress.LastProgressUtc = utcNow;
+            }
 
-        return peers;
+            TimeSpan elapsed = utcNow - progress.LastProgressUtc;
+            int queueDepth = GetReportedQueueDepth(entry.Peer);
+            connectionMessageQueue.TryGetCatchUpPendingBytes(entry.Peer, out long pendingBytes);
+            bool timedOut = elapsed >= NetworkJoinLimits.ReplayAppliedTimeout;
+            bool queueExceeded = queueDepth > NetworkJoinLimits.MaxReplayPackets ||
+                                 connectionMessageQueue.HasCatchUpOverflowed(entry.Peer);
+            bool bytesExceeded = pendingBytes > NetworkJoinLimits.MaxReplayPendingBytes;
+            if (!timedOut && !queueExceeded && !bytesExceeded) continue;
+
+            // Make the join terminal before disconnecting. Network receive is polled after this
+            // check, so an acknowledgement already in flight cannot restart synchronization.
+            if (!entry.State.TryAbortJoinCatchUp()) continue;
+
+            string queueDescription = connectionMessageQueue.DescribeCatchUp(entry.Peer);
+            int clearedPackets = connectionMessageQueue.AbortCatchUp(entry.Peer);
+            string disconnectCode = timedOut
+                ? "JoinReplayAppliedTimeout"
+                : "JoinReplayQueueLimit";
+
+            joinCatchUpProgress.Remove(entry.Peer);
+
+            Logger.Warning(
+                "Aborting stalled campaign join for peer {Peer}: reason={Reason} phase={Phase} " +
+                "stalled={ElapsedSeconds:0.0}s timeout={TimeoutSeconds:0.0}s " +
+                "queue={QueueDepth} queueLimit={QueueLimit} pendingBytes={PendingBytes} " +
+                "pendingByteLimit={PendingByteLimit} cleared={ClearedPackets} {QueueDescription}",
+                entry.Peer.Id,
+                disconnectCode,
+                entry.State.JoinPhaseName,
+                elapsed.TotalSeconds,
+                NetworkJoinLimits.ReplayAppliedTimeout.TotalSeconds,
+                queueDepth,
+                NetworkJoinLimits.MaxReplayPackets,
+                pendingBytes,
+                NetworkJoinLimits.MaxReplayPendingBytes,
+                clearedPackets,
+                queueDescription);
+
+            joinPeerTerminator.Disconnect(entry.Peer, disconnectCode);
+        }
     }
 
-    private List<NetPeer> GetStalledJoiningPeers(IEnumerable<NetPeer> joinCatchUpPeers, DateTime utcNow) =>
-        joinCatchUpPeers
-            .Where(peer => utcNow - joinCatchUpStartedUtc[peer] >= JoinCatchUpPauseDelay)
-            .ToList();
+    private void AbortStalledPreEntryJoiners(DateTime utcNow)
+    {
+        var joining = connectionCollection
+            .Select(logic => (logic.Peer, State: logic.State as LoadingState))
+            .Where(entry => entry.State?.IsPreEntryPending == true)
+            .Select(entry => (entry.Peer, State: entry.State!))
+            .ToArray();
+        var activePeers = new HashSet<NetPeer>(
+            joining.Select(entry => entry.Peer),
+            ReferenceComparer<NetPeer>.Instance);
+
+        foreach (var peer in preEntryBackpressureStartedUtc.Keys
+                     .Where(peer => !activePeers.Contains(peer))
+                     .ToArray())
+        {
+            preEntryBackpressureStartedUtc.Remove(peer);
+        }
+
+        foreach (var entry in joining)
+        {
+            if (!connectionMessageQueue.TryGetCatchUpPacketsRemaining(
+                    entry.Peer,
+                    out int queueDepth))
+            {
+                preEntryBackpressureStartedUtc.Remove(entry.Peer);
+                continue;
+            }
+
+            connectionMessageQueue.TryGetCatchUpPendingBytes(entry.Peer, out long pendingBytes);
+            bool queueExceeded = queueDepth > NetworkJoinLimits.MaxReplayPackets ||
+                                 connectionMessageQueue.HasCatchUpOverflowed(entry.Peer);
+            bool bytesExceeded = pendingBytes > NetworkJoinLimits.MaxReplayPendingBytes;
+            bool safetyLimitExceeded = queueExceeded || bytesExceeded;
+            TimeSpan elapsed = TimeSpan.Zero;
+            bool timedOut = false;
+
+            if (!safetyLimitExceeded)
+            {
+                // Keep one watchdog window while the join queue remains above the lower threshold.
+                if (queueDepth <= config.ResumePacketsInQueue)
+                {
+                    preEntryBackpressureStartedUtc.Remove(entry.Peer);
+                    continue;
+                }
+
+                if (!preEntryBackpressureStartedUtc.TryGetValue(entry.Peer, out var startedUtc))
+                {
+                    if (queueDepth <= config.MaxPacketsInQueue) continue;
+
+                    startedUtc = utcNow;
+                    preEntryBackpressureStartedUtc.Add(entry.Peer, startedUtc);
+                }
+
+                elapsed = utcNow - startedUtc;
+                timedOut = elapsed >= NetworkJoinLimits.CampaignEntryTimeout;
+                if (!timedOut) continue;
+            }
+            else if (preEntryBackpressureStartedUtc.TryGetValue(entry.Peer, out var safetyStartedUtc))
+            {
+                elapsed = utcNow - safetyStartedUtc;
+            }
+
+            if (!entry.State.TryAbortPreEntryJoin()) continue;
+
+            string queueDescription = connectionMessageQueue.DescribeCatchUp(entry.Peer);
+            int clearedPackets = connectionMessageQueue.AbortCatchUp(entry.Peer);
+            string disconnectCode = timedOut
+                ? "JoinCampaignEntryTimeout"
+                : "JoinReplayQueueLimit";
+
+            preEntryBackpressureStartedUtc.Remove(entry.Peer);
+
+            Logger.Warning(
+                "Aborting stalled pre-entry campaign join for peer {Peer}: reason={Reason} phase={Phase} " +
+                "elapsed={ElapsedSeconds:0.0}s timeout={TimeoutSeconds:0.0}s " +
+                "queue={QueueDepth} queueLimit={QueueLimit} pendingBytes={PendingBytes} " +
+                "pendingByteLimit={PendingByteLimit} cleared={ClearedPackets} {QueueDescription}",
+                entry.Peer.Id,
+                disconnectCode,
+                entry.State.JoinPhaseName,
+                elapsed.TotalSeconds,
+                NetworkJoinLimits.CampaignEntryTimeout.TotalSeconds,
+                queueDepth,
+                NetworkJoinLimits.MaxReplayPackets,
+                pendingBytes,
+                NetworkJoinLimits.MaxReplayPendingBytes,
+                clearedPackets,
+                queueDescription);
+
+            joinPeerTerminator.Disconnect(entry.Peer, disconnectCode);
+        }
+    }
 
     private int GetReportedQueueDepth(NetPeer peer) =>
         connectionMessageQueue.TryGetCatchUpPacketsRemaining(peer, out int packetsRemaining)
@@ -131,8 +286,8 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
 
     internal void CheckForOverloadedPeers(DateTime utcNow)
     {
-        var joinCatchUpPeers = UpdateJoinCatchUpPeers(utcNow);
-        var stalledJoiningPeers = GetStalledJoiningPeers(joinCatchUpPeers, utcNow);
+        AbortStalledPreEntryJoiners(utcNow);
+        AbortStalledJoiners(utcNow);
 
         // While paused for overload, hold until every peer has drained below the (lower) resume
         // threshold, not just back under the pause threshold. The gap between the two thresholds is
@@ -140,7 +295,6 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         if (automaticPauseLease != null)
         {
             var stillDraining = GetLivePeersAboveThreshold(config.ResumePacketsInQueue)
-                .Concat(stalledJoiningPeers)
                 .Distinct()
                 .ToArray();
             cachedOverloadedPeers = stillDraining;
@@ -162,15 +316,6 @@ internal class OverloadedPeerManager : IOverloadedPeerManager
         }
 
         var overloadedPeers = GetLivePeersAboveThreshold(config.MaxPacketsInQueue);
-        if (stalledJoiningPeers.Count > 0)
-        {
-            PauseTime(
-                overloadedPeers.Concat(stalledJoiningPeers).Distinct().ToArray(),
-                utcNow,
-                "Game paused; a joining client needs to catch up");
-            return;
-        }
-
         if (overloadedPeers.Count == 0) return;
 
         PauseTime(

--- a/source/Coop.Tests/Client/Services/Connection/Handlers/DisconnectHandlerTests.cs
+++ b/source/Coop.Tests/Client/Services/Connection/Handlers/DisconnectHandlerTests.cs
@@ -26,7 +26,18 @@ public class DisconnectHandlerTests
         RunDisconnect(DisconnectReason.ConnectionFailed, "You have been Disconnected");
     }
 
-    private static void RunDisconnect(DisconnectReason reason, string expectedMessage)
+    [Theory]
+    [InlineData("JoinReplayAppliedTimeout", "Joining the campaign timed out while synchronizing.\nThe server stopped this join to keep the campaign responsive. Please try again.")]
+    [InlineData("JoinReplayQueueLimit", "Joining the campaign stopped because its synchronization queue exceeded the safety limit.\nPlease try again.")]
+    [InlineData("JoinCampaignEntryTimeout", "Joining the campaign timed out while loading the transferred save.\nThe server stopped this join to keep the campaign responsive. Please try again.")]
+    [InlineData("UnknownReason", "You have been Disconnected")]
+    [InlineData("", "You have been Disconnected")]
+    public void ServerDisconnect_ReturnsToMainMenuThenExplainsJoinFailure(string serverReason, string expected)
+    {
+        RunDisconnect(DisconnectReason.RemoteConnectionClose, expected, serverReason);
+    }
+
+    private static void RunDisconnect(DisconnectReason reason, string expectedMessage, string? serverReason = null)
     {
         var messageBroker = new TestMessageBroker();
         var finalizer = new Mock<ICoopFinalizer>(MockBehavior.Strict);
@@ -45,7 +56,7 @@ public class DisconnectHandlerTests
 
         messageBroker.Publish(
             handler,
-            new NetworkDisconnected(new DisconnectInfo { Reason = reason }));
+            new NetworkDisconnected(new DisconnectInfo { Reason = reason }, serverReason));
 
         gameState.Verify(value => value.GoToMainMenu(), Times.Once);
         finalizer.Verify(value => value.Finalize(expectedMessage), Times.Once);

--- a/source/Coop.Tests/Client/States/CampaignStateTests.cs
+++ b/source/Coop.Tests/Client/States/CampaignStateTests.cs
@@ -1,6 +1,10 @@
 ﻿using Autofac;
 using Common;
 using Common.Messaging;
+using Common.Network;
+using Coop.Core.Common;
+using System;
+using System.Threading;
 using Common.Tests.Utils;
 using Coop.Core.Client;
 using Coop.Core.Client.Messages;
@@ -18,8 +22,10 @@ using Xunit.Abstractions;
 
 namespace Coop.Tests.Client.States;
 
-public class CampaignStateTests
+public class CampaignStateTests : IDisposable
 {
+    public void Dispose() => clientLogic.State.Dispose();
+
     private readonly IClientLogic clientLogic;
     private readonly ClientTestComponent clientComponent;
 
@@ -42,6 +48,88 @@ public class CampaignStateTests
 
         // Assert
         //Assert.Single(TestMessageBroker.GetMessagesFromType<EnterMissionState>());
+    }
+
+    [Fact]
+    public void ReplayBatchAcknowledgement_WaitsForEarlierGameThreadApplicationAndEchoesId()
+    {
+        clientComponent.TestNetwork.CreatePeer();
+        _ = clientLogic.SetState<LoadingState>();
+        _ = clientLogic.SetState<CampaignState>();
+        using var earlierReplayStarted = new ManualResetEventSlim();
+        using var releaseEarlierReplay = new ManualResetEventSlim();
+        bool earlierReplayApplied = false;
+        GameThread.EnqueueSafe(
+            () =>
+            {
+                earlierReplayStarted.Set();
+                releaseEarlierReplay.Wait();
+                earlierReplayApplied = true;
+            },
+            context: nameof(ReplayBatchAcknowledgement_WaitsForEarlierGameThreadApplicationAndEchoesId));
+
+        try
+        {
+            Assert.True(earlierReplayStarted.Wait(TimeSpan.FromSeconds(5)));
+            TestMessageBroker.Publish(
+                this,
+                new NetworkJoinSync(JoinSyncSignal.ReplayBatchComplete, replayBatchId: 17));
+
+            Assert.False(earlierReplayApplied);
+            Assert.Equal(0, JoinSignalCount(JoinSyncSignal.ReplayBatchApplied));
+        }
+        finally
+        {
+            releaseEarlierReplay.Set();
+        }
+
+        DrainGameThread();
+
+        Assert.True(earlierReplayApplied);
+        NetworkJoinSync acknowledgement = Assert.Single(
+            clientComponent.TestNetwork
+                .GetPeerMessagesFromType<NetworkJoinSync>(clientComponent.TestNetwork.Peers[0]),
+            message => message.Signal == JoinSyncSignal.ReplayBatchApplied);
+        Assert.Equal(17, acknowledgement.ReplayBatchId);
+    }
+
+    [Fact]
+    public void FailedCampaignEntrySend_ReleasesTheFrameDrainLimit()
+    {
+        var container = clientComponent.Container;
+        _ = clientLogic.SetState<LoadingState>();
+        int previousLimitCount = GameThread.Instance.FrameDrainLimitCount;
+        var network = new Mock<INetwork>();
+        network
+            .Setup(value => value.SendAll(It.IsAny<IMessage>()))
+            .Throws<InvalidOperationException>();
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            _ = new CampaignState(
+                clientLogic,
+                container.Resolve<IMessageBroker>(),
+                network.Object,
+                container.Resolve<ILoadingInterface>(),
+                container.Resolve<IGameStateInterface>(),
+                container.Resolve<ICoopFinalizer>(),
+                container.Resolve<IMapTimeTrackerInterface>());
+        });
+
+        Assert.Equal(previousLimitCount, GameThread.Instance.FrameDrainLimitCount);
+    }
+
+    [Fact]
+    public void LeavingAJoiningCampaign_ReleasesTheFrameDrainLimit()
+    {
+        int previousLimitCount = GameThread.Instance.FrameDrainLimitCount;
+        _ = clientLogic.SetState<LoadingState>();
+        _ = clientLogic.SetState<CampaignState>();
+        Assert.Equal(previousLimitCount + 1, GameThread.Instance.FrameDrainLimitCount);
+
+        _ = clientLogic.SetState<MainMenuState>();
+
+        Assert.Equal(previousLimitCount, GameThread.Instance.FrameDrainLimitCount);
     }
 
     [Fact]

--- a/source/Coop.Tests/Mocks/TestNetwork.cs
+++ b/source/Coop.Tests/Mocks/TestNetwork.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace Coop.Tests.Mocks;
 
-public class TestNetwork : INetwork
+public class TestNetwork : INetwork, IBufferedNetwork
 {
     public INetworkConfig Config => throw new NotImplementedException();
 
@@ -117,6 +117,9 @@ public class TestNetwork : INetwork
             Send(peer, message);
         }
     }
+
+    public List<NetPeer> DiscardedPeers { get; } = new();
+    public void DiscardPendingMessages(NetPeer peer) => DiscardedPeers.Add(peer);
 
     public void FlushPendingMessages()
     {

--- a/source/Coop.Tests/Network/CoopNetworkBaseTests.cs
+++ b/source/Coop.Tests/Network/CoopNetworkBaseTests.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Network;
 using Common.PacketHandlers;
 using Common.Serialization;
+using Coop.Tests.Extensions;
 using Coop.Core.Common.Network;
 using LiteNetLib;
 using Moq;
@@ -33,6 +34,27 @@ public class CoopNetworkBaseTests
             sessionCancellation);
 
         Assert.Equal(60_000, network.AppliedDisconnectTimeout);
+    }
+
+    [Fact]
+    public void DiscardPendingMessages_RemovesOnlyTheAbortedPeersBufferedPayload()
+    {
+        var config = Mock.Of<INetworkConfig>();
+        var serializer = Mock.Of<ICommonSerializer>();
+        var batcher = new ReliableMessageBatcher<NetPeer>(serializer);
+        using var cancellation = new CancellationTokenSource();
+        using var network = new TestNetwork(config, serializer, batcher, cancellation);
+        var peers = new Mocks.TestNetwork();
+        var aborted = peers.CreatePeer();
+        var live = peers.CreatePeer();
+        live.Setup(live.Id, "127.0.0.2");
+        var sent = new System.Collections.Generic.List<NetPeer>();
+        batcher.Send(aborted, new byte[] { 1 }, (peer, _) => sent.Add(peer));
+        batcher.Send(live, new byte[] { 2 }, (peer, _) => sent.Add(peer));
+        Assert.Empty(sent);
+        ((IBufferedNetwork)network).DiscardPendingMessages(aborted);
+        batcher.FlushAll(_ => true, (peer, _) => sent.Add(peer));
+        Assert.Same(live, Assert.Single(sent));
     }
 
     private sealed class TestNetwork : CoopNetworkBase

--- a/source/Coop.Tests/Server/Connections/ConnectionMessageQueueMergeTests.cs
+++ b/source/Coop.Tests/Server/Connections/ConnectionMessageQueueMergeTests.cs
@@ -1,4 +1,4 @@
-﻿using Common.Messaging;
+using Common.Messaging;
 using Common.Network;
 using Common.Network.Messages;
 using Common.PacketHandlers;
@@ -126,7 +126,6 @@ public class ConnectionMessageQueueMergeTests
         Assert.Equal(tail, network.GetPeerPayloads(peer).Last());
         Assert.False(queue.TryHandleBroadcast(peer, Item(5)));
     }
-
 
     [Fact]
     public void AbortDisconnectAndSnapshotCuts_DiscardMergeCandidates()

--- a/source/Coop.Tests/Server/Connections/ConnectionMessageQueueMergeTests.cs
+++ b/source/Coop.Tests/Server/Connections/ConnectionMessageQueueMergeTests.cs
@@ -1,0 +1,179 @@
+﻿using Common.Messaging;
+using Common.Network;
+using Common.Network.Messages;
+using Common.PacketHandlers;
+using Common.Serialization;
+using Common.Tests.Utils;
+using Coop.Core.Server.Connections;
+using Coop.Core.Server.Services.ItemRosters.Messages;
+using Coop.Tests.Mocks;
+using GameInterface.Registry.Auto;
+using GameInterface.Services.Workshops.Messages;
+using LiteNetLib;
+using System;
+using System.Linq;
+using TaleWorlds.CampaignSystem.Roster;
+using Xunit;
+
+namespace Coop.Tests.Server.Connections;
+
+/// <summary>Checks safe adjacent merging, replay barriers and queue admission bounds.</summary>
+public class ConnectionMessageQueueMergeTests
+{
+    private readonly TestNetwork network = new();
+    private readonly TestMessageBroker broker = new();
+    private readonly ICommonSerializer serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+
+    private ConnectionMessageQueue Queue(int packets = 100000, long bytes = 128 * 1024 * 1024) =>
+        new(new Lazy<INetwork>(() => network), broker, serializer, packets, bytes);
+
+    private NetPeer Join(ConnectionMessageQueue queue)
+    {
+        var peer = network.CreatePeer();
+        queue.RegisterPeer(peer);
+        queue.BeginQueueing(peer);
+        return peer;
+    }
+
+    private MessagePacket Item(int amount, string roster = "roster", string item = "item", string? modifier = null) =>
+        MessagePacket.Create(new NetworkItemRosterUpdate(roster, item, modifier!, amount), serializer);
+
+    private void Drain(ConnectionMessageQueue queue, NetPeer peer)
+    {
+        while (queue.FlushBatch(peer).HasMore) { }
+    }
+
+    [Fact]
+    public void AdjacentItems_ReduceCountAndBytesWithoutMutatingSharedPackets()
+    {
+        using var queue = Queue();
+        var firstPeer = Join(queue);
+        var secondPeer = Join(queue);
+        var first = Item(1);
+        var next = Item(2);
+        queue.TryHandleBroadcast(firstPeer, first);
+        queue.TryHandleBroadcast(secondPeer, first);
+        queue.TryHandleBroadcast(firstPeer, next);
+
+        Assert.True(queue.TryGetCatchUpPacketsRemaining(firstPeer, out int count));
+        Assert.Equal(1, count);
+        Assert.True(queue.TryGetCatchUpPendingBytes(firstPeer, out long bytes));
+        Assert.Equal(Item(3).Data.Length, bytes);
+        Assert.Equal(1, serializer.Deserialize<NetworkItemRosterUpdate>(first.Data).Amount);
+        Assert.Contains("mergedAdjacent=1", queue.DescribeCatchUp(firstPeer));
+
+        Drain(queue, firstPeer);
+        Drain(queue, secondPeer);
+        Assert.Equal(3, ReadItems(firstPeer).Single().Amount);
+        Assert.Equal(1, ReadItems(secondPeer).Single().Amount);
+        Assert.True(queue.TryGetCatchUpPendingBytes(firstPeer, out bytes));
+        Assert.Equal(0, bytes);
+    }
+
+    [Theory]
+    [InlineData(-1, -1)]
+    [InlineData(-10, -10)]
+    [InlineData(1, -1)]
+    [InlineData(-1, 1)]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    [InlineData(int.MaxValue, 1)]
+    [InlineData(int.MinValue, -1)]
+    public void RemovalsSignChangesZeroAndIntegerOverflow_RemainSeparate(int first, int next)
+    {
+        using var queue = Queue();
+        var peer = Join(queue);
+        queue.TryHandleBroadcast(peer, Item(first));
+        queue.TryHandleBroadcast(peer, Item(next));
+        Drain(queue, peer);
+        Assert.Equal(new[] { first, next }, ReadItems(peer).Select(item => item.Amount));
+    }
+
+    [Fact]
+    public void ClearLifetimeWorkshopAndIdentityChanges_AreOrderedBarriers()
+    {
+        using var queue = Queue();
+        var peer = Join(queue);
+        var packets = new[]
+        {
+            Item(1), Item(2, modifier: "fine"), Item(3, item: "food"), Item(4, roster: "other"),
+            Item(5), MessagePacket.Create(new NetworkItemRosterClear("roster"), serializer), Item(6),
+            MessagePacket.Create(new NetworkDestroyInstance<ItemRoster>("roster"), serializer),
+            MessagePacket.Create(new NetworkCreateInstance<ItemRoster>("roster"), serializer), Item(7),
+            MessagePacket.Create(new AddOutputProgressForTown("workshop", 0.1f), serializer), Item(8)
+        };
+        foreach (var packet in packets) queue.TryHandleBroadcast(peer, packet);
+        Drain(queue, peer);
+        Assert.Equal(packets.Select(packet => packet.Data),
+            network.GetPeerPackets(peer).Cast<MessagePacket>().Select(packet => packet.Data));
+    }
+
+    [Fact]
+    public void FinalBaselineAndDrainedCandidates_DoNotCombineWithLaterTraffic()
+    {
+        using var queue = Queue();
+        var peer = Join(queue);
+        queue.TryHandleBroadcast(peer, Item(1));
+        Drain(queue, peer);
+        queue.TryHandleBroadcast(peer, Item(2));
+        queue.EndFinalBaselineCoverage(peer);
+        queue.TryHandleBroadcast(peer, Item(3));
+        queue.TryHandleBroadcast(peer, Item(4));
+        var tail = new NetworkItemRosterClear("tail");
+        while (queue.OpenWithTailBatch(peer, tail, () => true).HasMore) { }
+
+        Assert.Equal(new[] { 1, 2, 3, 4 }, ReadItems(peer).Select(item => item.Amount));
+        Assert.Equal(tail, network.GetPeerPayloads(peer).Last());
+        Assert.False(queue.TryHandleBroadcast(peer, Item(5)));
+    }
+
+
+    [Fact]
+    public void AbortDisconnectAndSnapshotCuts_DiscardMergeCandidates()
+    {
+        using var queue = Queue();
+        var peer = Join(queue);
+        queue.TryHandleBroadcast(peer, Item(1));
+        queue.TryHandleBroadcast(peer, Item(2));
+        Assert.Equal(1, queue.AbortCatchUp(peer));
+        queue.TryHandleBroadcast(peer, Item(100));
+        queue.BeginQueueing(peer);
+        queue.TryHandleBroadcast(peer, Item(4));
+        queue.BeginQueueing(peer);
+        queue.TryHandleBroadcast(peer, Item(5));
+        Drain(queue, peer);
+        Assert.Equal(new[] { 4, 5 }, ReadItems(peer).Select(item => item.Amount));
+
+        queue.TryHandleBroadcast(peer, Item(6));
+        broker.Publish(this, new PlayerDisconnected(peer, default));
+        queue.RegisterPeer(peer);
+        queue.TryHandleBroadcast(peer, Item(100));
+        queue.BeginQueueing(peer);
+        queue.TryHandleBroadcast(peer, Item(7));
+        Drain(queue, peer);
+        Assert.Equal(new[] { 4, 5, 7 }, ReadItems(peer).Select(item => item.Amount));
+    }
+
+    [Fact]
+    public void MergingAtPacketLimit_StillHonorsByteOverflowAndRetainsValidPrefix()
+    {
+        var first = Item(1);
+        using var queue = Queue(packets: 1, bytes: first.Data.Length);
+        var peer = Join(queue);
+        queue.TryHandleBroadcast(peer, first);
+        queue.TryHandleBroadcast(peer, Item(1));
+        Assert.False(queue.HasCatchUpOverflowed(peer));
+        queue.TryHandleBroadcast(peer, Item(int.MaxValue - 2));
+        Assert.True(queue.HasCatchUpOverflowed(peer));
+        queue.TryHandleBroadcast(peer, Item(1));
+        var result = queue.OpenWithTailBatch(peer, new NetworkItemRosterClear("tail"), () => true);
+        Assert.True(result.Overflowed);
+        Assert.Equal(2, ReadItems(peer).Single().Amount);
+        Assert.DoesNotContain(network.ImmediateSends, send => send.Payload is IMessage);
+    }
+
+    private NetworkItemRosterUpdate[] ReadItems(NetPeer peer) =>
+        network.GetPeerPackets(peer).Cast<MessagePacket>()
+            .Where(packet => packet.MessageType == typeof(NetworkItemRosterUpdate))
+            .Select(packet => serializer.Deserialize<NetworkItemRosterUpdate>(packet.Data)).ToArray();
+}

--- a/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
+++ b/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
@@ -51,6 +51,11 @@ public class ConnectionMessageQueueTests
 
     private bool NothingSentTo(NetPeer peer) => network.SentPayloads.ContainsKey(peer.Id) == false;
 
+    private void Drain(NetPeer peer)
+    {
+        while (queue.FlushBatch(peer).HasMore) { }
+    }
+
     [Fact]
     public void PeerVisibleBeforePlayerConnected_DropsWorldBroadcasts()
     {
@@ -94,7 +99,7 @@ public class ConnectionMessageQueueTests
         // Held, not sent, while the peer loads.
         Assert.True(NothingSentTo(peer));
 
-        queue.FlushBatch(peer);
+        Drain(peer);
 
         Assert.Equal(new IPacket[] { first, second, third }, network.GetPeerPackets(peer));
 
@@ -130,7 +135,7 @@ public class ConnectionMessageQueueTests
         Assert.True(queue.TryGetCatchUpPacketsRemaining(peer, out int queued));
         Assert.Equal(7, queued);
 
-        queue.FlushBatch(peer);
+        Drain(peer);
         Assert.True(queue.TryGetCatchUpPacketsRemaining(peer, out int draining));
         Assert.Equal(5, draining);
 

--- a/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
+++ b/source/Coop.Tests/Server/Connections/ConnectionMessageQueueTests.cs
@@ -11,6 +11,7 @@ using Coop.Tests.Mocks;
 using LiteNetLib;
 using System;
 using Xunit;
+using Moq;
 
 namespace Coop.Tests.Server.Connections;
 
@@ -22,7 +23,9 @@ public class ConnectionMessageQueueTests
 
     public ConnectionMessageQueueTests()
     {
-        queue = new ConnectionMessageQueue(new Lazy<INetwork>(() => network), messageBroker);
+        var serializer = new Mock<ICommonSerializer>();
+        serializer.Setup(value => value.Serialize(It.IsAny<object>())).Returns(new byte[16]);
+        queue = new ConnectionMessageQueue(new Lazy<INetwork>(() => network), messageBroker, serializer.Object);
     }
 
     /// <summary>Minimal broadcast packet stub.</summary>
@@ -69,7 +72,7 @@ public class ConnectionMessageQueueTests
         // Dropping phase: the queue takes the packet (true) but discards it — it is already in the save.
         Assert.True(queue.TryHandleBroadcast(peer, new FakePacket()));
 
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
 
         // The dropped packet is never replayed.
         Assert.True(NothingSentTo(peer));
@@ -91,7 +94,7 @@ public class ConnectionMessageQueueTests
         // Held, not sent, while the peer loads.
         Assert.True(NothingSentTo(peer));
 
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
 
         Assert.Equal(new IPacket[] { first, second, third }, network.GetPeerPackets(peer));
 
@@ -108,7 +111,7 @@ public class ConnectionMessageQueueTests
 
         Assert.False(queue.TryHandleBroadcast(peer, new FakeCampaignTimePacket()));
 
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
         Assert.True(NothingSentTo(peer));
     }
 
@@ -127,11 +130,11 @@ public class ConnectionMessageQueueTests
         Assert.True(queue.TryGetCatchUpPacketsRemaining(peer, out int queued));
         Assert.Equal(7, queued);
 
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
         Assert.True(queue.TryGetCatchUpPacketsRemaining(peer, out int draining));
         Assert.Equal(5, draining);
 
-        queue.OpenWithTail(peer, new NetworkJoinSync(JoinSyncSignal.WorldReady));
+        queue.OpenWithTailBatch(peer, new NetworkJoinSync(JoinSyncSignal.WorldReady), () => true);
         Assert.True(queue.TryGetCatchUpPacketsRemaining(peer, out int opened));
         Assert.Equal(5, opened);
 
@@ -163,7 +166,7 @@ public class ConnectionMessageQueueTests
         Assert.True(queue.TryHandleBroadcast(peer, held));
         Assert.True(NothingSentTo(peer));
 
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
         Assert.Equal(new IPacket[] { held }, network.GetPeerPackets(peer));
     }
 
@@ -172,14 +175,14 @@ public class ConnectionMessageQueueTests
     {
         var peer = Connect();
         queue.BeginQueueing(peer);
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
 
         var held = new FakePacket();
         Assert.True(queue.TryHandleBroadcast(peer, held));
         Assert.True(NothingSentTo(peer));
 
         var marker = new NetworkJoinSync(JoinSyncSignal.WorldReady);
-        queue.OpenWithTail(peer, marker);
+        queue.OpenWithTailBatch(peer, marker, () => true);
 
         Assert.Equal(new object[] { held, marker }, network.GetPeerPayloads(peer));
         Assert.False(queue.TryHandleBroadcast(peer, new FakePacket()));
@@ -193,13 +196,13 @@ public class ConnectionMessageQueueTests
 
         var beforeFlush = new FakePacket();
         queue.TryHandleBroadcast(peer, beforeFlush);
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
 
         var afterFlush = new FakePacket();
         queue.TryHandleBroadcast(peer, afterFlush);
 
         var marker = new NetworkJoinSync(JoinSyncSignal.WorldReady);
-        queue.OpenWithTail(peer, marker);
+        queue.OpenWithTailBatch(peer, marker, () => true);
 
         var live = new FakePacket();
         Assert.False(queue.TryHandleBroadcast(peer, live));
@@ -221,7 +224,7 @@ public class ConnectionMessageQueueTests
 
         // A late send cannot revive or replay the disconnected peer's held world stream.
         Assert.True(queue.TryHandleBroadcast(peer, new FakePacket()));
-        queue.Flush(peer);
+        queue.FlushBatch(peer);
         Assert.True(NothingSentTo(peer));
     }
 
@@ -232,10 +235,10 @@ public class ConnectionMessageQueueTests
         queue.BeginQueueing(disconnected);
         messageBroker.Publish(this, new PlayerDisconnected(disconnected, default));
 
-        queue.OpenWithTail(disconnected, new NetworkJoinSync(JoinSyncSignal.WorldReady));
+        queue.OpenWithTailBatch(disconnected, new NetworkJoinSync(JoinSyncSignal.WorldReady), () => true);
 
         var reconnected = Connect();
-        queue.OpenWithTail(disconnected, new NetworkJoinSync(JoinSyncSignal.WorldReady));
+        queue.OpenWithTailBatch(disconnected, new NetworkJoinSync(JoinSyncSignal.WorldReady), () => true);
 
         Assert.True(queue.TryHandleBroadcast(reconnected, new FakePacket()));
         Assert.True(NothingSentTo(disconnected));
@@ -275,7 +278,7 @@ public class ConnectionMessageQueueTests
 
         var joined = Connect();
         queue.BeginQueueing(joined);
-        queue.OpenWithTail(joined, new NetworkJoinSync(JoinSyncSignal.WorldReady));
+        queue.OpenWithTailBatch(joined, new NetworkJoinSync(JoinSyncSignal.WorldReady), () => true);
         queue.CompleteCatchUp(joined);
 
         Assert.True(queue.TryHandleBroadcast(loading, new FakePacket()));  // held

--- a/source/Coop.Tests/Server/Connections/JoinPeerTerminatorTests.cs
+++ b/source/Coop.Tests/Server/Connections/JoinPeerTerminatorTests.cs
@@ -1,0 +1,126 @@
+﻿using Common.Network;
+using Common.PacketHandlers;
+using Common.Serialization;
+using Common.Tests.Utils;
+using Coop.Core.Client;
+using Coop.Core.Client.Messages;
+using Coop.Core.Client.Services.Connection.Handlers;
+using Coop.Core.Common;
+using Coop.Core.Server.Connections;
+using GameInterface.Services.GameState.Interfaces;
+using LiteNetLib;
+using Moq;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using Xunit;
+
+namespace Coop.Tests.Server.Connections;
+
+/// <summary>Verifies that server join failures reach the client disconnect popup over the transport.</summary>
+public class JoinPeerTerminatorTests
+{
+    [Theory]
+    [InlineData(
+        "JoinReplayAppliedTimeout",
+        "Joining the campaign timed out while synchronizing.\n" +
+        "The server stopped this join to keep the campaign responsive. Please try again.")]
+    [InlineData(
+        "JoinReplayQueueLimit",
+        "Joining the campaign stopped because its synchronization queue exceeded the safety limit.\n" +
+        "Please try again.")]
+    [InlineData(
+        "JoinCampaignEntryTimeout",
+        "Joining the campaign timed out while loading the transferred save.\n" +
+        "The server stopped this join to keep the campaign responsive. Please try again.")]
+    public void Disconnect_DeliversReasonThroughClientBeforeFinalizing(
+        string code,
+        string expectedMessage)
+    {
+        RunDisconnect(peer => new JoinPeerTerminator().Disconnect(peer, code), code, expectedMessage);
+    }
+
+    [Theory]
+    [InlineData(new byte[0])]
+    [InlineData(new byte[] { 20 })]
+    [InlineData(new byte[] { 20, 0, 1 })]
+    public void Disconnect_MissingOrMalformedReasonUsesGenericPopup(byte[] data)
+    {
+        RunDisconnect(peer => peer.Disconnect(data), null, "You have been Disconnected");
+    }
+
+    [Fact]
+    public void Disconnect_UnknownReasonUsesGenericPopup()
+    {
+        RunDisconnect(peer => new JoinPeerTerminator().Disconnect(peer, "UnknownReason"),
+            "UnknownReason", "You have been Disconnected");
+    }
+
+    private static void RunDisconnect(Action<NetPeer> disconnect, string? expectedReason, string expectedMessage)
+    {
+        using var broker = new TestMessageBroker();
+        var gameState = new Mock<IGameStateInterface>(MockBehavior.Strict);
+        var finalizer = new Mock<ICoopFinalizer>(MockBehavior.Strict);
+        var sequence = new MockSequence();
+        gameState.InSequence(sequence).Setup(value => value.GoToMainMenu());
+        finalizer.InSequence(sequence).Setup(value => value.Finalize(expectedMessage));
+        using var handler = new DisconnectHandler(broker, finalizer.Object, gameState.Object);
+
+        var config = new Mock<INetworkConfig>();
+        config.SetupGet(value => value.DisconnectTimeout).Returns(TimeSpan.FromSeconds(5));
+        config.SetupGet(value => value.UpdateTime).Returns(TimeSpan.FromMilliseconds(15));
+        config.SetupGet(value => value.NetworkPollInterval).Returns(TimeSpan.FromMilliseconds(25));
+        using var cancellation = new CancellationTokenSource();
+        using var client = new CoopClient(config.Object, broker, Mock.Of<IPacketManager>(),
+            Mock.Of<IMessagePacketHandler>(), Mock.Of<ICommonSerializer>(),
+            Mock.Of<IReliableMessageBatcher<NetPeer>>(), cancellation);
+        var serverListener = new EventBasedNetListener();
+        serverListener.ConnectionRequestEvent += request => request.AcceptIfKey("join-disconnect-test");
+        NetPeer? serverPeer = null;
+        serverListener.PeerConnectedEvent += peer => serverPeer = peer;
+        var serverTransport = new NetManager(serverListener);
+        var clientTransport = new NetManager(client);
+
+        try
+        {
+            Assert.True(serverTransport.StartInManualMode(0));
+            Assert.True(clientTransport.StartInManualMode(0));
+            clientTransport.Connect(IPAddress.Loopback.ToString(), serverTransport.LocalPort, "join-disconnect-test");
+            PumpUntil(serverTransport, clientTransport, () =>
+                serverPeer != null && broker.GetMessagesFromType<NetworkConnected>().Any());
+
+            disconnect(serverPeer!);
+
+            PumpUntil(serverTransport, clientTransport, () =>
+                broker.GetMessagesFromType<NetworkDisconnected>().Any());
+            var disconnected = Assert.Single(broker.GetMessagesFromType<NetworkDisconnected>());
+            Assert.Equal(DisconnectReason.RemoteConnectionClose, disconnected.DisconnectInfo.Reason);
+            Assert.Equal(expectedReason, disconnected.ServerReason);
+            Assert.True(disconnected.DisconnectInfo.AdditionalData.IsNull);
+            gameState.Verify(value => value.GoToMainMenu(), Times.Once);
+            finalizer.Verify(value => value.Finalize(expectedMessage), Times.Once);
+        }
+        finally
+        {
+            clientTransport.Stop();
+            serverTransport.Stop();
+        }
+    }
+
+    private static void PumpUntil(NetManager server, NetManager client, Func<bool> complete)
+    {
+        var timer = Stopwatch.StartNew();
+        while (!complete() && timer.Elapsed < TimeSpan.FromSeconds(5))
+        {
+            server.ManualUpdate(15);
+            client.ManualUpdate(15);
+            server.PollEvents();
+            client.PollEvents();
+            Thread.Sleep(1);
+        }
+
+        Assert.True(complete(), "The bounded loopback join disconnect did not finish.");
+    }
+}

--- a/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
+++ b/source/Coop.Tests/Server/Connections/States/LoadingStateTests.cs
@@ -2,14 +2,14 @@
 using Common;
 using Common.Messaging;
 using Common.Network;
-using Common.Network.Coalescing;
 using Common.Network.Messages;
+using Common.Network.Coalescing;
 using Coop.Core.Server.Connections;
 using Coop.Core.Server.Connections.Messages;
 using Coop.Core.Server.Connections.States;
+using Coop.Core.Server.Services.MobileParties;
 using Coop.Core.Server.Services.Kingdoms;
 using Coop.Core.Server.Services.Kingdoms.Messages;
-using Coop.Core.Server.Services.MobileParties;
 using Coop.Core.Server.Services.MobileParties.Messages;
 using Coop.Tests.Extensions;
 using Coop.Tests.Mocks;
@@ -18,8 +18,10 @@ using GameInterface.Services.MobileParties.Data;
 using LiteNetLib;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -108,12 +110,8 @@ namespace Coop.Tests.Server.Connections.States
             Assert.Equal(0, SignalCount(JoinSyncSignal.WorldReady));
             SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
             Assert.Equal(1, SignalCount(JoinSyncSignal.WorldReady));
-            Assert.Empty(serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignSynchronized>());
             Assert.IsType<LoadingState>(connectionLogic.State);
             SendAndDrain(state, JoinSyncSignal.CatchUpApplied);
-            var synchronized = Assert.Single(
-                serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignSynchronized>());
-            Assert.Same(playerPeer, synchronized.PlayerId);
             Assert.IsType<CampaignState>(connectionLogic.State);
         }
 
@@ -135,6 +133,45 @@ namespace Coop.Tests.Server.Connections.States
 
             Assert.False(serverComponent.TestNetwork.SentNetworkMessages.ContainsKey(playerPeer.Id));
             Assert.IsType<LoadingState>(connectionLogic.State);
+        }
+
+        [Fact]
+        public void PlayerCampaignEntered_ReusedPeerIdentityCannotAdvanceOldConnection()
+        {
+            var currentState = connectionLogic.SetState<LoadingState>();
+            var replacementPeer = serverComponent.TestNetwork.CreatePeer();
+            replacementPeer.SetId(playerPeer.Id);
+            Assert.NotSame(playerPeer, replacementPeer);
+            Assert.Equal(playerPeer, replacementPeer);
+
+            currentState.PlayerCampaignEnteredHandler(
+                new MessagePayload<NetworkPlayerCampaignEntered>(
+                    replacementPeer,
+                    new NetworkPlayerCampaignEntered()));
+            DrainGameThread();
+
+            Assert.True(currentState.IsPreEntryPending);
+            Assert.Empty(serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignEntered>());
+        }
+
+        [Fact]
+        public void JoinSync_ReusedPeerIdentityCannotAdvanceOldConnection()
+        {
+            var currentState = connectionLogic.SetState<LoadingState>();
+            StartReplay(currentState);
+            var replacementPeer = serverComponent.TestNetwork.CreatePeer();
+            replacementPeer.SetId(playerPeer.Id);
+            Assert.NotSame(playerPeer, replacementPeer);
+            Assert.Equal(playerPeer, replacementPeer);
+
+            currentState.JoinSyncHandler(
+                new MessagePayload<NetworkJoinSync>(
+                    replacementPeer,
+                    new NetworkJoinSync(JoinSyncSignal.ReplayApplied)));
+            DrainGameThread();
+
+            Assert.True(currentState.IsWaitingForReplayApplied);
+            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Never);
         }
 
         [Fact]
@@ -161,51 +198,206 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
-        public void ReplayApplied_SendsKingdomBaselineAfterReplayMarker()
+        public void OversizedReplayBatch_WaitsForMatchingClientApplicationAcknowledgement()
         {
-            var state = connectionLogic.SetState<LoadingState>();
-            kingdomBaselineSender
-                .Setup(sender => sender.Send(playerPeer))
-                .Callback(() => serverComponent.TestNetwork.SendImmediate(
-                    playerPeer,
-                    new NetworkJoinCampaignKingdomBaseline(Array.Empty<PendingAllianceOfferBaseline>(), Array.Empty<PendingPeaceOfferBaseline>())));
-            StartReplay(state);
-            var beforeAck = serverComponent.TestNetwork.GetPeerMessages(playerPeer).ToArray();
-            Assert.DoesNotContain(beforeAck, message => message is NetworkJoinCampaignKingdomBaseline);
-            SendAndDrain(state, JoinSyncSignal.ReplayApplied);
-            Assert.Contains(
-                serverComponent.TestNetwork.GetPeerMessages(playerPeer),
-                message => message is NetworkJoinCampaignKingdomBaseline);
+            var connectionLogicMock = new Mock<IConnectionLogic>();
+            var networkMock = new Mock<INetwork>();
+            var queueMock = new Mock<IConnectionMessageQueue>();
+            var coalescerMock = new Mock<ISendCoalescer>();
+            var sentSignals = new List<NetworkJoinSync>();
+            connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
+            queueMock
+                .SetupSequence(queue => queue.FlushBatch(playerPeer))
+                .Returns(new JoinReplayBatchResult(1, NetworkJoinLimits.MaxReplayBatchBytes + 1, hasMore: true))
+                .Returns(new JoinReplayBatchResult(5, 500, hasMore: false));
+            networkMock
+                .Setup(network => network.SendImmediate(playerPeer, It.IsAny<IMessage>()))
+                .Callback<NetPeer, IMessage>((_, message) =>
+                {
+                    if (message is NetworkJoinSync signal) sentSignals.Add(signal);
+                });
+
+            var state = new LoadingState(
+                connectionLogicMock.Object,
+                serverComponent.TestMessageBroker,
+                networkMock.Object,
+                baselineSender.Object,
+                kingdomBaselineSender.Object,
+                queueMock.Object,
+                coalescerMock.Object);
+            connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
+
+            CampaignEntered(state);
+            DrainGameThread();
+
+            NetworkJoinSync firstBatch = Assert.Single(
+                sentSignals,
+                signal => signal.Signal == JoinSyncSignal.ReplayBatchComplete);
+            Assert.True(firstBatch.ReplayBatchId > 0);
+            Assert.DoesNotContain(
+                sentSignals,
+                signal => signal.Signal == JoinSyncSignal.ReplayComplete);
+            long progressBeforeAcknowledgement = state.JoinProgressVersion;
+
+            Signal(state, JoinSyncSignal.ReplayBatchApplied, firstBatch.ReplayBatchId + 1);
+            DrainGameThread();
+            queueMock.Verify(queue => queue.FlushBatch(playerPeer), Times.Once);
+            Assert.Equal(progressBeforeAcknowledgement, state.JoinProgressVersion);
+
+            Signal(state, JoinSyncSignal.ReplayBatchApplied, firstBatch.ReplayBatchId);
+            DrainGameThread();
+
+            queueMock.Verify(queue => queue.FlushBatch(playerPeer), Times.Exactly(2));
+            Assert.Equal(progressBeforeAcknowledgement + 1, state.JoinProgressVersion);
+            Assert.Single(sentSignals, signal => signal.Signal == JoinSyncSignal.ReplayComplete);
+
+            Signal(state, JoinSyncSignal.ReplayBatchApplied, firstBatch.ReplayBatchId);
+            DrainGameThread();
+            queueMock.Verify(queue => queue.FlushBatch(playerPeer), Times.Exactly(2));
+            Assert.Equal(progressBeforeAcknowledgement + 1, state.JoinProgressVersion);
+            state.Dispose();
         }
 
         [Fact]
-        public void KingdomBaseline_SentAlongsidePartyBaselineThroughFullJoinHandshake()
+        public void ReplayBatchReplyDuringMarkerSend_DoesNotContinueRecursively()
         {
-            var state = connectionLogic.SetState<LoadingState>();
-            StartReplay(state);
-            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Never);
+            var connectionLogicMock = new Mock<IConnectionLogic>();
+            var networkMock = new Mock<INetwork>();
+            var queueMock = new Mock<IConnectionMessageQueue>();
+            var coalescerMock = new Mock<ISendCoalescer>();
+            int flushCalls = 0;
+            connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
+            queueMock
+                .SetupSequence(queue => queue.FlushBatch(playerPeer))
+                .Returns(() =>
+                {
+                    flushCalls++;
+                    return new JoinReplayBatchResult(10, 1000, hasMore: true);
+                })
+                .Returns(() =>
+                {
+                    flushCalls++;
+                    return new JoinReplayBatchResult(5, 500, hasMore: false);
+                });
 
-            SendAndDrain(state, JoinSyncSignal.ReplayApplied);
-            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Once);
-            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Once);
+            LoadingState state = null!;
+            networkMock
+                .Setup(network => network.SendImmediate(playerPeer, It.IsAny<IMessage>()))
+                .Callback<NetPeer, IMessage>((_, message) =>
+                {
+                    if (message is NetworkJoinSync
+                        {
+                            Signal: JoinSyncSignal.ReplayBatchComplete,
+                        } batch)
+                    {
+                        Signal(state, JoinSyncSignal.ReplayBatchApplied, batch.ReplayBatchId);
+                        Assert.Equal(1, flushCalls);
+                    }
+                });
+            state = new LoadingState(
+                connectionLogicMock.Object,
+                serverComponent.TestMessageBroker,
+                networkMock.Object,
+                baselineSender.Object,
+                kingdomBaselineSender.Object,
+                queueMock.Object,
+                coalescerMock.Object);
+            connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
 
-            Signal(state, JoinSyncSignal.BaselineApplied);
-            Signal(state, JoinSyncSignal.FinalBaselineApplied);
+            CampaignEntered(state);
             DrainGameThread();
-            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
-            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
-            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(3));
-            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(3));
 
+            DrainGameThread();
+            Assert.Equal(2, flushCalls);
+            networkMock.Verify(
+                network => network.SendImmediate(
+                    playerPeer,
+                    It.Is<NetworkJoinSync>(message => message.Signal == JoinSyncSignal.ReplayComplete)),
+                Times.Once);
+            state.Dispose();
+        }
+
+        [Fact]
+        public void ReplayBatches_GateFinalBaselineAndWorldReadyContinuations()
+        {
+            var connectionLogicMock = new Mock<IConnectionLogic>();
+            var networkMock = new Mock<INetwork>();
+            var queueMock = new Mock<IConnectionMessageQueue>();
+            var coalescerMock = new Mock<ISendCoalescer>();
+            var senderMock = new Mock<IJoinCampaignBaselineSender>();
+            var sentSignals = new List<NetworkJoinSync>();
+            int openCalls = 0;
+            connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
+            queueMock
+                .SetupSequence(queue => queue.FlushBatch(playerPeer))
+                .Returns(default(JoinReplayBatchResult)) // initial replay
+                .Returns(default(JoinReplayBatchResult)) // first baseline
+                .Returns(default(JoinReplayBatchResult)) // refreshed baseline
+                .Returns(new JoinReplayBatchResult(1, NetworkJoinLimits.MaxReplayBatchBytes + 1, hasMore: true))
+                .Returns(default(JoinReplayBatchResult));
+            queueMock
+                .Setup(queue => queue.OpenWithTailBatch(
+                    playerPeer,
+                    It.IsAny<IMessage>(),
+                    It.IsAny<Func<bool>>()))
+                .Returns((NetPeer _, IMessage marker, Func<bool> tryBeginOpen) =>
+                {
+                    if (++openCalls == 1)
+                        return new JoinReplayBatchResult(1, NetworkJoinLimits.MaxReplayBatchBytes + 1, hasMore: true);
+                    if (tryBeginOpen()) networkMock.Object.SendImmediate(playerPeer, marker);
+                    return default;
+                });
+            networkMock
+                .Setup(network => network.SendImmediate(playerPeer, It.IsAny<IMessage>()))
+                .Callback<NetPeer, IMessage>((_, message) =>
+                {
+                    if (message is NetworkJoinSync signal) sentSignals.Add(signal);
+                });
+            var state = new LoadingState(
+                connectionLogicMock.Object,
+                serverComponent.TestMessageBroker,
+                networkMock.Object,
+                senderMock.Object,
+                kingdomBaselineSender.Object,
+                queueMock.Object,
+                coalescerMock.Object);
+            connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
+
+            CampaignEntered(state);
+            DrainGameThread();
+            SendAndDrain(state, JoinSyncSignal.ReplayApplied);
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
             SendAndDrain(state, JoinSyncSignal.BaselineApplied);
-            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
-            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
+            Assert.Equal(2, senderMock.Invocations.Count);
+            NetworkJoinSync finalBaselineBatch = sentSignals.Last(
+                signal => signal.Signal == JoinSyncSignal.ReplayBatchComplete);
 
+            Signal(
+                state,
+                JoinSyncSignal.ReplayBatchApplied,
+                finalBaselineBatch.ReplayBatchId);
+            DrainGameThread();
+
+            senderMock.Verify(sender => sender.Send(playerPeer), Times.Exactly(3));
+            queueMock.Verify(queue => queue.EndFinalBaselineCoverage(playerPeer), Times.Once);
             SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
-            // both senders must have fired the same number of times at every step above —
-            // if a future change moves one call out of QueueBaseline, this diverges here.
-            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
-            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
+            Assert.DoesNotContain(
+                sentSignals,
+                signal => signal.Signal == JoinSyncSignal.WorldReady);
+            NetworkJoinSync worldReadyBatch = sentSignals
+                .Where(signal => signal.Signal == JoinSyncSignal.ReplayBatchComplete)
+                .Last();
+            Assert.NotEqual(finalBaselineBatch.ReplayBatchId, worldReadyBatch.ReplayBatchId);
+
+            Signal(state, JoinSyncSignal.ReplayBatchApplied, worldReadyBatch.ReplayBatchId);
+            DrainGameThread();
+
+            Assert.Contains(sentSignals, signal => signal.Signal == JoinSyncSignal.WorldReady);
+            queueMock.Verify(queue => queue.OpenWithTailBatch(
+                playerPeer,
+                It.IsAny<IMessage>(),
+                It.IsAny<Func<bool>>()), Times.Exactly(2));
+            state.Dispose();
         }
 
         [Fact]
@@ -214,7 +406,6 @@ namespace Coop.Tests.Server.Connections.States
             var connectionLogicMock = new Mock<IConnectionLogic>();
             var networkMock = new Mock<INetwork>();
             var baselineSender = new Mock<IJoinCampaignBaselineSender>();
-            var kingdomBaselineSender = new Mock<IJoinCampaignKingdomBaseLineSender>();
             connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
 
             var state = new LoadingState(
@@ -254,6 +445,53 @@ namespace Coop.Tests.Server.Connections.States
         }
 
         [Fact]
+        public void FinalBaseline_EndsCoverageAfterReplayAndImmediatelyBeforeCapture()
+        {
+            var connectionLogicMock = new Mock<IConnectionLogic>();
+            var networkMock = new Mock<INetwork>();
+            var queueMock = new Mock<IConnectionMessageQueue>();
+            var coalescerMock = new Mock<ISendCoalescer>();
+            var senderMock = new Mock<IJoinCampaignBaselineSender>();
+            var calls = new List<string>();
+            connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
+            queueMock
+                .Setup(queue => queue.EndFinalBaselineCoverage(playerPeer))
+                .Callback(() => calls.Add("cut"));
+            queueMock
+                .Setup(queue => queue.FlushBatch(playerPeer))
+                .Callback(() => calls.Add("flush"))
+                .Returns(default(JoinReplayBatchResult));
+            senderMock
+                .Setup(sender => sender.Send(playerPeer))
+                .Callback(() => calls.Add("send"));
+
+            var state = new LoadingState(
+                connectionLogicMock.Object,
+                serverComponent.TestMessageBroker,
+                networkMock.Object,
+                senderMock.Object,
+                kingdomBaselineSender.Object,
+                queueMock.Object,
+                coalescerMock.Object);
+            connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
+
+            StartBaseline(state);
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            queueMock.Verify(
+                queue => queue.EndFinalBaselineCoverage(playerPeer),
+                Times.Never);
+
+            calls.Clear();
+            SendAndDrain(state, JoinSyncSignal.BaselineApplied);
+
+            Assert.Equal(new[] { "flush", "cut", "send" }, calls);
+            queueMock.Verify(
+                queue => queue.EndFinalBaselineCoverage(playerPeer),
+                Times.Once);
+            state.Dispose();
+        }
+
+        [Fact]
         public void BaselineRefreshRequestDuringInitialBaselineSend_IsAccepted()
         {
             var state = connectionLogic.SetState<LoadingState>();
@@ -268,6 +506,56 @@ namespace Coop.Tests.Server.Connections.States
             StartBaseline(state);
             DrainGameThread();
             baselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void BaselineRequestLimit_BoundsFlushAndSendWorkForBrokenClients()
+        {
+            var connectionLogicMock = new Mock<IConnectionLogic>();
+            var networkMock = new Mock<INetwork>();
+            var queueMock = new Mock<IConnectionMessageQueue>();
+            var coalescerMock = new Mock<ISendCoalescer>();
+            var senderMock = new Mock<IJoinCampaignBaselineSender>();
+            connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
+            var state = new LoadingState(
+                connectionLogicMock.Object,
+                serverComponent.TestMessageBroker,
+                networkMock.Object,
+                senderMock.Object,
+                kingdomBaselineSender.Object,
+                queueMock.Object,
+                coalescerMock.Object);
+            connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
+
+            StartBaseline(state);
+            for (int sent = 1; sent < LoadingState.MaxBaselinesPerJoin; sent++)
+            {
+                SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            }
+
+            senderMock.Verify(
+                sender => sender.Send(playerPeer),
+                Times.Exactly(LoadingState.MaxBaselinesPerJoin));
+            coalescerMock.Verify(
+                coalescer => coalescer.Flush(networkMock.Object),
+                Times.Exactly(LoadingState.MaxBaselinesPerJoin + 1));
+            queueMock.Verify(
+                queue => queue.FlushBatch(playerPeer),
+                Times.Exactly(LoadingState.MaxBaselinesPerJoin + 1));
+
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+
+            senderMock.Verify(
+                sender => sender.Send(playerPeer),
+                Times.Exactly(LoadingState.MaxBaselinesPerJoin));
+            coalescerMock.Verify(
+                coalescer => coalescer.Flush(networkMock.Object),
+                Times.Exactly(LoadingState.MaxBaselinesPerJoin + 1));
+            queueMock.Verify(
+                queue => queue.FlushBatch(playerPeer),
+                Times.Exactly(LoadingState.MaxBaselinesPerJoin + 1));
+            Assert.True(state.IsJoinCatchUpPending);
+            state.Dispose();
         }
 
         [Fact]
@@ -293,6 +581,106 @@ namespace Coop.Tests.Server.Connections.States
             Assert.IsType<LoadingState>(connectionLogic.State);
             SendAndDrain(state, JoinSyncSignal.CatchUpApplied);
             Assert.IsType<CampaignState>(connectionLogic.State);
+        }
+
+        [Fact]
+        public void FinalReplayOverflow_DoesNotOpenOrEmitWorldReady()
+        {
+            var connectionLogicMock = new Mock<IConnectionLogic>();
+            var networkMock = new Mock<INetwork>();
+            var queueMock = new Mock<IConnectionMessageQueue>();
+            var coalescerMock = new Mock<ISendCoalescer>();
+            var senderMock = new Mock<IJoinCampaignBaselineSender>();
+            connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
+            queueMock
+                .Setup(queue => queue.OpenWithTailBatch(
+                    playerPeer,
+                    It.IsAny<IMessage>(),
+                    It.IsAny<Func<bool>>()))
+                .Returns(new JoinReplayBatchResult(
+                    packetsSent: 0,
+                    bytesSent: 0,
+                    hasMore: false,
+                    overflowed: true));
+            var state = new LoadingState(
+                connectionLogicMock.Object,
+                serverComponent.TestMessageBroker,
+                networkMock.Object,
+                senderMock.Object,
+                kingdomBaselineSender.Object,
+                queueMock.Object,
+                coalescerMock.Object);
+            connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
+
+            StartBaseline(state);
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            SendAndDrain(state, JoinSyncSignal.BaselineApplied);
+            SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
+
+            networkMock.Verify(
+                network => network.SendImmediate(
+                    playerPeer,
+                    It.Is<NetworkJoinSync>(message => message.Signal == JoinSyncSignal.WorldReady)),
+                Times.Never);
+            connectionLogicMock.Verify(logic => logic.EnterCampaign(), Times.Never);
+            Assert.True(state.IsJoinCatchUpPending);
+            state.Dispose();
+        }
+
+        [Fact]
+        public void PlayerCampaignSynchronized_IsPublishedOnlyAtTheTerminalJoinPhase()
+        {
+            // The trap this guards: the message named PlayerCampaignEntered is published at CampaignEntryQueued,
+            // the SECOND of eleven join phases — before the replay flush and both baselines. Anything that needs the
+            // peer's world to be consistent (resuming a battle it dropped out of) must key off the terminal phase
+            // instead, or it fires five phases early against an unreplicated world.
+            var completions = new List<NetPeer>();
+            serverComponent.TestMessageBroker.Subscribe<PlayerCampaignSynchronized>(
+                payload => completions.Add(payload.What.PlayerId));
+
+            var state = connectionLogic.SetState<LoadingState>();
+
+            CampaignEntered(state);
+            DrainGameThread();
+            Assert.Empty(completions);
+
+            SendAndDrain(state, JoinSyncSignal.ReplayApplied);
+            Assert.Empty(completions);
+
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            Assert.Empty(completions);
+
+            SendAndDrain(state, JoinSyncSignal.BaselineApplied);
+            Assert.Empty(completions);
+
+            SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
+            Assert.Empty(completions);
+
+            SendAndDrain(state, JoinSyncSignal.CatchUpApplied);
+
+            Assert.Equal(new[] { playerPeer }, completions);
+            Assert.IsType<CampaignState>(connectionLogic.State);
+        }
+
+        [Fact]
+        public void PlayerCampaignSynchronized_IsNotPublishedWhenTheJoinIsAbandoned()
+        {
+            var completions = new List<NetPeer>();
+            serverComponent.TestMessageBroker.Subscribe<PlayerCampaignSynchronized>(
+                payload => completions.Add(payload.What.PlayerId));
+
+            var state = connectionLogic.SetState<LoadingState>();
+            StartReplay(state);
+            SendAndDrain(state, JoinSyncSignal.ReplayApplied);
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            SendAndDrain(state, JoinSyncSignal.BaselineApplied);
+            SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
+
+            // The peer drops out of the loading state before the terminal phase applies.
+            connectionLogic.SetState<CampaignState>();
+            SendAndDrain(state, JoinSyncSignal.CatchUpApplied);
+
+            Assert.Empty(completions);
         }
 
         [Fact]
@@ -340,9 +728,114 @@ namespace Coop.Tests.Server.Connections.States
                 connectionLogic.Dispose();
             });
 
-            Assert.Empty(
-                serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignSynchronized>());
             Assert.Null(connectionLogic.State);
+        }
+
+        [Fact]
+        public void AbortedJoin_DoesNotSendQueuedBaseline()
+        {
+            var state = connectionLogic.SetState<LoadingState>();
+            StartReplay(state);
+
+            WhileGameThreadBlocked(() =>
+            {
+                Signal(state, JoinSyncSignal.ReplayApplied);
+                Assert.True(state.TryAbortJoinCatchUp());
+            });
+
+            Assert.True(state.IsAborted);
+            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Never);
+        }
+
+        [Fact]
+        public void PreEntryAbort_CannotAbortAfterReplayPhaseStarts()
+        {
+            var state = connectionLogic.SetState<LoadingState>();
+
+            Assert.True(state.IsPreEntryPending);
+            StartReplay(state);
+
+            Assert.False(state.IsPreEntryPending);
+            Assert.True(state.IsWaitingForReplayApplied);
+            Assert.False(state.TryAbortPreEntryJoin());
+            Assert.False(state.IsAborted);
+        }
+
+        [Fact]
+        public void AbortedJoin_DoesNotOpenQueuedWorldTail()
+        {
+            var state = connectionLogic.SetState<LoadingState>();
+            StartBaseline(state);
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            SendAndDrain(state, JoinSyncSignal.BaselineApplied);
+
+            WhileGameThreadBlocked(() =>
+            {
+                Signal(state, JoinSyncSignal.FinalBaselineApplied);
+                Assert.True(state.TryAbortJoinCatchUp());
+            });
+
+            Assert.True(state.IsAborted);
+            Assert.Equal(0, SignalCount(JoinSyncSignal.WorldReady));
+        }
+
+        [Fact]
+        public async Task WorldTailOpen_AndConcurrentAbortAreSerialized()
+        {
+            var connectionLogicMock = new Mock<IConnectionLogic>();
+            var networkMock = new Mock<INetwork>();
+            var queueMock = new Mock<IConnectionMessageQueue>();
+            var coalescerMock = new Mock<ISendCoalescer>();
+            connectionLogicMock.SetupGet(logic => logic.Peer).Returns(playerPeer);
+            var state = new LoadingState(
+                connectionLogicMock.Object,
+                serverComponent.TestMessageBroker,
+                networkMock.Object,
+                baselineSender.Object,
+                kingdomBaselineSender.Object,
+                queueMock.Object,
+                coalescerMock.Object);
+            connectionLogicMock.SetupGet(logic => logic.State).Returns(state);
+            using var worldReadyFlushEntered = new ManualResetEventSlim(false);
+            using var releaseWorldReadyFlush = new ManualResetEventSlim(false);
+            int blockWorldReadyFlush = 0;
+            coalescerMock
+                .Setup(value => value.Flush(networkMock.Object))
+                .Callback(() =>
+                {
+                    if (Volatile.Read(ref blockWorldReadyFlush) == 0) return;
+                    worldReadyFlushEntered.Set();
+                    releaseWorldReadyFlush.Wait();
+                });
+
+            StartBaseline(state);
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            SendAndDrain(state, JoinSyncSignal.BaselineApplied);
+            Volatile.Write(ref blockWorldReadyFlush, 1);
+            Signal(state, JoinSyncSignal.FinalBaselineApplied);
+            Assert.True(worldReadyFlushEntered.Wait(TimeSpan.FromSeconds(5)));
+
+            Task<bool> abortTask = Task.Run(state.TryAbortJoinCatchUp);
+            try
+            {
+                Assert.False(await abortTask.WaitAsync(TimeSpan.FromSeconds(5)));
+            }
+            finally
+            {
+                releaseWorldReadyFlush.Set();
+            }
+
+            DrainGameThread();
+            Assert.True(state.TryAbortJoinCatchUp());
+            Assert.True(state.IsAborted);
+            queueMock.Verify(
+                value => value.OpenWithTailBatch(
+                    playerPeer,
+                    It.IsAny<IMessage>(),
+                    It.IsAny<Func<bool>>()),
+                Times.Once);
+            connectionLogicMock.Verify(value => value.EnterCampaign(), Times.Never);
+            state.Dispose();
         }
 
         [Fact]
@@ -395,6 +888,54 @@ namespace Coop.Tests.Server.Connections.States
             SendAndDrain(state, JoinSyncSignal.ReplayApplied);
         }
 
+        [Fact]
+        public void ReplayApplied_SendsKingdomBaselineAfterReplayMarker()
+        {
+            var state = connectionLogic.SetState<LoadingState>();
+            kingdomBaselineSender
+                .Setup(sender => sender.Send(playerPeer))
+                .Callback(() => serverComponent.TestNetwork.SendImmediate(
+                    playerPeer,
+                    new NetworkJoinCampaignKingdomBaseline(Array.Empty<PendingAllianceOfferBaseline>(), Array.Empty<PendingPeaceOfferBaseline>())));
+            StartReplay(state);
+            var beforeAck = serverComponent.TestNetwork.GetPeerMessages(playerPeer).ToArray();
+            Assert.DoesNotContain(beforeAck, message => message is NetworkJoinCampaignKingdomBaseline);
+            SendAndDrain(state, JoinSyncSignal.ReplayApplied);
+            Assert.Contains(
+                serverComponent.TestNetwork.GetPeerMessages(playerPeer),
+                message => message is NetworkJoinCampaignKingdomBaseline);
+        }
+
+        [Fact]
+        public void KingdomBaseline_SentAlongsidePartyBaselineThroughFullJoinHandshake()
+        {
+            var state = connectionLogic.SetState<LoadingState>();
+            StartReplay(state);
+            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Never);
+
+            SendAndDrain(state, JoinSyncSignal.ReplayApplied);
+            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Once);
+            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Once);
+
+            Signal(state, JoinSyncSignal.BaselineApplied);
+            Signal(state, JoinSyncSignal.FinalBaselineApplied);
+            DrainGameThread();
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            SendAndDrain(state, JoinSyncSignal.BaselineRequested);
+            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(3));
+            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(3));
+
+            SendAndDrain(state, JoinSyncSignal.BaselineApplied);
+            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
+            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
+
+            SendAndDrain(state, JoinSyncSignal.FinalBaselineApplied);
+            // both senders must have fired the same number of times at every step above —
+            // if a future change moves one call out of QueueBaseline, this diverges here.
+            baselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
+            kingdomBaselineSender.Verify(sender => sender.Send(playerPeer), Times.Exactly(4));
+        }
+
         private void StartReplay(LoadingState state)
         {
             CampaignEntered(state);
@@ -407,15 +948,17 @@ namespace Coop.Tests.Server.Connections.States
             DrainGameThread();
         }
 
-        private void CampaignEntered(LoadingState state, NetPeer peer = null) =>
+        private void CampaignEntered(LoadingState state, NetPeer? peer = null) =>
             state.PlayerCampaignEnteredHandler(
                 new MessagePayload<NetworkPlayerCampaignEntered>(
                     peer ?? playerPeer,
                     new NetworkPlayerCampaignEntered()));
 
-        private void Signal(LoadingState state, JoinSyncSignal signal) =>
+        private void Signal(LoadingState state, JoinSyncSignal signal, int replayBatchId = 0) =>
             state.JoinSyncHandler(
-                new MessagePayload<NetworkJoinSync>(playerPeer, new NetworkJoinSync(signal)));
+                new MessagePayload<NetworkJoinSync>(
+                    playerPeer,
+                    new NetworkJoinSync(signal, replayBatchId)));
 
         private int SignalCount(JoinSyncSignal signal) =>
             serverComponent.TestNetwork

--- a/source/Coop.Tests/Server/Services/Time/OverloadedPeerManagerTests.cs
+++ b/source/Coop.Tests/Server/Services/Time/OverloadedPeerManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Common.Messaging;
+using Common.Network;
 using Common.Network.Messages;
 using Coop.Core.Server.Connections;
 using Coop.Core.Server.Connections.Messages;
@@ -146,7 +147,7 @@ public class OverloadedPeerManagerTests
     }
 
     [Fact]
-    public void InitialJoinCatchUp_PausesAfterTwentySecondsRegardlessOfPacketCount()
+    public void InitialJoinCatchUp_DoesNotPauseAfterTwentySeconds()
     {
         var timeControlMock = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
         var pauseLeaseMock = new Mock<IAutomaticPauseLease>();
@@ -161,24 +162,21 @@ public class OverloadedPeerManagerTests
 
         manager.CheckForOverloadedPeers(startedUtc);
         manager.CheckForOverloadedPeers(
-            startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay - TimeSpan.FromTicks(1));
+            startedUtc + TimeSpan.FromSeconds(20) - TimeSpan.FromTicks(1));
 
         timeControlMock.Verify(
             t => t.ServerAcquireAutomaticPause(),
             Times.Never());
 
-        manager.CheckForOverloadedPeers(startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay);
+        manager.CheckForOverloadedPeers(startedUtc + TimeSpan.FromSeconds(20));
 
         timeControlMock.Verify(
             t => t.ServerAcquireAutomaticPause(),
-            Times.Once());
-        Assert.Contains(
-            serverComponent.TestMessageBroker.GetMessagesFromType<SendInformationMessage>(),
-            message => message.Text == "Game paused; a joining client needs to catch up");
+            Times.Never());
     }
 
     [Fact]
-    public void FinalJoinCatchUp_RemainsPausedUntilCatchUpCompletes()
+    public void FinalJoinCatchUp_DoesNotPauseWhileCatchingUp()
     {
         var timeControlMock = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
         var pauseLeaseMock = new Mock<IAutomaticPauseLease>();
@@ -194,11 +192,11 @@ public class OverloadedPeerManagerTests
 
         peer.SetQueueLength(100);
         manager.CheckForOverloadedPeers(startedUtc);
-        manager.CheckForOverloadedPeers(startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay);
+        manager.CheckForOverloadedPeers(startedUtc + TimeSpan.FromSeconds(20));
 
         peer.SetQueueLength(0);
         manager.CheckForOverloadedPeers(
-            startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay + TimeSpan.FromSeconds(1));
+            startedUtc + TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(1));
 
         pauseLeaseMock.Verify(lease => lease.TryRelease(), Times.Never());
 
@@ -206,13 +204,13 @@ public class OverloadedPeerManagerTests
         SendAndDrain(state, peer, JoinSyncSignal.FinalBaselineApplied);
         SendAndDrain(state, peer, JoinSyncSignal.CatchUpApplied);
         manager.CheckForOverloadedPeers(
-            startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay + TimeSpan.FromSeconds(2));
+            startedUtc + TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(2));
 
-        pauseLeaseMock.Verify(lease => lease.TryRelease(), Times.Once());
+        pauseLeaseMock.Verify(lease => lease.TryRelease(), Times.Never());
     }
 
     [Fact]
-    public void FinalJoinCatchUp_DisconnectResumesPause()
+    public void FinalJoinCatchUp_DisconnectDoesNotChangeTime()
     {
         var timeControlMock = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
         var pauseLeaseMock = new Mock<IAutomaticPauseLease>();
@@ -227,15 +225,15 @@ public class OverloadedPeerManagerTests
         peer.SetQueueLength(NetworkJoinSync.CompletionPacketThreshold + 1);
         DateTime startedUtc = DateTime.UtcNow;
         manager.CheckForOverloadedPeers(startedUtc);
-        manager.CheckForOverloadedPeers(startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay);
+        manager.CheckForOverloadedPeers(startedUtc + TimeSpan.FromSeconds(20));
 
         serverComponent.TestMessageBroker.Publish(
             this,
             new PlayerDisconnected(peer, default));
         manager.CheckForOverloadedPeers(
-            startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay + TimeSpan.FromSeconds(1));
+            startedUtc + TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(1));
 
-        pauseLeaseMock.Verify(lease => lease.TryRelease(), Times.Once());
+        pauseLeaseMock.Verify(lease => lease.TryRelease(), Times.Never());
     }
 
     [Fact]
@@ -252,16 +250,143 @@ public class OverloadedPeerManagerTests
 
         manager.CheckForOverloadedPeers(startedUtc);
         manager.CheckForOverloadedPeers(
-            startedUtc + OverloadedPeerManager.JoinCatchUpPauseDelay + TimeSpan.FromSeconds(1));
+            startedUtc + TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(1));
 
         timeControlMock.Verify(
             t => t.ServerAcquireAutomaticPause(),
             Times.Never());
     }
 
+    [Fact]
+    public void StalledJoin_AbortsAndDiscardsReplayWithoutPausingLivePlayer()
+    {
+        var connections = serverComponent.Container.Resolve<ConnectionCollection>();
+        var manager = (OverloadedPeerManager)serverComponent.Container.Resolve<IOverloadedPeerManager>();
+        var time = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
+        var peer = AddConnectedPeer(connections);
+        var state = StartInitialCatchUp(connections, peer);
+        var started = DateTime.UtcNow;
+        manager.CheckForOverloadedPeers(started);
+        manager.CheckForOverloadedPeers(started + NetworkJoinLimits.ReplayAppliedTimeout);
+
+        Assert.True(state.IsAborted);
+        Assert.Contains(peer, TestNetwork.DiscardedPeers);
+        Assert.False(serverComponent.Container.Resolve<IConnectionMessageQueue>()
+            .TryGetCatchUpPacketsRemaining(peer, out _));
+        time.Verify(value => value.ServerAcquireAutomaticPause(), Times.Never());
+        SendAndDrain(state, peer, JoinSyncSignal.BaselineRequested);
+        Assert.True(state.IsAborted);
+    }
+
+    [Fact]
+    public void JoinApplicationProgress_RenewsOnlyThatPeersWatchdog()
+    {
+        var connections = serverComponent.Container.Resolve<ConnectionCollection>();
+        var manager = (OverloadedPeerManager)serverComponent.Container.Resolve<IOverloadedPeerManager>();
+        var first = AddConnectedPeer(connections);
+        var second = AddConnectedPeer(connections);
+        var progressing = StartInitialCatchUp(connections, first);
+        var stalled = StartInitialCatchUp(connections, second);
+        var started = DateTime.UtcNow;
+        manager.CheckForOverloadedPeers(started);
+        SendAndDrain(progressing, first, JoinSyncSignal.BaselineRequested);
+        manager.CheckForOverloadedPeers(started + NetworkJoinLimits.ReplayAppliedTimeout - TimeSpan.FromSeconds(1));
+        manager.CheckForOverloadedPeers(started + NetworkJoinLimits.ReplayAppliedTimeout);
+        Assert.False(progressing.IsAborted);
+        Assert.True(stalled.IsAborted);
+        serverComponent.Container.Resolve<Mock<ITimeControlInterface>>()
+            .Verify(value => value.ServerAcquireAutomaticPause(), Times.Never());
+    }
+
+    [Fact]
+    public void LoadingJoin_DoesNotPreventLiveOverloadPauseFromReleasing()
+    {
+        var connections = serverComponent.Container.Resolve<ConnectionCollection>();
+        var manager = (OverloadedPeerManager)serverComponent.Container.Resolve<IOverloadedPeerManager>();
+        var time = serverComponent.Container.Resolve<Mock<ITimeControlInterface>>();
+        var lease = new Mock<IAutomaticPauseLease>();
+        lease.Setup(value => value.TryRelease()).Returns(true);
+        time.Setup(value => value.ServerAcquireAutomaticPause()).Returns(lease.Object);
+        var joining = AddConnectedPeer(connections);
+        var live = AddConnectedPeer(connections);
+        StartInitialCatchUp(connections, joining);
+        live.SetQueueLength(AbovePauseThreshold);
+        var started = DateTime.UtcNow;
+        manager.CheckForOverloadedPeers(started);
+        live.SetQueueLength(BelowResumeThreshold);
+        manager.CheckForOverloadedPeers(started + TimeSpan.FromSeconds(25));
+        time.Verify(value => value.ServerAcquireAutomaticPause(), Times.Once());
+        lease.Verify(value => value.TryRelease(), Times.Once());
+    }
+
+    [Fact]
+    public void PreEntryBacklog_ExpiresAtDeadlineWithoutPausingAndRejectsLateEntry()
+    {
+        var connections = serverComponent.Container.Resolve<ConnectionCollection>();
+        var peer = AddConnectedPeer(connections);
+        var state = connections.ConnectionStates[peer].SetState<LoadingState>();
+        var queue = new Mock<IConnectionMessageQueue>();
+        int heldPackets = AbovePauseThreshold;
+        queue.Setup(value => value.TryGetCatchUpPacketsRemaining(peer, out heldPackets)).Returns(true);
+        var terminator = new Mock<IJoinPeerTerminator>();
+        using var manager = CreateWatchdog(queue.Object, terminator.Object);
+        var started = DateTime.UtcNow;
+        manager.CheckForOverloadedPeers(started);
+        manager.CheckForOverloadedPeers(started + NetworkJoinLimits.CampaignEntryTimeout - TimeSpan.FromTicks(1));
+        Assert.False(state.IsAborted);
+        terminator.Verify(value => value.Disconnect(peer, It.IsAny<string>()), Times.Never());
+        manager.CheckForOverloadedPeers(started + NetworkJoinLimits.CampaignEntryTimeout);
+        AssertAbortedBeforeEntry(state, peer);
+        queue.Verify(value => value.AbortCatchUp(peer), Times.Once());
+        terminator.Verify(value => value.Disconnect(peer, "JoinCampaignEntryTimeout"), Times.Once());
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void PreEntrySafetyLimit_AbortsImmediatelyAndRejectsLateEntry(bool overflowed, bool bytesExceeded)
+    {
+        var connections = serverComponent.Container.Resolve<ConnectionCollection>();
+        var peer = AddConnectedPeer(connections);
+        var state = connections.ConnectionStates[peer].SetState<LoadingState>();
+        var queue = new Mock<IConnectionMessageQueue>();
+        int heldPackets = 1;
+        long pendingBytes = bytesExceeded ? NetworkJoinLimits.MaxReplayPendingBytes + 1 : 16;
+        queue.Setup(value => value.TryGetCatchUpPacketsRemaining(peer, out heldPackets)).Returns(true);
+        queue.Setup(value => value.TryGetCatchUpPendingBytes(peer, out pendingBytes)).Returns(true);
+        queue.Setup(value => value.HasCatchUpOverflowed(peer)).Returns(overflowed);
+        var terminator = new Mock<IJoinPeerTerminator>();
+        using var manager = CreateWatchdog(queue.Object, terminator.Object);
+        manager.CheckForOverloadedPeers(DateTime.UtcNow);
+        AssertAbortedBeforeEntry(state, peer);
+        queue.Verify(value => value.AbortCatchUp(peer), Times.Once());
+        terminator.Verify(value => value.Disconnect(peer, "JoinReplayQueueLimit"), Times.Once());
+    }
+
+    private OverloadedPeerManager CreateWatchdog(IConnectionMessageQueue queue, IJoinPeerTerminator terminator) =>
+        new(serverComponent.Container.Resolve<INetworkConfig>(), TestMessageBroker,
+            new Lazy<INetwork>(() => TestNetwork),
+            serverComponent.Container.Resolve<ITimeControlInterface>(),
+            serverComponent.Container.Resolve<IConnectionCollection>(), queue, terminator);
+
+    private IMessageBroker TestMessageBroker => serverComponent.TestMessageBroker;
+
+    private void AssertAbortedBeforeEntry(LoadingState state, LiteNetLib.NetPeer peer)
+    {
+        Assert.True(state.IsAborted);
+        state.PlayerCampaignEnteredHandler(
+            new MessagePayload<NetworkPlayerCampaignEntered>(peer, new NetworkPlayerCampaignEntered()));
+        DrainGameThread();
+        Assert.True(state.IsAborted);
+        Assert.Empty(serverComponent.TestMessageBroker.GetMessagesFromType<PlayerCampaignEntered>());
+        serverComponent.Container.Resolve<Mock<ITimeControlInterface>>()
+            .Verify(value => value.ServerAcquireAutomaticPause(), Times.Never());
+    }
+
     private LiteNetLib.NetPeer AddConnectedPeer(ConnectionCollection connections)
     {
         var peer = TestNetwork.CreatePeer();
+        peer.Setup(peer.Id, $"127.0.0.{connections.ConnectionStates.Count + 1}");
         connections.PlayerJoiningHandler(new MessagePayload<PlayerConnected>(this, new PlayerConnected(peer)));
         return peer;
     }

--- a/source/E2E.Tests/Services/TroopRosters/JoinRosterReplayTests.cs
+++ b/source/E2E.Tests/Services/TroopRosters/JoinRosterReplayTests.cs
@@ -1,0 +1,249 @@
+﻿using Common;
+using Common.Messaging;
+using Common.Network;
+using Common.PacketHandlers;
+using Common.Serialization;
+using Common.Tests.Utils;
+using Coop.Core.Server.Connections;
+using Coop.Core.Server.Services.ItemRosters.Messages;
+using E2E.Tests.Environment.Instance;
+using E2E.Tests.Util;
+using GameInterface.Services.TroopRosters.Messages;
+using GameInterface.Services.Workshops.Messages;
+using LiteNetLib;
+using Moq;
+using ProtoBuf;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using TaleWorlds.CampaignSystem;
+using TaleWorlds.CampaignSystem.Roster;
+using TaleWorlds.Core;
+using Xunit.Abstractions;
+
+namespace E2E.Tests.Services.TroopRosters;
+
+/// <summary>Compares original and compacted replay against native item and troop roster behavior.</summary>
+public class JoinRosterReplayTests : SyncTestBase
+{
+    private readonly string items;
+    private readonly string item;
+    private readonly string otherItem;
+    private readonly string troops;
+    private readonly string character;
+
+    public JoinRosterReplayTests(ITestOutputHelper output) : base(output)
+    {
+        items = "join-replay-items";
+        Server.CreateRegisteredObject<ItemRoster>(items);
+        foreach (var client in Clients)
+            client.CreateRegisteredObject<ItemRoster>(items);
+        item = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        otherItem = TestEnvironment.CreateRegisteredObject<ItemObject>();
+        troops = TestEnvironment.CreateRegisteredObject<TroopRoster>();
+        character = TestEnvironment.CreateRegisteredObject<CharacterObject>();
+        foreach (var client in Clients)
+            client.Call(() =>
+            {
+                Assert.True(client.ObjectManager.TryGetObject<ItemObject>(item, out var food));
+                food.IsFood = true;
+                food.Value = 23;
+                food.ItemType = ItemObject.ItemTypeEnum.Goods;
+            });
+    }
+
+    [ProtoContract]
+    public readonly struct ObserveRosters : ICommand { }
+
+    [Fact]
+    public void RetainedReplay_MatchesOriginalAtEveryConsumerAndAfterClearRepopulate()
+    {
+        var serializer = Server.Resolve<ICommonSerializer>();
+        var messages = new List<IMessage>();
+        for (int i = 0; i < 64; i++) messages.Add(Item(1));
+        messages.Add(Item(2, otherItem));
+        messages.Add(new ObserveRosters());
+        for (int i = 0; i < 8; i++) messages.Add(Item(-10));
+        messages.Add(Item(3));
+        messages.Add(new ObserveRosters());
+        messages.Add(new NetworkItemRosterClear(items));
+        messages.Add(Item(4, otherItem));
+        messages.Add(Item(5));
+        messages.Add(new ObserveRosters());
+        messages.Add(Troop(TroopRosterElementOperation.AddCounts(5, 5, 100, true)));
+        messages.Add(Troop(TroopRosterElementOperation.AddCounts(-4, 0, 50, true)));
+        messages.Add(Troop(TroopRosterElementOperation.AddCounts(4, 0, 7, true)));
+        messages.Add(new ObserveRosters());
+        messages.Add(Troop(TroopRosterElementOperation.AddCounts(-5, -1, 0, true)));
+        messages.Add(Troop(TroopRosterElementOperation.SetXp(999)));
+        messages.Add(Troop(TroopRosterElementOperation.AddCounts(2, 0, 7, true)));
+        messages.Add(Troop(TroopRosterElementOperation.SetXp(12)));
+        messages.Add(Troop(TroopRosterElementOperation.AddCounts(-2, 0, 3, false)));
+        messages.Add(new ObserveRosters());
+        var packets = messages.Select(message => MessagePacket.Create(message, serializer)).ToArray();
+        var sent = new List<MessagePacket>();
+        var network = new Mock<INetwork>();
+        network.Setup(value => value.SendImmediate(It.IsAny<NetPeer>(), It.IsAny<IPacket>()))
+            .Callback<NetPeer, IPacket>((_, packet) => sent.Add((MessagePacket)packet));
+        var broker = new TestMessageBroker();
+        using var queue = new ConnectionMessageQueue(new Lazy<INetwork>(() => network.Object), broker, serializer);
+        var peer = Clients.First().NetPeer;
+        queue.RegisterPeer(peer);
+        queue.BeginQueueing(peer);
+        foreach (var packet in packets) queue.TryHandleBroadcast(peer, packet);
+        while (queue.FlushBatch(peer).HasMore) { }
+        var replay = sent.ToArray();
+        Assert.True(replay.Length < packets.Length / 3);
+
+        var clients = Clients.Take(2).ToArray();
+        var observations = new[] { new List<string>(), new List<string>() };
+        for (int i = 0; i < clients.Length; i++)
+        {
+            int index = i;
+            var client = clients[i];
+            client.Resolve<IMessageBroker>().Subscribe<ObserveRosters>(_ =>
+                GameThread.RunSafe(() => observations[index].Add(State(client))));
+            foreach (var packet in i == 0 ? packets : replay)
+                client.SimulatePacket(Server.NetPeer, packet);
+        }
+
+        Assert.Equal(5, observations[0].Count);
+        Assert.Equal(observations[0], observations[1]);
+        clients[1].Call(() =>
+        {
+            Assert.True(clients[1].ObjectManager.TryGetObject<ItemRoster>(items, out var inventory));
+            Assert.Equal(5, inventory.TotalFood);
+            Assert.Equal(1, inventory.FoodVariety);
+            Assert.Equal(115, inventory.TotalValue);
+            Assert.Equal(115, inventory.TradeGoodsTotalValue);
+            Assert.True(clients[1].ObjectManager.TryGetObject<TroopRoster>(troops, out var roster));
+            var element = Assert.Single(roster.GetTroopRoster());
+            Assert.Equal(0, element.Number);
+            Assert.Equal(0, element.WoundedNumber);
+            Assert.Equal(15, element.Xp);
+        });
+    }
+
+    private IMessage Item(int amount, string? id = null) =>
+        new NetworkItemRosterUpdate(items, id ?? item, null!, amount);
+
+    private IMessage Troop(TroopRosterElementOperation operation) =>
+        new NetworkTroopRosterElementBatch(troops, character, new[] { operation });
+
+    private string State(EnvironmentInstance client)
+    {
+        Assert.True(client.ObjectManager.TryGetObject<ItemRoster>(items, out var itemRoster));
+        Assert.True(client.ObjectManager.TryGetObject<TroopRoster>(troops, out var troopRoster));
+        var itemRows = itemRoster.Select(row =>
+        {
+            Assert.True(client.ObjectManager.TryGetId(row.EquipmentElement.Item, out var id));
+            return $"{id}:{row.Amount}";
+        });
+        var troopRows = troopRoster.GetTroopRoster().Select(row =>
+        {
+            Assert.True(client.ObjectManager.TryGetId(row.Character, out var id));
+            return $"{id}:{row.Number}:{row.WoundedNumber}:{row.Xp}";
+        });
+        return string.Join(",", itemRows) + "|" + string.Join(",", troopRows) +
+            $"|{itemRoster.TotalFood}:{itemRoster.FoodVariety}:{itemRoster.TotalValue}:" +
+            $"{itemRoster.TradeGoodsTotalValue}:{itemRoster.NumberOfPackAnimals}:" +
+            $"{itemRoster.NumberOfMounts}:{itemRoster.NumberOfLivestockAnimals}:" +
+            $"{troopRoster.TotalManCount}:{troopRoster.TotalWounded}";
+    }
+}
+
+/// <summary>Checks bounded replay compaction and records synthetic packet-volume savings.</summary>
+public class JoinReplayVolumeTests
+{
+    private readonly ITestOutputHelper output;
+    private readonly ICommonSerializer serializer = new ProtoBufSerializer(new SerializableTypeMapper());
+
+    public JoinReplayVolumeTests(ITestOutputHelper output) => this.output = output;
+
+    [Fact]
+    public void AdjacentBursts_MeasureRetainedBytesCountsAndQueueWork()
+    {
+        var packets = new List<MessagePacket>();
+        for (int burst = 0; burst < 1000; burst++)
+        {
+            string id = "roster-" + burst;
+            for (int i = 0; i < 16; i++) Add(new NetworkItemRosterUpdate(id, "item", null!, 1));
+            for (int i = 0; i < 16; i++) Add(new NetworkTroopRosterElementBatch(id, "troop",
+                new[] { TroopRosterElementOperation.AddCounts(1, 0, 1, true) }));
+            Add(new AddOutputProgressForTown("workshop", 0.1f));
+            Add(new AddOutputProgressForTown("workshop", -0.03f));
+        }
+
+        Run(packets.Take(34).ToArray(), false);
+        Run(packets.Take(34).ToArray(), true);
+        var baseline = Run(packets, false);
+        var reduced = Run(packets, true);
+        Assert.Equal(34000, baseline.Packets.Length);
+        Assert.Equal(4000, reduced.Packets.Length);
+        Assert.True(reduced.Bytes < baseline.Bytes);
+        Assert.Equal(16000, reduced.Packets.Where(packet => packet.MessageType == typeof(NetworkItemRosterUpdate))
+            .Sum(packet => serializer.Deserialize<NetworkItemRosterUpdate>(packet.Data).Amount));
+        var originalOperations = packets.Where(packet => packet.MessageType == typeof(NetworkTroopRosterElementBatch))
+            .SelectMany(packet => serializer.Deserialize<NetworkTroopRosterElementBatch>(packet.Data).Operations);
+        var replayOperations = reduced.Packets.Where(packet => packet.MessageType == typeof(NetworkTroopRosterElementBatch))
+            .SelectMany(packet => serializer.Deserialize<NetworkTroopRosterElementBatch>(packet.Data).Operations);
+        Assert.Equal(originalOperations, replayOperations);
+        var originalProgress = packets.Where(packet => packet.MessageType == typeof(AddOutputProgressForTown)).ToArray();
+        var replayProgress = reduced.Packets.Where(packet => packet.MessageType == typeof(AddOutputProgressForTown)).ToArray();
+        Assert.Equal(originalProgress.Select(packet => packet.Data), replayProgress.Select(packet => packet.Data));
+        Assert.Equal(Progress(originalProgress), Progress(replayProgress));
+        output.WriteLine($"Synthetic adjacent 16-message bursts: {baseline.Packets.Length} to {reduced.Packets.Length} packets; " +
+            $"{baseline.Bytes} to {reduced.Bytes} bytes. Admission {baseline.AdmitMs:F2} to {reduced.AdmitMs:F2} ms; " +
+            $"drain {baseline.DrainMs:F2} to {reduced.DrainMs:F2} ms. No live join timing measured.");
+
+        void Add(IMessage message) => packets.Add(MessagePacket.Create(message, serializer));
+    }
+
+    [Fact]
+    public void TroopMerges_BoundOperationsPreservePayloadAndRejectDifferentIdentities()
+    {
+        var operations = new[] { TroopRosterElementOperation.AddCounts(1, 1, 7, false) };
+        var packet = MessagePacket.Create(new NetworkTroopRosterElementBatch("roster", "troop", operations), serializer);
+        operations[0] = TroopRosterElementOperation.SetXp(999);
+        var packets = Enumerable.Repeat(packet, 65).ToArray();
+        var result = Run(packets, true);
+        Assert.Equal(new[] { 32, 32, 1 }, result.Packets.Select(value =>
+            serializer.Deserialize<NetworkTroopRosterElementBatch>(value.Data).Operations.Length));
+        Assert.All(result.Packets.SelectMany(value => serializer.Deserialize<NetworkTroopRosterElementBatch>(value.Data).Operations),
+            operation => Assert.Equal(TroopRosterElementOperationKind.AddCounts, operation.Kind));
+        var other = MessagePacket.Create(new NetworkTroopRosterElementBatch("other", "troop", operations), serializer);
+        Assert.False(packet.TryMergeForJoinCatchUp(other, serializer, out _));
+        other = MessagePacket.Create(new NetworkTroopRosterElementBatch("roster", "hero", operations), serializer);
+        Assert.False(packet.TryMergeForJoinCatchUp(other, serializer, out _));
+    }
+
+    private int Progress(IEnumerable<MessagePacket> packets)
+    {
+        float progress = 0;
+        foreach (var packet in packets)
+            progress += serializer.Deserialize<AddOutputProgressForTown>(packet.Data).ProgressToAdd;
+        return BitConverter.SingleToInt32Bits(progress);
+    }
+
+    private (MessagePacket[] Packets, long Bytes, double AdmitMs, double DrainMs) Run(
+        IEnumerable<MessagePacket> packets, bool merge)
+    {
+        var sent = new List<MessagePacket>();
+        var network = new Mock<INetwork>();
+        network.Setup(value => value.SendImmediate(It.IsAny<NetPeer>(), It.IsAny<IPacket>()))
+            .Callback<NetPeer, IPacket>((_, packet) => sent.Add((MessagePacket)packet));
+        using var queue = new ConnectionMessageQueue(new Lazy<INetwork>(() => network.Object), new TestMessageBroker(), serializer);
+        var peer = (NetPeer)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(NetPeer));
+        queue.RegisterPeer(peer);
+        queue.BeginQueueing(peer);
+        if (!merge) queue.EndFinalBaselineCoverage(peer);
+        var timer = Stopwatch.StartNew();
+        foreach (var packet in packets) queue.TryHandleBroadcast(peer, packet);
+        double admit = timer.Elapsed.TotalMilliseconds;
+        Assert.False(queue.HasCatchUpOverflowed(peer));
+        Assert.True(queue.TryGetCatchUpPendingBytes(peer, out long bytes));
+        timer.Restart();
+        while (queue.FlushBatch(peer).HasMore) { }
+        double drain = timer.Elapsed.TotalMilliseconds;
+        return (sent.ToArray(), bytes, admit, drain);
+    }
+}

--- a/source/GameInterface/Services/TroopRosters/Messages/NetworkTroopRosterElementBatch.cs
+++ b/source/GameInterface/Services/TroopRosters/Messages/NetworkTroopRosterElementBatch.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Messaging;
 using ProtoBuf;
+using System;
 
 namespace GameInterface.Services.TroopRosters.Messages;
 
@@ -8,8 +9,9 @@ namespace GameInterface.Services.TroopRosters.Messages;
 /// identities only once.
 /// </summary>
 [ProtoContract(SkipConstructor = true)]
-internal readonly struct NetworkTroopRosterElementBatch : ICommand
+internal readonly struct NetworkTroopRosterElementBatch : ICommand, IJoinCatchUpMergeMessage
 {
+    private const int MaxJoinCatchUpOperations = 32;
     [ProtoMember(1)]
     public readonly string RosterId;
 
@@ -18,6 +20,26 @@ internal readonly struct NetworkTroopRosterElementBatch : ICommand
 
     [ProtoMember(3)]
     public readonly TroopRosterElementOperation[] Operations;
+
+    public string JoinCatchUpMergeKey => $"{RosterId}:{CharacterId}";
+
+    public bool TryMerge(IMessage next, out IMessage merged)
+    {
+        merged = null;
+        if (next is not NetworkTroopRosterElementBatch other ||
+            RosterId != other.RosterId || CharacterId != other.CharacterId ||
+            Operations == null || other.Operations == null ||
+            Operations.Length == 0 || other.Operations.Length == 0 ||
+            Operations.Length > MaxJoinCatchUpOperations - other.Operations.Length)
+            return false;
+
+        // Keep every clamping, removal and XP operation in order; bound a single game-thread apply.
+        var operations = new TroopRosterElementOperation[Operations.Length + other.Operations.Length];
+        Array.Copy(Operations, operations, Operations.Length);
+        Array.Copy(other.Operations, 0, operations, Operations.Length, other.Operations.Length);
+        merged = new NetworkTroopRosterElementBatch(RosterId, CharacterId, operations);
+        return true;
+    }
 
     public NetworkTroopRosterElementBatch(string rosterId, string characterId,
         TroopRosterElementOperation[] operations)


### PR DESCRIPTION
## PR Checklist

- [x] All new classes have class-level documentation comments
- [x] Tests for the changes have been added

## PR Type

- [x] Bug fix

## What is the current behavior?

a loading player's replay backlog can pause the whole campaign after the join grace period. replay also drains in large bursts, putting pressure on the reliable channel and the joining client's game thread.

## What is the new behavior?

loading players catch up without triggering the global overload pause. their replay is bounded by packet count, serialized bytes and server frame time, with at most four batches awaiting ordered client application. the joining client applies queued work under an 8 ms frame budget. stalled or oversized joins are disconnected individually; overload protection for players already in the campaign is preserved. failed joins show whether replay timed out, exceeded its queue limit, or timed out loading the save. queue-order tests drain every bounded batch before checking FIFO.

adjacent positive item additions are combined, and adjacent troop updates share bounded batches while retaining every operation in order. item removals, clears, object lifetimes and other intervening events remain barriers. the native roster regression test checks original and compacted replay at intermediate observations, including over-removal, clear/repopulate and troop XP changes.

the existing party and kingdom baselines, join lifecycle events, save metadata and exact-build validation remain in place. clients and servers must use the matching new build for the added replay acknowledgements. no required members were added to the public network or configuration interfaces.

## Bot Changelog Entry

- Reduced campaign join catch-up stalls and prevented slow-loading players from pausing the campaign for everyone.

## Other information

validated the review repair with a release build, all unit/integration suites (2,553 passed; 14 skips), and 28 focused disconnect/queue tests. seven loopback cases cover the actual server-to-client disconnect payload, including missing, malformed and unknown reasons. an independent agent reviewed commit a185d5686 with no unresolved findings. simulated gameplay E2E tests were not rerun for this repair.

native save capture remains synchronous and can still cause a brief hitch. this change targets replay workload and the global catch-up pause; live campaign load times have not been measured.
