### PR TITLE
Fix players getting stuck after natural raid completion

### DIFF
--- a/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
+++ b/source/E2E.Tests/Services/Villages/VillageHostileActionTests.cs
@@ -981,6 +981,19 @@ public class VillageHostileActionTests : MapEventTestBase
     [Fact]
     public void RaidFinalizeRequest_EndingSlowRaidMovesRaiderToVillageGate()
     {
+        AssertSlowRaidExit(naturalCompletion: false, lateFinalizeRequest: false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RaidMapEventUpdate_NaturalCompletionMovesRaiderToVillageGate(bool lateFinalizeRequest)
+    {
+        AssertSlowRaidExit(naturalCompletion: true, lateFinalizeRequest);
+    }
+
+    private void AssertSlowRaidExit(bool naturalCompletion, bool lateFinalizeRequest)
+    {
         var client = Clients.First();
         var (_, mobilePartyId) = CreatePlayerHeroParty("PlayerOne");
         var target = CreateVillageTarget();
@@ -1001,7 +1014,10 @@ public class VillageHostileActionTests : MapEventTestBase
                     mobileParty.Position = insidePosition;
                     mobileParty.CurrentSettlement = settlement;
                     mobileParty.ResetNavigationToHold();
+                    mobileParty.PartyMoveMode = MoveModeType.Point;
                 }
+                Assert.NotEqual(MoveModeType.Hold, mobileParty.PartyMoveMode);
+                Assert.Contains(mobileParty, settlement.Parties);
             });
         }
 
@@ -1044,12 +1060,103 @@ public class VillageHostileActionTests : MapEventTestBase
             .Append(AccessTools.Method(typeof(GameMenu), nameof(GameMenu.ExitToLast)))
             .ToList();
 
-        client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkMapEventFinalizeAttempted(mapEventId!)), disabledMethods);
+        var raidCompletedCount = 0;
+        if (naturalCompletion)
+        {
+            var villageTypeId = TestEnvironment.CreateRegisteredObject<VillageType>();
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<MapEvent>(mapEventId!, out var mapEvent));
+                Assert.True(Server.ObjectManager.TryGetObject<MobileParty>(mobilePartyId, out var mobileParty));
+                Assert.True(Server.ObjectManager.TryGetObject<Settlement>(target.SettlementId, out var settlement));
+                Assert.True(Server.ObjectManager.TryGetObject<VillageType>(villageTypeId, out var villageType));
+                villageType._productions = new MBList<(ItemObject, float)>();
+                settlement.Village.VillageType = villageType;
+                // Synthetic factions need distinct ids for vanilla's ordered stance lookup.
+                mobileParty.ActualClan.Id = new MBGUID(1);
+                ((Kingdom)settlement.MapFaction).Id = new MBGUID(2);
+                VillageHostileFactionStanceHelper.ApplyWarStance(mobileParty.MapFaction, settlement.MapFaction);
+                Assert.True(mapEvent.AttackerSide.LeaderParty.MapFaction.IsAtWarWith(mapEvent.DefenderSide.LeaderParty.MapFaction));
+                Assert.True(mapEvent.DefenderSide.LeaderParty.MapFaction.IsAtWarWith(mapEvent.AttackerSide.LeaderParty.MapFaction));
+                Assert.False(mapEvent.DiplomaticallyFinished);
+                Assert.Equal(0, mapEvent.DefenderSide.TroopCount);
+                CampaignEvents.RaidCompletedEvent.AddNonSerializedListener(this, (winner, component) =>
+                {
+                    Assert.True(GameThread.Instance.IsGameThread);
+                    Assert.False(AllowedThread.IsThisThreadAllowed());
+                    Assert.True(mapEvent._isFinishCalled);
+                    Assert.True(Server.ObjectManager.TryGetId(mapEvent, out var completingMapEventId));
+                    Assert.Equal(mapEventId, completingMapEventId);
+                    Assert.Equal(BattleSideEnum.Attacker, winner);
+                    Assert.Same(mapEvent.Component, component);
+                    raidCompletedCount++;
+                });
+
+                // Seed accumulated damage, but let the real update decide when the raid finishes.
+                var raid = Assert.IsType<RaidEventComponent>(mapEvent.Component);
+                settlement.SettlementHitPoints = 1f;
+                raid._nextSettlementDamage = 0.06f;
+                mapEvent.Update();
+                Assert.False(mapEvent.IsFinalized);
+                Assert.True(mapEvent.WasEverInLootingPhase);
+                Assert.True(settlement.SettlementHitPoints < 1f);
+                Assert.Same(settlement, mobileParty.CurrentSettlement);
+                Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkClosePvpEncounter>());
+
+                settlement.SettlementHitPoints = 0.01f;
+                raid._nextSettlementDamage = 0.06f;
+                mapEvent.Update();
+                Assert.True(mapEvent.IsFinalized);
+                Assert.True(mapEvent._isFinishCalled);
+                Assert.Equal(BattleState.AttackerVictory, mapEvent.BattleState);
+                Assert.Equal(1, raidCompletedCount);
+                mapEvent.Update();
+                Assert.Equal(1, raidCompletedCount);
+            }, disabledMethods);
+
+            Server.Call(() =>
+            {
+                Assert.True(Server.ObjectManager.TryGetObject<Settlement>(target.SettlementId, out var settlement));
+                Assert.Equal(0f, settlement.SettlementHitPoints);
+            });
+            foreach (var instance in Clients.Append(Server))
+            {
+                instance.Call(() =>
+                {
+                    Assert.False(instance.ObjectManager.TryGetObject<MapEvent>(mapEventId!, out _));
+                    Assert.True(instance.ObjectManager.TryGetObject<Village>(target.VillageId, out var village));
+                    Assert.Equal(Village.VillageStates.Looted, village.VillageState);
+                });
+            }
+        }
+        else
+        {
+            client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkMapEventFinalizeAttempted(mapEventId!)), disabledMethods);
+        }
+
+        if (lateFinalizeRequest)
+            client.Call(() => client.Resolve<INetwork>().SendAll(new NetworkMapEventFinalizeAttempted(mapEventId!)), disabledMethods);
+
         AssertRaidPartyMovedToVillageGate(Server, mobilePartyId, target.SettlementId);
         foreach (var syncedClient in Clients)
         {
             AssertRaidPartyMovedToVillageGate(syncedClient, mobilePartyId, target.SettlementId);
         }
+
+        var close = Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkClosePvpEncounter>());
+        Assert.Contains(GetPartyBaseId(mobilePartyId), close.PartyIds);
+        Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkPartyLeaveSettlement>());
+        Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkRaidBattleResetToVillage>());
+        AssertHasPlayerEncounter(client, expected: false);
+        if (naturalCompletion)
+        {
+            Assert.Equal(1, raidCompletedCount);
+            Assert.Single(Server.InternalMessages.GetMessages<MapEventFinalizeAttempted>());
+        }
+        if (lateFinalizeRequest)
+            Assert.Single(Server.NetworkSentMessages.GetMessages<NetworkMapEventFinalized>());
+        else
+            Assert.Empty(Server.NetworkSentMessages.GetMessages<NetworkMapEventFinalized>());
     }
 
     [Fact]
@@ -2758,6 +2865,8 @@ public class VillageHostileActionTests : MapEventTestBase
             Assert.True(instance.ObjectManager.TryGetObject<Settlement>(settlementId, out var settlement));
 
             Assert.Null(mobileParty.CurrentSettlement);
+            Assert.DoesNotContain(mobileParty, settlement.Parties);
+            Assert.Null(mobileParty.MapEvent);
             Assert.True(mobileParty.Position.Distance(settlement.GatePosition) < 0.001f);
             Assert.True(mobileParty.MoveTargetPoint.Distance(mobileParty.Position) < 0.001f);
             Assert.Equal(MoveModeType.Hold, mobileParty.PartyMoveMode);

--- a/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
+++ b/source/GameInterface/Services/MapEvents/Patches/MapEventPatches.cs
@@ -100,6 +100,28 @@ internal class MapEventPatches
         MessageBroker.Instance.Publish(__instance, new PartyRemovedFromMapEvent(removedParty));
     }
 
+    [HarmonyPatch(nameof(MapEvent.FinishBattle))]
+    [HarmonyPrefix]
+    private static bool Prefix_FinishBattle(MapEvent __instance)
+    {
+        if (CallOriginalPolicy.IsOriginalAllowed()) return true;
+
+        if (ModInformation.IsServer
+            && __instance.IsRaidHostileAction()
+            && __instance.BattleState == BattleState.AttackerVictory
+            && __instance.MapEventSettlement?.SettlementHitPoints <= 1E-05f
+            && __instance.ContainsPlayerParty())
+        {
+            // Keep vanilla's bookkeeping before finalization destroys the registry entry.
+            __instance._isFinishCalled = true;
+            // Natural raid completion needs the authoritative exit before vanilla clears the participants.
+            MessageBroker.Instance.Publish(__instance, new MapEventFinalizeAttempted(__instance));
+            return false;
+        }
+
+        return true;
+    }
+
     [HarmonyPatch(nameof(MapEvent.FinalizeEventAux))]
     [HarmonyPrefix]
     [HarmonyPriority(Priority.First)]


### PR DESCRIPTION
## What is the current behavior?

naturally finishing a raid can leave the server party inside the village after the raid event is gone. a later exit request doesnt clear that state.

## What is the new behavior?

completed player raids use the existing authoritative finalization path to move attackers to the village gate and close their encounters. vanilla completion bookkeeping runs before the event is unregistered.

Resolves https://github.com/Bannerlord-Coop-Team/Bannerlord-Coop-Issues/issues/1698

## How to test

added E2E coverage through `MapEvent.Update`, with and without a late exit request. checks server/client settlement membership, gate position, hold behavior and completion once.

```text
dotnet test source/E2E.Tests/E2E.Tests.csproj -c Release -p:PostBuildEvent= -p:NuGetAudit=false --filter "FullyQualifiedName~E2E.Tests.Services.Villages.VillageHostileActionTests|FullyQualifiedName~E2E.Tests.Services.MapEvents.CoopBattleFinalizeTests|FullyQualifiedName~E2E.Tests.Services.MobileParties.MobilePartyMovementTests"
```

- before fix: both natural-completion cases fail because server `CurrentSettlement` is still set; requested exit passes.
- after fix: 101 passed, 0 failed, 0 skipped.
- independent review found no blocking issues.

headless tests only, no live game run. the synthetic fixture emits handled lookup errors; exact client raid HP sync and live menu rendering are not covered.

## Bot Changelog Entry

- Fixed players getting stuck in a village after completing a raid.
