### PR TITLE
Fix rejected puppet deaths leaving unkillable agents

### DIFF
--- a/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
+++ b/source/E2E.Tests/Environment/MockEngine/MissionEngineFixture.cs
@@ -725,7 +725,17 @@ public sealed class MissionEngineFixture : IDisposable
 
         registrationMock?.RegisteredBlow?.Invoke(__instance, blow);
 
-        victim.Health -= blow.InflictedDamage;
+        // Agent.HandleBlow ignores non-damaging blows and clamps damage under local death guards.
+        if (blow.InflictedDamage <= 0) return false;
+        float damage = Math.Min(blow.InflictedDamage, victim.Health);
+        if (__instance.CurrentMortalityState == Agent.MortalityState.Immortal
+            || victim.Mission.DisableDying
+            || Mission.Current.Mode == MissionMode.Conversation
+            || Mission.Current.Mode == MissionMode.CutScene)
+        {
+            damage = 0f;
+        }
+        victim.Health = Math.Max(0f, victim.Health - damage);
         if (TryActiveMock(out var activeMock)
             && activeMock.DismountRiderOnNextBlow)
         {

--- a/source/E2E.Tests/Services/Missions/BattleDeathMirrorTests.cs
+++ b/source/E2E.Tests/Services/Missions/BattleDeathMirrorTests.cs
@@ -7,6 +7,7 @@ using Missions;
 using Missions.Agents;
 using Missions.Battles;
 using Missions.Messages;
+using Moq;
 using TaleWorlds.Core;
 using TaleWorlds.MountAndBlade;
 using Xunit;
@@ -19,8 +20,10 @@ public class BattleDeathMirrorTests : MissionTestEnvironment
 {
     public BattleDeathMirrorTests(ITestOutputHelper output) : base(output) { }
 
-    [Fact]
-    public void OwnedDeath_ReplicatesAffectorAndDeathAction_WhilePreservingKilledState()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void OwnedDeath_ReplicatesAffectorAndDeathAction_WhenLocalDeathGuardClears(bool rejectUntilNextTick)
     {
         using var fixture = new MissionEngineFixture();
         var owner = Clients.First();
@@ -37,6 +40,7 @@ public class BattleDeathMirrorTests : MissionTestEnvironment
         peer.Call(() =>
         {
             var mock = CreateConnectedMission(fixture, peer, missionInstanceId);
+            mock.Shell.DisableDying = rejectUntilNextTick;
             peerController = peer.Resolve<CoopBattleController>();
             var registry = peer.Resolve<INetworkAgentRegistry>();
             BasicCharacterObject character = Game.Current.PlayerTroop;
@@ -81,6 +85,17 @@ public class BattleDeathMirrorTests : MissionTestEnvironment
         Assert.Equal(BoneBodyPartType.Head, message.VictimBodyPart);
 
         Assert.True(AgentMirror.TryGet(peerVictim, out var victimMirror));
+        if (rejectUntilNextTick)
+        {
+            Assert.True(victimMirror.IsActive);
+            Assert.Equal(100f, victimMirror.Health);
+            peer.Call(() =>
+            {
+                Assert.True(peer.Resolve<INetworkAgentRegistry>().TryGetAgentInfo(victimId, out _));
+                victimMirror.Mission.DisableDying = false;
+                peerController.OnMissionTick(0f);
+            });
+        }
         Assert.False(victimMirror.IsActive);
         Assert.True(victimMirror.WasKilled);
         Assert.Equal(321, victimMirror.DeathAction);
@@ -181,6 +196,125 @@ public class BattleDeathMirrorTests : MissionTestEnvironment
         Assert.Equal(3587, victimMirror.DeathAction);
 
         GC.KeepAlive(peerController);
+    }
+
+    [Theory]
+    [InlineData(true, Agent.MortalityState.Mortal, MissionMode.Battle, false, 100f)]
+    [InlineData(false, Agent.MortalityState.Immortal, MissionMode.Battle, false, 100f)]
+    [InlineData(false, Agent.MortalityState.Mortal, MissionMode.Conversation, false, 100f)]
+    [InlineData(false, Agent.MortalityState.Mortal, MissionMode.CutScene, false, 100f)]
+    [InlineData(true, Agent.MortalityState.Mortal, MissionMode.Battle, true, 100f)]
+    [InlineData(false, Agent.MortalityState.Immortal, MissionMode.Battle, true, 100f)]
+    [InlineData(false, Agent.MortalityState.Mortal, MissionMode.Conversation, true, 100f)]
+    [InlineData(false, Agent.MortalityState.Mortal, MissionMode.CutScene, true, 100f)]
+    [InlineData(true, Agent.MortalityState.Mortal, MissionMode.Battle, false, 1f)]
+    [InlineData(true, Agent.MortalityState.Mortal, MissionMode.Battle, true, 1f)]
+    public void RejectedDeath_RetainsPuppetAndAttributionUntilRetrySucceeds(
+        bool disableDying, Agent.MortalityState mortality, MissionMode mode, bool wounded, float health)
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var broker = peer.Resolve<IMessageBroker>();
+            var casualties = new CasualtyAttributionMap();
+            var mountRepairer = new Mock<IPuppetMountStateRepairer>();
+            using var applier = new PuppetDeathApplier(
+                broker, peer.Resolve<ICoopMissionComponent>(), casualties, mountRepairer.Object);
+            var victimId = Guid.NewGuid();
+            var victim = mock.SpawnAgent(
+                new AgentBuildData(Game.Current.PlayerTroop).Controller(AgentControllerType.None));
+            Assert.True(AgentMirror.TryGet(victim, out var mirror));
+            Assert.True(registry.TryRegisterAgent("owner", victimId, victim));
+            casualties.Record(victimId, "party", 7, "troop");
+            mirror.Health = health;
+            mock.Shell.DisableDying = disableDying;
+            mock.Shell._missionMode = mode;
+            victim.SetMortalityState(mortality);
+            var death = new NetworkBattleAgentDied(
+                victimId, wounded, Guid.Empty, 100, BoneBodyPartType.Head, 456);
+
+            int registeredBlows = 0;
+            mock.RegisteredBlow = (_, _) => registeredBlows++;
+            broker.Publish(this, death);
+            applier.DrainPendingDeaths();
+            applier.DrainPendingDeaths();
+            applier.DrainPendingDeaths();
+
+            Assert.Equal(0, registeredBlows);
+            Assert.True(mirror.IsActive);
+            Assert.Equal(health, mirror.Health);
+            Assert.True(registry.TryGetAgentInfo(victimId, out var info));
+            Assert.Same(victim, info.Agent);
+            Assert.Equal("party", casualties.GetOrDefault(victimId).MapEventPartyId);
+            mountRepairer.Verify(x => x.RepairAfterRiderDeath(It.IsAny<Agent>()), Times.Never);
+
+            mock.Shell.DisableDying = false;
+            mock.Shell._missionMode = MissionMode.Battle;
+            victim.SetMortalityState(Agent.MortalityState.Mortal);
+            applier.DrainPendingDeaths();
+
+            Assert.False(mirror.IsActive);
+            Assert.Equal(!wounded, mirror.WasKilled);
+            Assert.Equal(456, mirror.DeathAction);
+            Assert.False(registry.TryGetAgentInfo(victimId, out _));
+            Assert.Null(casualties.GetOrDefault(victimId).MapEventPartyId);
+
+            Assert.Equal(1, registeredBlows);
+            broker.Publish(this, death);
+            applier.DrainPendingDeaths();
+            applier.DrainPendingDeaths();
+            Assert.Equal(1, registeredBlows);
+            mountRepairer.Verify(x => x.RepairAfterRiderDeath(It.IsAny<Agent>()), Times.Once);
+        });
+    }
+
+    [Theory]
+    [InlineData(false, 0f, false)]
+    [InlineData(true, 0f, false)]
+    [InlineData(false, 0f, true)]
+    [InlineData(true, 0f, true)]
+    [InlineData(false, 0.5f, true)]
+    [InlineData(true, 0.5f, true)]
+    [InlineData(false, 0.999f, true)]
+    [InlineData(true, 0.999f, true)]
+    public void ActiveBelowOneHealthPuppet_ReceivesTerminalBlowBeforeDeregistration(
+        bool wounded, float health, bool guardsEnabled)
+    {
+        using var fixture = new MissionEngineFixture();
+        var peer = Clients.First();
+        SetControllerId(peer, "peer");
+
+        peer.Call(() =>
+        {
+            var mock = fixture.CreateMission(peer);
+            var registry = peer.Resolve<INetworkAgentRegistry>();
+            var broker = peer.Resolve<IMessageBroker>();
+            using var applier = new PuppetDeathApplier(
+                broker, peer.Resolve<ICoopMissionComponent>(), new CasualtyAttributionMap(),
+                peer.Resolve<IPuppetMountStateRepairer>());
+            var victimId = Guid.NewGuid();
+            var victim = mock.SpawnAgent(
+                new AgentBuildData(Game.Current.PlayerTroop).Controller(AgentControllerType.None));
+            Assert.True(AgentMirror.TryGet(victim, out var mirror));
+            mirror.Health = health;
+            mock.Shell.DisableDying = guardsEnabled;
+            mock.Shell._missionMode = guardsEnabled ? MissionMode.Conversation : MissionMode.Battle;
+            victim.SetMortalityState(guardsEnabled ? Agent.MortalityState.Immortal : Agent.MortalityState.Mortal);
+            Assert.True(registry.TryRegisterAgent("owner", victimId, victim));
+
+            broker.Publish(this, new NetworkBattleAgentDied(
+                victimId, wounded, Guid.Empty, 0, BoneBodyPartType.Head, 456));
+
+            Assert.False(mirror.IsActive);
+            Assert.Equal(!wounded, mirror.WasKilled);
+            Assert.Equal(456, mirror.DeathAction);
+            Assert.False(registry.TryGetAgentInfo(victimId, out _));
+        });
     }
 
     [Fact]

--- a/source/Missions/Battles/PuppetDeathApplier.cs
+++ b/source/Missions/Battles/PuppetDeathApplier.cs
@@ -21,7 +21,7 @@ namespace Missions.Battles;
 public interface IPuppetDeathApplier : IDisposable
 {
     /// <summary>
-    /// [Game thread] Apply deaths that arrived before their deployment-buffered puppets registered.
+    /// [Game thread] Retry deaths awaiting puppet registration or acceptance by the native agent.
     /// </summary>
     void DrainPendingDeaths();
 }
@@ -37,6 +37,7 @@ public class PuppetDeathApplier : IPuppetDeathApplier
     private readonly IPuppetMountStateRepairer puppetMountStateRepairer;
     private readonly Dictionary<Guid, NetworkBattleAgentDied> pendingDeaths =
         new Dictionary<Guid, NetworkBattleAgentDied>();
+    private readonly HashSet<Guid> completedDeaths = new HashSet<Guid>();
 
     public PuppetDeathApplier(
         IMessageBroker messageBroker,
@@ -56,6 +57,7 @@ public class PuppetDeathApplier : IPuppetDeathApplier
     {
         messageBroker.Unsubscribe<NetworkBattleAgentDied>(Handle_NetworkBattleAgentDied);
         pendingDeaths.Clear();
+        completedDeaths.Clear();
     }
 
     private void Handle_NetworkBattleAgentDied(MessagePayload<NetworkBattleAgentDied> payload)
@@ -74,12 +76,16 @@ public class PuppetDeathApplier : IPuppetDeathApplier
             if (!TryApplyDeath(payload.What))
             {
                 pendingDeaths[payload.What.AgentId] = payload.What;
-                string reason = Mission.Current == null ? "mission-unavailable" : "puppet-unregistered";
+                string reason = Mission.Current == null ? "mission-unavailable" : "puppet-unregistered-or-active";
                 Logger.Information(
                     "[BattleDeath] Deferring death: agentId={AgentId} reason={Reason} pendingDeaths={PendingDeaths}",
                     payload.What.AgentId,
                     reason,
                     pendingDeaths.Count);
+            }
+            else
+            {
+                pendingDeaths.Remove(payload.What.AgentId);
             }
         });
     }
@@ -98,12 +104,15 @@ public class PuppetDeathApplier : IPuppetDeathApplier
 
     private bool TryApplyDeath(NetworkBattleAgentDied death)
     {
+        if (completedDeaths.Contains(death.AgentId)) return true;
+
         var registry = coopMissionComponent.AgentRegistry;
         if (!registry.TryGetAgentInfo(death.AgentId, out var info)) return false;
         Mission mission = Mission.Current;
         if (mission == null) return false;
 
         Agent agent = info.Agent;
+        if (agent != null && agent.Mission != mission) return false;
         int agentIndex = -1;
         float healthBefore = -1f;
         float healthAfter = healthBefore;
@@ -122,13 +131,24 @@ public class PuppetDeathApplier : IPuppetDeathApplier
             healthAfter = healthBefore;
             activeBefore = agent.IsActive();
             activeAfter = activeBefore;
-            appliedDeath = activeBefore && healthBefore > 0f;
+            appliedDeath = activeBefore;
         }
         if (appliedDeath)
         {
             mortalityBefore = agent.CurrentMortalityState;
+            // Native guards still allow Die below one health; otherwise avoid repeating hit effects.
+            if (healthBefore >= 1f
+                && (agent.CurrentMortalityState == Agent.MortalityState.Immortal
+                    || disableDying
+                    || missionMode == MissionMode.Conversation
+                    || missionMode == MissionMode.CutScene))
+            {
+                return false;
+            }
+
             Agent mount = agent.MountAgent;
-            LogMountState("before", agent, mount);
+            if (!pendingDeaths.ContainsKey(death.AgentId))
+                LogMountState("before", agent, mount);
 
             Agent affectorAgent = null;
             if (death.AffectorAgentId != Guid.Empty
@@ -141,7 +161,8 @@ public class PuppetDeathApplier : IPuppetDeathApplier
             var killingBlow = death.DeathAction >= 0
                 ? CreateReplicatedKillingBlow(blow, death.DeathAction)
                 : default;
-            blow.InflictedDamage = Math.Max(blow.InflictedDamage, (int)Math.Ceiling(agent.Health));
+            // HandleBlow ignores zero-damage blows even when an active agent already has zero health.
+            blow.InflictedDamage = Math.Max(1, Math.Max(blow.InflictedDamage, (int)Math.Ceiling(agent.Health)));
             appliedDamage = blow.InflictedDamage;
             var agentState = death.Wounded ? AgentState.Unconscious : AgentState.Killed;
 
@@ -158,12 +179,23 @@ public class PuppetDeathApplier : IPuppetDeathApplier
                     }
                 });
 
-            puppetMountStateRepairer.RepairAfterRiderDeath(mount);
-            LogMountState("after", agent, mount);
-
             healthAfter = agent.Health;
             activeAfter = agent.IsActive();
             mortalityAfter = agent.CurrentMortalityState;
+            if (activeAfter)
+            {
+                if (!pendingDeaths.ContainsKey(death.AgentId))
+                {
+                    Logger.Warning(
+                        "[BattleDeath] Retaining rejected death for retry: agentId={AgentId} " +
+                        "health={Health:0.0} mortality={Mortality} disableDying={DisableDying} missionMode={MissionMode}",
+                        death.AgentId, healthAfter, mortalityAfter, disableDying, missionMode);
+                }
+                return false;
+            }
+
+            puppetMountStateRepairer.RepairAfterRiderDeath(mount);
+            LogMountState("after", agent, mount);
         }
 
         // Deregister after the game-thread kill. Removing on the poll thread before the queued apply would
@@ -205,25 +237,6 @@ public class PuppetDeathApplier : IPuppetDeathApplier
                 disableDying,
                 missionMode,
                 deregistered);
-            if (activeAfter && healthAfter > 0f)
-            {
-                Logger.Error(
-                    "[BattleDeath] Replicated death did not kill puppet: agentId={AgentId} " +
-                    "authority={Authority} agentIndex={AgentIndex} healthBefore={HealthBefore:0.0} " +
-                    "healthAfter={HealthAfter:0.0} activeAfter={ActiveAfter} " +
-                    "mortalityBefore={MortalityBefore} mortalityAfter={MortalityAfter} " +
-                    "disableDying={DisableDying} missionMode={MissionMode}",
-                    death.AgentId,
-                    info.CurrentAuthority,
-                    agentIndex,
-                    healthBefore,
-                    healthAfter,
-                    activeAfter,
-                    mortalityBefore,
-                    mortalityAfter,
-                    disableDying,
-                    missionMode);
-            }
         }
         else
         {
@@ -248,6 +261,7 @@ public class PuppetDeathApplier : IPuppetDeathApplier
                 info.CurrentAuthority);
         }
         casualties.Forget(death.AgentId);
+        completedDeaths.Add(death.AgentId);
         return true;
     }
 


### PR DESCRIPTION
## What is the current behavior?
replicated deaths can remove a puppet's network registration even when a local death guard leaves it alive, making it unkillable.

Related to https://github.com/Bannerlord-Coop-Team/Bannerlord-Coop-Issues/issues/1688. the reporter's log is missing, so this failure path is reproduced by tests rather than confirmed from that run.

## What is the new behavior?
keep the puppet registered and retry when local death guards clear. only remove registration and casualty attribution after terminal application, and ignore completed duplicate deaths. blocked retries dont repeat native hit effects.

## How to test
`dotnet test source/E2E.Tests/E2E.Tests.csproj -c Release -p:PostBuildEvent= --filter FullyQualifiedName~E2E.Tests.Services.Missions`

812 mission E2E tests pass, including 23 death-mirror cases covering two-client broadcast, blocked retries, killed/wounded outcomes, duplicate deaths, and health boundaries. regressions failed before the fixes. independent review passed. these are headless mock-engine tests, not a live-game reproduction.

## Bot Changelog Entry
- Fixed a case where enemies could remain unkillable after their death was received during a protected mission state.
