### PR TITLE
Show Discord Main Menu presence outside co-op sessions

### DIFF
--- a/source/Coop.Core/Client/ClientModule.cs
+++ b/source/Coop.Core/Client/ClientModule.cs
@@ -66,9 +66,7 @@ public class ClientModule : CommonModule
         builder.RegisterType<JoinDebugCommands.DisconnectCoopCommand>().As<ICoopCommand>().InstancePerDependency();
 #endif
 
-        // The presence adapter owns connection disposal on its serialized worker queue.
-        builder.RegisterType<DiscordRpcConnection>().As<IDiscordRpcConnection>().InstancePerDependency().ExternallyOwned();
-        builder.RegisterType<DiscordPresenceClient>().As<IDiscordPresenceClient>().InstancePerLifetimeScope();
+        builder.RegisterModule<DiscordPresenceModule>();
         builder.RegisterType<ClientContext>().AsSelf().InstancePerLifetimeScope();
         builder.RegisterType<ClientLogic>().As<ILogic>().As<IClientLogic>().InstancePerLifetimeScope();
         builder.RegisterType<CoopClient>().As<ICoopClient>().As<INetwork>().As<IRelayNetwork>().As<INetEventListener>().InstancePerLifetimeScope();

--- a/source/Coop.Core/Client/Services/Discord/DiscordPresenceClient.cs
+++ b/source/Coop.Core/Client/Services/Discord/DiscordPresenceClient.cs
@@ -9,6 +9,7 @@ namespace Coop.Core.Client.Services.Discord;
 public interface IDiscordPresenceClient : IDisposable
 {
     void SetPresence(string details, string state, DateTime startedAtUtc);
+    void SetMainMenu();
     void ClearPresence();
 }
 
@@ -59,6 +60,8 @@ public sealed class DiscordPresenceClient : IDiscordPresenceClient
             ApplyLatestPresence();
         });
     }
+
+    public void SetMainMenu() => SetPresence(null, "Main Menu", DateTime.UtcNow);
 
     public void ClearPresence() => Enqueue(() =>
     {

--- a/source/Coop.Core/Client/Services/Discord/DiscordPresenceHandler.cs
+++ b/source/Coop.Core/Client/Services/Discord/DiscordPresenceHandler.cs
@@ -119,13 +119,14 @@ internal sealed class DiscordPresenceHandler : IHandler
     {
         lock (gate)
         {
-            if (lastDetails != null) presenceClient.ClearPresence();
+            if (disposed) return;
+            if (lastState != "Main Menu") presenceClient.SetMainMenu();
             connectedAtUtc = null;
             campaignReady = false;
             battleId = null;
             playerCount = 1;
             lastDetails = null;
-            lastState = null;
+            lastState = "Main Menu";
         }
     }
 
@@ -134,8 +135,8 @@ internal sealed class DiscordPresenceHandler : IHandler
         lock (gate)
         {
             if (disposed) return;
-            disposed = true;
             ClearSession();
+            disposed = true;
         }
         messageBroker.Unsubscribe<NetworkConnected>(Handle_Connected);
         messageBroker.Unsubscribe<ClientCampaignReady>(Handle_CampaignReady);

--- a/source/Coop.Core/Client/Services/Discord/DiscordPresenceModule.cs
+++ b/source/Coop.Core/Client/Services/Discord/DiscordPresenceModule.cs
@@ -1,0 +1,13 @@
+﻿using Autofac;
+
+namespace Coop.Core.Client.Services.Discord;
+
+public sealed class DiscordPresenceModule : Module
+{
+    protected override void Load(ContainerBuilder builder)
+    {
+        // The presence adapter owns connection disposal on its serialized worker queue.
+        builder.RegisterType<DiscordRpcConnection>().As<IDiscordRpcConnection>().InstancePerDependency().ExternallyOwned();
+        builder.RegisterType<DiscordPresenceClient>().As<IDiscordPresenceClient>().InstancePerLifetimeScope();
+    }
+}

--- a/source/Coop.Core/CoopartiveMultiplayerExperience.cs
+++ b/source/Coop.Core/CoopartiveMultiplayerExperience.cs
@@ -8,6 +8,7 @@ using Common.Network.Session;
 using Common.Network.Session.Messages;
 using Coop.Core.Client;
 using Coop.Core.Client.Messages;
+using Coop.Core.Client.Services.Discord;
 using Coop.Core.Client.Services.Session;
 using Coop.Core.Common.Configuration;
 using Coop.Core.Common.Services.Connection.Messages;
@@ -36,6 +37,8 @@ namespace Coop.Core
         private IMessageBroker messageBroker;
         private INetworkConfig configuration;
         private IContainer container;
+        private readonly IContainer presenceContainer;
+        private readonly IDiscordPresenceClient presenceClient;
         private readonly SteamOrDirectJoinEndpointPreparer joinEndpointPreparer = new SteamOrDirectJoinEndpointPreparer();
         private readonly ServerProcessManager serverProcessManager;
         private readonly Action<string> setCrashPhase;
@@ -71,6 +74,15 @@ namespace Coop.Core
             this.setCrashPhase = setCrashPhase ?? (_ => { });
             this.coopLogFilePath = coopLogFilePath;
 
+            if (!standaloneServerProcess)
+            {
+                var builder = new ContainerBuilder();
+                builder.RegisterModule<DiscordPresenceModule>();
+                presenceContainer = builder.Build();
+                presenceClient = presenceContainer.Resolve<IDiscordPresenceClient>();
+                presenceClient.SetMainMenu();
+            }
+
             messageBroker.Subscribe<AttemptJoin>(Handle);
             messageBroker.Subscribe<AttemptHost>(Handle);
             messageBroker.Subscribe<HostSaveGame>(Handle);
@@ -91,7 +103,19 @@ namespace Coop.Core
             }
         }
 
-        public void Dispose() => DestroyContainer();
+        public void EndSession() => DestroyContainer();
+
+        public void Dispose()
+        {
+            try
+            {
+                EndSession();
+            }
+            finally
+            {
+                presenceContainer?.Dispose();
+            }
+        }
 
         private void Handle(MessagePayload<AttemptJoin> obj)
         {
@@ -447,6 +471,7 @@ namespace Coop.Core
 
             DestroyContainer();
             setCrashPhase("starting-server");
+            presenceClient?.ClearPresence();
 
             ModInformation.IsServer = true;
 
@@ -618,6 +643,11 @@ namespace Coop.Core
 
             ContainerBuilder builder = new ContainerBuilder();
             builder.RegisterModule<ClientModule>();
+            if (presenceClient != null)
+            {
+                // Session teardown must not close the application-owned Discord connection.
+                builder.RegisterInstance(presenceClient).As<IDiscordPresenceClient>().ExternallyOwned();
+            }
             builder.RegisterModule<GameInterfaceModule>();
             builder.RegisterInstance(new CoopLogFile(coopLogFilePath)).As<ICoopLogFile>().SingleInstance();
 
@@ -716,6 +746,7 @@ namespace Coop.Core
                     // Post-session resolves (console cheats, leftover patches) must fail gracefully.
                     GameInterface.ContainerProvider.Clear();
                     setCrashPhase("idle");
+                    if (ModInformation.IsServer) presenceClient?.SetMainMenu();
                 }
             }
         }

--- a/source/Coop.Tests/Autofac/ContainerBuildTests.cs
+++ b/source/Coop.Tests/Autofac/ContainerBuildTests.cs
@@ -5,6 +5,7 @@ using Common.Network;
 using Common.Network.Session;
 using Coop.Core.Common.Configuration;
 using Coop.Core.Client;
+using Coop.Core.Client.Services.Discord;
 using Coop.Core.Server;
 using Coop.Core.Server.Services.Telemetry;
 using Coop.Tests.Mocks;
@@ -79,6 +80,7 @@ namespace Coop.Tests.Autofac
             var server = container.Resolve<INetwork>();
             Assert.NotNull(server);
             Assert.False(container.IsRegistered<IVoiceClient>());
+            Assert.False(container.IsRegistered<IDiscordPresenceClient>());
             Assert.False(container.IsRegistered<IVoiceAudio>());
 
             var logic = container.Resolve<ILogic>();

--- a/source/Coop.Tests/Client/Services/Discord/DiscordPresenceClientTests.cs
+++ b/source/Coop.Tests/Client/Services/Discord/DiscordPresenceClientTests.cs
@@ -18,6 +18,40 @@ public class DiscordPresenceClientTests : IAsyncLifetime
         client = new DiscordPresenceClient(connection);
     }
 
+    [Fact]
+    public async Task MainMenuBeforeConnection_InitializesWithoutPlayerOrSessionDetails()
+    {
+        client.SetMainMenu();
+        await Drain();
+
+        AssertMainMenu();
+        Assert.Equal(1, connection.InitializeCalls);
+    }
+
+    [Fact]
+    public async Task MainMenuAfterCampaign_ReplacesPlayerCountAndSurvivesReadyWithStaleActivity()
+    {
+        client.SetPresence("In a co-op campaign", "3 players", startedAt);
+        await Drain();
+        var capturedPresence = connection.CurrentPresence;
+
+        client.SetMainMenu();
+        await Drain();
+        connection.CompleteReady(capturedPresence);
+        await Drain();
+
+        AssertMainMenu();
+        Assert.Equal(1, connection.InitializeCalls);
+    }
+
+    private void AssertMainMenu()
+    {
+        Assert.Equal("Main Menu", connection.CurrentPresence!.State);
+        Assert.Null(connection.CurrentPresence.Details);
+        Assert.Null(connection.CurrentPresence.Party);
+        Assert.Equal(DiscordPresenceClient.ArtworkKey, connection.CurrentPresence.Assets.LargeImageKey);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/source/Coop.Tests/Client/Services/Discord/DiscordPresenceHandlerTests.cs
+++ b/source/Coop.Tests/Client/Services/Discord/DiscordPresenceHandlerTests.cs
@@ -87,7 +87,7 @@ public class DiscordPresenceHandlerTests : IDisposable
     [InlineData("disconnect")]
     [InlineData("end")]
     [InlineData("menu")]
-    public void SessionEnd_ClearsBattleAndIgnoresLateEventsUntilNewConnection(string reason)
+    public void SessionEnd_RestoresMainMenuAndIgnoresLateEventsUntilNewConnection(string reason)
     {
         EnterCampaign();
         broker.Publish(this, new BattleMissionReady("battle"));
@@ -97,7 +97,7 @@ public class DiscordPresenceHandlerTests : IDisposable
             case "end": broker.Publish(this, new EndCoopMode()); break;
             case "menu": broker.Publish(this, new MainMenuEntered()); break;
         }
-        client.Verify(c => c.ClearPresence(), Times.Once);
+        client.Verify(c => c.SetMainMenu(), Times.Once);
         client.Invocations.Clear();
         broker.Publish(this, new NetworkConnectedPlayersChanged(8));
         broker.Publish(this, new BattleMissionEnded("battle"));
@@ -111,7 +111,7 @@ public class DiscordPresenceHandlerTests : IDisposable
     }
 
     [Fact]
-    public void DisconnectAndDispose_ClearOnlyOnceAndUnsubscribe()
+    public void DisconnectAndDispose_RestoreMainMenuOnlyOnceAndUnsubscribe()
     {
         EnterCampaign();
         broker.Publish(this, new NetworkDisconnected(default));
@@ -121,24 +121,25 @@ public class DiscordPresenceHandlerTests : IDisposable
         EnterCampaign();
         broker.Publish(this, new BattleMissionReady("battle"));
 
-        client.Verify(c => c.ClearPresence(), Times.Once);
+        client.Verify(c => c.SetMainMenu(), Times.Once);
         client.Verify(c => c.SetPresence("In a co-op campaign", "1 player", startedAt), Times.Once);
         client.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public void DisposeActiveSession_ClearsPresence()
+    public void DisposeActiveSession_RestoresMainMenu()
     {
         EnterCampaign();
         handler.Dispose();
-        client.Verify(c => c.ClearPresence(), Times.Once);
+        client.Verify(c => c.SetMainMenu(), Times.Once);
     }
 
     [Fact]
-    public void DisposeFailedJoin_DoesNotStartDiscord()
+    public void DisposeFailedJoin_RestoresMainMenu()
     {
         broker.Publish(this, new NetworkConnected());
         handler.Dispose();
+        client.Verify(c => c.SetMainMenu(), Times.Once);
         client.VerifyNoOtherCalls();
     }
 

--- a/source/Coop.Tests/Client/Services/Discord/DiscordPresenceModuleTests.cs
+++ b/source/Coop.Tests/Client/Services/Discord/DiscordPresenceModuleTests.cs
@@ -1,0 +1,69 @@
+﻿using Autofac;
+using Common.Messaging;
+using Common.Network.Messages;
+using Coop.Core.Client.Messages;
+using Coop.Core.Client.Services.Discord;
+using DiscordRPC;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Coop.Tests.Client.Services.Discord;
+
+public class DiscordPresenceModuleTests
+{
+    [Fact]
+    public async Task SharedPresence_SurvivesSessionDisposalAndClosesWithApplication()
+    {
+        var connection = new Mock<IDiscordRpcConnection>();
+        connection.Setup(c => c.Initialize()).Returns(true);
+        var builder = new ContainerBuilder();
+        builder.RegisterModule<DiscordPresenceModule>();
+        builder.RegisterInstance(connection.Object).As<IDiscordRpcConnection>().ExternallyOwned();
+        using var application = builder.Build();
+        var presence = (DiscordPresenceClient)application.Resolve<IDiscordPresenceClient>();
+        using var broker = new MessageBroker();
+
+        presence.SetMainMenu();
+        await presence.PendingWork;
+        VerifyMainMenu(connection, Times.Once());
+
+        for (int i = 0; i < 2; i++)
+        {
+            using (var session = CreateSession(presence, broker))
+            {
+                Assert.Same(presence, session.Resolve<IDiscordPresenceClient>());
+                broker.Publish(this, new NetworkConnected());
+                broker.Publish(this, new ClientCampaignReady());
+                await presence.PendingWork;
+                connection.Verify(c => c.SetPresence(It.Is<RichPresence>(p =>
+                    p.Details == "In a co-op campaign" && p.State == "1 player")), Times.Exactly(i + 1));
+            }
+            await presence.PendingWork;
+            VerifyMainMenu(connection, Times.Exactly(i + 2));
+            connection.Verify(c => c.Dispose(), Times.Never);
+        }
+
+        connection.Verify(c => c.Initialize(), Times.Once);
+        application.Dispose();
+        await presence.PendingWork;
+        connection.Verify(c => c.Dispose(), Times.Once);
+    }
+
+    private static IContainer CreateSession(IDiscordPresenceClient presence, IMessageBroker broker)
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterModule<DiscordPresenceModule>();
+        builder.RegisterInstance(presence).As<IDiscordPresenceClient>().ExternallyOwned();
+        builder.RegisterInstance(broker).As<IMessageBroker>().ExternallyOwned();
+        builder.RegisterType<DiscordPresenceHandler>().AutoActivate();
+        return builder.Build();
+    }
+
+    private static void VerifyMainMenu(Mock<IDiscordRpcConnection> connection, Times times)
+    {
+        connection.Verify(c => c.SetPresence(It.Is<RichPresence>(p =>
+            p.State == "Main Menu" && p.Details == null && p.Party == null)), times);
+    }
+}

--- a/source/Coop/CoopMod.cs
+++ b/source/Coop/CoopMod.cs
@@ -609,7 +609,7 @@ namespace Coop
 
             if (Coop.Running)
             {
-                Coop.Dispose();
+                Coop.EndSession();
             }
         }
 


### PR DESCRIPTION
## What is the current behavior?
Discord presence only appears after joining a co-op server.

## What is the new behavior?
Show `Main Menu` on startup and after leaving a server, without player details or a player count. Connected presence stays unchanged. Dedicated servers do not publish activity.

## How to test
23 focused tests passed. Release mod compile passed without deployment.

With Discord open, launch the mod and check for `Main Menu` without a player count. Join a server, check the existing campaign presence, then disconnect and check that `Main Menu` returns. Live Discord UI has not been tested.

## Bot Changelog Entry
- Discord now shows Main Menu before joining a server and after disconnecting, without a player count.
